### PR TITLE
feat(gui): surface server URL in status strip with browser+copy (SPEC-2785)

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1684,6 +1684,48 @@ fn search_github_repositories(
     parse_github_repository_search_results(&String::from_utf8_lossy(&output.stdout))
 }
 
+/// SPEC-2785 FR-E: exact same-origin match between the embedded server's
+/// bound URL and a frontend-supplied URL. Used as the pre-spawn gate by
+/// [`AppRuntime::open_server_url_events`] so a renderer compromise cannot
+/// smuggle an arbitrary URL into the OS opener.
+///
+/// Comparison is byte-exact. Trailing-slash and case differences are NOT
+/// normalized — the frontend derives its URL from `window.location.origin`
+/// so the two strings are always produced by the same source and any drift
+/// is a bug worth surfacing rather than papering over.
+fn validate_server_url(allowed: Option<&str>, requested: &str) -> bool {
+    matches!(allowed, Some(value) if value == requested)
+}
+
+/// SPEC-2785 FR-C / FR-E: launch the platform default browser for a URL
+/// argument (analogous to [`open_path_with_os_default`] but reserved for URLs
+/// that have already cleared [`validate_server_url`]). The opener receives
+/// the URL via argv directly, never through a shell, so URL contents cannot
+/// trigger shell metacharacter expansion.
+fn open_url_with_os_default(url: &str) -> Result<(), std::io::Error> {
+    use std::process::Command;
+    let child = if cfg!(target_os = "macos") {
+        let mut cmd = Command::new("open");
+        cmd.arg(url);
+        cmd.spawn()?
+    } else if cfg!(target_os = "windows") {
+        let mut cmd = Command::new("cmd");
+        // The empty "" before the URL is required by `start` so that a URL
+        // beginning with quoted text is not interpreted as a window title.
+        cmd.args(["/C", "start", "", url]);
+        cmd.spawn()?
+    } else {
+        let mut cmd = Command::new("xdg-open");
+        cmd.arg(url);
+        cmd.spawn()?
+    };
+    std::thread::spawn(move || {
+        let mut child = child;
+        let _ = child.wait();
+    });
+    Ok(())
+}
+
 /// SPEC-2041 Phase 19 (FR-065): launch the platform default opener
 /// (`open` on macOS, `xdg-open` on Linux, `explorer` on Windows). Errors are
 /// silently dropped so the modal does not surface noise; the path is logged
