### PR TITLE
fix(logging): adapt Logs window reader to canonical JSONL shape (SPEC-1924 US-14)

### DIFF
--- a/crates/gwt-core/src/logging/mod.rs
+++ b/crates/gwt-core/src/logging/mod.rs
@@ -24,6 +24,7 @@ pub mod event;
 pub mod fmt_layer;
 pub mod housekeep;
 pub mod init;
+pub mod reader;
 pub mod ui_forwarder;
 pub mod writer;
 
@@ -31,4 +32,5 @@ pub use config::{LogLevel, LoggingConfig};
 pub use event::LogEvent;
 pub use housekeep::{housekeep, HousekeepReport};
 pub use init::{apply_log_level_to_handle, init, LoggingHandles, ReloadHandle};
+pub use reader::{read_log_file, LogFileEntry, ReadDiagnostics, ReadOutcome};
 pub use writer::{current_log_file, log_file_for_date, LOG_FILE_BASENAME};

--- a/crates/gwt-core/src/logging/reader.rs
+++ b/crates/gwt-core/src/logging/reader.rs
@@ -25,7 +25,7 @@
 //! this reader; do not re-implement `serde_json::from_str::<LogEvent>` on
 //! disk lines (SPEC-1924 FR-037 / SC-011).
 //!
-//! See [`tracing_subscriber::fmt`] for the writer side; the relevant
+//! See [`mod@tracing_subscriber::fmt`] for the writer side; the relevant
 //! configuration lives in `crates/gwt-core/src/logging/fmt_layer.rs`.
 
 use std::{

--- a/crates/gwt-core/src/logging/reader.rs
+++ b/crates/gwt-core/src/logging/reader.rs
@@ -1,0 +1,341 @@
+//! Canonical log file reader (SPEC-1924 US-14 / FR-035 / FR-036 / FR-037).
+//!
+//! The structured runtime log file at
+//! `~/.gwt/projects/<repo-hash>/logs/gwt.log.YYYY-MM-DD` is written by
+//! `tracing_subscriber::fmt::layer().json()` (see `fmt_layer.rs`) using the
+//! shape:
+//!
+//! ```json
+//! {"timestamp":"...","level":"INFO","fields":{"message":"...","k":"v"},"target":"..."}
+//! ```
+//!
+//! In-process the UI forwarder produces [`LogEvent`] values with an
+//! auto-assigned `id`, mapped `severity` / `source`, and a hoisted `message`.
+//! These two shapes are intentionally different: the on-disk shape is the
+//! standard `tracing` JSON Lines format (compatible with external tooling)
+//! and `id` is only meaningful inside a single process.
+//!
+//! This module provides the glue: [`LogFileEntry`] mirrors the on-disk shape
+//! exactly, and [`read_log_file`] turns the JSONL file into a
+//! [`Vec<LogEvent>`] suitable for the Logs window snapshot path. Malformed
+//! lines are skipped and counted in [`ReadDiagnostics`] so a single corrupt
+//! flush never blanks the snapshot.
+//!
+//! Logs window, future CLI subcommands, and the daemon must all go through
+//! this reader; do not re-implement `serde_json::from_str::<LogEvent>` on
+//! disk lines (SPEC-1924 FR-037 / SC-011).
+//!
+//! See [`tracing_subscriber::fmt`] for the writer side; the relevant
+//! configuration lives in `crates/gwt-core/src/logging/fmt_layer.rs`.
+
+use std::{
+    io::{self, BufRead, BufReader},
+    path::{Path, PathBuf},
+};
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use super::{LogEvent, LogLevel};
+
+/// Result of [`read_log_file`].
+#[derive(Debug, Clone)]
+pub struct ReadOutcome {
+    /// Successfully decoded log events in source order. `id` is assigned in
+    /// read order starting at `1`.
+    pub entries: Vec<LogEvent>,
+    /// Diagnostic counters describing the read (skipped malformed lines etc.).
+    pub diagnostics: ReadDiagnostics,
+}
+
+/// Diagnostic counters for a single [`read_log_file`] invocation.
+#[derive(Debug, Clone)]
+pub struct ReadDiagnostics {
+    /// Absolute path of the file that was read (so the UI can surface the
+    /// source when warning about skipped lines).
+    pub path: PathBuf,
+    /// Number of non-empty lines that failed JSON / shape validation and were
+    /// skipped. Empty lines do not count.
+    pub skipped: usize,
+}
+
+/// JSON Lines record as emitted by `tracing_subscriber::fmt::json()`.
+///
+/// Top-level fields not listed here (`span`, `spans`, `threadId`, …) are
+/// silently ignored via `#[serde(deny_unknown_fields)]` *not* being set.
+#[derive(Debug, Clone, Deserialize)]
+pub struct LogFileEntry {
+    pub timestamp: DateTime<Utc>,
+    pub level: String,
+    #[serde(default)]
+    pub target: String,
+    #[serde(default)]
+    pub fields: serde_json::Map<String, serde_json::Value>,
+}
+
+impl LogFileEntry {
+    /// Convert this on-disk record into an in-memory [`LogEvent`].
+    ///
+    /// `id` is taken from the caller so that [`read_log_file`] can assign
+    /// monotonically increasing ids in source order without any global state.
+    pub fn into_log_event(mut self, id: u64) -> LogEvent {
+        let severity = parse_level(&self.level);
+
+        let message = take_string(&mut self.fields, "message").unwrap_or_default();
+        let detail = take_string(&mut self.fields, "detail");
+
+        LogEvent {
+            id,
+            severity,
+            source: self.target,
+            message,
+            detail,
+            timestamp: self.timestamp,
+            fields: self.fields,
+        }
+    }
+}
+
+/// Read a canonical structured log file and return the decoded events.
+///
+/// Behavior:
+///
+/// - Returns `Ok(ReadOutcome { entries: vec![], diagnostics: { skipped: 0 } })`
+///   when `path` does not exist (matches the previous GUI behavior: an empty
+///   Logs window is acceptable before any event has been emitted).
+/// - Empty lines and an unterminated trailing line are tolerated and do not
+///   count as `skipped`.
+/// - Lines that fail to decode are skipped and counted in
+///   `diagnostics.skipped`; the rest are returned.
+/// - `id` is assigned in read order starting from `1` and is in-memory only.
+pub fn read_log_file(path: &Path) -> io::Result<ReadOutcome> {
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(ReadOutcome {
+                entries: Vec::new(),
+                diagnostics: ReadDiagnostics {
+                    path: path.to_path_buf(),
+                    skipped: 0,
+                },
+            });
+        }
+        Err(error) => return Err(error),
+    };
+
+    let reader = BufReader::new(file);
+    let mut entries = Vec::new();
+    let mut skipped = 0_usize;
+    let mut next_id: u64 = 1;
+
+    for line in reader.lines() {
+        let line = line?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<LogFileEntry>(trimmed) {
+            Ok(entry) => {
+                entries.push(entry.into_log_event(next_id));
+                next_id += 1;
+            }
+            Err(_) => {
+                skipped += 1;
+            }
+        }
+    }
+
+    Ok(ReadOutcome {
+        entries,
+        diagnostics: ReadDiagnostics {
+            path: path.to_path_buf(),
+            skipped,
+        },
+    })
+}
+
+fn parse_level(level: &str) -> LogLevel {
+    match level.to_ascii_uppercase().as_str() {
+        "ERROR" => LogLevel::Error,
+        "WARN" | "WARNING" => LogLevel::Warn,
+        "INFO" => LogLevel::Info,
+        // tracing emits DEBUG/TRACE — both collapse to Debug to match
+        // `LogLevel::from_tracing`.
+        _ => LogLevel::Debug,
+    }
+}
+
+fn take_string(
+    fields: &mut serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Option<String> {
+    match fields.remove(key)? {
+        serde_json::Value::String(s) => Some(s),
+        // tracing sometimes records `Debug` fields as their `{:?}` string
+        // form which serializes as a JSON string anyway; everything else
+        // (numbers, booleans, objects) is unexpected for `message`/`detail`
+        // and we fall back to its JSON representation rather than dropping
+        // the information silently.
+        other => Some(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn write_lines(lines: &[&str]) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("gwt.log.2026-05-20");
+        let mut file = std::fs::File::create(&path).expect("create");
+        for line in lines {
+            file.write_all(line.as_bytes()).expect("write line");
+            file.write_all(b"\n").expect("write newline");
+        }
+        (dir, path)
+    }
+
+    const PROD_LINE_INFO: &str = r#"{"timestamp":"2026-05-20T09:00:00.015355+09:00","level":"INFO","fields":{"message":"PTY resize completed","cols":72,"rows":24,"outcome":"ok"},"target":"gwt::resize::pty"}"#;
+    const PROD_LINE_WARN: &str = r#"{"timestamp":"2026-05-20T09:00:00.020000+09:00","level":"WARN","fields":{"message":"slow flush","elapsed_ms":120},"target":"gwt::flush"}"#;
+    const PROD_LINE_ERROR: &str = r#"{"timestamp":"2026-05-20T09:00:00.030000+09:00","level":"ERROR","fields":{"message":"git failed","detail":"exit status 128"},"target":"gwt::git"}"#;
+    const PROD_LINE_NO_MESSAGE: &str = r#"{"timestamp":"2026-05-20T09:00:00.040000+09:00","level":"INFO","fields":{"k":"v"},"target":"gwt::nomsg"}"#;
+    const UNKNOWN_FIELD_LINE: &str = r#"{"timestamp":"2026-05-20T09:00:00.050000+09:00","level":"INFO","fields":{"message":"with span"},"target":"gwt::span","span":{"name":"outer"},"spans":[{"name":"outer"}]}"#;
+    const MALFORMED_LINE: &str = r#"{"foo":"bar"}"#;
+
+    #[test]
+    fn reads_production_shape_jsonl_round_trip() {
+        let (_dir, path) = write_lines(&[PROD_LINE_INFO, PROD_LINE_WARN, PROD_LINE_ERROR]);
+
+        let outcome = read_log_file(&path).expect("read ok");
+
+        assert_eq!(outcome.diagnostics.skipped, 0);
+        assert_eq!(outcome.entries.len(), 3);
+
+        // ids are assigned in source order, in-memory only.
+        assert_eq!(outcome.entries[0].id, 1);
+        assert_eq!(outcome.entries[1].id, 2);
+        assert_eq!(outcome.entries[2].id, 3);
+
+        // level -> severity
+        assert_eq!(outcome.entries[0].severity, LogLevel::Info);
+        assert_eq!(outcome.entries[1].severity, LogLevel::Warn);
+        assert_eq!(outcome.entries[2].severity, LogLevel::Error);
+
+        // target -> source, fields.message -> message
+        assert_eq!(outcome.entries[0].source, "gwt::resize::pty");
+        assert_eq!(outcome.entries[0].message, "PTY resize completed");
+
+        // fields.detail -> detail
+        assert_eq!(
+            outcome.entries[2].detail.as_deref(),
+            Some("exit status 128")
+        );
+
+        // residual fields retained, message/detail removed.
+        assert!(!outcome.entries[0].fields.contains_key("message"));
+        assert_eq!(
+            outcome.entries[0].fields.get("outcome"),
+            Some(&serde_json::Value::String("ok".to_string()))
+        );
+        assert!(!outcome.entries[2].fields.contains_key("detail"));
+    }
+
+    #[test]
+    fn skips_malformed_lines_and_returns_remaining_entries() {
+        let (_dir, path) = write_lines(&[PROD_LINE_INFO, MALFORMED_LINE, PROD_LINE_WARN]);
+
+        let outcome = read_log_file(&path).expect("read ok");
+
+        assert_eq!(outcome.entries.len(), 2);
+        assert_eq!(outcome.diagnostics.skipped, 1);
+        assert_eq!(outcome.diagnostics.path, path);
+        // ids are assigned only to successfully decoded entries and remain
+        // monotonic.
+        assert_eq!(outcome.entries[0].id, 1);
+        assert_eq!(outcome.entries[1].id, 2);
+    }
+
+    #[test]
+    fn missing_file_returns_empty_outcome() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("does-not-exist.log");
+
+        let outcome = read_log_file(&path).expect("read ok");
+
+        assert!(outcome.entries.is_empty());
+        assert_eq!(outcome.diagnostics.skipped, 0);
+        assert_eq!(outcome.diagnostics.path, path);
+    }
+
+    #[test]
+    fn empty_file_returns_empty_outcome() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("gwt.log.empty");
+        std::fs::File::create(&path).expect("create");
+
+        let outcome = read_log_file(&path).expect("read ok");
+
+        assert!(outcome.entries.is_empty());
+        assert_eq!(outcome.diagnostics.skipped, 0);
+    }
+
+    #[test]
+    fn ignores_blank_lines_without_counting_as_skipped() {
+        let (_dir, path) = write_lines(&["", "   ", PROD_LINE_INFO, "", PROD_LINE_WARN, "   "]);
+
+        let outcome = read_log_file(&path).expect("read ok");
+
+        assert_eq!(outcome.entries.len(), 2);
+        assert_eq!(outcome.diagnostics.skipped, 0);
+    }
+
+    #[test]
+    fn tolerates_trailing_unterminated_line() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("gwt.log.trail");
+        let mut file = std::fs::File::create(&path).expect("create");
+        file.write_all(PROD_LINE_INFO.as_bytes()).expect("write");
+        file.write_all(b"\n").expect("write nl");
+        // last line has no trailing newline
+        file.write_all(PROD_LINE_WARN.as_bytes()).expect("write");
+
+        let outcome = read_log_file(&path).expect("read ok");
+
+        assert_eq!(outcome.entries.len(), 2);
+        assert_eq!(outcome.diagnostics.skipped, 0);
+    }
+
+    #[test]
+    fn unknown_top_level_fields_are_ignored() {
+        let (_dir, path) = write_lines(&[UNKNOWN_FIELD_LINE]);
+
+        let outcome = read_log_file(&path).expect("read ok");
+
+        assert_eq!(outcome.entries.len(), 1);
+        assert_eq!(outcome.diagnostics.skipped, 0);
+        assert_eq!(outcome.entries[0].message, "with span");
+        assert_eq!(outcome.entries[0].source, "gwt::span");
+        // span / spans are not mapped to LogEvent and must not leak into
+        // `fields` (those keys are siblings of `fields`, not children).
+        assert!(!outcome.entries[0].fields.contains_key("span"));
+        assert!(!outcome.entries[0].fields.contains_key("spans"));
+    }
+
+    #[test]
+    fn missing_message_field_yields_empty_message() {
+        let (_dir, path) = write_lines(&[PROD_LINE_NO_MESSAGE]);
+
+        let outcome = read_log_file(&path).expect("read ok");
+
+        assert_eq!(outcome.entries.len(), 1);
+        assert_eq!(outcome.entries[0].message, "");
+        assert_eq!(
+            outcome.entries[0].fields.get("k"),
+            Some(&serde_json::Value::String("v".to_string()))
+        );
+    }
+}

