### PR TITLE
fix(gui): register /release-notes-window.js to unblock splash boot

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -186,6 +186,15 @@ pub fn custom_agent_env_editor_js() -> &'static str {
     include_str!("../web/custom-agent-env-editor.js")
 }
 
+// SPEC-2780 — release notes window with version selector. app.js imports this
+// via `import { createReleaseNotesWindow } from "/release-notes-window.js"` at
+// module top level. Missing this route causes the ES module load to fail and
+// the splash to hang because none of the boot wiring (mission briefing,
+// WebSocket connect, operator shell) runs.
+pub fn release_notes_window_js() -> &'static str {
+    include_str!("../web/release-notes-window.js")
+}
+
 pub const ROOT_JS_MODULE_ASSETS: &[RootJsModuleAsset] = &[
     RootJsModuleAsset {
         path: "/branch-cleanup-modal.js",
@@ -331,6 +340,11 @@ pub const ROOT_JS_MODULE_ASSETS: &[RootJsModuleAsset] = &[
         path: "/custom-agent-env-editor.js",
         source: custom_agent_env_editor_js,
         marker: "renderCustomAgentEnvEditor",
+    },
+    RootJsModuleAsset {
+        path: "/release-notes-window.js",
+        source: release_notes_window_js,
+        marker: "createReleaseNotesWindow",
     },
 ];
 
@@ -1106,6 +1120,87 @@ mod tests {
                 asset.path,
                 asset.marker,
             );
+        }
+    }
+
+    /// SPEC-2780 follow-up — every top-level `import ... from "/x.js"` in any
+    /// shipped JS module must be registered in `ROOT_JS_MODULE_ASSETS` or the
+    /// embedded server returns 404 at runtime, the ES module load aborts, and
+    /// the splash hangs because no boot wiring runs. We learned this the hard
+    /// way when `/release-notes-window.js` was added to `app.js` without a
+    /// matching route; assert here so the regression cannot recur silently.
+    #[test]
+    fn every_root_js_module_import_in_app_assets_is_registered() {
+        use std::collections::BTreeSet;
+
+        // Crawl every embedded JS source registered with the server plus
+        // `app.js` (the entrypoint) for `from "/X.js"` patterns.
+        let mut imports: BTreeSet<String> = BTreeSet::new();
+        let mut sources: Vec<(&str, &str)> = vec![("/app.js", app_js())];
+        for asset in root_js_module_assets() {
+            sources.push((asset.path, (asset.source)()));
+        }
+
+        for (origin, source) in &sources {
+            collect_root_js_imports(source, origin, &mut imports);
+        }
+
+        let registered: BTreeSet<String> = root_js_module_assets()
+            .iter()
+            .map(|asset| asset.path.to_string())
+            .collect();
+
+        let missing: Vec<String> = imports
+            .difference(&registered)
+            .filter(|path| *path != "/app.js")
+            .cloned()
+            .collect();
+
+        assert!(
+            missing.is_empty(),
+            "embedded JS modules import these paths but they are not registered \
+             in ROOT_JS_MODULE_ASSETS (will 404 at runtime and freeze splash): {:?}",
+            missing,
+        );
+    }
+
+    fn collect_root_js_imports(
+        source: &str,
+        origin: &str,
+        out: &mut std::collections::BTreeSet<String>,
+    ) {
+        // Tolerant scanner for top-level absolute-path module imports of the
+        // shape `from "/something.js"` or `from '/something.js'`. We do not
+        // need a full JS parser here; the goal is to catch obvious 404 traps.
+        for line in source.lines() {
+            let trimmed = line.trim_start();
+            if !trimmed.starts_with("import")
+                && !trimmed.starts_with("} from")
+                && !trimmed.contains(" from ")
+            {
+                continue;
+            }
+            for quote in ['"', '\''] {
+                let mut rest = line;
+                while let Some(idx) = rest.find(quote) {
+                    let after = &rest[idx + 1..];
+                    if let Some(end) = after.find(quote) {
+                        let candidate = &after[..end];
+                        if candidate.starts_with('/') && candidate.ends_with(".js") {
+                            // Ignore the entrypoint itself; app.js is served by
+                            // a dedicated handler, not via root_js_module_assets.
+                            if candidate != "/app.js" {
+                                out.insert(candidate.to_string());
+                            }
+                        }
+                        rest = &after[end + 1..];
+                    } else {
+                        break;
+                    }
+                }
+            }
+            // Suppress the unused-variable lint when no match path is taken.
+            let _ = origin;
         }
     }
 


### PR DESCRIPTION
## Summary

GUI WebView を起動するとスプラッシュ画面で固着し、Operator UI に遷移しないバグを修正します。`app.js` が ES module top-level で `import { createReleaseNotesWindow } from "/release-notes-window.js"` を要求するにも関わらず、`crates/gwt/src/embedded_web.rs::ROOT_JS_MODULE_ASSETS` に対応するルーティングが未登録だったため embedded server が 404 を返し、ES module 評価が停止して `wireMissionBriefing` を含む全 boot wiring がスキップされていました。SPEC-2780 (commit bff193e27 feat(gui): add release notes window with version selector) でルーティング登録が漏れていた回帰です。

## Changes

- `crates/gwt/src/embedded_web.rs`:
  - `release_notes_window_js()` ヘルパを追加し `include_str!("../web/release-notes-window.js")` で埋め込み配信。
  - `ROOT_JS_MODULE_ASSETS` に `path: "/release-notes-window.js" / marker: "createReleaseNotesWindow"` のエントリを追加。
- `embedded_web::tests::every_root_js_module_import_in_app_assets_is_registered` を新規追加。`app.js` および全 registered module の本文を走査して `from "/X.js"` の絶対パス import を抽出し、未登録パスが残ったら CI で失敗させる。同種のルーティング漏れを今後 silent に混入させない。

## Testing

- `cargo test -p gwt --bin gwt embedded_web` — 90 tests PASS（新規 regression guard を含む）
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings` — PASS
- `RUSTDOCFLAGS="-D warnings" cargo doc -p gwt --no-deps --document-private-items` — PASS
- `cargo fmt --all` — clean
- `bunx commitlint --from HEAD~1 --to HEAD` — PASS
- `target/debug/gwt --headless` 起動 → `curl -I /release-notes-window.js` で `HTTP/1.1 200 OK` 確認 (修正前は 404)
- Playwright で WebView にアクセス → スプラッシュ通過 → Operator UI が "Connected" 状態で完全描画されるのを確認 (修正前は splash で固着)

## Closing Issues

None

## Related Issues

- SPEC-2780 (release notes window with version selector) の routing registration 漏れリグレッション修正

## Checklist

- [x] テスト追加 (新規 regression guard) ・既存テスト PASS
- [x] clippy / fmt / rustdoc 通過
- [x] commitlint 通過 (Conventional Commits)
- [x] GUI smoke (HTTP 200 + Playwright で splash 通過確認)
- [x] 回帰防止: 今後新しい root JS module を app.js に import したら自動で CI が失敗するように

🤖 Generated with [Claude Code](https://claude.com/claude-code)
