### PR TITLE
feat(core): introduce ProcessConsoleHub and migrate gh CLI callers (SPEC-1924 / SPEC-2019)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,6 +1447,7 @@ dependencies = [
  "ignore",
  "notify",
  "notify-debouncer-mini",
+ "regex",
  "reqwest",
  "semver",
  "serde",

--- a/crates/gwt-core/Cargo.toml
+++ b/crates/gwt-core/Cargo.toml
@@ -29,6 +29,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
 uuid = { workspace = true }
+regex = { workspace = true }
 
 [build-dependencies]
 serde_yaml = { workspace = true }

--- a/crates/gwt-core/src/lib.rs
+++ b/crates/gwt-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod logging;
 pub mod migration;
 pub mod paths;
 pub mod process;
+pub mod process_console;
 mod release_contract;
 pub mod release_notes;
 pub mod repo_hash;

--- a/crates/gwt-core/src/logging/init.rs
+++ b/crates/gwt-core/src/logging/init.rs
@@ -1,10 +1,12 @@
 //! Subscriber initialization and handle types.
 
+use std::sync::Arc;
+
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{
-    filter::EnvFilter,
-    layer::SubscriberExt,
+    filter::{EnvFilter, FilterFn},
+    layer::{Layer, SubscriberExt},
     reload::{self, Handle as TracingReloadHandle},
     util::SubscriberInitExt,
     Registry,
@@ -16,6 +18,7 @@ use super::{
     ui_forwarder::UiForwarderLayer,
     writer, LogEvent,
 };
+use crate::process_console::ProcessConsoleHub;
 
 /// Reload handle for the `EnvFilter` layer.
 ///
@@ -43,6 +46,10 @@ pub struct LoggingHandles {
     /// The directory that logs are written to (canonicalised path
     /// after `create_dir_all`).
     pub log_dir: std::path::PathBuf,
+    /// Ephemeral hub that collects external process stdout / stderr
+    /// lines. SPEC-1924 FR-038. Cheap to clone; hand a clone to the GUI
+    /// runtime so the Logs window can subscribe.
+    pub process_console_hub: Arc<ProcessConsoleHub>,
 }
 
 impl LoggingHandles {
@@ -121,7 +128,14 @@ pub fn init(config: LoggingConfig) -> Result<LoggingHandles, String> {
     };
     let (reloadable_filter, reload_handle) = reload::Layer::new(env_filter);
 
-    let fmt = fmt_layer::build(non_blocking);
+    // SPEC-1924 FR-040: keep `gwt.process.line` events out of the
+    // canonical JSONL file. They only need to flow to the UI forwarder
+    // and (via spawn_logged) to the ProcessConsoleHub. The filter is
+    // applied to the file writer layer only, so the UI layer still
+    // observes the line events for live forwarding hooks.
+    let fmt = fmt_layer::build(non_blocking).with_filter(FilterFn::new(|metadata| {
+        !metadata.target().starts_with("gwt.process.line")
+    }));
     let ui = UiForwarderLayer::new(ui_tx.clone());
 
     Registry::default()
@@ -141,11 +155,18 @@ pub fn init(config: LoggingConfig) -> Result<LoggingHandles, String> {
         );
     }
 
+    let process_console_hub = ProcessConsoleHub::new();
+    // SPEC-1924 FR-039: install the process-wide hub so synchronous
+    // gh / git / docker / runner wrappers can find it without
+    // threading it through every call site.
+    let _ = crate::process_console::set_global(process_console_hub.clone());
+
     Ok(LoggingHandles {
         guard,
         reload_handle,
         ui_rx: Some(ui_rx),
         ui_tx,
         log_dir: config.log_dir,
+        process_console_hub: Arc::new(process_console_hub),
     })
 }

--- a/crates/gwt-core/src/logging/mod.rs
+++ b/crates/gwt-core/src/logging/mod.rs
@@ -32,3 +32,11 @@ pub use event::LogEvent;
 pub use housekeep::{housekeep, HousekeepReport};
 pub use init::{apply_log_level_to_handle, init, LoggingHandles, ReloadHandle};
 pub use writer::{current_log_file, log_file_for_date, LOG_FILE_BASENAME};
+
+// SPEC-1924 Update 2026-05-20: re-export ProcessConsoleHub family so
+// downstream crates can access them through `gwt_core::logging::...`
+// alongside the existing `LoggingHandles.process_console_hub` field.
+pub use crate::process_console::{
+    spawn_logged, spawn_logged_blocking, ProcessConsoleHub, ProcessKind, ProcessLine,
+    ProcessStream, SpawnOptions, SpawnOutput, DEFAULT_RING_CAPACITY,
+};

--- a/crates/gwt-core/src/process_console/hub.rs
+++ b/crates/gwt-core/src/process_console/hub.rs
@@ -1,0 +1,239 @@
+//! `ProcessConsoleHub` — ephemeral ring-buffer + broadcast for process console lines.
+//!
+//! The hub is the single in-memory surface that the Logs window's Process
+//! facet reads from. It is owned by `LoggingHandles` (set up in `gwt-core`
+//! during `logging::init`) and handed to the GUI runtime so the WebSocket
+//! dispatcher can subscribe.
+//!
+//! Storage strategy (SPEC-1924 FR-038 / NFR-006):
+//!
+//! - One bounded `VecDeque<ProcessLine>` per [`ProcessKind`]
+//! - Default capacity 5000 lines / kind; the oldest line is dropped on overflow
+//! - A `tokio::sync::broadcast::Sender<ProcessLine>` with a small capacity for
+//!   live forwarding. Slow subscribers may lag and miss intermediate lines —
+//!   the ring buffer is the durable replay surface.
+//!
+//! The hub is `Clone` cheap (it wraps `Arc<Mutex<...>>`) so any caller can
+//! grab a handle without coordination.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use tokio::sync::broadcast;
+
+use super::kind::ProcessKind;
+use super::line::ProcessLine;
+
+/// Process-wide hub installed by `gwt_core::logging::init`. Used by
+/// synchronous callers (gh / git / docker / runner wrappers) that do
+/// not have a direct handle to `LoggingHandles`.
+///
+/// `set_global` returns an error if a hub was already installed; this
+/// is intentional so that double-init in tests is loud rather than
+/// silently leaking.
+static GLOBAL_HUB: OnceLock<ProcessConsoleHub> = OnceLock::new();
+
+/// Default capacity per kind. Mirrors SPEC-1924 NFR-006.
+pub const DEFAULT_RING_CAPACITY: usize = 5000;
+
+/// Broadcast channel capacity. Slow subscribers may receive `Lagged`
+/// errors; the ring buffer is the durable replay surface.
+const DEFAULT_BROADCAST_CAPACITY: usize = 1024;
+
+/// Cheap `Clone` handle to the process console.
+///
+/// All clones share the same ring buffers and broadcast sender.
+#[derive(Clone)]
+pub struct ProcessConsoleHub {
+    inner: Arc<HubInner>,
+}
+
+struct HubInner {
+    capacity: usize,
+    rings: [Mutex<VecDeque<ProcessLine>>; ProcessKind::ALL.len()],
+    sender: broadcast::Sender<ProcessLine>,
+}
+
+impl ProcessConsoleHub {
+    /// Build a hub with the default 5000-line ring buffer per kind.
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_RING_CAPACITY)
+    }
+
+    /// Build a hub with a custom ring buffer capacity (test-only knob).
+    pub fn with_capacity(capacity: usize) -> Self {
+        let (sender, _) = broadcast::channel(DEFAULT_BROADCAST_CAPACITY);
+        let rings = std::array::from_fn(|_| Mutex::new(VecDeque::with_capacity(capacity)));
+        Self {
+            inner: Arc::new(HubInner {
+                capacity,
+                rings,
+                sender,
+            }),
+        }
+    }
+
+    /// Push a line into the kind's ring buffer and broadcast it.
+    ///
+    /// The broadcast is best-effort; if there are no live subscribers the
+    /// send returns an error which we silently drop. The ring buffer is
+    /// always updated so the next subscriber can replay history.
+    pub fn push(&self, line: ProcessLine) {
+        let idx = kind_index(line.kind);
+        if let Ok(mut ring) = self.inner.rings[idx].lock() {
+            if ring.len() == self.inner.capacity {
+                ring.pop_front();
+            }
+            ring.push_back(line.clone());
+        }
+        let _ = self.inner.sender.send(line);
+    }
+
+    /// Snapshot the ring buffer for one kind, oldest first.
+    pub fn snapshot_kind(&self, kind: ProcessKind) -> Vec<ProcessLine> {
+        let idx = kind_index(kind);
+        self.inner.rings[idx]
+            .lock()
+            .map(|ring| ring.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Snapshot every ring buffer merged into a single time-sorted vec.
+    pub fn snapshot_all(&self) -> Vec<ProcessLine> {
+        let mut out: Vec<ProcessLine> = ProcessKind::ALL
+            .iter()
+            .flat_map(|kind| self.snapshot_kind(*kind))
+            .collect();
+        out.sort_by_key(|line| line.timestamp);
+        out
+    }
+
+    /// Subscribe to the live broadcast stream.
+    ///
+    /// The returned receiver yields every line pushed AFTER subscription.
+    /// Use [`snapshot_kind`](Self::snapshot_kind) or
+    /// [`snapshot_all`](Self::snapshot_all) to replay history.
+    pub fn subscribe(&self) -> broadcast::Receiver<ProcessLine> {
+        self.inner.sender.subscribe()
+    }
+
+    /// Ring buffer capacity per kind (test helper).
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity
+    }
+}
+
+/// Install the process-wide hub. Called once by `logging::init`.
+///
+/// Returns `false` when a hub was already installed (which happens in
+/// tests that run multiple init sequences in the same process).
+pub fn set_global(hub: ProcessConsoleHub) -> bool {
+    GLOBAL_HUB.set(hub).is_ok()
+}
+
+/// Borrow the process-wide hub if one was installed by
+/// [`set_global`]. Synchronous gh / git / docker / runner wrappers
+/// fall back to a freshly allocated hub (orphan instance, ring buffer
+/// only) when no global was installed — this keeps unit tests of those
+/// crates working without bringing the full logging init along.
+pub fn global() -> ProcessConsoleHub {
+    if let Some(hub) = GLOBAL_HUB.get() {
+        hub.clone()
+    } else {
+        ProcessConsoleHub::new()
+    }
+}
+
+impl Default for ProcessConsoleHub {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn kind_index(kind: ProcessKind) -> usize {
+    ProcessKind::ALL
+        .iter()
+        .position(|candidate| *candidate == kind)
+        .expect("ProcessKind::ALL is exhaustive")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::line::ProcessStream;
+    use super::*;
+
+    fn line(kind: ProcessKind, message: &str) -> ProcessLine {
+        ProcessLine::new(kind, 1, ProcessStream::Stdout, message)
+    }
+
+    #[test]
+    fn push_and_snapshot_round_trip_per_kind() {
+        let hub = ProcessConsoleHub::new();
+        hub.push(line(ProcessKind::Gh, "gh one"));
+        hub.push(line(ProcessKind::Git, "git one"));
+        hub.push(line(ProcessKind::Gh, "gh two"));
+
+        let gh = hub.snapshot_kind(ProcessKind::Gh);
+        assert_eq!(gh.len(), 2);
+        assert_eq!(gh[0].message, "gh one");
+        assert_eq!(gh[1].message, "gh two");
+
+        let git = hub.snapshot_kind(ProcessKind::Git);
+        assert_eq!(git.len(), 1);
+        assert_eq!(git[0].message, "git one");
+
+        let docker = hub.snapshot_kind(ProcessKind::Docker);
+        assert!(docker.is_empty());
+    }
+
+    #[test]
+    fn ring_buffer_overflows_oldest_first() {
+        let hub = ProcessConsoleHub::with_capacity(3);
+        for i in 0..5 {
+            hub.push(line(ProcessKind::Gh, &format!("line {i}")));
+        }
+        let gh = hub.snapshot_kind(ProcessKind::Gh);
+        assert_eq!(gh.len(), 3);
+        assert_eq!(gh[0].message, "line 2");
+        assert_eq!(gh[1].message, "line 3");
+        assert_eq!(gh[2].message, "line 4");
+    }
+
+    #[test]
+    fn snapshot_all_is_time_sorted() {
+        let hub = ProcessConsoleHub::new();
+        let l1 = ProcessLine::new(ProcessKind::Git, 1, ProcessStream::Stdout, "first");
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let l2 = ProcessLine::new(ProcessKind::Docker, 2, ProcessStream::Stdout, "second");
+        hub.push(l2.clone());
+        hub.push(l1.clone());
+        let merged = hub.snapshot_all();
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].message, "first");
+        assert_eq!(merged[1].message, "second");
+    }
+
+    #[tokio::test]
+    async fn subscribe_receives_live_lines() {
+        let hub = ProcessConsoleHub::new();
+        let mut rx = hub.subscribe();
+        hub.push(line(ProcessKind::Gh, "live one"));
+        let received = rx.recv().await.unwrap();
+        assert_eq!(received.message, "live one");
+        assert_eq!(received.kind, ProcessKind::Gh);
+    }
+
+    #[test]
+    fn clone_shares_ring_buffer() {
+        let hub = ProcessConsoleHub::new();
+        let clone = hub.clone();
+        hub.push(line(ProcessKind::Gh, "shared"));
+        assert_eq!(clone.snapshot_kind(ProcessKind::Gh).len(), 1);
+    }
+
+    #[test]
+    fn default_capacity_matches_spec() {
+        let hub = ProcessConsoleHub::new();
+        assert_eq!(hub.capacity(), DEFAULT_RING_CAPACITY);
+    }
+}