@@ -1810,6 +1852,12 @@ pub struct AppRuntime {
     /// windows. Reset every time the user reopens the picker, so this is a
     /// transient in-memory map and is not persisted with the session state.
     pub(crate) file_tree_worktree_roots: HashMap<String, PathBuf>,
+    /// SPEC-2785 FR-E: embedded server URL captured after the axum bind so
+    /// `open_server_url_events` can reject requests whose origin differs from
+    /// the bound URL. `None` before the server is started (e.g. during early
+    /// AppRuntime construction or unit tests that never call
+    /// `set_server_url`).
+    pub(crate) server_url: Option<String>,
 }
 
 impl ProjectTabRuntime {
@@ -1892,6 +1940,7 @@ impl AppRuntime {
             pty_writers,
             persist_dispatcher,
             file_tree_worktree_roots: HashMap::new(),
+            server_url: None,
         };
         app.rebuild_window_lookup();
         app.seed_window_pty_statuses();
@@ -1956,6 +2005,13 @@ impl AppRuntime {
 
     pub(crate) fn set_hook_forward_target(&mut self, target: HookForwardTarget) {
         self.hook_forward_target = Some(target);
+    }
+
+    /// SPEC-2785 FR-E: capture the embedded server URL after the axum bind
+    /// completes so `open_server_url_events` can reject mismatched origin
+    /// requests before invoking the OS opener.
+    pub(crate) fn set_server_url(&mut self, url: String) {
+        self.server_url = Some(url);
     }
 
     pub(crate) fn handle_frontend_event(
@@ -2266,6 +2322,7 @@ impl AppRuntime {
             FrontendEvent::OpenUpdateLog { log_path } => {
                 self.open_update_log_events(&client_id, log_path)
             }
+            FrontendEvent::OpenServerUrl { url } => self.open_server_url_events(&client_id, url),
             FrontendEvent::ListCustomAgents => vec![OutboundEvent::reply(
                 client_id,
                 gwt::custom_agents_dispatch::list_event(),
@@ -2661,6 +2718,34 @@ impl AppRuntime {
                 ),
             )],
         }
+    }
+
+    /// SPEC-2785 US-1 / FR-C / FR-E: user clicked the server URL cell in the
+    /// status strip. The renderer-supplied `url` is treated as untrusted and
+    /// is only forwarded to [`open_url_with_os_default`] when it matches the
+    /// embedded server's bound URL captured by [`Self::set_server_url`].
+    /// Mismatched origins (or an unset server URL) are dropped with a trace
+    /// log so a compromised renderer cannot redirect the OS opener to an
+    /// arbitrary URL. The handler returns no outbound events; the click is a
+    /// side-effect only.
+    fn open_server_url_events(&self, _client_id: &str, url: String) -> Vec<OutboundEvent> {
+        if validate_server_url(self.server_url.as_deref(), &url) {
+            if let Err(error) = open_url_with_os_default(&url) {
+                tracing::trace!(
+                    target: "gwt::open_server_url",
+                    %error,
+                    "failed to spawn OS browser opener"
+                );
+            }
+        } else {
+            tracing::trace!(
+                target: "gwt::open_server_url",
+                requested = %url,
+                allowed = ?self.server_url,
+                "rejected open_server_url request: origin mismatch"
+            );
+        }
+        Vec::new()
     }
 
     /// SPEC-2041 Phase 19 (FR-065): user pressed `Open log` on the failed
@@ -7254,6 +7339,7 @@ exit 1
             pty_writers,
             persist_dispatcher,
             file_tree_worktree_roots: HashMap::new(),
+            server_url: None,
         };
         runtime.rebuild_window_lookup();
         runtime.seed_window_pty_statuses();
@@ -14688,6 +14774,78 @@ exit 1
         let missing = logs_root.path().join("does-not-exist.log");
         let resolved = super::validate_update_log_path(missing.to_str().unwrap(), logs_root.path());
         assert!(resolved.is_none(), "missing files must be rejected");
+    }
+
+    // SPEC-2785 FR-E: open_server_url requests must be gated by an exact
+    // same-origin match against the embedded server's bound URL. The shared
+    // validator function is reused by `AppRuntime::open_server_url_events`
+    // so a mismatched origin cannot smuggle an arbitrary URL into the OS
+    // opener.
+    #[test]
+    fn validate_server_url_accepts_exact_bound_url() {
+        let allowed = Some("http://127.0.0.1:54321/");
+        assert!(super::validate_server_url(
+            allowed,
+            "http://127.0.0.1:54321/"
+        ));
+    }
+
+    #[test]
+    fn validate_server_url_rejects_different_port() {
+        let allowed = Some("http://127.0.0.1:54321/");
+        assert!(!super::validate_server_url(
+            allowed,
+            "http://127.0.0.1:54322/"
+        ));
+    }
+
+    #[test]
+    fn validate_server_url_rejects_different_scheme() {
+        let allowed = Some("http://127.0.0.1:54321/");
+        assert!(!super::validate_server_url(
+            allowed,
+            "https://127.0.0.1:54321/"
+        ));
+    }
+
+    #[test]
+    fn validate_server_url_rejects_when_allowed_is_none() {
+        assert!(!super::validate_server_url(None, "http://127.0.0.1:54321/"));
+    }
+
+    #[test]
+    fn validate_server_url_rejects_external_origin() {
+        let allowed = Some("http://127.0.0.1:54321/");
+        assert!(!super::validate_server_url(allowed, "http://evil.example/"));
+    }
+
+    // SPEC-2785 SC-4: `open_server_url_events` returns an empty event list and
+    // performs no OS opener side effect when the requested URL does not match
+    // the configured server URL. The state mutation guard is `server_url`
+    // being None or unequal to the request.
+    #[test]
+    fn open_server_url_events_rejects_mismatched_origin() {
+        let temp = tempdir().expect("tempdir");
+        let (mut runtime, _events) = sample_runtime_with_events(temp.path(), Vec::new(), None);
+        runtime.set_server_url("http://127.0.0.1:54321/".to_string());
+        let outbound =
+            runtime.open_server_url_events("client-1", "http://evil.example/".to_string());
+        assert!(
+            outbound.is_empty(),
+            "mismatched origin must yield no outbound events"
+        );
+    }
+
+    #[test]
+    fn open_server_url_events_rejects_when_server_url_unset() {
+        let temp = tempdir().expect("tempdir");
+        let (runtime, _events) = sample_runtime_with_events(temp.path(), Vec::new(), None);
+        let outbound =
+            runtime.open_server_url_events("client-1", "http://127.0.0.1:54321/".to_string());
+        assert!(
+            outbound.is_empty(),
+            "unset server URL must reject any open request"
+        );
     }
 
     #[test]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1939,6 +1939,7 @@ mod tests {
             pty_writers: Arc::new(RwLock::new(HashMap::new())),
             persist_dispatcher,
             file_tree_worktree_roots: HashMap::new(),
