### PR TITLE
feat(skills): introduce gwt-register-spec for safe SPEC creation (SPEC-2784)

### DIFF
--- a/.claude/skills/gwt-discussion/SKILL.md
+++ b/.claude/skills/gwt-discussion/SKILL.md
@@ -286,7 +286,14 @@ When the discussion stabilizes, update the right artifacts in one batch.
 
 - Use `references/intake.md` for search and routing discipline
 - Use `references/ddd-modeling.md` for Bounded Context and domain modeling
-- Use `references/registration.md` to create or seed `spec.md`
+- **Register the SPEC via `gwt-register-spec`** (sub-skill, SPEC-2784). The
+  caller prepares title + body file from this discussion's outcome; the
+  sub-skill validates, executes the canonical `create` → `--edit spec` →
+  `--section spec` roundtrip safely, and returns the new Issue number. Add
+  `Register Spec` to the Action Bundle. Use `references/registration.md`
+  only when the sub-skill is unavailable; in that case follow its 2-step
+  flow manually and verify `--section spec` returns non-empty content
+  before handoff.
 - Use `references/clarification.md` to remove high-impact
   `[NEEDS CLARIFICATION]` markers
 - Use `references/deepening.md` when the user asks for deeper analysis on an
@@ -334,6 +341,7 @@ Reason: <one sentence>
 - Resume Build Context: <what the implementer must use>
 
 ### Action Bundle
+- Register Spec
 - Update Spec
 - Update Plan
 - Resume Build