--- a/crates/gwt-core/tests/logging_init.rs
+++ b/crates/gwt-core/tests/logging_init.rs
@@ -8,7 +8,7 @@
 
 use std::time::{Duration, Instant};
 
-use gwt_core::logging::{current_log_file, init, LogLevel, LoggingConfig};
+use gwt_core::logging::{current_log_file, init, read_log_file, LogLevel, LoggingConfig};
 
 #[test]
 fn init_writes_tracing_events_as_jsonl_to_gwt_log() {
@@ -66,5 +66,30 @@ fn init_writes_tracing_events_as_jsonl_to_gwt_log() {
     assert!(
         content.contains("warning sample"),
         "expected warn event in log file"
+    );
+
+    // SPEC-1924 US-14 / T-LFR-006: the on-disk JSONL produced by the live
+    // writer must be replayable by the new reader without any skipped lines.
+    let outcome = read_log_file(&log_path).expect("read_log_file should succeed");
+    assert_eq!(
+        outcome.diagnostics.skipped, 0,
+        "writer/reader shape mismatch: read_log_file skipped {} line(s)",
+        outcome.diagnostics.skipped
+    );
+    assert!(
+        outcome
+            .entries
+            .iter()
+            .any(|e| e.message == "hello from test" && e.source == "gwt_core::logging::test"),
+        "expected hello event to round-trip via read_log_file, got: {:?}",
+        outcome.entries
+    );
+    assert!(
+        outcome
+            .entries
+            .iter()
+            .any(|e| e.message == "warning sample"
+                && e.severity == gwt_core::logging::LogLevel::Warn),
+        "expected warn event to round-trip via read_log_file with Warn severity"
     );
 }

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -3985,13 +3985,24 @@ impl AppRuntime {
         }
 
         match load_log_entries_from_dir(&self.log_dir) {
-            Ok(entries) => vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::LogEntries {
-                    id: id.to_string(),
-                    entries,
-                },
-            )],
+            Ok(outcome) => {
+                let mut events = vec![OutboundEvent::reply(
+                    client_id,
+                    BackendEvent::LogEntries {
+                        id: id.to_string(),
+                        entries: outcome.entries,
+                    },
+                )];
+                if outcome.diagnostics.skipped > 0 {
+                    events.push(OutboundEvent::reply(
+                        client_id,
+                        BackendEvent::LogEntryAppended {
+                            entry: skipped_lines_warning(&outcome.diagnostics),
+                        },
+                    ));
+                }
+                events
+            }
             Err(error) => vec![OutboundEvent::reply(
                 client_id,
                 BackendEvent::LogError {
@@ -4629,43 +4640,35 @@ impl AppRuntime {
     }
 }
 
-fn load_log_entries_from_dir(log_dir: &Path) -> Result<Vec<gwt_core::logging::LogEvent>, String> {
+/// Read the active canonical log file via the SPEC-1924 FR-035 reader.
+///
+/// Returns the decoded snapshot together with `ReadDiagnostics` so the caller
+/// can surface a non-blocking warning when malformed lines were skipped
+/// (FR-036 / SC-010). IO errors other than `NotFound` are forwarded as a
+/// human-readable message so the Logs window can switch to an error state
+/// without crashing the agent.
+fn load_log_entries_from_dir(log_dir: &Path) -> Result<gwt_core::logging::ReadOutcome, String> {
     let path = gwt_core::logging::current_log_file(log_dir);
-    let file = match std::fs::File::open(&path) {
-        Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(error) => {
-            return Err(format!(
-                "Failed to open log file {}: {error}",
-                path.display()
-            ))
-        }
-    };
-    let reader = std::io::BufReader::new(file);
-    let mut entries = Vec::new();
-    for (index, line) in std::io::BufRead::lines(reader).enumerate() {
-        let line = line.map_err(|error| {
-            format!(
-                "Failed to read log line {} from {}: {error}",
-                index + 1,
-                path.display()
-            )
-        })?;
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let entry =
-            serde_json::from_str::<gwt_core::logging::LogEvent>(trimmed).map_err(|error| {
-                format!(
-                    "Failed to parse log line {} from {}: {error}",
-                    index + 1,
-                    path.display()
-                )
-            })?;
-        entries.push(entry);
-    }
-    Ok(entries)
+    gwt_core::logging::read_log_file(&path)
+        .map_err(|error| format!("Failed to read log file {}: {error}", path.display()))
+}
+
+/// Build the synthetic warning event surfaced when `read_log_file` skipped
+/// malformed lines. Keeps the message phrasing consistent with the Logs
+/// window expectation of a single notice per load (FR-036 / SC-010).
+fn skipped_lines_warning(
+    diagnostics: &gwt_core::logging::ReadDiagnostics,
+) -> gwt_core::logging::LogEvent {
+    let count = diagnostics.skipped;
+    let plural = if count == 1 { "line" } else { "lines" };
+    gwt_core::logging::LogEvent::new(
+        gwt_core::logging::LogLevel::Warn,
+        "gwt_core::logging::reader",
+        format!(
+            "Skipped {count} malformed {plural} while reading {}",
+            diagnostics.path.display()
+        ),
+    )
 }
 
 fn spawn_branch_cleanup_async(
@@ -6487,7 +6490,7 @@ mod tests {
             coordination_events_path, load_snapshot, post_entry, AuthorKind, BoardAudienceScope,
             BoardEntry, BoardEntryKind, BoardMention, BoardMentionTargetKind, CoordinationEvent,
         },
-        logging::{current_log_file, LogEvent, LogLevel},
+        logging::{current_log_file, LogLevel},
         paths::gwt_cache_dir,
         repo_hash::detect_repo_hash,
     };
@@ -11806,14 +11809,16 @@ exit 1
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let window_id = combined_window_id("tab-1", "logs-1");
         let log_path = current_log_file(&runtime.log_dir);
-        let entry =
-            LogEvent::new(LogLevel::Warn, "pty", "runtime stalled").with_detail("retrying read");
+        // Write the canonical on-disk JSONL shape produced by
+        // `tracing_subscriber::fmt::layer().json()` (see
+        // `crates/gwt-core/src/logging/fmt_layer.rs`) so the reader exercises
+        // the production format end-to-end (SPEC-1924 FR-035).
         fs::write(
             &log_path,
-            format!(
-                "{}\n",
-                serde_json::to_string(&entry).expect("serialize log event")
-            ),
+            "{\"timestamp\":\"2026-05-20T09:00:00.000000+00:00\",\
+             \"level\":\"WARN\",\
+             \"fields\":{\"message\":\"runtime stalled\",\"detail\":\"retrying read\"},\
+             \"target\":\"pty\"}\n",
         )
         .expect("write log snapshot");
 
@@ -11833,8 +11838,80 @@ exit 1
                 && id == &window_id
                 && entries.len() == 1
                 && entries[0].message == "runtime stalled"
+                && entries[0].detail.as_deref() == Some("retrying read")
+                && entries[0].source == "pty"
                 && matches!(entries[0].severity, LogLevel::Warn)
         ));
+    }
+
+    /// SPEC-1924 US-14 / FR-036 / SC-010 — when canonical log file contains
+    /// malformed lines, the Logs window receives the surviving entries plus
+    /// exactly one Warning notice via `LogEntryAppended`.
+    #[test]
+    fn app_runtime_load_logs_emits_warning_for_skipped_lines() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "logs-1",
+            repo,
+            WindowPreset::Logs,
+            WindowProcessStatus::Ready,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "logs-1");
+        let log_path = current_log_file(&runtime.log_dir);
+        let good = "{\"timestamp\":\"2026-05-20T09:00:00.000000+00:00\",\
+            \"level\":\"INFO\",\"fields\":{\"message\":\"ok\"},\"target\":\"gwt\"}";
+        let malformed = "{\"foo\":\"bar\"}";
+        fs::write(&log_path, format!("{good}\n{malformed}\n{good}\n")).expect("write log snapshot");
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::LoadLogs {
+                id: window_id.clone(),
+            },
+        );
+
+        assert_eq!(
+            events.len(),
+            2,
+            "expected LogEntries + LogEntryAppended for skipped notice, got {:?}",
+            events
+        );
+
+        let entries_match = matches!(
+            &events[0],
+            OutboundEvent {
+                target: DispatchTarget::Client(client_id),
+                event: BackendEvent::LogEntries { id, entries },
+            } if client_id == "client-1"
+                && id == &window_id
+                && entries.len() == 2
+                && entries.iter().all(|e| e.message == "ok")
+        );
+        assert!(
+            entries_match,
+            "first event must be LogEntries: {:?}",
+            events[0]
+        );
+
+        let warning_match = matches!(
+            &events[1],
+            OutboundEvent {
+                target: DispatchTarget::Client(client_id),
+                event: BackendEvent::LogEntryAppended { entry },
+            } if client_id == "client-1"
+                && entry.severity == LogLevel::Warn
+                && entry.source == "gwt_core::logging::reader"
+                && entry.message.contains("Skipped 1 malformed line")
+        );
+        assert!(
+            warning_match,
+            "second event must be a Warn LogEntryAppended notice: {:?}",
+            events[1]
+        );
     }
 
     #[test]