+            server_url: None,
         };
         runtime.rebuild_window_lookup();
         runtime.seed_window_pty_statuses();
@@ -5988,6 +5989,11 @@ fn main() -> wry::Result<()> {
     .expect("embedded server");
     app.set_hook_forward_target(server.hook_forward_target());
     let front_door = gui_front_door_launch_surface(server.url());
+    // SPEC-2785 FR-E: hand the bound URL to AppRuntime so
+    // `open_server_url_events` can gate `OpenServerUrl` requests against it.
+    // Must run before the WebView surface boots; the first frontend message
+    // is `FrontendReady` which does not exercise this code path.
+    app.set_server_url(front_door.browser_url.to_string());
     eprintln!("gwt browser URL: {}", front_door.browser_url);
     if serve_args.is_some() {
         eprintln!("gwt serve: press Ctrl-C to stop");

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -405,6 +405,14 @@ pub enum FrontendEvent {
     OpenUpdateLog {
         log_path: Option<String>,
     },
+    /// SPEC-2785 US-1 / FR-C: user clicked the server URL cell in the status
+    /// strip. Backend opens the URL in the OS default browser only when it
+    /// matches the embedded server's bound URL (FR-E same-origin gate). The
+    /// renderer-supplied `url` is treated as untrusted and validated against
+    /// `AppRuntime::server_url` before any opener is spawned.
+    OpenServerUrl {
+        url: String,
+    },
     /// Settings > Custom Agents: list every stored custom agent. Response is
     /// [`BackendEvent::CustomAgentList`].
     ListCustomAgents,
@@ -2200,6 +2208,22 @@ mod tests {
             matches!(event, FrontendEvent::OpenStartWork),
             "Start Work must be a global command, not a Branches window event"
         );
+    }
+
+    // SPEC-2785 US-1 AS-1 / FR-C: frontend → backend WS payload contract for
+    // opening the server URL in the OS default browser.
+    #[test]
+    fn frontend_event_accepts_open_server_url() {
+        let event: FrontendEvent = serde_json::from_value(serde_json::json!({
+            "kind": "open_server_url",
+            "url": "http://127.0.0.1:54321/"
+        }))
+        .expect("deserialize open_server_url");
+
+        assert!(matches!(
+            event,
+            FrontendEvent::OpenServerUrl { ref url } if url == "http://127.0.0.1:54321/"
+        ));
     }
 
     #[test]

--- a/crates/gwt/tests/serve_mode_test.rs
+++ b/crates/gwt/tests/serve_mode_test.rs
@@ -136,6 +136,36 @@ fn serve_mode_starts_server_without_opening_webview() {
         "default serve mode must bind to 127.0.0.1, got {url}",
     );
 
+    // SPEC-2785 US-2 AS-2 / FR-F: `gwt serve` must announce the Ctrl-C
+    // shutdown contract on stderr so headless operators know how to stop
+    // the server gracefully. We drain stderr a little further to confirm
+    // the line, bounded by a small follow-up budget so this test never
+    // blocks indefinitely on a quiet stderr.
+    let mut saw_ctrl_c_hint = false;
+    let ctrl_c_deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < ctrl_c_deadline {
+        match rx.recv_timeout(Duration::from_millis(500)) {
+            Ok(line) => {
+                transcript.push(line.clone());
+                if line.contains("gwt serve: press Ctrl-C to stop") {
+                    saw_ctrl_c_hint = true;
+                    break;
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    if !saw_ctrl_c_hint {
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = reader_handle.join();
+        panic!(
+            "expected 'gwt serve: press Ctrl-C to stop' on stderr after URL line. transcript:\n{}",
+            transcript.join("\n")
+        );
+    }
+
     let healthz = format!("{url}healthz");
     let client = reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(5))
@@ -152,4 +182,114 @@ fn serve_mode_starts_server_without_opening_webview() {
     // verifies that the wait completed successfully — that is, we did not
     // leak the child process.
     let _ = status;
+}
+
+/// SPEC-2785 US-2 AS-3 / FR-F: `GWT_BROWSER_URL_FILE` is the canonical
+/// non-stderr handoff channel for CI / Playwright. Setting it to a writable
+/// path must persist the bound URL there so harnesses can consume the URL
+/// without parsing stderr.
+#[test]
+#[ignore = "Spawns the full gwt binary and requires a warm ~/.gwt; opt in with --ignored"]
+fn serve_mode_writes_browser_url_to_handoff_file_when_env_set() {
+    let temp_cwd = tempfile::tempdir().expect("temp cwd");
+    let handoff_dir = tempfile::tempdir().expect("handoff dir");
+    let handoff_path = handoff_dir.path().join("gwt-browser-url.txt");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_gwt"))
+        .arg("serve")
+        .arg("--port")
+        .arg("0")
+        .arg("--no-open")
+        .env("GWT_FORCE_NEW_INSTANCE", "1")
+        .env("GWT_BROWSER_URL_FILE", &handoff_path)
+        .current_dir(temp_cwd.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn gwt serve");
+
+    let stderr = child.stderr.take().expect("stderr handle");
+    let (tx, rx) = mpsc::channel::<String>();
+    let reader_handle = thread::Builder::new()
+        .name("gwt-serve-stderr-reader".to_string())
+        .spawn(move || {
+            let reader = BufReader::new(stderr);
+            for line in reader.lines().map_while(Result::ok) {
+                if tx.send(line).is_err() {
+                    break;
+                }
+            }
+        })
+        .expect("spawn stderr reader thread");
+
+    // Wait for the URL line so we know the embedded server has started and
+    // the handoff file has been written by the parent process.
+    let started = Instant::now();
+    let timeout = Duration::from_secs(180);
+    let mut url: Option<String> = None;
+    let mut transcript: Vec<String> = Vec::new();
+    loop {
+        let remaining = match timeout.checked_sub(started.elapsed()) {
+            Some(remaining) if !remaining.is_zero() => remaining,
+            _ => break,
+        };
+        match rx.recv_timeout(remaining.min(Duration::from_secs(1))) {
+            Ok(line) => {
+                transcript.push(line.clone());
+                if let Some(rest) = line.strip_prefix("gwt browser URL: ") {
+                    url = Some(rest.trim().to_string());
+                    break;
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    let url = match url {
+        Some(value) => value,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = reader_handle.join();
+            panic!(
+                "did not observe 'gwt browser URL:' on stderr within {timeout:?}. transcript:\n{}",
+                transcript.join("\n")
+            );
+        }
+    };
+
+    // The handoff file is written by the parent immediately after the
+    // stderr announcement, but the two are independent syscalls; tolerate
+    // a tiny race by polling for a short while before failing.
+    let mut file_contents = String::new();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if let Ok(text) = std::fs::read_to_string(&handoff_path) {
+            if !text.trim().is_empty() {
+                file_contents = text;
+                break;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = reader_handle.join();
+
+    assert!(
+        !file_contents.is_empty(),
+        "GWT_BROWSER_URL_FILE must be populated; path={}",
+        handoff_path.display()
+    );
+    assert_eq!(
+        file_contents.trim(),
+        url.trim(),
+        "handoff file contents must match the stderr URL line",
+    );
+    assert!(
+        file_contents.trim().starts_with("http://127.0.0.1:"),
+        "handoff URL must point at the local embedded server, got {file_contents:?}"
+    );
 }

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -615,6 +615,81 @@
         });
       }
 
+      // SPEC-2785 US-1 / FR-A〜G: server URL cell in op-status-strip. URL is
+      // derived from `window.location` (frontend is always loaded from the
+      // bound URL, so this is the canonical source) and matches the backend
+      // `AppRuntime::server_url` exactly. Clicking the URL value forwards an
+      // `OpenServerUrl` event to the backend which performs an exact
+      // same-origin check before invoking the OS opener. Clicking the copy
+      // glyph writes the URL to the clipboard with a transient `Copied`
+      // affordance; clipboard rejection downgrades to an inline error state
+      // (no modal) and logs to console for diagnostics.
+      const serverUrlValue = document.getElementById("op-strip-server-url");
+      const serverUrlCopy = document.getElementById("op-strip-server-url-copy");
+      if (serverUrlValue && !serverUrlValue.dataset.serverUrlBound) {
+        serverUrlValue.dataset.serverUrlBound = "true";
+        const serverUrl = new URL("/", window.location.href).toString();
+        serverUrlValue.textContent = serverUrl;
+        serverUrlValue.title = serverUrl;
+        if (serverUrlCopy) {
+          serverUrlCopy.dataset.url = serverUrl;
+        }
+        const openServerUrlInBrowser = () => {
+          send({ kind: "open_server_url", url: serverUrl });
+        };
+        serverUrlValue.addEventListener("click", openServerUrlInBrowser);
+        serverUrlValue.addEventListener("keydown", (event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            openServerUrlInBrowser();
+          }
+        });
+
+        if (serverUrlCopy && !serverUrlCopy.dataset.serverUrlBound) {
+          serverUrlCopy.dataset.serverUrlBound = "true";
+          let copyResetTimer = 0;
+          const flashCopyState = (state, baseLabel) => {
+            serverUrlCopy.dataset.state = state;
+            serverUrlValue.dataset.state = state;
+            if (baseLabel) {
+              serverUrlCopy.setAttribute("aria-label", baseLabel);
+            }
+            if (copyResetTimer) {
+              window.clearTimeout(copyResetTimer);
+            }
+            copyResetTimer = window.setTimeout(() => {
+              serverUrlCopy.removeAttribute("data-state");
+              serverUrlValue.removeAttribute("data-state");
+              serverUrlCopy.setAttribute("aria-label", "Copy server URL");
+              copyResetTimer = 0;
+            }, 1500);
+          };
+          const copyServerUrl = () => {
+            if (!navigator.clipboard?.writeText) {
+              console.warn(
+                "navigator.clipboard.writeText unavailable; cannot copy server URL",
+              );
+              flashCopyState("error", "Copy failed; clipboard unavailable");
+              return;
+            }
+            navigator.clipboard
+              .writeText(serverUrl)
+              .then(() => flashCopyState("copied", "Copied server URL"))
+              .catch((error) => {
+                console.warn("clipboard.writeText rejected", error);
+                flashCopyState("error", "Copy failed; permission denied");
+              });
+          };
+          serverUrlCopy.addEventListener("click", copyServerUrl);
+          serverUrlCopy.addEventListener("keydown", (event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              copyServerUrl();
+            }
+          });
+        }
+      }
+
       const updateCtaController = createUpdateCtaController({
         document,
         send,

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -295,6 +295,24 @@
             <span class="op-status-strip__live-dot" aria-hidden="true"></span>
             <span class="op-status-strip__label">LIVE</span>
           </div>
+          <div class="op-status-strip__cell op-status-strip__cell--server-url">
+            <span class="op-status-strip__label">URL</span>
+            <span
+              class="op-status-strip__value op-status-strip__server-url-value"
+              id="op-strip-server-url"
+              role="button"
+              tabindex="0"
+              aria-label="Open server URL in browser"
+              title=""
+            >—</span>
+            <button
+              type="button"
+              class="op-status-strip__server-url-copy"
+              id="op-strip-server-url-copy"
+              aria-label="Copy server URL"
+              title="Copy URL"
+            >&#x29C9;</button>
+          </div>
           <div class="op-status-strip__cell op-status-strip__cell--active">
             <span class="op-status-strip__label">ACTIVE</span>
             <span class="op-status-strip__value" id="op-strip-active" aria-label="Active agents">0</span>

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -875,6 +875,61 @@ body::after {
   color: var(--color-state-blocked);
 }
 
+/* SPEC-2785 FR-A / FR-B / FR-G: server URL cell sits immediately right of
+   the LIVE indicator with the full http://host:port/ URL. The value is
+   clickable (opens external browser via backend IPC) and a sibling copy
+   icon writes the URL to the clipboard. The value is constrained with
+   ellipsis so a long URL cannot crowd out the other status cells. */
+.op-status-strip__cell--server-url {
+  min-width: 0;
+}
+
+.op-status-strip__server-url-value {
+  color: var(--color-state-active);
+  cursor: pointer;
+  max-width: 28ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  outline: none;
+}
+
+.op-status-strip__server-url-value:hover,
+.op-status-strip__server-url-value:focus-visible {
+  text-decoration: underline;
+}
+
+.op-status-strip__server-url-value[data-state="copied"] {
+  color: var(--color-state-idle);
+}
+
+.op-status-strip__server-url-copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: var(--space-1);
+  padding: 0 var(--space-1);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: color-mix(in oklab, var(--color-status-strip-fg) 75%, transparent);
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
+}
+
+.op-status-strip__server-url-copy:hover,
+.op-status-strip__server-url-copy:focus-visible {
+  border-color: color-mix(in oklab, var(--color-status-strip-fg) 40%, transparent);
+  color: var(--color-status-strip-fg);
+  outline: none;
+}
+
+.op-status-strip__server-url-copy[data-state="copied"] {
+  color: var(--color-state-active);
+  border-color: color-mix(in oklab, var(--color-state-active) 60%, transparent);
+}
+
 /* ============================================================
    Canvas area — Operator overrides on existing layout
    ============================================================ */


### PR DESCRIPTION
## Summary

- GUI 起動時にサーバー URL がアプリ内で確認できない問題を解消し、ステータスバー左寄せに完全 URL セルと隣接コピーアイコンを追加。URL クリックで OS デフォルトブラウザを起動、コピーアイコンで clipboard 書き込み。
- 既存 `op-status-strip` を拡張し、backend 側は `OpenServerUrl` inbound event + `validate_server_url` (same-origin gate) + `open_url_with_os_default` (argv 直接渡し) を新設。
- Headless (`gwt serve`) の既存出力契約 (stderr `gwt browser URL: ...` / `gwt serve: press Ctrl-C to stop` / `GWT_BROWSER_URL_FILE`) は変更せず、SPEC レベルで明文化し regression test を強化。

Closes #2785

## Test plan

- [x] `cargo test -p gwt --lib` (681 PASS, +1 protocol roundtrip)
- [x] `cargo test -p gwt --bin gwt` (391 PASS, +5 validate_server_url + 2 open_server_url_events rejection)
- [x] `cargo test -p gwt-core --all-features` (6 PASS)
- [x] `cargo test -p gwt --test serve_mode_test -- --ignored` (warm cache でローカル PASS, +Ctrl-C 行 assertion + `GWT_BROWSER_URL_FILE` ファイル書き込み assertion)
- [x] `cargo clippy -p gwt --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] 手動 smoke (`target/debug/gwt serve --port 0 --no-open`): stderr 出力 + `GWT_BROWSER_URL_FILE` 書き込み + `/` HTML が URL セル要素を配信 (HTTP 200) を確認
- [ ] CI 全 jobs green
- [ ] レビュー後 develop merge