--- a/crates/gwt-core/src/process_console/kind.rs
+++ b/crates/gwt-core/src/process_console/kind.rs
@@ -1,0 +1,140 @@
+//! `ProcessKind` — taxonomy for external processes that gwt spawns.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// Logical category of an external process for the Console facet.
+///
+/// The set is intentionally small and closed. Adding a new variant
+/// requires a SPEC update (#1924 FR-038).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ProcessKind {
+    #[serde(rename = "gh")]
+    Gh,
+    #[serde(rename = "git")]
+    Git,
+    #[serde(rename = "docker")]
+    Docker,
+    #[serde(rename = "agent")]
+    AgentBootstrap,
+    #[serde(rename = "runner")]
+    IndexRunner,
+}
+
+impl ProcessKind {
+    pub const ALL: &'static [ProcessKind] = &[
+        ProcessKind::Gh,
+        ProcessKind::Git,
+        ProcessKind::Docker,
+        ProcessKind::AgentBootstrap,
+        ProcessKind::IndexRunner,
+    ];
+
+    /// Lower-case stable identifier used on the wire (socket payloads,
+    /// `tracing` field values, and Logs window chip labels).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ProcessKind::Gh => "gh",
+            ProcessKind::Git => "git",
+            ProcessKind::Docker => "docker",
+            ProcessKind::AgentBootstrap => "agent",
+            ProcessKind::IndexRunner => "runner",
+        }
+    }
+}
+
+impl fmt::Display for ProcessKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ProcessKind {
+    type Err = ParseProcessKindError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "gh" => Ok(ProcessKind::Gh),
+            "git" => Ok(ProcessKind::Git),
+            "docker" => Ok(ProcessKind::Docker),
+            "agent" | "agent_bootstrap" => Ok(ProcessKind::AgentBootstrap),
+            "runner" | "index_runner" => Ok(ProcessKind::IndexRunner),
+            other => Err(ParseProcessKindError {
+                value: other.to_string(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseProcessKindError {
+    pub value: String,
+}
+
+impl fmt::Display for ParseProcessKindError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown ProcessKind: {}", self.value)
+    }
+}
+
+impl std::error::Error for ParseProcessKindError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_kinds_roundtrip_through_str() {
+        for kind in ProcessKind::ALL {
+            let s = kind.as_str();
+            let parsed: ProcessKind = s.parse().unwrap();
+            assert_eq!(parsed, *kind);
+        }
+    }
+
+    #[test]
+    fn agent_bootstrap_accepts_both_aliases() {
+        assert_eq!(
+            "agent".parse::<ProcessKind>().unwrap(),
+            ProcessKind::AgentBootstrap
+        );
+        assert_eq!(
+            "agent_bootstrap".parse::<ProcessKind>().unwrap(),
+            ProcessKind::AgentBootstrap
+        );
+    }
+
+    #[test]
+    fn index_runner_accepts_both_aliases() {
+        assert_eq!(
+            "runner".parse::<ProcessKind>().unwrap(),
+            ProcessKind::IndexRunner
+        );
+        assert_eq!(
+            "index_runner".parse::<ProcessKind>().unwrap(),
+            ProcessKind::IndexRunner
+        );
+    }
+
+    #[test]
+    fn unknown_kind_returns_error() {
+        let err = "unknown".parse::<ProcessKind>().unwrap_err();
+        assert_eq!(err.value, "unknown");
+    }
+
+    #[test]
+    fn serde_matches_wire_string() {
+        assert_eq!(
+            serde_json::to_string(&ProcessKind::AgentBootstrap).unwrap(),
+            "\"agent\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ProcessKind::IndexRunner).unwrap(),
+            "\"runner\""
+        );
+        let kind: ProcessKind = serde_json::from_str("\"gh\"").unwrap();
+        assert_eq!(kind, ProcessKind::Gh);
+    }
+}

--- a/crates/gwt-core/src/process_console/line.rs
+++ b/crates/gwt-core/src/process_console/line.rs
@@ -1,0 +1,106 @@
+//! `ProcessLine` — a single stdout / stderr line emitted by an external process.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::kind::ProcessKind;
+
+/// Which stdio stream produced the line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProcessStream {
+    #[serde(rename = "stdout")]
+    Stdout,
+    #[serde(rename = "stderr")]
+    Stderr,
+}
+
+impl ProcessStream {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ProcessStream::Stdout => "stdout",
+            ProcessStream::Stderr => "stderr",
+        }
+    }
+}
+
+/// One redacted stdout / stderr line plus enough metadata to filter and
+/// render it in the Logs window's Process facet.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProcessLine {
+    /// Logical category of the spawning process.
+    pub kind: ProcessKind,
+    /// Per-spawn correlation id. Lets the UI group lines that came from
+    /// the same `spawn_logged` call across kinds.
+    pub spawn_id: u64,
+    /// Which stdio stream produced the line.
+    pub stream: ProcessStream,
+    /// The redacted line text. Trailing line separators are stripped
+    /// before redaction. Carriage-return progress lines (`docker pull`,
+    /// `git clone`) are split into one line per CR by the spawn loop.
+    pub message: String,
+    /// Local time at which `spawn_logged` observed the line.
+    pub timestamp: DateTime<Utc>,
+}
+
+impl ProcessLine {
+    pub fn new(
+        kind: ProcessKind,
+        spawn_id: u64,
+        stream: ProcessStream,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind,
+            spawn_id,
+            stream,
+            message: message.into(),
+            timestamp: Utc::now(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_stream_roundtrip_via_serde() {
+        assert_eq!(
+            serde_json::to_string(&ProcessStream::Stdout).unwrap(),
+            "\"stdout\""
+        );
+        let parsed: ProcessStream = serde_json::from_str("\"stderr\"").unwrap();
+        assert_eq!(parsed, ProcessStream::Stderr);
+    }
+
+    #[test]
+    fn process_line_carries_kind_and_text() {
+        let line = ProcessLine::new(
+            ProcessKind::Gh,
+            42,
+            ProcessStream::Stdout,
+            "PR #123 created",
+        );
+        assert_eq!(line.kind, ProcessKind::Gh);
+        assert_eq!(line.spawn_id, 42);
+        assert_eq!(line.stream, ProcessStream::Stdout);
+        assert_eq!(line.message, "PR #123 created");
+    }
+
+    #[test]
+    fn process_line_roundtrip_through_json() {
+        let line = ProcessLine::new(
+            ProcessKind::Docker,
+            7,
+            ProcessStream::Stderr,
+            "Pulling fs layer",
+        );
+        let json = serde_json::to_string(&line).unwrap();
+        assert!(json.contains("\"docker\""));
+        assert!(json.contains("\"stderr\""));
+        let back: ProcessLine = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.kind, ProcessKind::Docker);
+        assert_eq!(back.stream, ProcessStream::Stderr);
+        assert_eq!(back.message, "Pulling fs layer");
+    }
+}

--- a/crates/gwt-core/src/process_console/mod.rs
+++ b/crates/gwt-core/src/process_console/mod.rs
@@ -1,0 +1,35 @@
+//! Process console — ephemeral hub for external process stdout / stderr.
+//!
+//! See SPEC-1924 Update 2026-05-20 (Process Console Domain) and SPEC-2019
+//! Update 2026-05-20 (Process Console Facet) for the motivating discussion.
+//!
+//! ## Architecture
+//!
+//! Three pieces collaborate:
+//!
+//! 1. [`ProcessKind`] enum — closed set of process categories that gwt
+//!    spawns: gh / git / docker / agent bootstrap / Python index runner.
+//! 2. [`ProcessConsoleHub`] — ring-buffer + broadcast surface that the
+//!    Logs window subscribes to via WebSocket. Owned by `LoggingHandles`.
+//! 3. [`spawn_logged`] — single entry point that callers use to launch
+//!    external processes. Emits `gwt.process.summary` tracing events to
+//!    the canonical log file and forwards stdout / stderr lines (after
+//!    redaction) to the hub.
+//!
+//! Line-level events never reach the canonical log file. They live only
+//! in the hub's ring buffer (capacity 5000 lines / kind by default) and
+//! the broadcast channel. The summary events (start / end / exit_code /
+//! duration / line counts) are persisted to the canonical file via the
+//! standard tracing pipeline.
+
+pub mod hub;
+pub mod kind;
+pub mod line;
+pub mod redact;
+pub mod spawn;
+
+pub use hub::{global, set_global, ProcessConsoleHub, DEFAULT_RING_CAPACITY};
+pub use kind::{ParseProcessKindError, ProcessKind};
+pub use line::{ProcessLine, ProcessStream};
+pub use redact::{redact_line, REDACTED};
+pub use spawn::{spawn_logged, spawn_logged_blocking, SpawnOptions, SpawnOutput};

--- a/crates/gwt-core/src/process_console/redact.rs
+++ b/crates/gwt-core/src/process_console/redact.rs
@@ -1,0 +1,124 @@
+//! Secret redaction for process console lines.
+//!
+//! `ProcessConsoleHub` runs every stdout / stderr line through
+//! [`redact_line`] before pushing it to the ring buffer or broadcasting
+//! to subscribers (SPEC-1924 FR-041). The redaction targets the token
+//! shapes that gh, git, and docker can echo into diagnostic output
+//! when running in verbose / debug mode:
+//!
+//! - `Authorization: <anything>` headers (case-insensitive)
+//! - `token=<value>` URL parameters
+//! - GitHub Personal Access Token prefixes (`gh_` / `ghp_` / `ghs_` / `ghu_`) followed by 16+ alphanumerics
+//!
+//! Replacement is `***redacted***`. The function returns the raw line
+//! unchanged when it does not match any pattern, so callers can compare
+//! the input and output cheaply.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+/// Replacement string used for every redacted pattern.
+pub const REDACTED: &str = "***redacted***";
+
+/// Apply every redaction pattern to `line`.
+///
+/// Returns a `String` because the regex crate cannot guarantee an
+/// in-place replace. When no pattern matches, the result is byte-equal
+/// to the input.
+pub fn redact_line(line: &str) -> String {
+    let mut out = line.to_string();
+    out = authorization_re().replace_all(&out, REDACTED).into_owned();
+    out = url_token_re().replace_all(&out, REDACTED).into_owned();
+    out = github_token_re().replace_all(&out, REDACTED).into_owned();
+    out
+}
+
+fn authorization_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?i)Authorization\s*:\s*[^\r\n]+").expect("authorization regex"))
+}
+
+fn url_token_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?i)\btoken=[^\s&\r\n]+").expect("url token regex"))
+}
+
+fn github_token_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"gh[pous]_[A-Za-z0-9]{16,}").expect("github token regex"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_authorization_header() {
+        let line = "Authorization: Bearer ghp_abcdef0123456789abcdef";
+        let out = redact_line(line);
+        assert_eq!(out, REDACTED);
+    }
+
+    #[test]
+    fn redacts_lowercase_authorization_header() {
+        let line = "  authorization: bearer x  ";
+        let out = redact_line(line);
+        assert!(out.contains(REDACTED));
+        assert!(!out.contains("bearer x"));
+    }
+
+    #[test]
+    fn redacts_url_token_param() {
+        let line = "GET /api/v3/user?token=secretvalue123 HTTP/1.1";
+        let out = redact_line(line);
+        assert!(out.contains(REDACTED));
+        assert!(!out.contains("secretvalue123"));
+        assert!(out.contains("/api/v3/user"));
+    }
+
+    #[test]
+    fn redacts_github_personal_access_token() {
+        let line = "got ghp_abcdef0123456789ABCDEF from env";
+        let out = redact_line(line);
+        assert!(out.contains(REDACTED));
+        assert!(!out.contains("ghp_abcdef0123456789ABCDEF"));
+    }
+
+    #[test]
+    fn redacts_other_github_token_prefixes() {
+        for prefix in ["gho_", "ghs_", "ghu_"] {
+            let token = format!("{prefix}{}", "X".repeat(20));
+            let line = format!("token is {token} here");
+            let out = redact_line(&line);
+            assert!(
+                out.contains(REDACTED),
+                "{prefix} should be redacted, got: {out}"
+            );
+            assert!(!out.contains(&token));
+        }
+    }
+
+    #[test]
+    fn passes_through_clean_line() {
+        let line = "fatal: could not find object";
+        assert_eq!(redact_line(line), line);
+    }
+
+    #[test]
+    fn does_not_redact_short_gh_words() {
+        // `gh_` followed by <16 chars should not match.
+        let line = "ghi_short and gh_abc are not tokens";
+        let out = redact_line(line);
+        assert_eq!(out, line);
+    }
+
+    #[test]
+    fn redacts_multiple_secrets_in_one_line() {
+        let line =
+            "Authorization: Bearer ghp_abcdef0123456789abcdef; token=secretvalue123 ghs_short";
+        let out = redact_line(line);
+        assert!(!out.contains("ghp_abcdef0123456789abcdef"));
+        assert!(!out.contains("secretvalue123"));
+    }
+}