@@ -14889,5 +14966,86 @@ exit 1
                 .map(|i| (i.id.clone(), i.status_category.clone()))
                 .collect::<Vec<_>>()
         );
+    }
+
+    // SPEC-1924 US-14 FR-035 / FR-036 / SC-010 / SC-011 — verify the Logs
+    // window snapshot reader goes through `gwt_core::logging::read_log_file`
+    // and that the synthetic warning event is well-formed when malformed
+    // lines are skipped.
+
+    const PROD_LINE_INFO: &str = r#"{"timestamp":"2026-05-20T09:00:00.015355+09:00","level":"INFO","fields":{"message":"PTY resize completed","outcome":"ok"},"target":"gwt::resize::pty"}"#;
+    const MALFORMED_LINE: &str = r#"{"foo":"bar"}"#;
+
+    fn write_canonical_log_file(log_dir: &Path, lines: &[&str]) {
+        fs::create_dir_all(log_dir).expect("create log dir");
+        let log_path = current_log_file(log_dir);
+        let mut file = fs::File::create(&log_path).expect("create log file");
+        for line in lines {
+            file.write_all(line.as_bytes()).expect("write line");
+            file.write_all(b"\n").expect("write newline");
+        }
+    }
+
+    #[test]
+    fn load_log_entries_from_dir_returns_outcome_with_no_skipped_lines() {
+        let dir = tempdir().expect("tempdir");
+        write_canonical_log_file(dir.path(), &[PROD_LINE_INFO]);
+
+        let outcome = super::load_log_entries_from_dir(dir.path()).expect("read ok");
+
+        assert_eq!(outcome.entries.len(), 1);
+        assert_eq!(outcome.entries[0].message, "PTY resize completed");
+        assert_eq!(outcome.diagnostics.skipped, 0);
+    }
+
+    #[test]
+    fn load_log_entries_from_dir_counts_skipped_lines() {
+        let dir = tempdir().expect("tempdir");
+        write_canonical_log_file(
+            dir.path(),
+            &[PROD_LINE_INFO, MALFORMED_LINE, PROD_LINE_INFO],
+        );
+
+        let outcome = super::load_log_entries_from_dir(dir.path()).expect("read ok");
+
+        assert_eq!(outcome.entries.len(), 2);
+        assert_eq!(outcome.diagnostics.skipped, 1);
+    }
+
+    #[test]
+    fn load_log_entries_from_dir_returns_empty_outcome_when_file_missing() {
+        let dir = tempdir().expect("tempdir");
+
+        let outcome = super::load_log_entries_from_dir(dir.path()).expect("read ok");
+
+        assert!(outcome.entries.is_empty());
+        assert_eq!(outcome.diagnostics.skipped, 0);
+    }
+
+    #[test]
+    fn skipped_lines_warning_is_warn_severity_and_includes_count_and_path() {
+        let diagnostics = gwt_core::logging::ReadDiagnostics {
+            path: PathBuf::from("/tmp/gwt.log.2026-05-20"),
+            skipped: 3,
+        };
+
+        let event = super::skipped_lines_warning(&diagnostics);
+
+        assert_eq!(event.severity, LogLevel::Warn);
+        assert_eq!(event.source, "gwt_core::logging::reader");
+        assert!(event.message.contains("Skipped 3 malformed lines"));
+        assert!(event.message.contains("/tmp/gwt.log.2026-05-20"));
+    }
+
+    #[test]
+    fn skipped_lines_warning_singular_for_one_line() {
+        let diagnostics = gwt_core::logging::ReadDiagnostics {
+            path: PathBuf::from("/tmp/x.log"),
+            skipped: 1,
+        };
+
+        let event = super::skipped_lines_warning(&diagnostics);
+
+        assert!(event.message.contains("Skipped 1 malformed line "));
     }
 }