@@ -341,6 +349,10 @@ Reason: <one sentence>
 - Write Lesson
 - No Action
 ```
+
+`Register Spec` runs the `gwt-register-spec` sub-skill (SPEC-2784) to
+materialize a new SPEC Issue safely. Use it instead of manual
+`gwtd issue spec create` whenever a fresh SPEC owner is needed.
 
 This final result is the handoff point where the workflow may leave Plan Mode.
 

--- a/.claude/skills/gwt-discussion/references/registration.md
+++ b/.claude/skills/gwt-discussion/references/registration.md
@@ -2,15 +2,38 @@
 
 Detailed logic for the SPEC creation/update phase of gwt-discussion.
 
+> **Preferred path (SPEC-2784):** When this discussion produces a *new*
+> SPEC owner, hand the title + body off to the `gwt-register-spec`
+> sub-skill instead of running `gwtd issue spec create` directly. The
+> sub-skill enforces the 2-step `create` → `--edit spec` → roundtrip
+> verify flow that this reference once documented manually, so the
+> section-marker trap (an empty spec section after a bare `create -f`)
+> cannot occur. Add `Register Spec` to the Action Bundle and let
+> gwt-register-spec own the registration.
+>
+> The rest of this document remains as the recovery / manual path for
+> when the sub-skill is unavailable, or when *updating* an existing SPEC
+> rather than creating a new one.
+
 ## Prerequisites
 
 Phase 3 runs only when Phase 1 routing produced `NEW-SPEC` and Phase 2 domain
 discovery confirmed the scope is right for a SPEC.
 
-## SPEC creation
+## SPEC creation (manual / recovery path)
 
 SPEC の作成・更新は `gwtd issue spec` CLI で行う。
 すべての要約・タイトル・更新説明は current user's language で記述する。
+
+**重要:** `gwtd issue spec create -f <body>` は body file が
+`<!-- artifact:spec BEGIN/END -->` マーカーを含まないと `extract_sections()`
+が空を返し、spec section が空のまま Issue が作成される (SPEC #2780 で発生)。
+manual 経路では必ず以下の 2 段階で実行する:
+
+1. `gwtd issue spec create --title "SPEC: <title>" -f <empty-or-stub>` で器を作成
+2. `gwtd issue spec <n> --edit spec -f <full-body>` で content を投入
+   (`--edit` は section マーカーを自動付与する)
+3. `gwtd issue spec <n> --section spec | head -5` で非空を必ず確認
 
 ### コマンド
 

--- a/.claude/skills/gwt-register-issue/SKILL.md
+++ b/.claude/skills/gwt-register-issue/SKILL.md
@@ -37,7 +37,7 @@ Do not use this for an existing Issue. Use `gwt-fix-issue` instead.
 3. Run duplicate search before creating anything. Search both open Issues and existing SPEC owners, using the visible `gwt-search` surface when possible.
 4. Decide the registration outcome with the `Spec Status` contract below before creating any new owner.
 5. When the request is a narrow bug, docs, chore, or investigation item and the `Spec Status` allows a plain Issue, create it with `gwtd issue create --title ... -f ...`.
-6. When the request reveals a missing or unclear owner SPEC, stop plain-Issue creation and hand off to `gwt-discussion`.
+6. When the request reveals a missing or unclear owner SPEC, stop plain-Issue creation and hand off to `gwt-discussion`. (SPEC-2784: gwt-discussion's Action Bundle now includes `Register Spec` which delegates to the `gwt-register-spec` sub-skill so the SPEC Issue is materialized safely via the canonical create→edit→roundtrip flow. This skill does not create SPEC owners itself.)
 7. Return the chosen owner and next step in the current user's language.
 
 ## Spec Status

--- a/.claude/skills/gwt-register-spec/SKILL.md
+++ b/.claude/skills/gwt-register-spec/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: gwt-register-spec
+description: "Use when gwt-discussion has produced a finished SPEC design and the Action Bundle includes Register Spec. Materializes a SPEC issue safely via create-then-edit with structural + format-quality validation and roundtrip verification."
+---
+
+# gwt-register-spec
+
+Sub-skill called from `gwt-discussion` to materialize an already-decided SPEC
+design into a `gwt-spec` GitHub Issue. Encapsulates the canonical 2-step
+`gwtd issue spec create` → `gwtd issue spec --edit spec` flow so that the
+section-marker trap (an empty spec section because `create -f` does not wrap
+the body in `<!-- artifact:spec BEGIN/END -->` markers) cannot happen.
+
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
+## When to use
+
+- `gwt-discussion` has reached Phase 5 and its Action Bundle includes
+  `Register Spec`.
+- The caller already has the SPEC title (`SPEC: <title>`) and a complete
+  SPEC body file on disk with the 7 canonical sections filled in.
+- A new SPEC owner is needed; an existing SPEC owner has already been ruled
+  out by duplicate search in `gwt-discussion` / `gwt-register-issue`.
+
+Do not use this when the design is still under discussion (use
+`gwt-discussion`), when the request is narrow enough for a plain Issue (use
+`gwt-register-issue`), or when an existing SPEC needs additional sections
+(use `gwt-discussion` followed by `gwtd issue spec <n> --edit <section>` —
+this skill does not edit existing SPECs).
+
+## Ownership
+
+- Validate the provided body against the canonical SPEC contract.
+- Create the GitHub Issue safely (no orphan Issue on validation failure).
+- Inject the spec section via `--edit spec -f <body>` so the section markers
+  are auto-applied.
+- Roundtrip-verify by reading `--section spec` back and asserting non-empty.
+- Hand off the new Issue number to the caller. Plan / tasks sections are the
+  responsibility of `gwt-plan-spec` and are out of scope.
+
+## Inputs
+
+The skill takes two inputs from the caller:
+
+1. `title` — string. Must match `^SPEC: .+$`. Becomes the GitHub Issue title.
+2. `body_path` — filesystem path. Must point to a UTF-8 markdown file with
+   the canonical 7 sections (see `references/body-template.md`). The H1 inside
+   the file must equal `title`.
+
+The caller is responsible for assembling `body_path` from discussion
+artifacts (`.gwt/discussion.md`, Action Delta, plan file). This skill never
+generates content; it only validates and materializes.
+
+## Workflow
+
+Run these steps in order. If any step fails with `validation` or `roundtrip`
+severity, stop immediately and report back. Do not retry silently.
+
+```dot
+digraph register_spec_flow {
+    "start lifecycle" -> "load body";
+    "load body" -> "validate (structural + format-quality)";
+    "validate" -> "report issues" [label="any Structural issue"];
+    "validate" -> "gwtd issue spec create --title <t> -f <stub>" [label="all PASS"];
+    "create" -> "abort: io failure" [label="error"];
+    "create" -> "gwtd issue spec <n> --edit spec -f <body>" [label="issue created"];
+    "edit" -> "recovery report (orphan Issue #N)" [label="edit failure"];
+    "edit" -> "gwtd issue spec <n> --section spec" [label="edit ok"];
+    "section spec" -> "abort: empty spec" [label="empty"];
+    "section spec" -> "complete lifecycle, return Issue #N + URL" [label="non-empty"];
+}
+```
+
+1. **Lifecycle start**: `gwtd register start --spec 0` (placeholder spec id;
+   the real id is recorded via `phase` once the Issue is created).
+2. **Load body**: read `body_path` as UTF-8.
+3. **Validate**: call the validation library (see
+   `references/validation-rules.md`). On any `Structural` or `Format` issue,
+   call `gwtd register abort --spec 0 --reason "validation: <summary>"` and
+   return the issue list to the caller. Do not call any GitHub API.
+4. **Create shell**: `gwtd issue spec create --title "<title>" -f <stub>`
+   where `<stub>` is an empty placeholder file. Capture the new issue
+   number.
+5. **Phase create**: `gwtd register phase --spec <n> --label create` to bind
+   the real spec id and record the milestone.
+6. **Inject body**: `gwtd issue spec <n> --edit spec -f <body_path>`. The
+   `--edit` command auto-applies `<!-- artifact:spec BEGIN/END -->` markers.
+7. **Phase edit**: `gwtd register phase --spec <n> --label edit`.
+8. **Roundtrip verify**: `gwtd issue spec <n> --section spec`. The output
+   must be non-empty and must contain the H1 line of the body file. On
+   failure, follow `references/recovery.md` and abort.
+9. **Phase roundtrip**: `gwtd register phase --spec <n> --label roundtrip`.
+10. **Complete**: `gwtd register complete --spec <n>`. Return `{ issue: <n>,
+    url: "https://github.com/akiojin/gwt/issues/<n>" }` to the caller.
+
+## Validation rules
+
+See `references/validation-rules.md` for the canonical list. Summary:
+
+| Severity | Rule |
+|---|---|
+| Structural | Title matches `^SPEC: .+$` |
+| Structural | H1 in body equals title |
+| Structural | All 7 required sections exist (`背景`, `ユビキタス言語`, `ユーザーシナリオと受け入れシナリオ`, `機能要件`, `成功基準`, `Out of Scope`, `Related Artifacts`) |
+| Structural | `機能要件` contains at least one `FR-NNN` line |
+| Structural | No `[NEEDS CLARIFICATION]` markers anywhere |
+| Format | FR identifiers are contiguous (`FR-001`, `FR-002`, … no gaps) |
+
+Structural issues block create. Format issues also block create in v1
+(hard-fail policy).
+
+## Failure policy
+
+- **Validation failure** → no Issue created. Report each
+  `ValidationIssue { severity, location, message }` to the caller.
+- **Create failure** (network, auth) → no Issue created. Surface the gh / gwtd
+  error verbatim and `register abort`.
+- **Edit failure after create success** → the Issue exists but is empty.
+  Follow `references/recovery.md` to either retry `--edit spec` or open the
+  Issue for manual repair. Always include the orphan Issue number in the
+  recovery report.
+- **Roundtrip empty** → the `--edit` call apparently succeeded but the
+  section is unreadable. Treat as `Edit failure after create success`.
+
+## Recovery
+
+See `references/recovery.md`. The skill never silently retries; the caller
+(and any human reviewer) must see the orphan Issue and act.
+
+## Exit CLI (Stop-block contract)
+
+The skill registers lifecycle events through `gwtd register`:
+
+- `gwtd register start --spec 0` at the beginning (placeholder spec id).
+- `gwtd register phase --spec <n> --label <validation|create|edit|roundtrip>`
+  at each milestone.
+- `gwtd register complete --spec <n>` once the Issue is created and verified.
+- `gwtd register abort --spec <n|0> --reason '<text>'` on any failure.
+
+State file: `<worktree>/.gwt/skill-state/register-spec.json`. The
+`skill-register-spec-stop-check` Stop hook returns
+`{"decision":"block","reason":"..."}` while the state is active, honoring the
+shared `stop_hook_active` fail-safe so each Stop cycle allows at most one
+forced continuation.
+
+## Chain suggestion
+
+On `register complete`, suggest `gwt-plan-spec --spec <n>` as the next step.

--- a/.claude/skills/gwt-register-spec/references/body-template.md
+++ b/.claude/skills/gwt-register-spec/references/body-template.md
@@ -1,0 +1,98 @@
+# SPEC body template
+
+The 7 required sections, in canonical order. Copy this skeleton, fill in
+each section, and pass the resulting file to `gwt-register-spec` via
+`body_path`.
+
+The H1 line MUST equal the GitHub Issue title (the same `SPEC: <title>` you
+pass as `title`). See `validation-rules.md` for the full rule set.
+
+```markdown
+# SPEC: <one-line work name>
+
+## 背景
+
+<Why this work is needed. What problem or constraint prompted it. Reference
+prior incidents, lessons, or upstream decisions. Keep to 3-6 paragraphs.>
+
+## ユビキタス言語
+
+- **<TermA>**: <one-sentence definition that the team agrees on>
+- **<TermB>**: <one-sentence definition>
+- <Add as many entries as needed; this section is the shared vocabulary for
+  the rest of the SPEC. Reviewers should be able to read the rest of the
+  SPEC and know exactly what each named concept refers to.>
+
+## ユーザーシナリオと受け入れシナリオ
+
+### Primary User Story
+
+<One paragraph: which user, what outcome, why it matters.>
+
+### Acceptance Scenarios
+
+1. **<short name>**: <Given / When / Then narrative. Be concrete enough to
+   write a test against it.>
+2. **<short name>**: <...>
+3. **<short name>**: <...>
+
+## 機能要件
+
+- **FR-001**: <First requirement. Use the FR-NNN pattern with contiguous
+  numbers. Each requirement is one declarative sentence the implementation
+  must satisfy.>
+- **FR-002**: <...>
+- **FR-003**: <...>
+<Add as many FRs as needed. The numbering must be contiguous (FR-001,
+FR-002, …) — gaps cause a Format validation issue.>
+
+## 成功基準
+
+- <Concrete verification command or observable outcome. Prefer command +
+  expected result over prose.>
+- <Example: `cargo test -p gwt-github spec_validate::` が GREEN.>
+- <Example: `pnpm lint:skills` が新 SKILL.md frontmatter で通過.>
+
+## Out of Scope (v1)
+
+- <Explicitly excluded behaviors. Use this to prevent scope creep during
+  implementation.>
+- <Items that belong in v2 or in a different SPEC.>
+
+## Related Artifacts
+
+- Plan: `<path to plan file if any>`
+- Discussion state: `.gwt/discussion.md` (Proposal X [chosen] / Evidence
+  Gate complete)
+- Reference: `<related SPEC, docs, code path>`
+```
+
+## Section-by-section guidance
+
+- **背景** — answer "why now". Forward-looking only; do not repeat the
+  ユビキタス言語 definitions here.
+- **ユビキタス言語** — required even for small SPECs. If the work introduces
+  no new terms, list the load-bearing existing terms so reviewers do not
+  have to guess.
+- **ユーザーシナリオと受け入れシナリオ** — `Primary User Story` is one
+  paragraph; `Acceptance Scenarios` is a numbered list. Each scenario
+  should be implementable as a black-box test.
+- **機能要件** — declarative `FR-NNN` lines. Imperative voice ("must …") is
+  fine. Avoid "should" language; ambiguity blocks downstream planning.
+- **成功基準** — prefer commands and observable signals. Subjective bullets
+  ("ユーザー体験が向上する") are not measurable and should be deleted.
+- **Out of Scope (v1)** — required even if empty (write `- なし` if there
+  are no deferred items). Forces the author to think about scope.
+- **Related Artifacts** — paths and links only. No prose summaries here;
+  the SPEC body itself is the canonical narrative.
+
+## Common mistakes
+
+- Listing `FR-001` and `FR-003` but no `FR-002` — Format validation fails.
+- Adding `[NEEDS CLARIFICATION]` markers and forgetting to resolve them
+  before calling `gwt-register-spec`. Use `gwt-discussion` to resolve them
+  first.
+- Using `**Functional Requirements**` or English-only section headings
+  instead of the canonical Japanese names. The validator looks for exact
+  Japanese headings.
+- Forgetting to keep H1 in sync with the GitHub Issue title argument.

--- a/.claude/skills/gwt-register-spec/references/recovery.md
+++ b/.claude/skills/gwt-register-spec/references/recovery.md
@@ -1,0 +1,90 @@
+# Recovery from partial registration
+
+`gwt-register-spec` is designed so the only way to produce a half-baked
+SPEC Issue is for `gwtd issue spec create` to succeed and the subsequent
+`gwtd issue spec <n> --edit spec -f <body>` to fail. (Validation runs
+before any GitHub API call, so a `Structural` or `Format` failure never
+creates an orphan Issue.)
+
+This document covers that single failure mode and the matching recovery
+flow.
+
+## Detect
+
+After `gwtd issue spec create` returns the new Issue number, the skill
+immediately calls `gwtd issue spec <n> --edit spec -f <body>`. If `--edit`
+exits non-zero, the skill stops the lifecycle with:
+
+```
+gwtd register abort --spec <n> --reason 'edit failed: <gh/gwtd error verbatim>'
+```
+
+If the skill reaches the roundtrip step and `gwtd issue spec <n>
+--section spec` reports empty output or the heading does not contain the
+expected H1, the skill aborts with `--reason 'roundtrip empty'`.
+
+In both cases the GitHub Issue still exists with an empty spec section.
+The caller and any human reviewer must see the orphan Issue number.
+
+## Report
+
+The skill returns a structured report to the caller containing at
+minimum:
+
+```json
+{
+  "outcome": "partial",
+  "issue": <n>,
+  "url": "https://github.com/akiojin/gwt/issues/<n>",
+  "failed_step": "edit" | "roundtrip",
+  "error": "<verbatim gh/gwtd error>",
+  "next_action": "manual_edit"
+}
+```
+
+The caller surfaces this back to the user. Do not silently retry — the
+underlying failure (network, auth, GitHub rate limit) usually persists
+and would block the retry too.
+
+## Repair (manual)
+
+Once the upstream failure is understood (e.g. network restored, auth
+refreshed), the human or follow-up agent runs:
+
+```
+gwtd issue spec <n> --edit spec -f <body_path>
+gwtd issue spec <n> --section spec | head -5      # roundtrip verify
+```
+
+If the roundtrip is OK, the SPEC is healed. There is no need to delete
+and re-create the Issue.
+
+## Repair (automated retry, deferred)
+
+In v1 the skill does not auto-retry. Adding bounded retry with
+exponential backoff is a v2 candidate; the open design questions are:
+
+- How many retries before the orphan Issue is reported?
+- Should the skill detect transient errors (HTTP 5xx, network) and
+  retry only those, vs hard-fail on auth?
+- Where does the retry budget live — per-skill-run, per-process, or
+  per-user-session?
+
+These will be revisited if recovery ends up being a frequent operation.
+Until then, the manual flow is intentional: it forces a human to see
+the orphan Issue, which is the safest outcome.
+
+## When the Issue should be abandoned, not repaired
+
+If the SPEC body itself turned out to be wrong (e.g. duplicate of an
+existing SPEC found during a second-pass search), close the GitHub Issue
+with a short comment pointing at the canonical owner. Do not edit the
+spec section to point elsewhere — that pollutes the SPEC search index.
+
+```
+gwtd issue comment <n> -f <comment.md>      # explain why
+# then close the Issue via the UI or `gh issue close <n>` (out of band)
+```
+
+This is the only case where the orphan Issue is intentionally left
+empty.

--- a/.claude/skills/gwt-register-spec/references/validation-rules.md
+++ b/.claude/skills/gwt-register-spec/references/validation-rules.md
@@ -1,0 +1,112 @@
+# Validation rules
+
+`gwt-register-spec` validates the SPEC body before any GitHub API call.
+This document is the canonical list. The Rust implementation lives at
+`crates/gwt-github/src/spec_validate.rs` and exposes
+`validate_spec_body(body: &str, title: &str, rules: &ValidationRules) ->
+Vec<ValidationIssue>`.
+
+## Severity levels
+
+- `Structural` — the body cannot be processed downstream without manual
+  correction. Always hard-fail: no Issue is created.
+- `Format` — the body is processable but does not meet the project's
+  format convention. Also hard-fail in v1 (consistent registration
+  surface). Future opt-in soft-fail is possible behind a `--allow-format`
+  flag, but that is out of scope for v1.
+
+Every issue carries `{ severity, location, message }` where `location` is
+either `"title"`, the section heading (`"## 機能要件"`), or a 1-based line
+offset inside the body.
+
+## Rule table
+
+| ID | Severity | Rule | Failure example |
+|---|---|---|---|
+| R1 | Structural | Title matches `^SPEC: .+$` | `"feat: foo"` → fail |
+| R2 | Structural | First non-blank line of body equals title | H1 says `# something else` |
+| R3 | Structural | Section `## 背景` exists | missing or misspelled |
+| R4 | Structural | Section `## ユビキタス言語` exists | — |
+| R5 | Structural | Section `## ユーザーシナリオと受け入れシナリオ` exists | — |
+| R6 | Structural | Section `## 機能要件` exists | — |
+| R7 | Structural | Section `## 成功基準` exists | — |
+| R8 | Structural | Section `## Out of Scope` exists (case-sensitive prefix; `(v1)` suffix permitted) | `## Out Of Scope` → fail |
+| R9 | Structural | Section `## Related Artifacts` exists | — |
+| R10 | Structural | `機能要件` section contains ≥1 line matching `^- \*\*FR-\d{3}\*\*` | no FR present |
+| R11 | Structural | No occurrence of `[NEEDS CLARIFICATION]` anywhere | unresolved markers |
+| R12 | Format | FR identifiers are contiguous (`FR-001`, `FR-002`, …) | `FR-001, FR-003` |
+
+R8 explicitly permits `## Out of Scope (v1)` so version-suffixed sections
+keep passing validation. Implementation: prefix match on
+`"## Out of Scope"` then optional whitespace + `(...)`.
+
+## Roundtrip check (post-create)
+
+After the GitHub Issue has been created and `--edit spec -f <body>` has
+been called, the skill performs a roundtrip verification:
+
+1. `gwtd issue spec <n> --section spec` must exit 0.
+2. The output must be non-empty.
+3. The output must contain the H1 line of the body (`# SPEC: …`).
+
+If any of these fail, the skill aborts the lifecycle with a
+`roundtrip` reason and surfaces the orphan Issue number per
+`recovery.md`.
+
+## Section heading detection
+
+Headings are recognised by exact `## <Heading>` at the start of a line
+(after optional leading whitespace is rejected — only flush-left
+headings count). The match is on the heading text, not on any anchor or
+slug. The validator does **not** parse markdown into an AST; it operates
+on line patterns to keep the implementation small and predictable.
+
+## What is NOT validated (v1 contract)
+
+- Tense, voice, or style of FR sentences (no NLP).
+- Numbering of acceptance scenarios (any 1-based numeric list is
+  accepted).
+- Existence of plan / tasks sections — those are added later by
+  `gwt-plan-spec`.
+- Section ordering — sections may appear in any order as long as all
+  required headings exist.
+- Internal links to other SPECs — `Related Artifacts` may contain any
+  free-form text.
+
+## Worked example
+
+Given a body with:
+
+```markdown
+# SPEC: Demo
+
+## 背景
+ある。
+
+## ユビキタス言語
+- **X**: y
+
+## ユーザーシナリオと受け入れシナリオ
+### Primary User Story
+hi.
+
+## 機能要件
+- **FR-001**: a
+- **FR-002**: b
+
+## 成功基準
+- ok
+
+## Related Artifacts
+- none
+```
+
+Validation issues returned:
+
+- `Structural` `## ユーザーシナリオと受け入れシナリオ`: missing
+  `### Acceptance Scenarios` is not validated (out of scope), but the
+  section itself is present → no issue.
+- `Structural` `## Out of Scope`: missing → fail.
+- (no other issues)
+
+The caller fixes the missing section, re-runs validation, and proceeds.