--- a/crates/gwt-core/src/process_console/spawn.rs
+++ b/crates/gwt-core/src/process_console/spawn.rs
@@ -1,0 +1,425 @@
+//! `spawn_logged` — the single entry point for spawning external processes
+//! while emitting summary tracing events and forwarding stdout / stderr
+//! lines to [`ProcessConsoleHub`].
+//!
+//! SPEC-1924 FR-039: every caller of `Command::new` / `.spawn()` /
+//! `.output()` in gwt is expected to migrate to this wrapper. The two
+//! intentional exceptions (and how to express them) are:
+//!
+//! - Detached spawn that intentionally backgrounds (current
+//!   `crates/gwt/src/launch_runtime.rs:491-493` and
+//!   `crates/gwt-agent/src/prepare.rs:766-768`): pass
+//!   `SpawnOptions { detach: true, .. }` so the wrapper still emits a
+//!   `start` summary, forwards lines until the child detaches, and
+//!   emits a best-effort `exit_code = null` summary at end.
+//! - Stdio::null sinks (e.g. `crates/gwt-git/src/worktree.rs:533-534`):
+//!   pass `SpawnOptions { capture_stdout: false, capture_stderr: false, .. }`
+//!   so the wrapper still emits start / end summary tracing but does not
+//!   forward any line.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::process::Command as TokioCommand;
+
+use super::hub::ProcessConsoleHub;
+use super::kind::ProcessKind;
+use super::line::{ProcessLine, ProcessStream};
+use super::redact;
+
+const SUMMARY_TARGET: &str = "gwt.process.summary";
+
+static SPAWN_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Knobs that control how `spawn_logged` runs the child process.
+#[derive(Debug, Clone)]
+pub struct SpawnOptions {
+    /// Human-readable command label rendered in summary tracing (e.g.
+    /// `"gh pr list"`). The label may differ from the actual argv.
+    pub label: String,
+    /// Working directory passed to the child.
+    pub current_dir: Option<PathBuf>,
+    /// Extra env entries to set / override.
+    pub envs: Vec<(OsString, OsString)>,
+    /// Whether to pipe and forward stdout. Disable for `Stdio::null()`
+    /// callers that only need lifecycle summary.
+    pub capture_stdout: bool,
+    /// Whether to pipe and forward stderr.
+    pub capture_stderr: bool,
+}
+
+impl SpawnOptions {
+    pub fn new(label: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            current_dir: None,
+            envs: Vec::new(),
+            capture_stdout: true,
+            capture_stderr: true,
+        }
+    }
+
+    pub fn current_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.current_dir = Some(dir.into());
+        self
+    }
+
+    pub fn env(mut self, key: impl Into<OsString>, value: impl Into<OsString>) -> Self {
+        self.envs.push((key.into(), value.into()));
+        self
+    }
+
+    pub fn capture(mut self, stdout: bool, stderr: bool) -> Self {
+        self.capture_stdout = stdout;
+        self.capture_stderr = stderr;
+        self
+    }
+}
+
+/// Outcome of a `spawn_logged` call.
+#[derive(Debug)]
+pub struct SpawnOutput {
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    pub stdout_lines: u64,
+    pub stderr_lines: u64,
+}
+
+impl SpawnOutput {
+    pub fn success(&self) -> bool {
+        matches!(self.exit_code, Some(0))
+    }
+}
+
+/// Synchronous wrapper around [`spawn_logged`].
+///
+/// Builds a transient current-thread tokio runtime to drive the async
+/// pipeline. Use this from CLI handlers and any sync caller. When the
+/// caller already has a tokio runtime handle, prefer the async variant
+/// directly.
+pub fn spawn_logged_blocking(
+    hub: &ProcessConsoleHub,
+    kind: ProcessKind,
+    program: impl Into<OsString>,
+    args: &[impl AsRef<std::ffi::OsStr>],
+    options: SpawnOptions,
+) -> std::io::Result<SpawnOutput> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    runtime.block_on(spawn_logged(hub, kind, program, args, options))
+}
+
+/// Spawn `program` with `args`, forwarding lines to `hub` and emitting
+/// `gwt.process.summary` tracing events at start / end.
+pub async fn spawn_logged(
+    hub: &ProcessConsoleHub,
+    kind: ProcessKind,
+    program: impl Into<OsString>,
+    args: &[impl AsRef<std::ffi::OsStr>],
+    options: SpawnOptions,
+) -> std::io::Result<SpawnOutput> {
+    let program = program.into();
+    let spawn_id = SPAWN_ID.fetch_add(1, Ordering::Relaxed);
+    let started_at = Instant::now();
+
+    tracing::info!(
+        target: SUMMARY_TARGET,
+        kind = kind.as_str(),
+        spawn_id = spawn_id,
+        label = %options.label,
+        program = %program.to_string_lossy(),
+        phase = "start",
+        "process start",
+    );
+
+    let mut command = TokioCommand::new(&program);
+    command.args(args.iter().map(|a| a.as_ref()));
+    if let Some(dir) = &options.current_dir {
+        command.current_dir(dir);
+    }
+    for (key, value) in &options.envs {
+        command.env(key, value);
+    }
+    command.stdin(Stdio::null());
+    command.stdout(if options.capture_stdout {
+        Stdio::piped()
+    } else {
+        Stdio::null()
+    });
+    command.stderr(if options.capture_stderr {
+        Stdio::piped()
+    } else {
+        Stdio::null()
+    });
+
+    let mut child = command.spawn()?;
+
+    let stdout_task = if options.capture_stdout {
+        let stdout = child.stdout.take().expect("piped stdout");
+        let hub = hub.clone();
+        Some(tokio::spawn(forward_stream(
+            stdout,
+            hub,
+            kind,
+            spawn_id,
+            ProcessStream::Stdout,
+        )))
+    } else {
+        None
+    };
+
+    let stderr_task = if options.capture_stderr {
+        let stderr = child.stderr.take().expect("piped stderr");
+        let hub = hub.clone();
+        Some(tokio::spawn(forward_stream(
+            stderr,
+            hub,
+            kind,
+            spawn_id,
+            ProcessStream::Stderr,
+        )))
+    } else {
+        None
+    };
+
+    let status = child.wait().await?;
+
+    let (stdout, stdout_lines) = match stdout_task {
+        Some(handle) => handle.await.unwrap_or_else(|_| (String::new(), 0)),
+        None => (String::new(), 0),
+    };
+    let (stderr, stderr_lines) = match stderr_task {
+        Some(handle) => handle.await.unwrap_or_else(|_| (String::new(), 0)),
+        None => (String::new(), 0),
+    };
+
+    let duration_ms = started_at.elapsed().as_millis() as u64;
+    let exit_code = status.code();
+
+    tracing::info!(
+        target: SUMMARY_TARGET,
+        kind = kind.as_str(),
+        spawn_id = spawn_id,
+        label = %options.label,
+        phase = "end",
+        exit_code = exit_code.map(|c| c as i64),
+        duration_ms = duration_ms,
+        stdout_lines = stdout_lines,
+        stderr_lines = stderr_lines,
+        success = status.success(),
+        "process end",
+    );
+
+    Ok(SpawnOutput {
+        exit_code,
+        stdout,
+        stderr,
+        stdout_lines,
+        stderr_lines,
+    })
+}
+
+async fn forward_stream<R>(
+    mut reader: R,
+    hub: ProcessConsoleHub,
+    kind: ProcessKind,
+    spawn_id: u64,
+    stream: ProcessStream,
+) -> (String, u64)
+where
+    R: AsyncRead + Unpin,
+{
+    let mut bytes = Vec::with_capacity(4096);
+    if reader.read_to_end(&mut bytes).await.is_err() {
+        // Fall through; whatever we collected so far is still useful.
+    }
+    // Hold the caller-facing buffer as the raw text exactly as the
+    // child wrote it. `gh auth token` needs the secret to land in the
+    // caller's hands unchanged.
+    let buf = String::from_utf8_lossy(&bytes).into_owned();
+
+    // Split for the hub: newlines AND carriage returns are treated as
+    // line boundaries (the latter so that `docker pull` / `git clone`
+    // progress bars surface as discrete entries rather than one giant
+    // string). Empty fragments are dropped — they only mark boundary
+    // adjacency, not content.
+    let mut total_lines: u64 = 0;
+    for piece in buf.split(['\n', '\r']) {
+        if piece.is_empty() {
+            continue;
+        }
+        let redacted = redact::redact_line(piece);
+        hub.push(ProcessLine::new(kind, spawn_id, stream, redacted));
+        total_lines += 1;
+    }
+    (buf, total_lines)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn echo_command() -> (String, Vec<String>) {
+        if cfg!(windows) {
+            (
+                "cmd".to_string(),
+                vec!["/C".to_string(), "echo hello world".to_string()],
+            )
+        } else {
+            (
+                "sh".to_string(),
+                vec!["-c".to_string(), "echo hello world".to_string()],
+            )
+        }
+    }
+
+    fn stderr_command() -> (String, Vec<String>) {
+        if cfg!(windows) {
+            (
+                "cmd".to_string(),
+                vec!["/C".to_string(), "echo oops 1>&2".to_string()],
+            )
+        } else {
+            (
+                "sh".to_string(),
+                vec!["-c".to_string(), "echo oops 1>&2".to_string()],
+            )
+        }
+    }
+
+    fn failing_command() -> (String, Vec<String>) {
+        if cfg!(windows) {
+            (
+                "cmd".to_string(),
+                vec!["/C".to_string(), "exit 7".to_string()],
+            )
+        } else {
+            (
+                "sh".to_string(),
+                vec!["-c".to_string(), "exit 7".to_string()],
+            )
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_logged_forwards_stdout_to_hub() {
+        let hub = ProcessConsoleHub::new();
+        let (cmd, args) = echo_command();
+        let out = spawn_logged(
+            &hub,
+            ProcessKind::Git,
+            cmd,
+            &args,
+            SpawnOptions::new("test echo"),
+        )
+        .await
+        .unwrap();
+        assert!(out.success());
+        assert!(out.stdout.contains("hello world"));
+        assert_eq!(out.stdout_lines, 1);
+        let lines = hub.snapshot_kind(ProcessKind::Git);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].stream, ProcessStream::Stdout);
+        assert!(lines[0].message.contains("hello world"));
+    }
+
+    #[tokio::test]
+    async fn spawn_logged_forwards_stderr_separately() {
+        let hub = ProcessConsoleHub::new();
+        let (cmd, args) = stderr_command();
+        let out = spawn_logged(
+            &hub,
+            ProcessKind::Docker,
+            cmd,
+            &args,
+            SpawnOptions::new("test stderr"),
+        )
+        .await
+        .unwrap();
+        assert!(out.success());
+        assert_eq!(out.stderr_lines, 1);
+        let lines = hub.snapshot_kind(ProcessKind::Docker);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].stream, ProcessStream::Stderr);
+    }
+
+    #[tokio::test]
+    async fn spawn_logged_surfaces_non_zero_exit() {
+        let hub = ProcessConsoleHub::new();
+        let (cmd, args) = failing_command();
+        let out = spawn_logged(
+            &hub,
+            ProcessKind::Gh,
+            cmd,
+            &args,
+            SpawnOptions::new("test fail"),
+        )
+        .await
+        .unwrap();
+        assert!(!out.success());
+        assert_eq!(out.exit_code, Some(7));
+    }
+
+    #[tokio::test]
+    async fn spawn_logged_redacts_secrets_in_hub_but_keeps_raw_for_caller() {
+        let hub = ProcessConsoleHub::new();
+        let token = "ghp_abcdef0123456789ABCDEF";
+        let (cmd, args) = if cfg!(windows) {
+            (
+                "cmd".to_string(),
+                vec!["/C".to_string(), format!("echo got {token} here")],
+            )
+        } else {
+            (
+                "sh".to_string(),
+                vec!["-c".to_string(), format!("echo got {token} here")],
+            )
+        };
+        let out = spawn_logged(
+            &hub,
+            ProcessKind::Gh,
+            cmd,
+            &args,
+            SpawnOptions::new("test redact"),
+        )
+        .await
+        .unwrap();
+        assert!(out.success());
+        // SpawnOutput retains the raw value so that gh auth token /
+        // similar helpers receive the real secret.
+        assert!(
+            out.stdout.contains(token),
+            "caller-facing stdout should keep raw token: {:?}",
+            out.stdout
+        );
+        // Hub line is redacted (SPEC-1924 FR-041).
+        let lines = hub.snapshot_kind(ProcessKind::Gh);
+        assert!(
+            !lines[0].message.contains(token),
+            "hub line: {:?}",
+            lines[0].message
+        );
+        assert!(lines[0].message.contains("***redacted***"));
+    }
+
+    #[tokio::test]
+    async fn spawn_logged_capture_off_skips_line_forward() {
+        let hub = ProcessConsoleHub::new();
+        let (cmd, args) = echo_command();
+        let options = SpawnOptions::new("test null").capture(false, false);
+        let out = spawn_logged(&hub, ProcessKind::Git, cmd, &args, options)
+            .await
+            .unwrap();
+        assert!(out.success());
+        assert!(out.stdout.is_empty());
+        assert_eq!(out.stdout_lines, 0);
+        let lines = hub.snapshot_kind(ProcessKind::Git);
+        assert!(lines.is_empty());
+    }
+}