### PR DESCRIPTION
## Summary

GUI Logs ウィンドウのスナップショット読み込みが `Failed to parse log line 1 from .../gwt.log.2026-05-20: missing field 'id' at line 1 column 233` で全件失敗していたバグを修正します。`tracing_subscriber::fmt::layer().json()` が書く on-disk JSONL の shape (`{timestamp/level/target/fields}`) と、`load_log_entries_from_dir` が期待していた `LogEvent` shape (`id/severity/source/message/...`) が完全不一致になっていました。

writer / canonical file format は SPEC-1924 FR-031〜FR-033 のまま不変にし、reader 側を on-disk shape に合わせるアダプタを `gwt-core::logging` に集約します (Proposal A)。失敗行は skip + Warn severity の synthetic notice 1 件として UI に通知します。

## Changes

- `crates/gwt-core/src/logging/reader.rs` (新規): `LogFileEntry` 型と `read_log_file(path) -> io::Result<ReadOutcome>` を公開。`level→severity`, `target→source`, `fields.message→message`, `fields.detail→detail` を変換し、`id` は読み出し順で in-memory auto-assign。parse 失敗行は `ReadDiagnostics { skipped, path }` にカウントして残りを返す。8 件の単体テストでカバー (production shape / malformed line / empty file / blank lines / trailing unterminated / unknown top-level field / missing message)。
- `crates/gwt-core/src/logging/mod.rs`: `read_log_file / LogFileEntry / ReadDiagnostics / ReadOutcome` を再エクスポート。
- `crates/gwt-core/tests/logging_init.rs`: writer→reader round-trip 統合テストを追加 (T-LFR-006)。
- `crates/gwt/src/app_runtime/mod.rs`:
  - `load_log_entries_from_dir` を gwt-core 経由のラッパに置き換え、`serde_json::from_str::<LogEvent>` の直接呼び出しを削除 (SC-011 / FR-037)。
  - `ReadDiagnostics.skipped > 0` のときは `skipped_lines_warning` で Warn severity の `LogEntryAppended` を 1 件追加で送出 (FR-036 / SC-010)。
  - 既存 `app_runtime_load_logs_replies_with_current_log_snapshot` を canonical on-disk shape を書くよう修正、`app_runtime_load_logs_emits_warning_for_skipped_lines` を新規追加。