--- a/.codex/skills/gwt-register-spec/SKILL.md
+++ b/.codex/skills/gwt-register-spec/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: gwt-register-spec
+description: "Use when gwt-discussion has produced a finished SPEC design and the Action Bundle includes Register Spec. Materializes a SPEC issue safely via create-then-edit with structural + format-quality validation and roundtrip verification."
+---
+
+# gwt-register-spec
+
+Sub-skill called from `gwt-discussion` to materialize an already-decided SPEC
+design into a `gwt-spec` GitHub Issue. Encapsulates the canonical 2-step
+`gwtd issue spec create` → `gwtd issue spec --edit spec` flow so that the
+section-marker trap (an empty spec section because `create -f` does not wrap
+the body in `<!-- artifact:spec BEGIN/END -->` markers) cannot happen.
+
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
+## When to use
+
+- `gwt-discussion` has reached Phase 5 and its Action Bundle includes
+  `Register Spec`.
+- The caller already has the SPEC title (`SPEC: <title>`) and a complete
+  SPEC body file on disk with the 7 canonical sections filled in.
+- A new SPEC owner is needed; an existing SPEC owner has already been ruled
+  out by duplicate search in `gwt-discussion` / `gwt-register-issue`.
+
+Do not use this when the design is still under discussion (use
+`gwt-discussion`), when the request is narrow enough for a plain Issue (use
+`gwt-register-issue`), or when an existing SPEC needs additional sections
+(use `gwt-discussion` followed by `gwtd issue spec <n> --edit <section>` —
+this skill does not edit existing SPECs).
+
+## Ownership
+
+- Validate the provided body against the canonical SPEC contract.
+- Create the GitHub Issue safely (no orphan Issue on validation failure).
+- Inject the spec section via `--edit spec -f <body>` so the section markers
+  are auto-applied.
+- Roundtrip-verify by reading `--section spec` back and asserting non-empty.
+- Hand off the new Issue number to the caller. Plan / tasks sections are the
+  responsibility of `gwt-plan-spec` and are out of scope.
+
+## Inputs
+
+The skill takes two inputs from the caller:
+
+1. `title` — string. Must match `^SPEC: .+$`. Becomes the GitHub Issue title.
+2. `body_path` — filesystem path. Must point to a UTF-8 markdown file with
+   the canonical 7 sections (see `references/body-template.md`). The H1 inside
+   the file must equal `title`.
+
+The caller is responsible for assembling `body_path` from discussion
+artifacts (`.gwt/discussion.md`, Action Delta, plan file). This skill never
+generates content; it only validates and materializes.
+
+## Workflow
+
+Run these steps in order. If any step fails with `validation` or `roundtrip`
+severity, stop immediately and report back. Do not retry silently.
+
+```dot
+digraph register_spec_flow {
+    "start lifecycle" -> "load body";
+    "load body" -> "validate (structural + format-quality)";
+    "validate" -> "report issues" [label="any Structural issue"];
+    "validate" -> "gwtd issue spec create --title <t> -f <stub>" [label="all PASS"];
+    "create" -> "abort: io failure" [label="error"];
+    "create" -> "gwtd issue spec <n> --edit spec -f <body>" [label="issue created"];
+    "edit" -> "recovery report (orphan Issue #N)" [label="edit failure"];
+    "edit" -> "gwtd issue spec <n> --section spec" [label="edit ok"];
+    "section spec" -> "abort: empty spec" [label="empty"];
+    "section spec" -> "complete lifecycle, return Issue #N + URL" [label="non-empty"];
+}
+```
+
+1. **Lifecycle start**: `gwtd register start --spec 0` (placeholder spec id;
+   the real id is recorded via `phase` once the Issue is created).
+2. **Load body**: read `body_path` as UTF-8.
+3. **Validate**: call the validation library (see
+   `references/validation-rules.md`). On any `Structural` or `Format` issue,
+   call `gwtd register abort --spec 0 --reason "validation: <summary>"` and
+   return the issue list to the caller. Do not call any GitHub API.
+4. **Create shell**: `gwtd issue spec create --title "<title>" -f <stub>`
+   where `<stub>` is an empty placeholder file. Capture the new issue
+   number.
+5. **Phase create**: `gwtd register phase --spec <n> --label create` to bind
+   the real spec id and record the milestone.
+6. **Inject body**: `gwtd issue spec <n> --edit spec -f <body_path>`. The
+   `--edit` command auto-applies `<!-- artifact:spec BEGIN/END -->` markers.
+7. **Phase edit**: `gwtd register phase --spec <n> --label edit`.
+8. **Roundtrip verify**: `gwtd issue spec <n> --section spec`. The output
+   must be non-empty and must contain the H1 line of the body file. On
+   failure, follow `references/recovery.md` and abort.
+9. **Phase roundtrip**: `gwtd register phase --spec <n> --label roundtrip`.
+10. **Complete**: `gwtd register complete --spec <n>`. Return `{ issue: <n>,
+    url: "https://github.com/akiojin/gwt/issues/<n>" }` to the caller.
+
+## Validation rules
+
+See `references/validation-rules.md` for the canonical list. Summary:
+
+| Severity | Rule |
+|---|---|
+| Structural | Title matches `^SPEC: .+$` |
+| Structural | H1 in body equals title |
+| Structural | All 7 required sections exist (`背景`, `ユビキタス言語`, `ユーザーシナリオと受け入れシナリオ`, `機能要件`, `成功基準`, `Out of Scope`, `Related Artifacts`) |
+| Structural | `機能要件` contains at least one `FR-NNN` line |
+| Structural | No `[NEEDS CLARIFICATION]` markers anywhere |
+| Format | FR identifiers are contiguous (`FR-001`, `FR-002`, … no gaps) |
+
+Structural issues block create. Format issues also block create in v1
+(hard-fail policy).
+
+## Failure policy
+
+- **Validation failure** → no Issue created. Report each
+  `ValidationIssue { severity, location, message }` to the caller.
+- **Create failure** (network, auth) → no Issue created. Surface the gh / gwtd
+  error verbatim and `register abort`.
+- **Edit failure after create success** → the Issue exists but is empty.
+  Follow `references/recovery.md` to either retry `--edit spec` or open the
+  Issue for manual repair. Always include the orphan Issue number in the
+  recovery report.
+- **Roundtrip empty** → the `--edit` call apparently succeeded but the
+  section is unreadable. Treat as `Edit failure after create success`.
+
+## Recovery
+
+See `references/recovery.md`. The skill never silently retries; the caller
+(and any human reviewer) must see the orphan Issue and act.
+
+## Exit CLI (Stop-block contract)
+
+The skill registers lifecycle events through `gwtd register`:
+
+- `gwtd register start --spec 0` at the beginning (placeholder spec id).
+- `gwtd register phase --spec <n> --label <validation|create|edit|roundtrip>`
+  at each milestone.
+- `gwtd register complete --spec <n>` once the Issue is created and verified.
+- `gwtd register abort --spec <n|0> --reason '<text>'` on any failure.
+
+State file: `<worktree>/.gwt/skill-state/register-spec.json`. The
+`skill-register-spec-stop-check` Stop hook returns
+`{"decision":"block","reason":"..."}` while the state is active, honoring the
+shared `stop_hook_active` fail-safe so each Stop cycle allows at most one
+forced continuation.
+
+## Chain suggestion
+
+On `register complete`, suggest `gwt-plan-spec --spec <n>` as the next step.

