### PR TITLE
fix(gui): register release-notes-window.js in embedded_web allow-list

### DIFF
--- a/crates/gwt/playwright/tests/release-notes-live.spec.ts
+++ b/crates/gwt/playwright/tests/release-notes-live.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * SPEC #2780 — Release Notes window live E2E.
+ *
+ * Unlike the other release-notes related tests (the gwt-core parser unit
+ * tests and the linkedom DOM tests in `crates/gwt/web/__tests__/`), this
+ * spec runs against a **live** gwt backend over a real WebSocket. It does
+ * NOT use `installEmbeddedRoutes`, because the whole point is to exercise
+ * the `open_release_notes` -> `release_notes_payload` round-trip that the
+ * embedded-route tests skip.
+ *
+ * Required environment:
+ *   GWT_PLAYWRIGHT_BASE_URL=http://127.0.0.1:<port>   # a running gwt server
+ *
+ * The spec auto-skips when the env var is missing so CI runs without
+ * a live backend stay green; the live coverage runs explicitly via
+ * the gwt-verify --mode pre-pr flow once a real server is wired up.
+ */
+import { test, expect } from "@playwright/test";
+
+const BASE = process.env.GWT_PLAYWRIGHT_BASE_URL ?? "";
+
+// `serial` because every test in this file talks to the same live backend.
+// In parallel mode the chromium-dark and chromium-light projects race against
+// each other for the modal-backdrop state and the WebSocket session, which
+// flaps the click interception logic. Sequential execution keeps the spec
+// stable while leaving the rest of `pnpm test:visual` parallel.
+test.describe.serial("Release Notes window (live backend)", () => {
+  test.skip(!BASE, "GWT_PLAYWRIGHT_BASE_URL is not set; live E2E skipped");
+
+  test.beforeEach(async ({ page }) => {
+    // The Operator splash should auto-dismiss after ~1.45s and persists a
+    // sessionStorage flag so subsequent loads skip it entirely. We pre-set
+    // the flag here so the splash is skipped from the first load.
+    //
+    // KNOWN ISSUE (filed separately): in live mode the splash currently
+    // refuses to dismiss even when the sessionStorage flag is set. While
+    // that is open, force-hide the overlay client-side so the rest of the
+    // E2E can still exercise the Release Notes flow. Remove the force-hide
+    // once the splash dismiss bug is closed.
+    await page.addInitScript(() => {
+      try {
+        window.sessionStorage.setItem("gwt:ui:briefing", "1");
+      } catch {
+        /* no-op */
+      }
+    });
+    await page.goto(BASE);
+    // KNOWN ISSUE workarounds (track in follow-up Issue):
+    //  1. Splash overlay refuses to dismiss in live mode even with the
+    //     sessionStorage flag set; force-hide it.
+    //  2. Workspace state can carry over modal backdrops (file-tree picker,
+    //     etc.) that intercept pointer events. Inject a permanent style rule
+    //     that disables `pointer-events` on every modal-backdrop so any
+    //     late-arriving modal cannot steal the click on `#app-version`.
+    await page.addStyleTag({
+      content: `.modal-backdrop, #op-briefing { display: none !important; pointer-events: none !important; }`,
+    });
+    await page.evaluate(() => {
+      const overlay = document.getElementById("op-briefing");
+      if (overlay) overlay.hidden = true;
+    });
+    await expect(page.locator("#op-briefing")).toBeHidden();
+  });
+
+  test("clicking #app-version opens the Release Notes window with current version focused", async ({
+    page,
+  }) => {
+    const label = page.locator("#app-version");
+    await expect(label).toBeVisible();
+    const labelText = (await label.textContent())?.trim() ?? "";
+    const currentVersion = labelText.replace(/^v/, "").split(" -> ")[0];
+    expect(currentVersion).toMatch(/^\d+\.\d+\.\d+$/);
+
+    await label.click();
+
+    const window = page.locator("#release-notes-window");
+    await expect(window).toBeVisible();
+    await expect(window).toHaveAttribute("role", "dialog");
+
+    const selected = window.locator(".release-notes-sidebar-item.is-selected");
+    await expect(selected).toHaveAttribute("data-version", currentVersion);
+
+    // Right pane should render the corresponding entry's H2 (`v<version>`).
+    await expect(
+      window.locator(".release-notes-content h2"),
+    ).toHaveText(`v${currentVersion}`);
+  });
+
+  test("selecting a different version in the sidebar updates the content pane", async ({
+    page,
+  }) => {
+    await page.locator("#app-version").click();
+    const window = page.locator("#release-notes-window");
+    await expect(window).toBeVisible();
+
+    const items = window.locator(".release-notes-sidebar-item");
+    // Pick the second entry so we differ from the default selection.
+    await items.nth(1).click();
+
+    const target = await items.nth(1).getAttribute("data-version");
+    expect(target).toBeTruthy();
+    await expect(
+      window.locator(".release-notes-sidebar-item.is-selected"),
+    ).toHaveAttribute("data-version", target as string);
+    await expect(
+      window.locator(".release-notes-content h2"),
+    ).toHaveText(`v${target}`);
+  });
+
+  test("close button removes the window and isOpen reflects that", async ({
+    page,
+  }) => {
+    await page.locator("#app-version").click();
+    const window = page.locator("#release-notes-window");
+    await expect(window).toBeVisible();
+    await window.locator(".release-notes-close").click();
+    await expect(window).toHaveCount(0);
+  });
+
+  test("keyboard activation (Enter on #app-version) opens the window", async ({
+    page,
+  }) => {
+    const label = page.locator("#app-version");
+    await expect(label).toBeVisible();
+    // Use locator.press so Playwright handles focus + key dispatch atomically;
+    // separate focus()+keyboard.press() races against any element that competes
+    // for focus during workspace boot.
+    await label.press("Enter");
+    await expect(page.locator("#release-notes-window")).toBeVisible();
+  });
+});

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -58,6 +58,10 @@ pub fn update_cta_js() -> &'static str {
     include_str!("../web/update-cta.js")
 }
 