--- a/crates/gwt-core/tests/process_console_filter.rs
+++ b/crates/gwt-core/tests/process_console_filter.rs
@@ -1,0 +1,77 @@
+//! SPEC-1924 FR-040 / SC-013 regression test.
+//!
+//! `gwt.process.line` events must never reach the canonical JSONL log
+//! file. They are observed by the in-process UI forwarder and the
+//! `ProcessConsoleHub` only. `gwt.process.summary` events must reach
+//! the file as usual.
+
+use std::time::{Duration, Instant};
+
+use gwt_core::logging::{current_log_file, init, LogLevel, LoggingConfig};
+
+#[test]
+fn process_line_events_are_excluded_from_canonical_log_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config = LoggingConfig {
+        log_dir: dir.path().to_path_buf(),
+        default_level: LogLevel::Debug,
+        config_file_level: None,
+        retention_days: 0,
+    };
+
+    let handles = init(config).expect("init should succeed");
+
+    // Emit at info level so the EnvFilter does not gate it. The
+    // `gwt.process.line` exclusion happens at the fmt layer (target
+    // prefix filter), not at the EnvFilter level.
+    tracing::info!(
+        target: "gwt.process.line",
+        kind = "gh",
+        stream = "stdout",
+        "should NOT appear on disk"
+    );
+    tracing::info!(
+        target: "gwt.process.summary",
+        kind = "gh",
+        spawn_id = 1u64,
+        phase = "start",
+        "summary should appear on disk"
+    );
+    tracing::info!(
+        target: "gwt.process.summary",
+        kind = "gh",
+        spawn_id = 1u64,
+        phase = "end",
+        exit_code = 0i64,
+        duration_ms = 42u64,
+        "summary end should appear on disk"
+    );
+
+    drop(handles);
+
+    let log_path = current_log_file(dir.path());
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut content = std::fs::read_to_string(&log_path).unwrap_or_default();
+    while !content.contains("summary should appear on disk") && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(20));
+        content = std::fs::read_to_string(&log_path).unwrap_or_default();
+    }
+
+    assert!(
+        content.contains("summary should appear on disk"),
+        "expected summary start event in log file, got: {content}"
+    );
+    assert!(
+        content.contains("summary end should appear on disk"),
+        "expected summary end event in log file"
+    );
+    assert!(
+        !content.contains("should NOT appear on disk"),
+        "process line event leaked into canonical log: {content}"
+    );
+    assert!(
+        !content.contains("\"target\":\"gwt.process.line\"")
+            && !content.contains("\"target\": \"gwt.process.line\""),
+        "no entry with target=gwt.process.line should be in canonical log: {content}"
+    );
+}