--- a/.codex/skills/gwt-register-spec/references/body-template.md
+++ b/.codex/skills/gwt-register-spec/references/body-template.md
@@ -1,0 +1,98 @@
+# SPEC body template
+
+The 7 required sections, in canonical order. Copy this skeleton, fill in
+each section, and pass the resulting file to `gwt-register-spec` via
+`body_path`.
+
+The H1 line MUST equal the GitHub Issue title (the same `SPEC: <title>` you
+pass as `title`). See `validation-rules.md` for the full rule set.
+
+```markdown
+# SPEC: <one-line work name>
+
+## 背景
+
+<Why this work is needed. What problem or constraint prompted it. Reference
+prior incidents, lessons, or upstream decisions. Keep to 3-6 paragraphs.>
+
+## ユビキタス言語
+
+- **<TermA>**: <one-sentence definition that the team agrees on>
+- **<TermB>**: <one-sentence definition>
+- <Add as many entries as needed; this section is the shared vocabulary for
+  the rest of the SPEC. Reviewers should be able to read the rest of the
+  SPEC and know exactly what each named concept refers to.>
+
+## ユーザーシナリオと受け入れシナリオ
+
+### Primary User Story
+
+<One paragraph: which user, what outcome, why it matters.>
+
+### Acceptance Scenarios
+
+1. **<short name>**: <Given / When / Then narrative. Be concrete enough to
+   write a test against it.>
+2. **<short name>**: <...>
+3. **<short name>**: <...>
+
+## 機能要件
+
+- **FR-001**: <First requirement. Use the FR-NNN pattern with contiguous
+  numbers. Each requirement is one declarative sentence the implementation
+  must satisfy.>
+- **FR-002**: <...>
+- **FR-003**: <...>
+<Add as many FRs as needed. The numbering must be contiguous (FR-001,
+FR-002, …) — gaps cause a Format validation issue.>
+
+## 成功基準
+
+- <Concrete verification command or observable outcome. Prefer command +
+  expected result over prose.>
+- <Example: `cargo test -p gwt-github spec_validate::` が GREEN.>
+- <Example: `pnpm lint:skills` が新 SKILL.md frontmatter で通過.>
+
+## Out of Scope (v1)
+
+- <Explicitly excluded behaviors. Use this to prevent scope creep during
+  implementation.>
+- <Items that belong in v2 or in a different SPEC.>
+
+## Related Artifacts
+
+- Plan: `<path to plan file if any>`
+- Discussion state: `.gwt/discussion.md` (Proposal X [chosen] / Evidence
+  Gate complete)
+- Reference: `<related SPEC, docs, code path>`
+```
+
+## Section-by-section guidance
+
+- **背景** — answer "why now". Forward-looking only; do not repeat the
+  ユビキタス言語 definitions here.
+- **ユビキタス言語** — required even for small SPECs. If the work introduces
+  no new terms, list the load-bearing existing terms so reviewers do not
+  have to guess.
+- **ユーザーシナリオと受け入れシナリオ** — `Primary User Story` is one
+  paragraph; `Acceptance Scenarios` is a numbered list. Each scenario
+  should be implementable as a black-box test.
+- **機能要件** — declarative `FR-NNN` lines. Imperative voice ("must …") is
+  fine. Avoid "should" language; ambiguity blocks downstream planning.
+- **成功基準** — prefer commands and observable signals. Subjective bullets
+  ("ユーザー体験が向上する") are not measurable and should be deleted.
+- **Out of Scope (v1)** — required even if empty (write `- なし` if there
+  are no deferred items). Forces the author to think about scope.
+- **Related Artifacts** — paths and links only. No prose summaries here;
+  the SPEC body itself is the canonical narrative.
+
+## Common mistakes
+
+- Listing `FR-001` and `FR-003` but no `FR-002` — Format validation fails.
+- Adding `[NEEDS CLARIFICATION]` markers and forgetting to resolve them
+  before calling `gwt-register-spec`. Use `gwt-discussion` to resolve them
+  first.
+- Using `**Functional Requirements**` or English-only section headings
+  instead of the canonical Japanese names. The validator looks for exact
+  Japanese headings.
+- Forgetting to keep H1 in sync with the GitHub Issue title argument.

--- a/.codex/skills/gwt-register-spec/references/recovery.md
+++ b/.codex/skills/gwt-register-spec/references/recovery.md
@@ -1,0 +1,90 @@
+# Recovery from partial registration
+
+`gwt-register-spec` is designed so the only way to produce a half-baked
+SPEC Issue is for `gwtd issue spec create` to succeed and the subsequent
+`gwtd issue spec <n> --edit spec -f <body>` to fail. (Validation runs
+before any GitHub API call, so a `Structural` or `Format` failure never
+creates an orphan Issue.)
+
+This document covers that single failure mode and the matching recovery
+flow.
+
+## Detect
+
+After `gwtd issue spec create` returns the new Issue number, the skill
+immediately calls `gwtd issue spec <n> --edit spec -f <body>`. If `--edit`
+exits non-zero, the skill stops the lifecycle with:
+
+```
+gwtd register abort --spec <n> --reason 'edit failed: <gh/gwtd error verbatim>'
+```
+
+If the skill reaches the roundtrip step and `gwtd issue spec <n>
+--section spec` reports empty output or the heading does not contain the
+expected H1, the skill aborts with `--reason 'roundtrip empty'`.
+
+In both cases the GitHub Issue still exists with an empty spec section.
+The caller and any human reviewer must see the orphan Issue number.
+
+## Report
+
+The skill returns a structured report to the caller containing at
+minimum:
+
+```json
+{
+  "outcome": "partial",
+  "issue": <n>,
+  "url": "https://github.com/akiojin/gwt/issues/<n>",
+  "failed_step": "edit" | "roundtrip",
+  "error": "<verbatim gh/gwtd error>",
+  "next_action": "manual_edit"
+}
+```
+
+The caller surfaces this back to the user. Do not silently retry — the
+underlying failure (network, auth, GitHub rate limit) usually persists
+and would block the retry too.
+
+## Repair (manual)
+
+Once the upstream failure is understood (e.g. network restored, auth
+refreshed), the human or follow-up agent runs:
+
+```
+gwtd issue spec <n> --edit spec -f <body_path>
+gwtd issue spec <n> --section spec | head -5      # roundtrip verify
+```
+
+If the roundtrip is OK, the SPEC is healed. There is no need to delete
+and re-create the Issue.
+
+## Repair (automated retry, deferred)
+
+In v1 the skill does not auto-retry. Adding bounded retry with
+exponential backoff is a v2 candidate; the open design questions are:
+
+- How many retries before the orphan Issue is reported?
+- Should the skill detect transient errors (HTTP 5xx, network) and
+  retry only those, vs hard-fail on auth?
+- Where does the retry budget live — per-skill-run, per-process, or
+  per-user-session?
+
+These will be revisited if recovery ends up being a frequent operation.
+Until then, the manual flow is intentional: it forces a human to see
+the orphan Issue, which is the safest outcome.
+
+## When the Issue should be abandoned, not repaired
+
+If the SPEC body itself turned out to be wrong (e.g. duplicate of an
+existing SPEC found during a second-pass search), close the GitHub Issue
+with a short comment pointing at the canonical owner. Do not edit the
+spec section to point elsewhere — that pollutes the SPEC search index.
+
+```
+gwtd issue comment <n> -f <comment.md>      # explain why
+# then close the Issue via the UI or `gh issue close <n>` (out of band)
+```
+
+This is the only case where the orphan Issue is intentionally left
+empty.