+pub fn release_notes_window_js() -> &'static str {
+    include_str!("../web/release-notes-window.js")
+}
+
 pub fn terminal_context_menu_js() -> &'static str {
     include_str!("../web/terminal-context-menu.js")
 }
@@ -231,6 +235,11 @@ pub const ROOT_JS_MODULE_ASSETS: &[RootJsModuleAsset] = &[
         path: "/update-cta.js",
         source: update_cta_js,
         marker: "createUpdateCtaController",
+    },
+    RootJsModuleAsset {
+        path: "/release-notes-window.js",
+        source: release_notes_window_js,
+        marker: "createReleaseNotesWindow",
     },
     RootJsModuleAsset {
         path: "/terminal-context-menu.js",

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,40 @@
 # Lessons Learned
 
+## 2026-05-20 — Unit / Playwright snapshot tests は E2E ではない
+
+### 事象
+
+SPEC #2780 (Release Notes Window) 実装で、以下のテストが全て GREEN だった:
+
+- gwt-core release_notes::tests 12 件 PASS (parser unit)
+- protocol round-trip 5 件 PASS (serde 単体)
+- pnpm test:frontend-unit 507 件 PASS (linkedom + node:test の DOM 単体)
+- pnpm test:visual 34 件 PASS (Playwright snapshot、20 件は skip)
+- cargo clippy / fmt CLEAN
+- CI 全 13 check SUCCESS、auto-merge で v9.39.0 として release
+
+それにもかかわらず、production では **release-notes-window.js が 404 で配信されず、機能完全に死んでいた**。ユーザーが GUI を起動して確認するまで誰も気付かなかった。
+
+### 原因
+
+1. **crates/gwt/src/embedded_web.rs に新 JS module の RootJsModuleAsset エントリを追加し忘れた**。embedded server は allow-list ベースで asset を配信する設計だが、新規 web/ ファイルを追加した際に embedded_web.rs への登録が必須であることが workflow / spec / 既存テストのいずれでも強制されていなかった。
+2. **既存の Playwright spec で `GWT_PLAYWRIGHT_BASE_URL` 必須の live-mode tests (theme-toggle 等) は CI で env var が未設定のため全て skip されていた**。誰も live mode で動作確認していなかった。`pnpm test:visual` の "34 passed / 20 skipped" の "20 skipped" は全てこのカテゴリ。
+3. **Playwright snapshot tests は `installEmbeddedRoutes()` で frontend を route 経由で直接配信するため、embedded_web.rs の allow-list を経由しない**。つまり embedded server の asset routing は test されていない。
+
+### 再発防止策
+
+1. **新規 `crates/gwt/web/*.js` モジュール追加時は、必ず `crates/gwt/src/embedded_web.rs` に `RootJsModuleAsset` エントリと `pub fn <name>_js() -> &'static str` を追加する**。コンパイル時に検出できるよう、app.js の import 一覧と embedded_web.rs の RootJsModuleAsset を突き合わせる integration test を `crates/gwt/tests/embedded_web_routing_test.rs` として追加することを検討する（follow-up Issue）。
+2. **live mode E2E spec を最低 1 件は CI で実行する**。`gwt serve` を background で起動して `GWT_PLAYWRIGHT_BASE_URL` を設定する CI step を追加する（follow-up Issue）。
+3. **UI 変更を PR にする前に、`cargo run -p gwt --bin gwt` で実際に起動して manual smoke を実施する**。AGENTS.md「For UI or frontend changes, start the dev server and use the feature in a browser before reporting the task as complete」を厳守する。「Playwright tests 通った = 動く」と勘違いしない。
+4. **PR body の checklist で「目視確認はレビュアー側で実施」と書いて user に押し付けない**。テストカバレッジに穴がある場合は明示的に "I cannot verify the live UI in this environment" と書き、leaving-it-to-reviewer の責務逃れをしない。
+5. **同じ trap が広範に存在する**: `crates/gwt/web/__tests__/playwright-embedded-routes.test.mjs` は app.js の import を `installEmbeddedRoutes` の ROOT_MODULES と突き合わせるが、embedded_web.rs の RootJsModuleAsset との突き合わせは存在しない。すべての route 配信経路を相互検証する skeleton test が要る。
+
+### 検証
+
+- `crates/gwt/playwright/tests/release-notes-live.spec.ts` を新規追加 (live backend、`installEmbeddedRoutes` 不使用)。最初は 8/8 RED で embedded_web.rs の欠落と splash auto-dismiss bug を可視化。embedded_web.rs を修正後、4/4 GREEN。
+
+---
+
 ## 2026-05-20 — `gwtd issue spec create -f <body>` は section マーカーを付けない
 
 ### 事象


### PR DESCRIPTION
## Summary

- v9.39.0 でリリースされた Release Notes Window (SPEC-2780) が production で完全に死んでいた問題を修正します。`crates/gwt/web/release-notes-window.js` の embedded server allow-list (`RootJsModuleAsset`) への登録が漏れており、bundled binary が `/release-notes-window.js` で 404 を返していました。
- 同時に、unit/Playwright snapshot tests が全 GREEN で CI を通り auto-merge されたにも関わらず機能が壊れていた事実を `tasks/lessons.md` に記録し、live mode E2E spec を新規追加して同種の retraction を CI で検出できる skeleton を整えます。

## Changes

- `crates/gwt/src/embedded_web.rs`: `release_notes_window_js()` 関数と `RootJsModuleAsset { path: "/release-notes-window.js", source: release_notes_window_js, marker: "createReleaseNotesWindow" }` を `update-cta.js` の隣に追加。
- `crates/gwt/playwright/tests/release-notes-live.spec.ts` (新規): 実 `gwt serve` backend に対する live E2E spec 4 件 (click / sidebar 切替 / close / keyboard Enter)。`installEmbeddedRoutes` を使わず実 WebSocket round-trip を検証。`test.describe.serial` で chromium-dark + chromium-light を逐次実行することで race を防止。
- `tasks/lessons.md`: 「unit + Playwright snapshot tests は E2E ではない」事象、原因 (embedded_web.rs 登録漏れ + live mode tests が CI skip されていた事実)、再発防止策 (新 web/*.js 追加時の embedded_web.rs 登録強制、live mode を CI に組み込む、UI 変更後の manual smoke 必須、reviewer 責務逃れの禁止) を記録。

## Testing

- [x] `cargo build -p gwt --bin gwt --bin gwtd` — OK
- [x] `cargo clippy -p gwt --all-targets --all-features -- -D warnings` — CLEAN
- [x] `cargo fmt --check` — CLEAN
- [x] `pnpm lint:skills` — 33 SKILL.md frontmatter PASS
- [x] `curl http://127.0.0.1:<port>/release-notes-window.js` — pre-fix: 404、post-fix: **200**
- [x] Live E2E (`GWT_PLAYWRIGHT_BASE_URL=http://127.0.0.1:<port>/ pnpm exec playwright test release-notes-live.spec.ts --workers=1`) — **8 passed** (chromium-dark 4 + chromium-light 4)
- [x] 手動再現: `./target/debug/gwt serve --no-open` 起動 → ブラウザで splash を強制 dismiss → `#app-version` クリック → Release Notes window が開くことを目視確認
- [ ] CI: 自動マージワークフローに任せる

### Acceptance (post-fix の振る舞い)

| シナリオ | 検証手段 |
|---|---|
| `#app-version` クリック → Release Notes window 開く | `release-notes-live.spec.ts::clicking #app-version opens the Release Notes window` |
| sidebar で別バージョン選択 → content pane 切替 | `release-notes-live.spec.ts::selecting a different version` |
| close button → window 閉じる | `release-notes-live.spec.ts::close button removes the window` |
| Enter キーで activation | `release-notes-live.spec.ts::keyboard activation` |

## Closing Issues

- None (本 PR は SPEC-2780 の hotfix; 関連 Issue の close は releaseワークフローが main 反映時に解決)

## Related Issues / Links

- Refs SPEC-2780 (本 fix の対象 SPEC)
- Refs #2796 (Operator splash auto-dismiss bug。本 PR の E2E spec が `addStyleTag` で workaround 中、独立 fix-up が必要)
- Refs `tasks/lessons.md` 2026-05-20 entry (本回帰から得た再発防止 lesson)

## Checklist

- [x] Tests added/updated (新規 live E2E spec 4 件)
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `pnpm lint:skills`)
- [x] Documentation updated (lessons.md に詳細記録)
- [x] Migration/backfill plan — N/A (純粋な hotfix)
- [x] CHANGELOG impact considered — `fix(gui):` で patch bump

## Context

ユーザーが Release Notes window の動作確認のため `gwt serve --no-open` でサーバーを起動し、ブラウザで実機検証を試みたところ、splash が auto-dismiss されない + `#app-version` クリック後も window が出ない現象が判明。serve mode で何が serve されているかを curl で確認したところ `/release-notes-window.js` が 404、embedded_web.rs を grep して RootJsModuleAsset 登録漏れを発見しました。

unit + Playwright snapshot tests + CI 全てが GREEN だったため、私 (Claude) は merge 後の SPEC-2780 を「verified」として扱い、PR body checklist にも「目視確認はレビュアー側で実施」と書いて user に責務を押し付けていました。これは AGENTS.md の「For UI or frontend changes, start the dev server and use the feature in a browser before reporting the task as complete」に違反していました。

`installEmbeddedRoutes()` を使う Playwright snapshot tests は embedded server の routing layer を一切経由しないため、本件のような allow-list 登録漏れを構造的に検出できません。本 PR の live E2E spec はそのギャップを埋める最初の一歩です。

## Risk / Impact

- **Affected areas**: `crates/gwt/src/embedded_web.rs` への 2 行追加 (新 asset entry)、`crates/gwt/playwright/tests/` に新規 spec ファイル 1 件、`tasks/lessons.md` の追記のみ。既存 API / 既存 routing への影響なし。
- **Rollback plan**: 単 commit を revert すれば pre-fix 状態 (404 のまま) に戻る。production は既に 404 状態なので revert しても新規 regression なし。
- **Production への即時影響**: 本 fix が release されるまで、v9.39.0 ユーザーは Release Notes window を使えない。impact は中程度 (機能未利用、crash なし)。

## Notes

- splash auto-dismiss bug (#2796) を fix するまで、live E2E spec は `addStyleTag` で splash を強制 hide する workaround を含む。#2796 close 時にこの workaround も撤去する follow-up が必要。
- 同種の retraction 防止のため、follow-up Issue (未登録) で「app.js の import と embedded_web.rs の RootJsModuleAsset を突き合わせる Rust integration test」を提案する予定。
- 報告セッション: `b2c09766-54bb-42d4-a35f-7924f62aa561` (work/20260520-0019)
