### PR TITLE
fix(issue-cache): detect spec issues by body header to keep refresh resilient to label loss

### DIFF
--- a/crates/gwt/src/issue_cache.rs
+++ b/crates/gwt/src/issue_cache.rs
@@ -21,6 +21,12 @@ use serde_json::Value;
 
 const DETACHED_REPO_CACHE_DIR: &str = "__detached__";
 const SPEC_LABEL: &str = "gwt-spec";
+/// Substring that uniquely identifies a SPEC body header. We do not run the
+/// full regex here because callers only need to decide whether to fetch
+/// comments — a positive substring match is enough to trigger the comment
+/// fetch path. The actual structural parse still happens later in
+/// [`gwt_github::body::SpecBody::parse`].
+const SPEC_BODY_HEADER_MARKER: &str = "<!-- gwt-spec id=";
 const ISSUE_CACHE_REFRESH_META_FILE: &str = "refresh-meta.json";
 pub const ISSUE_CACHE_TTL: Duration = Duration::from_secs(15 * 60);
 
@@ -95,11 +101,7 @@ pub fn sync_issue_cache_from_remote(repo_path: &Path, cache_root: &Path) -> Resu
 
     let cache = Cache::new(cache_root.to_path_buf());
     for listed_snapshot in &snapshots {
-        let snapshot = if listed_snapshot
-            .labels
-            .iter()
-            .any(|label| label == SPEC_LABEL)
-        {
+        let snapshot = if is_spec_issue(listed_snapshot) {
             fetch_issue_snapshot(repo_path, listed_snapshot.number)?
         } else {
             listed_snapshot.clone()
@@ -126,6 +128,18 @@ pub fn issue_cache_has_entries(cache_root: &Path) -> bool {
                 .to_str()
                 .is_some_and(|name| name.parse::<u64>().is_ok())
     })
+}
+
+/// Decide whether an Issue should be fetched as a SPEC (with comments) during
+/// `sync_issue_cache_from_remote`. The label `gwt-spec` is the primary signal,
+/// but the body header is also authoritative — without this fallback, an
+/// Issue whose `gwt-spec` label has been removed (or was never applied) but
+/// whose body still carries section markers referencing comments would be
+/// cached without those comments, and the next [`gwt_github::cache::Cache::write_snapshot`]
+/// would fail with `MissingComment`.
+fn is_spec_issue(snapshot: &IssueSnapshot) -> bool {
+    snapshot.labels.iter().any(|label| label == SPEC_LABEL)
+        || snapshot.body.contains(SPEC_BODY_HEADER_MARKER)
 }
 
 fn gh_executable() -> std::ffi::OsString {
@@ -397,7 +411,7 @@ fn parse_issue_list_snapshots(json: &str) -> Result<Vec<IssueSnapshot>, String> 
 
 #[cfg(test)]
 mod tests {
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", unix))]
     use std::env;
     use std::fs;
 
@@ -607,6 +621,84 @@ exit /b 1\r\n",
             Some(value) => env::set_var("GWT_TEST_GH", value),
             None => env::remove_var("GWT_TEST_GH"),
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sync_remote_detects_spec_via_body_header_when_label_missing() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = crate::cli::fake_gh_test_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let temp = tempdir().expect("tempdir");
+        let repo_path = temp.path().join("repo");
+        let cache_root = temp.path().join("cache");
+        fs::create_dir_all(&repo_path).expect("create repo path");
+
+        let body_escaped = "<!-- gwt-spec id=42 version=1 -->\\n\
+            <!-- sections:\\nplan=comment:777\\nspec=body\\ntasks=body\\n-->\\n\\n\
+            <!-- artifact:spec BEGIN -->\\nSpec body\\n<!-- artifact:spec END -->\\n\\n\
+            <!-- artifact:tasks BEGIN -->\\n- [ ] T-001\\n<!-- artifact:tasks END -->";
+        let list_json = format!(
+            r#"[{{"number":42,"title":"Stripped label spec","body":"{body_escaped}","labels":[],"state":"OPEN","url":"https://example.test/issues/42","updatedAt":"2026-05-20T00:00:00Z"}}]"#,
+        );
+        let view_json = format!(
+            r#"{{"number":42,"title":"Stripped label spec","body":"{body_escaped}","labels":[],"state":"OPEN","updatedAt":"2026-05-20T00:00:00Z","comments":[{{"id":"IC_kwDOTest","url":"https://github.com/example/repo/issues/42#issuecomment-777","body":"<!-- artifact:plan BEGIN -->\nPlan body for stripped\n<!-- artifact:plan END -->","createdAt":"2026-05-20T00:00:00Z"}}]}}"#,
+        );
+        let fake_gh = repo_path.join("fake-gh");
+        let script = format!(
+            "#!/bin/sh\n\
+if [ \"$1 $2\" = \"issue list\" ]; then\n\
+  cat <<'JSON'\n\
+{list_json}\n\
+JSON\n\
+  exit 0\n\
+fi\n\
+if [ \"$1 $2\" = \"issue view\" ]; then\n\
+  cat <<'JSON'\n\
+{view_json}\n\
+JSON\n\
+  exit 0\n\
+fi\n\
+echo \"unexpected gh invocation $*\" >&2\n\
+exit 1\n",
+        );
+        fs::write(&fake_gh, script).expect("write fake gh");
+        fs::set_permissions(&fake_gh, fs::Permissions::from_mode(0o755)).expect("chmod fake gh");
+
+        gwt_core::process::hidden_command("git")
+            .args(["init", "-b", "main"])
+            .current_dir(&repo_path)
+            .status()
+            .expect("git init");
+
+        let old_gh = env::var_os("GWT_TEST_GH");
+        env::set_var("GWT_TEST_GH", &fake_gh);
+
+        let result = sync_issue_cache_from_remote(&repo_path, &cache_root);
+
+        match old_gh {
+            Some(value) => env::set_var("GWT_TEST_GH", value),
+            None => env::remove_var("GWT_TEST_GH"),
+        }
+
+        result.expect("sync should succeed when body header marks the issue as a spec");
+
+        let cache = Cache::new(cache_root);
+        let entry = cache
+            .load_entry(IssueNumber(42))
+            .expect("cached entry must exist");
+        assert_eq!(
+            entry
+                .spec_body
+                .sections
+                .get(&gwt_github::SectionName("plan".to_string())),
+            Some(&"Plan body for stripped".to_string()),
+            "plan section content from comment must be present even without gwt-spec label"
+        );
+        assert_eq!(entry.snapshot.comments.len(), 1);
+        assert_eq!(entry.snapshot.comments[0].id, gwt_github::CommentId(777));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

GUI Issue ウィンドウの refresh で `write issue cache: body parse error: comment for section 'plan' (comment:<id>) not found in provided comments` が発生し、その Issue 以降の cache 更新がブロックされていた問題を修正します。`sync_issue_cache_from_remote` の SPEC 判定がラベル `gwt-spec` のみで行われていたため、ラベルが外れた（または元々無い） gwt-spec body 入り Issue で comments fetch がスキップされ、`SpecBody::parse` が `MissingComment` を返して破綻していました。

## Changes

- `crates/gwt/src/issue_cache.rs`
  - 定数 `SPEC_BODY_HEADER_MARKER` を追加（gwt-spec body header の検出用部分文字列）
  - ヘルパー `is_spec_issue(snapshot)` を追加。`labels` に `gwt-spec` を含む **または** body に `gwt-spec id=` ヘッダコメントを含む場合に `true` を返す
  - `sync_issue_cache_from_remote` 内のラベル単独判定を `is_spec_issue(listed_snapshot)` に差し替え
  - ユーザー報告と同じ `MissingComment` エラーを再現する unix 向け unit test `sync_remote_detects_spec_via_body_header_when_label_missing` を追加（fake gh で `issue list` は label 空 + body header あり、`issue view` は comments を含む形を返す）

## Testing

- `cargo test -p gwt -p gwt-github -p gwt-core --all-features` 全 PASS（新規テスト含む）
- `cargo clippy --all-targets --all-features -- -D warnings` 警告 0
- `cargo fmt --check` clean
- `bunx commitlint --from HEAD~1 --to HEAD` PASS
- gwt-verify --mode pre-pr: Overall PASS（UI / release / frontend 系の変更なし、Playwright skip）

## Closing Issues

Closes #2794

## Related Issues

- SPEC #1930 — GitHub Issue ベース SPEC 管理（body header が SPEC の identity を担う原則の根拠）

## Checklist

- [x] Conventional Commits 準拠（`fix(issue-cache): ...`）
- [x] commitlint local check PASS
- [x] 既存テスト全 PASS
- [x] バグ報告と同一エラーを再現する RED テスト → GREEN
- [x] 外科的修正（4 行核心変更 + 定数 + ヘルパー）
- [ ] CI 全 check 完走（push 後のフォロー）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved SPEC issue detection during remote synchronization with multiple identification methods to ensure consistent and reliable issue classification

* **Tests**
  * Expanded test coverage to verify SPEC issue detection behavior across different configurations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2795?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->