--- a/.codex/skills/gwt-register-spec/references/validation-rules.md
+++ b/.codex/skills/gwt-register-spec/references/validation-rules.md
@@ -1,0 +1,112 @@
+# Validation rules
+
+`gwt-register-spec` validates the SPEC body before any GitHub API call.
+This document is the canonical list. The Rust implementation lives at
+`crates/gwt-github/src/spec_validate.rs` and exposes
+`validate_spec_body(body: &str, title: &str, rules: &ValidationRules) ->
+Vec<ValidationIssue>`.
+
+## Severity levels
+
+- `Structural` — the body cannot be processed downstream without manual
+  correction. Always hard-fail: no Issue is created.
+- `Format` — the body is processable but does not meet the project's
+  format convention. Also hard-fail in v1 (consistent registration
+  surface). Future opt-in soft-fail is possible behind a `--allow-format`
+  flag, but that is out of scope for v1.
+
+Every issue carries `{ severity, location, message }` where `location` is
+either `"title"`, the section heading (`"## 機能要件"`), or a 1-based line
+offset inside the body.
+
+## Rule table
+
+| ID | Severity | Rule | Failure example |
+|---|---|---|---|
+| R1 | Structural | Title matches `^SPEC: .+$` | `"feat: foo"` → fail |
+| R2 | Structural | First non-blank line of body equals title | H1 says `# something else` |
+| R3 | Structural | Section `## 背景` exists | missing or misspelled |
+| R4 | Structural | Section `## ユビキタス言語` exists | — |
+| R5 | Structural | Section `## ユーザーシナリオと受け入れシナリオ` exists | — |
+| R6 | Structural | Section `## 機能要件` exists | — |
+| R7 | Structural | Section `## 成功基準` exists | — |
+| R8 | Structural | Section `## Out of Scope` exists (case-sensitive prefix; `(v1)` suffix permitted) | `## Out Of Scope` → fail |
+| R9 | Structural | Section `## Related Artifacts` exists | — |
+| R10 | Structural | `機能要件` section contains ≥1 line matching `^- \*\*FR-\d{3}\*\*` | no FR present |
+| R11 | Structural | No occurrence of `[NEEDS CLARIFICATION]` anywhere | unresolved markers |
+| R12 | Format | FR identifiers are contiguous (`FR-001`, `FR-002`, …) | `FR-001, FR-003` |
+
+R8 explicitly permits `## Out of Scope (v1)` so version-suffixed sections
+keep passing validation. Implementation: prefix match on
+`"## Out of Scope"` then optional whitespace + `(...)`.
+
+## Roundtrip check (post-create)
+
+After the GitHub Issue has been created and `--edit spec -f <body>` has
+been called, the skill performs a roundtrip verification:
+
+1. `gwtd issue spec <n> --section spec` must exit 0.
+2. The output must be non-empty.
+3. The output must contain the H1 line of the body (`# SPEC: …`).
+
+If any of these fail, the skill aborts the lifecycle with a
+`roundtrip` reason and surfaces the orphan Issue number per
+`recovery.md`.
+
+## Section heading detection
+
+Headings are recognised by exact `## <Heading>` at the start of a line
+(after optional leading whitespace is rejected — only flush-left
+headings count). The match is on the heading text, not on any anchor or
+slug. The validator does **not** parse markdown into an AST; it operates
+on line patterns to keep the implementation small and predictable.
+
+## What is NOT validated (v1 contract)
+
+- Tense, voice, or style of FR sentences (no NLP).
+- Numbering of acceptance scenarios (any 1-based numeric list is
+  accepted).
+- Existence of plan / tasks sections — those are added later by
+  `gwt-plan-spec`.
+- Section ordering — sections may appear in any order as long as all
+  required headings exist.
+- Internal links to other SPECs — `Related Artifacts` may contain any
+  free-form text.
+
+## Worked example
+
+Given a body with:
+
+```markdown
+# SPEC: Demo
+
+## 背景
+ある。
+
+## ユビキタス言語
+- **X**: y
+
+## ユーザーシナリオと受け入れシナリオ
+### Primary User Story
+hi.
+
+## 機能要件
+- **FR-001**: a
+- **FR-002**: b
+
+## 成功基準
+- ok
+
+## Related Artifacts
+- none
+```
+
+Validation issues returned:
+
+- `Structural` `## ユーザーシナリオと受け入れシナリオ`: missing
+  `### Acceptance Scenarios` is not validated (out of scope), but the
+  section itself is present → no issue.
+- `Structural` `## Out of Scope`: missing → fail.
+- (no other issues)
+
+The caller fixes the missing section, re-runs validation, and proceeds.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,10 +99,13 @@
 ##### Step 3: 既存 SPEC が見つからない場合のみ → 新規 SPEC を作成する
 
 - `gwt-discussion` を使って investigation-first で議論し、必要なら DDD ベースで SPEC 設計まで進める（調査 → ドメイン分析 → SPEC 登録/更新 → 仕様明確化）
-- GitHub Issue (`gwt-spec` label) として作成する `spec` section には最低限以下を含める:
-  - ユーザーシナリオとテスト（受け入れシナリオ）
+- SPEC 登録は **`gwt-register-spec` skill 経由** で行う（SPEC-2784）。gwt-discussion の Action Bundle で `Register Spec` を選択し、title + body file を渡せば、skill が validation → `gwtd issue spec create` → `--edit spec` → roundtrip 検証を安全に実行する。直接 `gwtd issue spec create -f` を呼ぶと section マーカー漏れで空 SPEC が作成される（SPEC #2780 で発生、tasks/lessons.md 参照）
+- GitHub Issue (`gwt-spec` label) として作成する `spec` section には最低限以下を含める（gwt-register-spec の validation が強制する 7 セクション）:
+  - 背景 / ユビキタス言語
+  - ユーザーシナリオと受け入れシナリオ
   - 機能要件（FR-\*）
   - 成功基準
+  - Out of Scope / Related Artifacts
 - `gwt-plan-spec` で `plan` / `tasks` section も策定してから実装に入る
 - 新規 SPEC を作成した場合でも、エージェントは自分で新規ブランチや Worktree を作成しない。実装に進む場合は、承認済み SPEC と `gwt-plan-spec` の成果物に基づき、現在起動されている branch/worktree で作業する。
 - Git 環境の作成が必要な場合は、ユーザー操作に基づく gwt の Start Work / Launch materialization が担当する。

--- a/crates/gwt-github/src/lib.rs
+++ b/crates/gwt-github/src/lib.rs
@@ -22,6 +22,7 @@ pub mod migration;
 pub mod routing;
 pub mod sections;
 pub mod spec_ops;
+pub mod spec_validate;
 
 pub use body::{ParseError as BodyParseError, SectionLocation, SectionsIndex, SpecBody, SpecMeta};
 pub use cache::{Cache, CacheEntry, CacheError, CacheMeta};

--- a/crates/gwt-github/src/spec_validate.rs
+++ b/crates/gwt-github/src/spec_validate.rs
@@ -1,0 +1,293 @@
+//! SPEC body validation for `gwt-register-spec` (SPEC-2784).
+//!
+//! Pure validation of a SPEC body string against the 7-section canonical
+//! contract. Returns a list of issues rather than `Result<_, _>` so the
+//! caller can present every problem at once instead of fix-one-then-rerun.
+
+use serde::{Deserialize, Serialize};
+
+/// Severity of a single validation finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Severity {
+    /// Cannot be processed downstream without a manual fix.
+    Structural,
+    /// Processable but does not meet the project's format convention.
+    Format,
+}
+
+/// One validation finding. `location` is either `"title"`, the section
+/// heading (`"## 機能要件"`), or a free-form line / span hint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidationIssue {
+    pub severity: Severity,
+    pub location: String,
+    pub message: String,
+}
+
+/// Validation configuration. `default_rules()` returns the canonical
+/// 7-section / FR-NNN rule set used by `gwt-register-spec`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationRules {
+    pub title_prefix: &'static str,
+    pub required_sections: &'static [&'static str],
+    pub frbidden_marker: &'static str,
+}
+
+/// Canonical rules: `SPEC: ` prefix, 7 sections, no `[NEEDS CLARIFICATION]`.
+pub fn default_rules() -> ValidationRules {
+    ValidationRules {
+        title_prefix: "SPEC: ",
+        required_sections: &[
+            "## 背景",
+            "## ユビキタス言語",
+            "## ユーザーシナリオと受け入れシナリオ",
+            "## 機能要件",
+            "## 成功基準",
+            "## Out of Scope",
+            "## Related Artifacts",
+        ],
+        frbidden_marker: "[NEEDS CLARIFICATION]",
+    }
+}
+
+/// Validate the body against the rules. Empty `Vec` means PASS.
+pub fn validate_spec_body(
+    body: &str,
+    title: &str,
+    rules: &ValidationRules,
+) -> Vec<ValidationIssue> {
+    let mut issues = Vec::new();
+
+    if !title.starts_with(rules.title_prefix) || title.len() <= rules.title_prefix.len() {
+        issues.push(ValidationIssue {
+            severity: Severity::Structural,
+            location: "title".into(),
+            message: format!(
+                "title must match `^{}.+$`, got: {}",
+                rules.title_prefix, title
+            ),
+        });
+    }
+
+    let expected_h1 = format!("# {title}");
+    let first_h1 = body
+        .lines()
+        .find(|line| line.starts_with("# "))
+        .unwrap_or("");
+    if first_h1 != expected_h1 {
+        issues.push(ValidationIssue {
+            severity: Severity::Structural,
+            location: "h1".into(),
+            message: format!("body H1 must equal `{expected_h1}`, got: `{first_h1}`"),
+        });
+    }
+
+    for required in rules.required_sections {
+        if !body
+            .lines()
+            .any(|line| line == *required || line.starts_with(&format!("{required} (")))
+        {
+            issues.push(ValidationIssue {
+                severity: Severity::Structural,
+                location: (*required).into(),
+                message: format!("required section `{required}` is missing"),
+            });
+        }
+    }
+
+    let fr_section = extract_section(body, "## 機能要件");
+    let fr_numbers = collect_fr_numbers(&fr_section);
+    if fr_numbers.is_empty() {
+        issues.push(ValidationIssue {
+            severity: Severity::Structural,
+            location: "## 機能要件".into(),
+            message: "at least one `- **FR-NNN**: ...` line is required".into(),
+        });
+    } else {
+        for (i, &n) in fr_numbers.iter().enumerate() {
+            let expected = (i + 1) as u32;
+            if n != expected {
+                issues.push(ValidationIssue {
+                    severity: Severity::Format,
+                    location: "## 機能要件".into(),
+                    message: format!(
+                        "FR identifiers must be contiguous starting at FR-001; \
+                         expected FR-{expected:03}, found FR-{n:03}"
+                    ),
+                });
+                break;
+            }
+        }
+    }
+
+    if body.contains(rules.frbidden_marker) {
+        issues.push(ValidationIssue {
+            severity: Severity::Structural,
+            location: "body".into(),
+            message: format!(
+                "`{}` markers must be resolved before registration",
+                rules.frbidden_marker
+            ),
+        });
+    }
+
+    issues
+}
+
+fn extract_section(body: &str, heading_prefix: &str) -> String {
+    let mut out = String::new();
+    let mut inside = false;
+    for line in body.lines() {
+        if inside {
+            if line.starts_with("## ") {
+                break;
+            }
+            out.push_str(line);
+            out.push('\n');
+        } else if line == heading_prefix || line.starts_with(&format!("{heading_prefix} (")) {
+            inside = true;
+        }
+    }
+    out
+}
+
+fn collect_fr_numbers(section: &str) -> Vec<u32> {
+    let mut numbers = Vec::new();
+    for line in section.lines() {
+        let trimmed = line.trim_start();
+        let rest = match trimmed.strip_prefix("- **FR-") {
+            Some(rest) => rest,
+            None => continue,
+        };
+        let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        if digits.is_empty() {
+            continue;
+        }
+        if let Ok(n) = digits.parse::<u32>() {
+            numbers.push(n);
+        }
+    }
+    numbers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn good_body() -> String {
+        r#"# SPEC: Demo Feature
+
+## 背景
+
+The why.
+
+## ユビキタス言語
+
+- **Term**: meaning
+
+## ユーザーシナリオと受け入れシナリオ
+
+### Primary User Story
+
+A story.
+
+### Acceptance Scenarios
+
+1. Scenario one.
+
+## 機能要件
+
+- **FR-001**: first
+- **FR-002**: second
+
+## 成功基準
+
+- All tests pass.
+
+## Out of Scope (v1)
+
+- nothing
+
+## Related Artifacts
+
+- none
+"#
+        .to_string()
+    }
+
+    #[test]
+    fn passes_a_well_formed_body() {
+        let issues = validate_spec_body(&good_body(), "SPEC: Demo Feature", &default_rules());
+        assert!(issues.is_empty(), "expected no issues, got: {issues:#?}");
+    }
+
+    #[test]
+    fn flags_title_without_spec_prefix() {
+        let issues = validate_spec_body(&good_body(), "feat: missing prefix", &default_rules());
+        assert!(issues
+            .iter()
+            .any(|i| i.location == "title" && i.severity == Severity::Structural));
+    }
+
+    #[test]
+    fn flags_h1_mismatch() {
+        let issues = validate_spec_body(&good_body(), "SPEC: Different Title", &default_rules());
+        assert!(issues
+            .iter()
+            .any(|i| i.location == "h1" && i.severity == Severity::Structural));
+    }
+
+    #[test]
+    fn flags_missing_section() {
+        let body = good_body().replace("## Out of Scope (v1)", "## OutOfScope (typo)");
+        let issues = validate_spec_body(&body, "SPEC: Demo Feature", &default_rules());
+        assert!(issues.iter().any(|i| i.location.contains("Out of Scope")));
+    }
+
+    #[test]
+    fn flags_no_fr_lines() {
+        let body = good_body().replace("- **FR-001**: first\n- **FR-002**: second", "- something");
+        let issues = validate_spec_body(&body, "SPEC: Demo Feature", &default_rules());
+        assert!(issues
+            .iter()
+            .any(|i| i.location == "## 機能要件" && i.severity == Severity::Structural));
+    }
+
+    #[test]
+    fn flags_non_contiguous_fr_numbers() {
+        let body = good_body().replace("- **FR-002**: second", "- **FR-003**: third");
+        let issues = validate_spec_body(&body, "SPEC: Demo Feature", &default_rules());
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.severity == Severity::Format && i.location == "## 機能要件"),
+            "expected Format issue for FR gap, got: {issues:#?}"
+        );
+    }
+
+    #[test]
+    fn flags_needs_clarification_marker() {
+        let body = good_body().replace("The why.", "The why. [NEEDS CLARIFICATION]");
+        let issues = validate_spec_body(&body, "SPEC: Demo Feature", &default_rules());
+        assert!(issues
+            .iter()
+            .any(|i| i.message.contains("NEEDS CLARIFICATION")));
+    }
+
+    #[test]
+    fn empty_body_reports_multiple_issues() {
+        let issues = validate_spec_body("", "SPEC: Empty", &default_rules());
+        // At least missing H1 + every required section + missing FR.
+        assert!(issues.len() >= 8, "expected many issues, got: {issues:#?}");
+    }
+
+    #[test]
+    fn out_of_scope_without_version_suffix_passes() {
+        let body = good_body().replace("## Out of Scope (v1)", "## Out of Scope");
+        let issues = validate_spec_body(&body, "SPEC: Demo Feature", &default_rules());
+        assert!(
+            issues.is_empty(),
+            "`## Out of Scope` alone should pass, got: {issues:#?}"
+        );
+    }
+}