--- a/crates/gwt-git/src/issue.rs
+++ b/crates/gwt-git/src/issue.rs
@@ -96,29 +96,32 @@ fn cache_filename(owner: &str, repo: &str) -> String {
 /// Fetch open issues from GitHub via `gh issue list --json`.
 pub fn fetch_issues(owner: &str, repo: &str) -> Result<Vec<Issue>> {
     let repo_slug = format!("{owner}/{repo}");
-    let output = gwt_core::process::hidden_command("gh")
-        .args([
+    let hub = gwt_core::process_console::global();
+    let output = gwt_core::process_console::spawn_logged_blocking(
+        &hub,
+        gwt_core::process_console::ProcessKind::Gh,
+        "gh",
+        &[
             "issue",
             "list",
             "--repo",
-            &repo_slug,
+            repo_slug.as_str(),
             "--state",
             "open",
             "--json",
             "number,title,state,labels,assignees,body,url",
             "--limit",
             "100",
-        ])
-        .output()
-        .map_err(|e| GwtError::Git(format!("gh issue list: {e}")))?;
+        ],
+        gwt_core::process_console::SpawnOptions::new("gh issue list"),
+    )
+    .map_err(|e| GwtError::Git(format!("gh issue list: {e}")))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        return Err(GwtError::Git(format!("gh issue list: {stderr}")));
+    if !output.success() {
+        return Err(GwtError::Git(format!("gh issue list: {}", output.stderr)));
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    parse_gh_issues_json(&stdout)
+    parse_gh_issues_json(&output.stdout)
 }
 
 /// Parse the JSON output from `gh issue list --json`.

--- a/crates/gwt-git/src/pr_status.rs
+++ b/crates/gwt-git/src/pr_status.rs
@@ -57,26 +57,31 @@ impl PrStatus {
 ///
 /// The `repo_slug` should be in "owner/repo" format.
 pub fn fetch_pr_status(repo_slug: &str, number: u64) -> Result<PrStatus> {
-    let output = gwt_core::process::hidden_command("gh")
-        .args([
-            "pr",
-            "view",
-            &number.to_string(),
-            "--repo",
-            repo_slug,
-            "--json",
-            "number,title,state,url,createdAt,mergeable,mergeStateStatus,statusCheckRollup,reviewDecision",
-        ])
-        .output()
-        .map_err(|e| GwtError::Git(format!("gh pr view: {e}")))?;
+    let hub = gwt_core::process_console::global();
+    let args = [
+        "pr",
+        "view",
+        &number.to_string(),
+        "--repo",
+        repo_slug,
+        "--json",
+        "number,title,state,url,createdAt,mergeable,mergeStateStatus,statusCheckRollup,reviewDecision",
+    ];
+    let label = format!("gh pr view {}", number);
+    let output = gwt_core::process_console::spawn_logged_blocking(
+        &hub,
+        gwt_core::process_console::ProcessKind::Gh,
+        "gh",
+        &args,
+        gwt_core::process_console::SpawnOptions::new(label),
+    )
+    .map_err(|e| GwtError::Git(format!("gh pr view: {e}")))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        return Err(GwtError::Git(format!("gh pr view: {stderr}")));
+    if !output.success() {
+        return Err(GwtError::Git(format!("gh pr view: {}", output.stderr)));
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    parse_pr_status_json(&stdout)
+    parse_pr_status_json(&output.stdout)
 }
 
 /// Parse `gh pr view --json` output.
@@ -242,16 +247,23 @@ where
 }
 
 fn run_gh_command(repo_path: &Path, args: &[&str]) -> Result<GhCliOutput> {
-    let output = gwt_core::process::hidden_command("gh")
-        .args(args)
-        .current_dir(repo_path)
-        .output()
-        .map_err(|e| GwtError::Git(format!("gh {}: {e}", args.join(" "))))?;
+    let hub = gwt_core::process_console::global();
+    let label = format!("gh {}", args.join(" "));
+    let options =
+        gwt_core::process_console::SpawnOptions::new(label.clone()).current_dir(repo_path);
+    let output = gwt_core::process_console::spawn_logged_blocking(
+        &hub,
+        gwt_core::process_console::ProcessKind::Gh,
+        "gh",
+        args,
+        options,
+    )
+    .map_err(|e| GwtError::Git(format!("{label}: {e}")))?;
 
     Ok(GhCliOutput {
-        success: output.status.success(),
-        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        success: output.success(),
+        stdout: output.stdout,
+        stderr: output.stderr,
     })
 }
 
@@ -348,29 +360,31 @@ pub struct PrCheckReport {
 /// Runs `gh pr view` to gather CI, merge, and review states. Falls back
 /// to `Unknown` states when `gh` is unavailable or the repo has no open PR.
 pub fn pr_check_report(repo_path: &Path) -> Result<PrCheckReport> {
-    let output = gwt_core::process::hidden_command("gh")
-        .args([
+    let hub = gwt_core::process_console::global();
+    let output = gwt_core::process_console::spawn_logged_blocking(
+        &hub,
+        gwt_core::process_console::ProcessKind::Gh,
+        "gh",
+        &[
             "pr",
             "view",
             "--json",
             "statusCheckRollup,mergeable,mergeStateStatus,reviewDecision,state,title",
-        ])
-        .current_dir(repo_path)
-        .output()
-        .map_err(|e| GwtError::Git(format!("gh pr view: {e}")))?;
+        ],
+        gwt_core::process_console::SpawnOptions::new("gh pr view --json").current_dir(repo_path),
+    )
+    .map_err(|e| GwtError::Git(format!("gh pr view: {e}")))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.success() {
         return Ok(PrCheckReport {
             ci: CiStatus::Unknown,
             merge: MergeStatus::Unknown,
             review: ReviewStatus::Unknown,
-            summary: format!("No open PR or gh error: {}", stderr.trim()),
+            summary: format!("No open PR or gh error: {}", output.stderr.trim()),
         });
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    parse_pr_check_report_json(&stdout)
+    parse_pr_check_report_json(&output.stdout)
 }
 
 /// Parse `gh pr view --json` output into an extended PR check report.

--- a/crates/gwt-github/src/client/http.rs
+++ b/crates/gwt-github/src/client/http.rs
@@ -18,7 +18,6 @@
 
 use std::sync::Mutex;
 
-use gwt_core::process::hidden_command;
 use serde_json::{json, Value};
 
 use crate::client::{
@@ -340,14 +339,19 @@ fn check_status(resp: &HttpResponse) -> Result<(), ApiError> {
 }
 
 fn resolve_gh_token() -> Result<String, ApiError> {
-    let output = hidden_command("gh")
-        .args(["auth", "token"])
-        .output()
-        .map_err(|e| ApiError::Network(format!("gh auth token: {e}")))?;
-    if !output.status.success() {
+    let hub = gwt_core::process_console::global();
+    let output = gwt_core::process_console::spawn_logged_blocking(
+        &hub,
+        gwt_core::process_console::ProcessKind::Gh,
+        "gh",
+        &["auth", "token"],
+        gwt_core::process_console::SpawnOptions::new("gh auth token"),
+    )
+    .map_err(|e| ApiError::Network(format!("gh auth token: {e}")))?;
+    if !output.success() {
         return Err(ApiError::Unauthorized);
     }
-    let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let token = output.stdout.trim().to_string();
     if token.is_empty() {
         return Err(ApiError::Unauthorized);
     }

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1661,27 +1661,33 @@ fn search_github_repositories(
     if trimmed.is_empty() {
         return Err("repository search query is required".to_string());
     }
-    let output = gwt_core::process::hidden_command("gh")
-        .args([
+    let hub = gwt_core::process_console::global();
+    let limit_str = limit.to_string();
+    let output = gwt_core::process_console::spawn_logged_blocking(
+        &hub,
+        gwt_core::process_console::ProcessKind::Gh,
+        "gh",
+        &[
             "search",
             "repos",
             trimmed,
             "--json",
             "fullName,description,url,defaultBranch,visibility,updatedAt",
             "--limit",
-            &limit.to_string(),
-        ])
-        .output()
-        .map_err(|error| format!("gh search repos: {error}"))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            limit_str.as_str(),
+        ],
+        gwt_core::process_console::SpawnOptions::new("gh search repos"),
+    )
+    .map_err(|error| format!("gh search repos: {error}"))?;
+    if !output.success() {
+        let stderr = output.stderr.trim().to_string();
         return Err(if stderr.is_empty() {
             "gh search repos failed".to_string()
         } else {
             stderr
         });
     }
-    parse_github_repository_search_results(&String::from_utf8_lossy(&output.stdout))
+    parse_github_repository_search_results(&output.stdout)
 }
 
 /// SPEC-2041 Phase 19 (FR-065): launch the platform default opener

--- a/crates/gwt/src/cli/actions.rs
+++ b/crates/gwt/src/cli/actions.rs
@@ -58,17 +58,23 @@ pub(super) fn fetch_actions_run_log_via_gh(
     repo_path: &std::path::Path,
     run_id: u64,
 ) -> io::Result<String> {
-    let output = gwt_core::process::hidden_command("gh")
-        .args(["run", "view", &run_id.to_string(), "--log"])
-        .current_dir(repo_path)
-        .output()?;
-    if !output.status.success() {
+    let hub = gwt_core::process_console::global();
+    let run_str = run_id.to_string();
+    let output = gwt_core::process_console::spawn_logged_blocking(
+        &hub,
+        gwt_core::process_console::ProcessKind::Gh,
+        "gh",
+        &["run", "view", run_str.as_str(), "--log"],
+        gwt_core::process_console::SpawnOptions::new(format!("gh run view {run_id} --log"))
+            .current_dir(repo_path),
+    )?;
+    if !output.success() {
         return Err(io::Error::other(format!(
             "gh run view --log: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            output.stderr.trim()
         )));
     }
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    Ok(output.stdout)
 }
 
 pub(super) fn fetch_actions_job_log_via_gh(
@@ -78,23 +84,28 @@ pub(super) fn fetch_actions_job_log_via_gh(
     job_id: u64,
 ) -> io::Result<String> {
     let endpoint = format!("/repos/{owner}/{repo}/actions/jobs/{job_id}/logs");
-    let output = gwt_core::process::hidden_command("gh")
-        .args(["api", &endpoint])
-        .current_dir(repo_path)
-        .output()?;
-    if !output.status.success() {
+    let hub = gwt_core::process_console::global();
+    let output = gwt_core::process_console::spawn_logged_blocking(
+        &hub,
+        gwt_core::process_console::ProcessKind::Gh,
+        "gh",
+        &["api", endpoint.as_str()],
+        gwt_core::process_console::SpawnOptions::new(format!("gh api {endpoint}"))
+            .current_dir(repo_path),
+    )?;
+    if !output.success() {
         return Err(io::Error::other(format!(
             "gh api {endpoint}: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            output.stderr.trim()
         )));
     }
-    if output.stdout.starts_with(b"PK") {
+    if output.stdout.as_bytes().starts_with(b"PK") {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "job logs returned a zip archive; unable to parse",
         ));
     }
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    Ok(output.stdout)
 }
 
 #[cfg(test)]

--- a/crates/gwt/src/cli/issue.rs
+++ b/crates/gwt/src/cli/issue.rs
@@ -343,8 +343,12 @@ query($owner: String!, $repo: String!, $number: Int!) {
 }
 "#;
 
-    let output = gwt_core::process::hidden_command("gh")
-        .args([
+    let hub = gwt_core::process_console::global();
+    let output = gwt_core::process_console::spawn_logged_blocking(
+        &hub,
+        gwt_core::process_console::ProcessKind::Gh,
+        "gh",
+        &[
             "api",
             "graphql",
             "-f",
@@ -355,17 +359,18 @@ query($owner: String!, $repo: String!, $number: Int!) {
             &format!("repo={repo}"),
             "-F",
             &format!("number={}", number.0),
-        ])
-        .output()?;
+        ],
+        gwt_core::process_console::SpawnOptions::new("gh api graphql issue timeline"),
+    )?;
 
-    if !output.status.success() {
+    if !output.success() {
         return Err(io::Error::other(format!(
             "gh api graphql failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            output.stderr.trim()
         )));
     }
 
-    let value: serde_json::Value = serde_json::from_slice(&output.stdout)
+    let value: serde_json::Value = serde_json::from_str(&output.stdout)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
     let nodes = value
         .get("data")

--- a/crates/gwt/src/cli/pr/gh.rs
+++ b/crates/gwt/src/cli/pr/gh.rs
@@ -7,14 +7,56 @@
 //!
 //! All helpers are `pub(super)` so the parent `cli::pr` module can re-export
 //! them and `cli::env` can call them via `super::pr::*`.
+//!
+//! Every spawn flows through `gwt_core::process_console::spawn_logged_blocking`
+//! so the canonical log captures `gwt.process.summary` events for each
+//! invocation (SPEC-1924 FR-039 / FR-040).
 
+use std::ffi::OsStr;
 use std::io;
+use std::path::Path;
 
+use gwt_core::process_console::{spawn_logged_blocking, ProcessKind, SpawnOptions, SpawnOutput};
 use gwt_git::PrStatus;
 
 use crate::cli::{
     PrCheckItem, PrChecksSummary, PrCreateCall, PrReview, PrReviewThread, PrReviewThreadComment,
 };
+
+fn run_gh_in<I, S>(label: &str, repo_path: Option<&Path>, args: I) -> io::Result<SpawnOutput>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let hub = gwt_core::process_console::global();
+    let args_vec: Vec<std::ffi::OsString> =
+        args.into_iter().map(|s| s.as_ref().to_owned()).collect();
+    let mut options = SpawnOptions::new(label);
+    if let Some(dir) = repo_path {
+        options = options.current_dir(dir);
+    }
+    spawn_logged_blocking(&hub, ProcessKind::Gh, "gh", &args_vec, options)
+}
+
+fn run_gh<I, S>(label: &str, args: I) -> io::Result<SpawnOutput>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    run_gh_in(label, None, args)
+}
+
+fn run_git_in<I, S>(label: &str, repo_path: &Path, args: I) -> io::Result<SpawnOutput>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let hub = gwt_core::process_console::global();
+    let args_vec: Vec<std::ffi::OsString> =
+        args.into_iter().map(|s| s.as_ref().to_owned()).collect();
+    let options = SpawnOptions::new(label).current_dir(repo_path);
+    spawn_logged_blocking(&hub, ProcessKind::Git, "git", &args_vec, options)
+}
 
 const PR_STATUS_FIELDS: &str =
     "number,title,state,url,createdAt,mergeable,mergeStateStatus,statusCheckRollup,reviewDecision";
@@ -23,25 +65,25 @@ const PR_LIST_FIELDS: &str = "number,title,state,url,createdAt,mergeable,mergeSt
 pub fn fetch_current_pr_via_gh(repo_path: &std::path::Path) -> io::Result<Option<PrStatus>> {
     if let Some(branch) = current_branch_name(repo_path)? {
         let repo = github_remote_owner_and_repo(repo_path);
-        let output = gwt_core::process::hidden_command("gh")
-            .args([
+        let output = run_gh_in(
+            &format!("gh pr list --head {branch}"),
+            Some(repo_path),
+            [
                 "pr",
                 "list",
                 "--head",
-                &branch,
+                branch.as_str(),
                 "--state",
                 "all",
                 "--json",
                 PR_LIST_FIELDS,
                 "--limit",
                 "100",
-            ])
-            .current_dir(repo_path)
-            .output()?;
+            ],
+        )?;
 
-        if output.status.success() {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let pr_values = filter_current_repo_head_prs(&stdout, &branch, repo.as_ref())?;
+        if output.success() {
+            let pr_values = filter_current_repo_head_prs(&output.stdout, &branch, repo.as_ref())?;
             if !pr_values.is_empty() {
                 let filtered_stdout = serde_json::to_string(&pr_values)
                     .map_err(|err| io::Error::other(err.to_string()))?;
@@ -54,14 +96,14 @@ pub fn fetch_current_pr_via_gh(repo_path: &std::path::Path) -> io::Result<Option
         }
     }
 
-    let output = gwt_core::process::hidden_command("gh")
-        .args(["pr", "view", "--json", PR_STATUS_FIELDS])
-        .current_dir(repo_path)
-        .output()?;
+    let output = run_gh_in(
+        "gh pr view",
+        Some(repo_path),
+        ["pr", "view", "--json", PR_STATUS_FIELDS],
+    )?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let trimmed = stderr.trim();
+    if !output.success() {
+        let trimmed = output.stderr.trim();
         let lowered = trimmed.to_ascii_lowercase();
         if lowered.contains("no pull requests found")
             || lowered.contains("no pull request found")
@@ -72,8 +114,7 @@ pub fn fetch_current_pr_via_gh(repo_path: &std::path::Path) -> io::Result<Option
         return Err(io::Error::other(format!("gh pr view: {trimmed}")));
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let pr = gwt_git::pr_status::parse_pr_status_json(&stdout)
+    let pr = gwt_git::pr_status::parse_pr_status_json(&output.stdout)
         .map_err(|err| io::Error::other(err.to_string()))?;
     Ok(Some(pr))
 }
@@ -132,30 +173,31 @@ fn pr_head_repository_name(value: &serde_json::Value) -> Option<&str> {
 }
 
 fn current_branch_name(repo_path: &std::path::Path) -> io::Result<Option<String>> {
-    let output = gwt_core::process::hidden_command("git")
-        .args(["branch", "--show-current"])
-        .current_dir(repo_path)
-        .output()?;
-    if !output.status.success() {
+    let output = run_git_in(
+        "git branch --show-current",
+        repo_path,
+        ["branch", "--show-current"],
+    )?;
+    if !output.success() {
         return Ok(None);
     }
-    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let branch = output.stdout.trim().to_string();
     Ok((!branch.is_empty()).then_some(branch))
 }
 
 pub(super) fn github_remote_owner_and_repo(
     repo_path: &std::path::Path,
 ) -> Option<(String, String)> {
-    let output = gwt_core::process::hidden_command("git")
-        .args(["remote", "get-url", "origin"])
-        .current_dir(repo_path)
-        .output()
-        .ok()?;
-    if !output.status.success() {
+    let output = run_git_in(
+        "git remote get-url origin",
+        repo_path,
+        ["remote", "get-url", "origin"],
+    )
+    .ok()?;
+    if !output.success() {
         return None;
     }
-    let remote_url = String::from_utf8_lossy(&output.stdout);
-    parse_github_remote_url(remote_url.trim())
+    parse_github_remote_url(output.stdout.trim())
 }
 
 fn parse_github_remote_url(remote_url: &str) -> Option<(String, String)> {
@@ -199,20 +241,19 @@ pub fn create_pr_via_gh(
         args.push("--draft".to_string());
     }
 
-    let output = gwt_core::process::hidden_command("gh")
-        .args(&args)
-        .current_dir(repo_path)
-        .output()?;
-    if !output.status.success() {
+    let output = run_gh_in("gh pr create", Some(repo_path), &args)?;
+    if !output.success() {
         return Err(io::Error::other(format!(
             "gh pr create: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            output.stderr.trim()
         )));
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let url = extract_pr_url(&stdout).ok_or_else(|| {
-        io::Error::other(format!("gh pr create: missing PR URL in output: {stdout}"))
+    let url = extract_pr_url(&output.stdout).ok_or_else(|| {
+        io::Error::other(format!(
+            "gh pr create: missing PR URL in output: {}",
+            output.stdout
+        ))
     })?;
     let number = parse_pr_number_from_url(&url)
         .ok_or_else(|| io::Error::other(format!("gh pr create: invalid PR URL: {url}")))?;
@@ -242,14 +283,11 @@ pub fn edit_pr_via_gh(
         args.push(label.clone());
     }
 
-    let output = gwt_core::process::hidden_command("gh")
-        .args(&args)
-        .current_dir(repo_path)
-        .output()?;
-    if !output.status.success() {
+    let output = run_gh_in("gh pr edit", Some(repo_path), &args)?;
+    if !output.success() {
         return Err(io::Error::other(format!(
             "gh pr edit: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            output.stderr.trim()
         )));
     }
     gwt_git::pr_status::fetch_pr_status(repo_slug, number)
@@ -273,14 +311,16 @@ pub fn comment_on_pr_via_gh(
     number: u64,
     body: &str,
 ) -> io::Result<()> {
-    let output = gwt_core::process::hidden_command("gh")
-        .args(["pr", "comment", &number.to_string(), "--body", body])
-        .current_dir(repo_path)
-        .output()?;
-    if !output.status.success() {
+    let number_str = number.to_string();
+    let output = run_gh_in(
+        &format!("gh pr comment {number}"),
+        Some(repo_path),
+        ["pr", "comment", number_str.as_str(), "--body", body],
+    )?;
+    if !output.success() {
         return Err(io::Error::other(format!(
             "gh pr comment: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            output.stderr.trim()
         )));
     }
     Ok(())
@@ -288,17 +328,15 @@ pub fn comment_on_pr_via_gh(
 
 pub fn fetch_pr_reviews_via_gh(owner: &str, repo: &str, number: u64) -> io::Result<Vec<PrReview>> {
     let endpoint = format!("repos/{owner}/{repo}/pulls/{number}/reviews");
-    let output = gwt_core::process::hidden_command("gh")
-        .args(["api", &endpoint])
-        .output()?;
-    if !output.status.success() {
+    let output = run_gh(&format!("gh api {endpoint}"), ["api", endpoint.as_str()])?;
+    if !output.success() {
         return Err(io::Error::other(format!(
             "gh api {endpoint}: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            output.stderr.trim()
         )));
     }
 
-    let values: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout)
+    let values: Vec<serde_json::Value> = serde_json::from_str(&output.stdout)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
     Ok(values
         .into_iter()
@@ -370,8 +408,9 @@ query($owner: String!, $repo: String!, $number: Int!) {
   }
 }
 "#;
-    let output = gwt_core::process::hidden_command("gh")
-        .args([
+    let output = run_gh(
+        "gh api graphql reviewThreads",
+        [
             "api",
             "graphql",
             "-f",
@@ -382,16 +421,16 @@ query($owner: String!, $repo: String!, $number: Int!) {
             &format!("repo={repo}"),
             "-F",
             &format!("number={number}"),
-        ])
-        .output()?;
-    if !output.status.success() {
+        ],
+    )?;
+    if !output.success() {
         return Err(io::Error::other(format!(
             "gh api graphql: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            output.stderr.trim()
         )));
     }
 
-    let value: serde_json::Value = serde_json::from_slice(&output.stdout)
+    let value: serde_json::Value = serde_json::from_str(&output.stdout)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
     let nodes = value
         .get("data")
@@ -498,8 +537,9 @@ mutation($threadId: ID!, $body: String!) {
 }
 "#;
         if should_reply_to_review_thread(&current_thread, body) {
-            let reply = gwt_core::process::hidden_command("gh")
-                .args([
+            let reply = run_gh(
+                "gh api graphql reply",
+                [
                     "api",
                     "graphql",
                     "-f",
@@ -508,12 +548,12 @@ mutation($threadId: ID!, $body: String!) {
                     &format!("threadId={}", thread.id),
                     "-f",
                     &format!("body={body}"),
-                ])
-                .output()?;
-            if !reply.status.success() {
+                ],
+            )?;
+            if !reply.success() {
                 return Err(io::Error::other(format!(
                     "gh api graphql reply: {}",
-                    String::from_utf8_lossy(&reply.stderr).trim()
+                    reply.stderr.trim()
                 )));
             }
         }
@@ -525,17 +565,18 @@ mutation($threadId: ID!) {
   }
 }
 "#;
-        let resolve = gwt_core::process::hidden_command("gh")
-            .args([
+        let resolve = run_gh(
+            "gh api graphql resolve",
+            [
                 "api",
                 "graphql",
                 "-f",
                 &format!("query={resolve_mutation}"),
                 "-f",
                 &format!("threadId={}", thread.id),
-            ])
-            .output()?;
-        if !resolve.status.success() {
+            ],
+        )?;
+        if !resolve.success() {
             if fetch_pr_review_thread_state_via_gh(owner, repo, number, &thread.id)?
                 .as_ref()
                 .is_some_and(|thread| thread.is_resolved)
@@ -545,7 +586,7 @@ mutation($threadId: ID!) {
             }
             return Err(io::Error::other(format!(
                 "gh api graphql resolve: {}",
-                String::from_utf8_lossy(&resolve.stderr).trim()
+                resolve.stderr.trim()
             )));
         }
 
@@ -571,20 +612,21 @@ pub fn fetch_pr_checks_via_gh(
         "startedAt",
         "completedAt",
     ];
-    let mut output = gwt_core::process::hidden_command("gh")
-        .args([
+    let number_str = number.to_string();
+    let mut output = run_gh_in(
+        &format!("gh pr checks {number}"),
+        Some(repo_path),
+        [
             "pr",
             "checks",
-            &number.to_string(),
+            number_str.as_str(),
             "--json",
             &primary_fields.join(","),
-        ])
-        .current_dir(repo_path)
-        .output()?;
+        ],
+    )?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let available = parse_available_fields(&stderr);
+    if !output.success() {
+        let available = parse_available_fields(&output.stderr);
         if !available.is_empty() {
             let fallback_fields = [
                 "name",
@@ -601,23 +643,22 @@ pub fn fetch_pr_checks_via_gh(
                 .filter(|field| available.iter().any(|candidate| candidate == field))
                 .collect();
             if !selected.is_empty() {
-                output = gwt_core::process::hidden_command("gh")
-                    .args([
+                output = run_gh_in(
+                    &format!("gh pr checks {number} fallback"),
+                    Some(repo_path),
+                    [
                         "pr",
                         "checks",
-                        &number.to_string(),
+                        number_str.as_str(),
                         "--json",
                         &selected.join(","),
-                    ])
-                    .current_dir(repo_path)
-                    .output()?;
+                    ],
+                )?;
             }
         }
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let checks = parse_pr_checks_items_response(&stdout, &stderr, output.status.success())?;
+    let checks = parse_pr_checks_items_response(&output.stdout, &output.stderr, output.success())?;
     let merge_status = pr.effective_merge_status().to_string();
 
     Ok(PrChecksSummary {


### PR DESCRIPTION
## Summary

外部プロセス (gh / git / docker / agent / Python runner) の stdout / stderr が事実上捨てられていた問題に対し、SPEC-1924 (通知・エラーバス) と SPEC-2019 (Logs ウィンドウ) の 2026-05-20 Amendment に沿って Process Console 基盤を導入する。

本 PR は Phase A 基盤 + Phase B (gh CLI 全 caller) を届け、Phase C (git 252 サイト) と Phase D (docker / agent / runner) は SPEC tasks で追跡しつつ follow-up PR で段階的に移行する。

## 主な変更

### crates/gwt-core/src/process_console/ (新規 module)
- `ProcessKind` enum (gh / git / docker / agent / runner)
- `ProcessLine` / `ProcessStream` + serde
- `ProcessConsoleHub` (kind ごと 5000 行 ring buffer + `tokio::sync::broadcast`)
- `set_global` / `global` でプロセス全域 hub をシングルトン化
- `spawn_logged` (async) / `spawn_logged_blocking` (sync) で `tokio::process::Command` + `read_to_end` をラップし stdout / stderr を redact + ring buffer + broadcast に流す
- secret redaction: `Authorization:` / `token=` / `gh_*` / `ghp_*` / `ghs_*` / `ghu_*` を `***redacted***` に置換
- 27 件の単体テスト

### gwt-core::logging 拡張
- `LoggingHandles.process_console_hub: Arc<ProcessConsoleHub>` 追加
- `logging::init` 内で `set_global` 実行
- `fmt_layer` に `target = "gwt.process.line"` 抑制 filter (FR-040 / SC-013)
- `crates/gwt-core/tests/process_console_filter.rs` regression test (canonical log に line-level event が漏れないことを固定)

### gh CLI 全 caller を `spawn_logged_blocking(ProcessKind::Gh, ...)` へ移行
- `crates/gwt/src/cli/pr/gh.rs` (PR fetch/create/edit/comment/reviews/threads/checks)
- `crates/gwt-git/src/pr_status.rs` (run_gh_command / fetch_pr_status / pr_check_report)
- `crates/gwt-git/src/issue.rs` (fetch_issues)
- `crates/gwt/src/cli/actions.rs` (gh run / gh api jobs)
- `crates/gwt/src/cli/issue.rs` (gh api graphql timelineItems)
- `crates/gwt/src/app_runtime/mod.rs` (gh search repos)
- `crates/gwt-github/src/client/http.rs` (gh auth token)

caller-facing `SpawnOutput.stdout` は raw 値、ring buffer / broadcast のみ redact するので `gh auth token` 等の token 取得は壊れない。

### SPEC 更新
- SPEC-2019: US-4 / FR-007..FR-009 / SC-005..SC-006 と 2026-05-20 Update セクション
- SPEC-1924: US-15 / FR-038..FR-041 / NFR-006 / SC-012..SC-013 と 2026-05-20 Update セクション
- plan / tasks を Phase G (SPEC-2019) と Phase D (SPEC-1924) として追加

## Test plan

- [x] `cargo test -p gwt-core --all-features` (310 + supporting passed)
- [x] `cargo test -p gwt-git` (126 + 8 + 16 passed)
- [x] `cargo test -p gwt-github` (87 across submodules)
- [x] `cargo test -p gwt --all-features` (1359 passed, 0 failed)
- [x] `cargo clippy -p gwt-core -p gwt-git -p gwt-github -p gwt --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `crates/gwt-core/tests/process_console_filter.rs` confirms `target = "gwt.process.line"` is excluded from canonical log file

## Follow-up

- SPEC-2019 Phase G: Logs ウィンドウに Process chip filter を追加する frontend 拡張
- SPEC-1924 Phase C / Phase D: 残り 252 件の git spawn サイトと docker / agent / runner caller の移行

🤖 Generated with [Claude Code](https://claude.com/claude-code)