## Testing

- `cargo test -p gwt-core --all-features` — PASS (新規 8 reader tests + round-trip integration test)
- `cargo test -p gwt --all-features` — PASS (既存 + 新規 app_runtime tests)
- `cargo clippy -p gwt-core -p gwt --all-targets --all-features -- -D warnings` — PASS
- `cargo fmt --all -- --check` — PASS
- `bunx commitlint --from HEAD~1 --to HEAD` — PASS
- `target/debug/gwt` 起動 → `gwt browser URL: http://127.0.0.1:65181/` を `curl -fsS -I` で `HTTP/1.1 200 OK` 確認。
- 実 production log file `~/.gwt/projects/8a5edab282632443/logs/gwt.log.2026-05-20` (72,890 entries) を `read_log_file` で読み戻し: `entries: 72890, skipped: 0`、first entry: `PTY resize completed / gwt::resize::pty / Info` で正しく decode。
- `rg "serde_json::from_str::<.*LogEvent>" crates/gwt/src/` — 0 matches (SC-011 regression guard)

## Closing Issues

None

## Related Issues

- #1924 (SPEC-1924) — US-14 / FR-035 / FR-036 / FR-037 / NFR-005 / SC-010 / SC-011 を追加

## Checklist

- [x] テスト追加・既存テスト PASS
- [x] clippy / fmt 通過
- [x] commitlint 通過 (Conventional Commits)
- [x] SPEC-1924 spec / plan / tasks を更新済み
- [x] GUI smoke (HTTP 200 + real log file round-trip 72,890 entries / 0 skipped)
- [x] SC-011 regression guard (serde_json::from_str::<LogEvent> on disk lines: 0 matches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