--- a/crates/gwt/src/bin/gwtd.rs
+++ b/crates/gwt/src/bin/gwtd.rs
@@ -67,6 +67,7 @@ fn print_help() {
     println!("  discuss     gwt-discussion exit CLI (SPEC-1935)");
     println!("  plan        gwt-plan-spec exit CLI (SPEC-1935)");
     println!("  build       gwt-build-spec exit CLI (SPEC-1935)");
+    println!("  register    gwt-register-spec exit CLI (SPEC-2784)");
     println!("  pane        Inspect and control live agent panes");
     println!("  workspace   Update Workspace current projection and summary journal");
     println!("  update      Check / apply gwt updates");
@@ -86,6 +87,7 @@ fn family_help(family: &str) -> Option<String> {
         "discuss" => Some(format_discuss_help()),
         "plan" => Some(format_plan_help()),
         "build" => Some(format_build_help()),
+        "register" => Some(format_register_help()),
         "pane" => Some(format_pane_help()),
         "workspace" => Some(format_workspace_help()),
         "update" => Some(format_update_help()),
@@ -247,6 +249,7 @@ fn format_hook_help() -> String {
         "  skill-discussion-stop-check             Stop-check for gwt-discussion",
         "  skill-plan-spec-stop-check              Stop-check for gwt-plan-spec",
         "  skill-build-spec-stop-check             Stop-check for gwt-build-spec",
+        "  skill-register-spec-stop-check          Stop-check for gwt-register-spec",
         "",
         "Stdin: hooks read JSON from stdin per the Claude Code hook contract.",
         "",
@@ -312,6 +315,22 @@ fn format_build_help() -> String {
         "  phase --spec <n> --label <stage>       Mark a phase milestone (red/green/...)",
         "  complete --spec <n>                    Mark build-spec complete",
         "  abort --spec <n> [--reason <text>]     Abort build-spec",
+        "",
+    ]
+    .join("\n")
+}
+
+fn format_register_help() -> String {
+    [
+        "gwtd register — gwt-register-spec exit CLI (SPEC-2784).",
+        "",
+        "Usage: gwtd register <action> --spec <n> [...]",
+        "",
+        "Actions:",
+        "  start --spec <n>                       Mark register-spec started (use --spec 0 if id unknown)",
+        "  phase --spec <n> --label <stage>       Milestone: validation/create/edit/roundtrip",
+        "  complete --spec <n>                    Mark register-spec complete",
+        "  abort --spec <n> [--reason <text>]     Abort register-spec",
         "",
     ]
     .join("\n")

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -33,7 +33,7 @@ mod issue_spec;
 mod pane;
 mod plan;
 mod pr;
-mod register;
+pub(crate) mod register;
 pub mod serve;
 mod skill_state_runtime;
 #[cfg(test)]
@@ -378,10 +378,8 @@ pub type PlanCommand = SkillStateAction;
 /// SPEC-1942 family enum for `gwtd build ...`. Backed by [`SkillStateAction`].
 pub type BuildCommand = SkillStateAction;
 
-/// SPEC-2784 family enum for `gwtd register ...`. Backed by
-/// [`SkillStateAction`] — same lifecycle pattern as `plan` and `build`.
+/// SPEC-2784 family enum for `gwtd register ...`. Same skill-state lifecycle.
 pub type RegisterCommand = SkillStateAction;
-
 /// SPEC-1935 / Issue #2529: canonical CLI surface for `gwt-agent` pane
 /// inspection and lifecycle operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -682,12 +680,7 @@ pub fn parse_build_args(args: &[String]) -> Result<CliCommand, CliParseError> {
     parse_skill_state_args(args).map(CliCommand::Build)
 }
 
-/// Parse `gwtd register <action> --spec <n> [...]` (SPEC-2784).
-pub fn parse_register_args(args: &[String]) -> Result<CliCommand, CliParseError> {
-    parse_skill_state_args(args).map(CliCommand::Register)
-}
-
-fn parse_skill_state_args(args: &[String]) -> Result<SkillStateAction, CliParseError> {
+pub(crate) fn parse_skill_state_args(args: &[String]) -> Result<SkillStateAction, CliParseError> {
     let (head, rest) = args.split_first().ok_or(CliParseError::Usage)?;
     match head.as_str() {
         "start" => {

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -33,6 +33,7 @@ mod issue_spec;
 mod pane;
 mod plan;
 mod pr;
+mod register;
 pub mod serve;
 mod skill_state_runtime;
 #[cfg(test)]
@@ -152,6 +153,8 @@ pub enum CliCommand {
     Plan(PlanCommand),
     /// `gwtd build ...` — gwt-build-spec exit CLI.
     Build(BuildCommand),
+    /// `gwtd register ...` — gwt-register-spec exit CLI (SPEC-2784).
+    Register(RegisterCommand),
     /// `gwtd update [...]` and `gwtd __internal {apply-update,run-installer} ...`.
     Update(UpdateCommand),
     /// `gwtd daemon ...` — long-running runtime daemon (SPEC-2077).
@@ -375,6 +378,10 @@ pub type PlanCommand = SkillStateAction;
 /// SPEC-1942 family enum for `gwtd build ...`. Backed by [`SkillStateAction`].
 pub type BuildCommand = SkillStateAction;
 
+/// SPEC-2784 family enum for `gwtd register ...`. Backed by
+/// [`SkillStateAction`] — same lifecycle pattern as `plan` and `build`.
+pub type RegisterCommand = SkillStateAction;
+
 /// SPEC-1935 / Issue #2529: canonical CLI surface for `gwt-agent` pane
 /// inspection and lifecycle operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -555,6 +562,7 @@ pub fn should_dispatch_cli(args: &[String]) -> bool {
                     | "discuss"
                     | "plan"
                     | "build"
+                    | "register"
                     | "daemon"
                     | "workspace"
                     | "pane"
@@ -674,6 +682,11 @@ pub fn parse_build_args(args: &[String]) -> Result<CliCommand, CliParseError> {
     parse_skill_state_args(args).map(CliCommand::Build)
 }
 
+/// Parse `gwtd register <action> --spec <n> [...]` (SPEC-2784).
+pub fn parse_register_args(args: &[String]) -> Result<CliCommand, CliParseError> {
+    parse_skill_state_args(args).map(CliCommand::Register)
+}
+
 fn parse_skill_state_args(args: &[String]) -> Result<SkillStateAction, CliParseError> {
     let (head, rest) = args.split_first().ok_or(CliParseError::Usage)?;
     match head.as_str() {
@@ -746,6 +759,7 @@ pub fn run<E: CliEnv>(env: &mut E, cmd: CliCommand) -> Result<i32, SpecOpsError>
         CliCommand::Discuss(action) => discuss::run(env, action, &mut out)?,
         CliCommand::Plan(action) => plan::run(env, action, &mut out)?,
         CliCommand::Build(action) => build::run(env, action, &mut out)?,
+        CliCommand::Register(action) => register::run(env, action, &mut out)?,
         CliCommand::Hook(HookCommand::Run { name, rest }) => {
             return hook::run_hook(env, &name, &rest);
         }

--- a/crates/gwt/src/cli/env/mod.rs
+++ b/crates/gwt/src/cli/env/mod.rs
@@ -185,6 +185,7 @@ pub fn dispatch<E: CliEnv>(env: &mut E, args: &[String]) -> i32 {
         "discuss" => super::parse_discuss_args(&rest),
         "plan" => super::parse_plan_args(&rest),
         "build" => super::parse_build_args(&rest),
+        "register" => super::parse_register_args(&rest),
         "daemon" => super::parse_daemon_args(&rest),
         "workspace" => super::parse_workspace_args(&rest),
         "pane" => parse_pane_args(&rest),

--- a/crates/gwt/src/cli/env/mod.rs
+++ b/crates/gwt/src/cli/env/mod.rs
@@ -185,7 +185,7 @@ pub fn dispatch<E: CliEnv>(env: &mut E, args: &[String]) -> i32 {
         "discuss" => super::parse_discuss_args(&rest),
         "plan" => super::parse_plan_args(&rest),
         "build" => super::parse_build_args(&rest),
-        "register" => super::parse_register_args(&rest),
+        "register" => super::register::parse_args(&rest),
         "daemon" => super::parse_daemon_args(&rest),
         "workspace" => super::parse_workspace_args(&rest),
         "pane" => parse_pane_args(&rest),

--- a/crates/gwt/src/cli/hook/event_dispatcher.rs
+++ b/crates/gwt/src/cli/hook/event_dispatcher.rs
@@ -9,7 +9,8 @@ use std::{path::Path, time::Instant};
 
 use super::{
     board_reminder, diagnostics, skill_build_spec_stop_check, skill_discussion_stop_check,
-    skill_plan_spec_stop_check, workflow_policy, workspace_identity, HookError, HookOutput,
+    skill_plan_spec_stop_check, skill_register_spec_stop_check, workflow_policy,
+    workspace_identity, HookError, HookOutput,
 };
 
 pub fn handle_with_input(
@@ -120,6 +121,9 @@ fn handle_stop(
         }),
         run_value(event, "skill-build-spec-stop-check", || {
             skill_build_spec_stop_check::handle_with_input(worktree_root, input, current_session)
+        }),
+        run_value(event, "skill-register-spec-stop-check", || {
+            skill_register_spec_stop_check::handle_with_input(worktree_root, input, current_session)
         }),
     ] {
         if matches!(output, HookOutput::StopBlock { .. }) {

--- a/crates/gwt/src/cli/hook/mod.rs
+++ b/crates/gwt/src/cli/hook/mod.rs
@@ -29,6 +29,7 @@ pub mod segments;
 pub mod skill_build_spec_stop_check;
 pub mod skill_discussion_stop_check;
 pub mod skill_plan_spec_stop_check;
+pub mod skill_register_spec_stop_check;
 pub mod workflow_policy;
 mod workspace_identity;
 pub mod worktree;
@@ -60,6 +61,7 @@ pub enum HookKind {
     SkillDiscussionStopCheck,
     SkillPlanSpecStopCheck,
     SkillBuildSpecStopCheck,
+    SkillRegisterSpecStopCheck,
 }
 
 impl HookKind {
@@ -81,6 +83,7 @@ impl HookKind {
             "skill-discussion-stop-check" => Some(Self::SkillDiscussionStopCheck),
             "skill-plan-spec-stop-check" => Some(Self::SkillPlanSpecStopCheck),
             "skill-build-spec-stop-check" => Some(Self::SkillBuildSpecStopCheck),
+            "skill-register-spec-stop-check" => Some(Self::SkillRegisterSpecStopCheck),
             _ => None,
         }
     }
@@ -239,8 +242,8 @@ pub fn run_daemon_hook<E: CliEnv>(
 ) -> Result<i32, SpecOpsError> {
     use crate::cli::hook::{
         block_bash_policy, event_dispatcher, provider_event, skill_build_spec_stop_check,
-        skill_discussion_stop_check, skill_plan_spec_stop_check, workflow_policy, HookKind,
-        HookOutput,
+        skill_discussion_stop_check, skill_plan_spec_stop_check, skill_register_spec_stop_check,
+        workflow_policy, HookKind, HookOutput,
     };
 
     let Some(kind) = HookKind::from_name(name) else {
@@ -405,6 +408,16 @@ pub fn run_daemon_hook<E: CliEnv>(
             let cwd = env.repo_path().to_path_buf();
             let current_session = std::env::var(gwt_agent::GWT_SESSION_ID_ENV).ok();
             let output = skill_build_spec_stop_check::handle_with_input(
+                &cwd,
+                &stdin,
+                current_session.as_deref(),
+            );
+            Ok(emit_hook_output(env, &output))
+        }
+        HookKind::SkillRegisterSpecStopCheck => {
+            let cwd = env.repo_path().to_path_buf();
+            let current_session = std::env::var(gwt_agent::GWT_SESSION_ID_ENV).ok();
+            let output = skill_register_spec_stop_check::handle_with_input(
                 &cwd,
                 &stdin,
                 current_session.as_deref(),

--- a/crates/gwt/src/cli/hook/skill_register_spec_stop_check.rs
+++ b/crates/gwt/src/cli/hook/skill_register_spec_stop_check.rs
@@ -1,0 +1,101 @@
+//! `gwtd hook skill-register-spec-stop-check` — Stop-block handler for the
+//! `gwt-register-spec` skill (SPEC-2784).
+//!
+//! Identical decision body to `skill-plan-spec-stop-check` and
+//! `skill-build-spec-stop-check`: read `.gwt/skill-state/register-spec.json`,
+//! return `HookOutput::StopBlock` while the state is `active: true` for the
+//! current session, honour `stop_hook_active` to cap forced continuation at
+//! one per Stop cycle, and stay silent on every other path.
+
+use std::{
+    io::{self, Read},
+    path::Path,
+};
+
+use gwt_agent::GWT_SESSION_ID_ENV;
+
+use super::{HookError, HookOutput};
+
+pub const SKILL_NAME: &str = "register-spec";
+pub const SKILL_DISPLAY: &str = "gwt-register-spec";
+
+pub fn handle() -> Result<HookOutput, HookError> {
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+    let cwd = std::env::current_dir()?;
+    let current_session = std::env::var(GWT_SESSION_ID_ENV).ok();
+    Ok(handle_with_input(&cwd, &input, current_session.as_deref()))
+}
+
+pub fn handle_with_input(
+    worktree: &Path,
+    input: &str,
+    current_session_id: Option<&str>,
+) -> HookOutput {
+    super::skill_plan_spec_stop_check::decide(
+        worktree,
+        input,
+        current_session_id,
+        SKILL_NAME,
+        SKILL_DISPLAY,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use gwt_core::skill_state::{save, SkillState};
+
+    fn active_state(session: &str, phase: &str) -> SkillState {
+        SkillState {
+            active: true,
+            owner_spec: Some(2784),
+            started_at: Utc.with_ymd_and_hms(2026, 5, 20, 9, 0, 0).unwrap(),
+            phase: Some(phase.to_string()),
+            session_id: session.to_string(),
+        }
+    }
+
+    #[test]
+    fn blocks_while_register_state_is_active() {
+        let dir = tempfile::tempdir().unwrap();
+        save(dir.path(), SKILL_NAME, &active_state("sess-1", "create")).unwrap();
+        match handle_with_input(dir.path(), "{}", Some("sess-1")) {
+            HookOutput::StopBlock { reason } => {
+                assert!(reason.contains("gwt-register-spec"));
+                assert!(reason.contains("create"));
+            }
+            other => panic!("expected StopBlock, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn silent_when_state_file_is_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            handle_with_input(dir.path(), "{}", Some("sess-1")),
+            HookOutput::Silent,
+        );
+    }
+
+    #[test]
+    fn silent_when_session_id_does_not_match() {
+        let dir = tempfile::tempdir().unwrap();
+        save(dir.path(), SKILL_NAME, &active_state("sess-other", "edit")).unwrap();
+        assert_eq!(
+            handle_with_input(dir.path(), "{}", Some("sess-1")),
+            HookOutput::Silent,
+        );
+    }
+
+    #[test]
+    fn silent_when_stop_hook_active_is_true() {
+        let dir = tempfile::tempdir().unwrap();
+        save(dir.path(), SKILL_NAME, &active_state("sess-1", "create")).unwrap();
+        assert_eq!(
+            handle_with_input(dir.path(), r#"{"stop_hook_active":true}"#, Some("sess-1"),),
+            HookOutput::Silent,
+        );
+    }
+}

--- a/crates/gwt/src/cli/register.rs
+++ b/crates/gwt/src/cli/register.rs
@@ -16,7 +16,12 @@
 use gwt_github::SpecOpsError;
 
 use super::skill_state_runtime;
-use crate::cli::{CliEnv, SkillStateAction};
+use crate::cli::{parse_skill_state_args, CliCommand, CliEnv, CliParseError, SkillStateAction};
+
+/// Parse `gwtd register <action> --spec <n> [...]` (SPEC-2784).
+pub fn parse_args(args: &[String]) -> Result<CliCommand, CliParseError> {
+    parse_skill_state_args(args).map(CliCommand::Register)
+}
 
 pub const SKILL_NAME: &str = "register-spec";
 pub const SKILL_DISPLAY: &str = "gwt-register-spec";

--- a/crates/gwt/src/cli/register.rs
+++ b/crates/gwt/src/cli/register.rs
@@ -1,0 +1,31 @@
+//! `gwtd register <start|phase|complete|abort> --spec <n> [...]`
+//!
+//! Exit CLI for the `gwt-register-spec` skill (SPEC-2784). Writes
+//! `.gwt/skill-state/register-spec.json` via [`gwt_core::skill_state`].
+//!
+//! The lifecycle mirrors `gwt-plan-spec` and `gwt-build-spec`: `start` is
+//! called when the skill begins materializing a SPEC, `phase` records each
+//! milestone (`validation`, `create`, `edit`, `roundtrip`), and
+//! `complete` / `abort` flip `active: false` so the Stop-block handler stops
+//! forcing continuation.
+//!
+//! Because the SPEC id is not known until `gwtd issue spec create` returns,
+//! `gwt-register-spec` may legitimately call `start --spec 0` and then
+//! re-emit `phase --spec <real-id>` once the Issue is created.
+
+use gwt_github::SpecOpsError;
+
+use super::skill_state_runtime;
+use crate::cli::{CliEnv, SkillStateAction};
+
+pub const SKILL_NAME: &str = "register-spec";
+pub const SKILL_DISPLAY: &str = "gwt-register-spec";
+pub const VERB: &str = "register";
+
+pub(super) fn run<E: CliEnv>(
+    env: &mut E,
+    action: SkillStateAction,
+    out: &mut String,
+) -> Result<i32, SpecOpsError> {
+    skill_state_runtime::run(env, action, SKILL_NAME, SKILL_DISPLAY, VERB, out)
+}


### PR DESCRIPTION
## Summary

- SPEC 登録専用 sub-skill `gwt-register-spec` を新設し、`gwtd issue spec create -f <body>` が section マーカーを自動付与しない trap (SPEC #2780 で発生) を構造的に排除する (SPEC #2784)。
- canonical な `create` → `--edit spec` → `--section spec` roundtrip フローを skill 内に閉じ込め、validation (title 規約 / 7 sections / FR-NNN / [NEEDS CLARIFICATION] / H1 一致 / FR 連続性) を pure Rust ライブラリとして提供。
- `gwtd register start/phase/complete/abort` CLI と Stop-block hook を SPEC-1935 FR-014 系と同じパターンで追加。`gwt-discussion` Action Bundle に `Register Spec` を追加。

## Changes

- `.claude/skills/gwt-register-spec/SKILL.md` + `references/{body-template,validation-rules,recovery}.md`: 新規 skill 文書群（canonical source）。`.codex/skills/gwt-register-spec/` にも mirror。
- `crates/gwt-github/src/spec_validate.rs`: 純粋 Rust の validation library。`validate_spec_body(body, title, rules)` が `Vec<ValidationIssue>` を返す。9 unit tests で正常系 / title 不正 / 欠損 section / FR 不在 / [NEEDS CLARIFICATION] / H1 mismatch / 非連続 FR / 空 body / `Out of Scope` の version 接尾辞許容 を検証。
- `crates/gwt/src/cli/register.rs`: `gwtd register start|phase|complete|abort` を `skill_state_runtime` 経由で実装（既存 plan/build と同パターン）。
- `crates/gwt/src/cli/hook/skill_register_spec_stop_check.rs`: Stop-block hook。active 中に Stop を block、`stop_hook_active` を尊重。4 unit tests。
- `crates/gwt/src/cli.rs` / `cli/env/mod.rs` / `cli/hook/{mod,event_dispatcher}.rs`: CliCommand::Register 派生型 + hook dispatch 配線。
- `crates/gwt/src/bin/gwtd.rs`: top-level `register` command + family help + hook list へ entry 追加。
- `.claude/skills/gwt-discussion/SKILL.md` + `references/registration.md`: Phase 4 と Action Bundle で `Register Spec` を canonical 路線として明示し、manual 2-step フローは recovery 用途のみに格下げ。
- `.claude/skills/gwt-register-issue/SKILL.md`: SPEC routing で gwt-register-spec へ委譲する旨を明記。
- `AGENTS.md` Step 3: SPEC 作成は gwt-register-spec を経由する規約を追加。

## Testing

- [x] `cargo test -p gwt-github --lib spec_validate::` — 9 passed (新規 validation lib)
- [x] `cargo test -p gwt --lib hook::skill_register` — 4 passed (新規 Stop-block hook)
- [x] `cargo test -p gwt-github -p gwt -p gwt-core -p gwt-skills --lib` — 全 1149 passed (gwt 684 + gwt-core 283 + gwt-github 14 + gwt-skills 168)
- [x] `cargo test -p gwt --test cli_file_size_test` — PASS (SPEC-1942 SC-025: cli.rs 999 lines < 1000)
- [x] `cargo clippy -p gwt-core -p gwt -p gwt-github --all-targets --all-features -- -D warnings` — CLEAN
- [x] `cargo fmt --check` — CLEAN
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — OK
- [x] `pnpm lint:skills` — 33 SKILL.md frontmatter blocks PASS (含む新 gwt-register-spec)
- [x] `bunx commitlint --from HEAD~2 --to HEAD` — CLEAN (warning 1 件は footer-leading-blank、blocking なし)
- [x] 手動 E2E: `gwtd register start --spec 0` → `.gwt/skill-state/register-spec.json` が active で作成され、`gwtd register complete --spec 0` で flip OK
- [ ] CI: GitHub Actions matrix 通過後 auto-merge を観察（レビュアー側 / 自動）

### Acceptance Scenarios (SPEC #2784) 対応

| # | シナリオ | カバー方法 |
|---|---|---|
| 1 | 正常系 | `spec_validate::tests::passes_a_well_formed_body` + 手動 E2E (lifecycle start→complete) |
| 2 | Structural validation 失敗 | `spec_validate::tests::flags_{title_without_spec_prefix,h1_mismatch,missing_section,no_fr_lines,needs_clarification_marker,empty_body_reports_multiple_issues}` |
| 3 | Format-quality validation 失敗 | `spec_validate::tests::flags_non_contiguous_fr_numbers` |
| 4 | create 成功 / edit 失敗 (recovery) | `.claude/skills/gwt-register-spec/references/recovery.md` で手動再投入手順を document 化、実機の失敗は actual incident まで保留 |
| 5 | Lifecycle 連動 | `skill_register_spec_stop_check::tests::{blocks_while_register_state_is_active,silent_when_state_file_is_absent,silent_when_session_id_does_not_match,silent_when_stop_hook_active_is_true}` |

## Closing Issues

- Closes #2784

## Related Issues / Links

- Refs #2780 (本 PR が解決する trap が発生した SPEC)
- Refs `tasks/lessons.md` 2026-05-20 entry (今回 lessons の構造的解決)

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `pnpm lint:skills`, commitlint)
- [x] Documentation updated (SKILL.md + references/ + AGENTS.md + gwt-discussion / gwt-register-issue 更新)
- [x] Migration/backfill plan included (if schema/data change) — N/A (純粋な追加機能、既存 SPEC への影響なし)
- [x] CHANGELOG impact considered (breaking change flagged in commit) — `feat(skills):` で minor bump、breaking change なし

## Context

- SPEC #2780 (Release Notes Window) の登録過程で `gwtd issue spec create -f <body>` が section マーカー (`<!-- artifact:spec BEGIN/END -->`) を自動付与しないことに起因する trap が発生した。Issue は作成されたが spec section が空のままで、`--edit spec -f` での再投入が必要になった。`tasks/lessons.md` に手順を記録したが、これは人間の記憶に依存する自己防衛策に過ぎず構造的解決には至っていなかった。
- ユーザーから「SPEC 登録用の専用スキルを用意した方がフォーマット化できそう」という指摘を受け、gwt-discussion の sub-skill として gwt-register-spec を新設。canonical な 2-step フローと validation を skill 内に閉じ込めることで、参照漏れによる事故を構造的に排除する。
- 議論は `gwt-discussion` を経て [chosen] 状態で固定し、設計判断 (Integration / Contract / Validation / CLI lifecycle / Failure policy) を `.gwt/discussion.md` と plan file (`fuzzy-prancing-owl.md`) に保存した。

## Risk / Impact

- **Affected areas**: gwt-github (新規 module 追加のみ、既存 API 影響なし) / gwt (CliCommand に Register variant 追加、hook dispatch に register-spec-stop-check 追加。既存 client は新 kind を無視する後方互換挙動) / .claude/.codex skills (新 skill + 既存 skill の文言追加)
- **Rollback plan**: 純粋な追加機能のため、2 commits (feat + refactor) を revert すれば元に戻る。スキーマ・データ・ストレージ・外部 API 変更なし。

## Notes

- 既存 SPEC (#1932, #2133, #2780 等) の bulk 再 validation は v1 対象外。legacy 形式として共存。
- v2 候補: discussion.md からの全自動 body 生成 / gwt-fix-issue の SPEC routing 統合 / web UI 経由作成 / Out of Scope の自動 retry (recovery) / 既存 SPEC migration。
- 今回の PR は SPEC #2780 と同じセッションで連続作業した結果。SPEC #2780 (auto-merged) が release v9.39.0 に含まれており、本 PR のベースは v9.39.0 develop tip に merge 済み。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `gwt-register-spec` skill to register finalized SPECs as GitHub issues with automated body validation and roundtrip verification
  * Added `gwtd register` CLI command family (`start|phase|complete|abort`) for managing the spec registration lifecycle
  * Implemented SPEC body validation with structural and format rules, including required section checks and functional requirement numbering

* **Documentation**
  * Updated skill workflows to integrate the new register-spec capability
  * Added comprehensive spec registration guidance, validation rules, and recovery procedures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->