### PR TITLE
fix(gui): gate Linked issue section to Issue Bridge launches

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -2545,8 +2545,36 @@ mod tests {
         );
         assert!(
             html.contains("showSetupForms && launchWizard.show_branch_controls !== false")
-                && html.contains("showSetupForms && launchWizard.show_agent_settings"),
-            "expected branch and linked issue controls to be gated to setup forms",
+                && html.contains("showSetupForms && launchWizard.show_linked_issue"),
+            "expected branch and linked issue controls to be gated to setup forms \
+             (linked issue uses dedicated show_linked_issue flag per SPEC-2014 FR-057)",
+        );
+    }
+
+    // SPEC-2014 Amendment 2026-05-20 (US-25 / FR-057-059 / SC-032)
+    // The Launch Wizard "Linked issue" section must render through the
+    // `show_linked_issue` gate and must not contain an editable input that
+    // dispatches `set_linked_issue` / `clear_linked_issue` from the UI. The
+    // value is rendered as static read-only text.
+    #[test]
+    fn embedded_web_launch_wizard_linked_issue_is_readonly_for_issue_bridge() {
+        let html = frontend_bundle_source();
+
+        assert!(
+            html.contains("showSetupForms && launchWizard.show_linked_issue"),
+            "expected Linked issue section to be gated by show_linked_issue (FR-057)",
+        );
+        assert!(
+            !html.contains(r#"kind: "set_linked_issue""#),
+            "expected the frontend to stop dispatching set_linked_issue from the wizard UI (FR-058)",
+        );
+        assert!(
+            !html.contains(r#"kind: "clear_linked_issue""#),
+            "expected the frontend to stop dispatching clear_linked_issue from the wizard UI (FR-058)",
+        );
+        assert!(
+            html.contains("launchWizard.linked_issue_number") && html.contains("Issue number"),
+            "expected the Linked issue section to render the issue number as static read-only text",
         );
     }
 

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -225,6 +225,10 @@ pub struct LaunchWizardView {
     pub show_branch_controls: bool,
     pub show_manual_setup: bool,
     pub show_runtime_confirmation: bool,
+    // SPEC-2014 Amendment 2026-05-20 (FR-057): gate the Linked issue section
+    // so it only renders when the wizard was opened through the Knowledge
+    // Issue Bridge (linked_issue_kind == Some(Issue) AND number is some).
+    pub show_linked_issue: bool,
     pub runtime_resolution_pending: bool,
     pub runtime_resolution_message: Option<String>,
     pub primary_action_label: String,
@@ -1006,6 +1010,10 @@ impl LaunchWizardState {
             show_branch_controls: show_manual_setup && self.wizard_mode == LaunchWizardMode::Branch,
             show_manual_setup,
             show_runtime_confirmation,
+            show_linked_issue: matches!(
+                self.context.linked_issue_kind,
+                Some(LinkedIssueKind::Issue)
+            ) && self.linked_issue_number.is_some(),
             runtime_resolution_pending: self.runtime_resolution_pending,
             runtime_resolution_message: self.runtime_resolution_message.clone(),
             primary_action_label: self.primary_action_label(),
@@ -6099,6 +6107,69 @@ mod tests {
         let config = state.build_launch_config().expect("config");
 
         assert_eq!(config.linked_issue_number, Some(1234));
+    }
+
+    // SPEC-2014 Amendment 2026-05-20 (US-25 / FR-057 / SC-031)
+    // Launch Wizard view should gate the "Linked issue" section so it only
+    // appears when the wizard was opened through the Knowledge Issue Bridge
+    // (`linked_issue_kind == Some(Issue)` AND `linked_issue_number.is_some()`).
+    // SPEC Bridge, Active Work Add-Agent, Workspace Resume, and Branches paths
+    // must hide the section.
+    #[test]
+    fn view_shows_linked_issue_only_for_issue_kind() {
+        // Case 1: Knowledge Issue Bridge — kind=Issue + number=Some => true.
+        let issue_state = LaunchWizardState::open_with(
+            context_with_linked_issue(branch("develop"), "develop", LinkedIssueKind::Issue, 1938),
+            sample_agent_options(),
+            Vec::new(),
+        );
+        assert!(
+            issue_state.view().show_linked_issue,
+            "Issue Bridge (kind=Issue, number=Some) should set show_linked_issue=true"
+        );
+        assert_eq!(issue_state.view().linked_issue_number, Some(1938));
+
+        // Case 2: Knowledge SPEC Bridge — kind=Spec + number=Some => false.
+        let spec_state = LaunchWizardState::open_with(
+            context_with_linked_issue(branch("develop"), "develop", LinkedIssueKind::Spec, 2014),
+            sample_agent_options(),
+            Vec::new(),
+        );
+        assert!(
+            !spec_state.view().show_linked_issue,
+            "SPEC Bridge (kind=Spec) should set show_linked_issue=false"
+        );
+
+        // Case 3: Active Work Add-Agent / Workspace Resume — kind=None + number=Some => false.
+        let mut active_ctx = context(branch("develop"), "develop");
+        active_ctx.linked_issue_number = Some(1234);
+        let active_state =
+            LaunchWizardState::open_with(active_ctx, sample_agent_options(), Vec::new());
+        assert!(
+            !active_state.view().show_linked_issue,
+            "kind=None pre-fill (Active Work / Workspace Resume) should set show_linked_issue=false"
+        );
+
+        // Case 4: No number at all => false even for nominal Issue kind.
+        let mut no_number_ctx = context(branch("develop"), "develop");
+        no_number_ctx.linked_issue_kind = Some(LinkedIssueKind::Issue);
+        let no_number_state =
+            LaunchWizardState::open_with(no_number_ctx, sample_agent_options(), Vec::new());
+        assert!(
+            !no_number_state.view().show_linked_issue,
+            "linked_issue_number=None should always set show_linked_issue=false"
+        );
+
+        // Case 5: Default empty context (Branches / direct launch) => false.
+        let empty_state = LaunchWizardState::open_with(
+            context(branch("develop"), "develop"),
+            sample_agent_options(),
+            Vec::new(),
+        );
+        assert!(
+            !empty_state.view().show_linked_issue,
+            "default context (Branches / direct launch) should set show_linked_issue=false"
+        );
     }
 
     #[test]

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1449,10 +1449,13 @@ test("Launch wizard runtime confirmation shows summary without setup forms", () 
     /if\s*\(\s*showSetupForms\s*&&[\s\S]*?launchWizard\.show_codex_fast_mode[\s\S]*?\)\s*\{[\s\S]*?createLaunchSection\(\s*"Launch settings"/,
     "expected Launch settings controls to be part of setup forms only",
   );
+  // SPEC-2014 Amendment 2026-05-20 (FR-057): Linked issue is gated by its
+  // dedicated `show_linked_issue` flag so it only appears when the wizard
+  // was opened through the Knowledge Issue Bridge.
   assert.match(
     appSource,
-    /if\s*\(\s*showSetupForms\s*&&\s*launchWizard\.show_agent_settings\s*\)/,
-    "expected Linked issue controls to be part of setup forms only",
+    /if\s*\(\s*showSetupForms\s*&&\s*launchWizard\.show_linked_issue\s*\)/,
+    "expected Linked issue controls to be gated by show_linked_issue and setup forms",
   );
 });
 
@@ -1698,9 +1701,13 @@ test("Dynamically-created form fields without surrounding <label> have aria-labe
   // so screen readers announce their purpose instead of just "edit text"
   // (input/textarea) or the first option (select). This audit covers
   // the launch wizard and profile editor surfaces.
+  // SPEC-2014 Amendment 2026-05-20 (FR-058): the wizard "Issue number"
+  // field is now rendered as static read-only text (no <input>), so its
+  // accessibility name is conveyed by the surrounding launch-field label
+  // instead of a per-input aria-label. The audit entry is removed
+  // accordingly.
   const expected = [
     { selector: 'input\\.setAttribute\\("aria-label", "Branch name"\\)', desc: "wizard branch name" },
-    { selector: 'input\\.setAttribute\\("aria-label", "Issue number"\\)', desc: "wizard issue number" },
     { selector: 'keyInput\\.setAttribute\\("aria-label", `Env var key, row ', desc: "env var key" },
     { selector: 'valueInput\\.setAttribute\\("aria-label", `Env var value, row ', desc: "env var value" },
     { selector: 'keyInput\\.setAttribute\\("aria-label", `Disabled env key, row ', desc: "disabled env key" },

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -6864,35 +6864,23 @@
           panel.appendChild(section);
         }
 
-        if (showSetupForms && launchWizard.show_agent_settings) {
+        // SPEC-2014 Amendment 2026-05-20 (FR-057 / FR-058):
+        // The Linked issue section renders only when the wizard was opened
+        // through the Knowledge Issue Bridge. The issue number is shown as
+        // read-only text instead of an editable input.
+        if (showSetupForms && launchWizard.show_linked_issue) {
           const section = createLaunchSection(
             "Linked issue",
-            "Optional: Link an issue to this launch session.",
+            "Read-only: this agent will be linked to the originating issue.",
           );
           const grid = createNode("div", "launch-form-grid");
           const field = createLaunchField("Issue number", false);
-          const input = createNode("input", "launch-input");
-          input.type = "number";
-          input.min = "1";
-          // SPEC-2356 — see createLaunchField comment: aria-label is the
-          // programmatic name since launch-field labels are non-<label> divs.
-          input.setAttribute("aria-label", "Issue number");
-          input.value = launchWizard.linked_issue_number
-            ? launchWizard.linked_issue_number.toString()
-            : "";
-          input.placeholder = "e.g., 1938";
-          input.addEventListener("change", () => {
-            const value = input.value.trim();
-            if (value) {
-              sendWizardAction({
-                kind: "set_linked_issue",
-                issue_number: parseInt(value, 10),
-              });
-            } else {
-              sendWizardAction({ kind: "clear_linked_issue" });
-            }
-          });
-          field.appendChild(input);
+          // The launch-field label already announces "Issue number"; the
+          // static value div is read alongside that label so SR users hear
+          // "Issue number, #N" without needing a per-value aria-label.
+          const value = createNode("div", "launch-static-value");
+          value.textContent = `#${launchWizard.linked_issue_number}`;
+          field.appendChild(value);
           grid.appendChild(field);
           section.appendChild(grid);
           panel.appendChild(section);


### PR DESCRIPTION
## Summary

- Launch Wizard の "Linked issue" セクションを Knowledge Issue Bridge から起動した場合のみ描画し、読み取り専用テキスト表示に変更する。実運用で手入力されない編集可能 input を撤回し、Issue 文脈との関連付けを明示的に伝える UX に揃える。
- 表示判定は `linked_issue_kind == Some(Issue) && linked_issue_number.is_some()` の単一シグナル。SPEC Bridge / Active Work Add-Agent / Workspace Resume / Branches 経由ではセクション自体を非表示にする。

## Changes

- `crates/gwt/src/launch_wizard.rs`: `LaunchWizardView` に `show_linked_issue: bool` を追加し、`view()` で `matches!(self.context.linked_issue_kind, Some(LinkedIssueKind::Issue)) && self.linked_issue_number.is_some()` を計算してセットする。
- `crates/gwt/web/app.js:6867-6899`: "Linked issue" セクションの gating を `show_linked_issue` に差し替え、`<input type="number">` と `change` listener、`sendWizardAction({kind: "set_linked_issue" | "clear_linked_issue"})` dispatch を削除して `launch-static-value` div に `#${linked_issue_number}` を表示する read-only テキストへ変更。description を `"Read-only: this agent will be linked to the originating issue."` に更新。
- `crates/gwt/src/embedded_web.rs`: 既存 `expected branch and linked issue controls to be gated to setup forms` assertion を `show_linked_issue` 仕様に更新し、新規 `embedded_web_launch_wizard_linked_issue_is_readonly_for_issue_bridge` テストで `set_linked_issue` / `clear_linked_issue` dispatch が UI に残っていないことを assertion する。
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: Linked issue gating assertion を `show_linked_issue` に追随させ、フォーム入力ではなくなった "wizard issue number" aria-label 監査エントリを削除。

Backend の `LaunchWizardAction::SetLinkedIssue` / `ClearLinkedIssue` および対応ユニットテストは温存しており、外部 caller / 既存テスト互換性は保たれる (UI からは triggered されなくなるだけ)。

## Testing

- [x] `cargo test -p gwt --lib launch_wizard::tests::view_shows_linked_issue_only_for_issue_kind` — Issue kind では `show_linked_issue=true`、Spec / None / number=None では `false` を 5 パターンで assertion し PASS。
- [x] `cargo test -p gwt embedded_web::tests::embedded_web_launch_wizard_linked_issue_is_readonly_for_issue_bridge` — 新 gate と read-only 表示・dispatch 不在を assertion し PASS。
- [x] `cargo test -p gwt-core -p gwt --all-features` — 681 lib + 385 bin + workspace integration テスト全 PASS。
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — warning 0。
- [x] `cargo fmt -- --check` — diff 無し。
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — success。
- [x] `npm run test:frontend-bundle` — 全 bundle syntax check PASS。
- [x] `pnpm test:frontend-unit` — 507 / 507 PASS (Launch Wizard gating assertion 更新含む)。
- [x] `pnpm test:frontend-smoke` — 24 / 24 PASS。
- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 96 / 96 PASS。
- [ ] `pnpm test:visual`: 環境依存の既存 failures (Operator boot sequence overlay が pointer event を intercept) が 18 件あり、対象 spec (`chrome.spec.ts` / `theme-toggle.spec.ts` / `update-modal.spec.ts`) はすべて本 PR で touch していない surface。Launch Wizard / Linked issue を対象とする visual spec は存在しないため、CI 上の visual regression は GitHub Actions で確認する。

## Closing Issues

- None

## Related Issues / Links

- #2014 (SPEC-2014 Launch Wizard) Amendment 2026-05-20 (US-25 / FR-057-059 / SC-031-032 / T89-T95)

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (if user-facing change) — UX 変更は SPEC-2014 Amendment 2026-05-20 (`gwt-spec` Issue #2014) に集約。README に該当ガイドが無いため更新不要。
- [x] Migration/backfill plan included (if schema/data change) — schema/data 変更なし。backend action は互換維持。
- [x] CHANGELOG impact considered (breaking change flagged in commit) — Conventional Commits `fix(gui)` (非破壊)。release ワークフローが自動取り込み。

## Risk / Impact

- **Affected areas**: gwt GUI Launch Wizard の "Linked issue" セクション描画のみ。backend domain logic、launch request 構築、SetLinkedIssue / ClearLinkedIssue action 経路は変更なし。
- **Rollback plan**: 単一コミット (`c2b651980`) を revert すれば旧 input 経路 + always-show gating に戻る。state machine と launch config builder は変更していないため副作用なし。

## Notes

- 手動 GUI smoke は 4 経路 (Knowledge Issue Bridge / Knowledge SPEC Bridge / Workspace card "Add Agent to This Work" / Branches Window) で実施推奨。SPEC-2014 tasks セクションの "2026-05-20 LINKED ISSUE Visibility Retraction Verification" 節に検証エビデンスを記録済み。
