### PR TITLE
fix(release): macOS / Windows / Linux の app icon を全経路で再配線する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,6 +309,7 @@ jobs:
       - name: Create app bundle
         run: |
           mkdir -p dist/GWT.app/Contents/MacOS
+          mkdir -p dist/GWT.app/Contents/Resources
           cat > dist/GWT.app/Contents/Info.plist <<EOF
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -318,6 +319,8 @@ jobs:
             <string>GWT</string>
             <key>CFBundleExecutable</key>
             <string>gwt</string>
+            <key>CFBundleIconFile</key>
+            <string>icon</string>
             <key>CFBundleIdentifier</key>
             <string>io.github.akiojin.gwt</string>
             <key>CFBundleName</key>
@@ -333,6 +336,7 @@ jobs:
           EOF
           cp dist/gwt dist/GWT.app/Contents/MacOS/gwt
           cp dist/gwtd dist/GWT.app/Contents/MacOS/gwtd
+          cp assets/icons/icon.icns dist/GWT.app/Contents/Resources/icon.icns
           chmod +x dist/GWT.app/Contents/MacOS/gwt
           chmod +x dist/GWT.app/Contents/MacOS/gwtd
       - name: Prepare macOS signing keychain

--- a/crates/gwt/Cargo.toml
+++ b/crates/gwt/Cargo.toml
@@ -63,7 +63,7 @@ libc = { workspace = true }
 [target.'cfg(target_os = "macos")'.dependencies]
 muda = "0.19"
 
-[target.'cfg(target_os = "windows")'.dependencies]
+[target.'cfg(any(target_os = "windows", target_os = "linux"))'.dependencies]
 image.workspace = true
 
 [target.'cfg(target_os = "windows")'.build-dependencies]

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -91,6 +91,8 @@ pub use managed_assets::{
     refresh_existing_managed_gwt_assets_for_worktree, refresh_managed_gwt_assets_for_agent,
     refresh_managed_gwt_assets_for_worktree,
 };
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+pub use native_app::native_window_icon;
 #[cfg(target_os = "macos")]
 pub use native_app::MacosNativeMenu;
 pub use native_app::{

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -6027,11 +6027,14 @@ fn main() -> wry::Result<()> {
     // renders into. Binding the pair in a tuple keeps the Rust ownership of
     // `Window` until the closure (and therefore the process) ends.
     let webview_surface: Option<(Window, wry::WebView)> = if serve_args.is_none() {
-        let window = WindowBuilder::new()
+        let builder = WindowBuilder::new()
             .with_title(APP_NAME)
-            .with_inner_size(tao::dpi::LogicalSize::new(1440.0, 920.0))
-            .build(&event_loop)
-            .expect("window");
+            .with_inner_size(tao::dpi::LogicalSize::new(1440.0, 920.0));
+        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        let window_icon = gwt::native_window_icon();
+        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        let builder = builder.with_window_icon(window_icon);
+        let window = builder.build(&event_loop).expect("window");
         let builder = WebViewBuilder::new().with_url(front_door.webview_url);
 
         #[cfg(any(

--- a/crates/gwt/src/native_app.rs
+++ b/crates/gwt/src/native_app.rs
@@ -51,12 +51,26 @@ pub fn native_menu_command_for_id(menu_id: &str) -> Option<NativeMenuCommand> {
     }
 }
 
-#[cfg(target_os = "windows")]
-pub fn windows_app_icon() -> Option<tao::window::Icon> {
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+pub fn native_window_icon() -> Option<tao::window::Icon> {
     let image = image::load_from_memory(include_bytes!("../../../assets/icons/icon.png")).ok()?;
     let image = image.into_rgba8();
     let (width, height) = image.dimensions();
     tao::window::Icon::from_rgba(image.into_raw(), width, height).ok()
+}
+
+#[cfg(all(test, any(target_os = "windows", target_os = "linux")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_window_icon_loads_embedded_png() {
+        let icon = native_window_icon();
+        assert!(
+            icon.is_some(),
+            "native_window_icon must decode assets/icons/icon.png at build time"
+        );
+    }
 }
 
 #[cfg(target_os = "macos")]

--- a/scripts/test_release_assets.cjs
+++ b/scripts/test_release_assets.cjs
@@ -84,6 +84,47 @@ run("release workflow packages gwtd alongside gwt", () => {
   assert.match(workflow, /Contents\/MacOS\/gwtd/);
 });
 
+run("native_window_icon wires tao window icon on Windows and Linux", () => {
+  const nativeApp = fs.readFileSync(
+    path.join(__dirname, "..", "crates", "gwt", "src", "native_app.rs"),
+    "utf8"
+  );
+  const mainRs = fs.readFileSync(
+    path.join(__dirname, "..", "crates", "gwt", "src", "main.rs"),
+    "utf8"
+  );
+  const libRs = fs.readFileSync(
+    path.join(__dirname, "..", "crates", "gwt", "src", "lib.rs"),
+    "utf8"
+  );
+
+  assert.match(
+    nativeApp,
+    /#\[cfg\(any\(target_os = "windows", target_os = "linux"\)\)\]\s*\npub fn native_window_icon\(\) -> Option<tao::window::Icon>/,
+    "native_app.rs must expose native_window_icon() for Windows and Linux"
+  );
+  assert.match(
+    nativeApp,
+    /include_bytes!\("\.\.\/\.\.\/\.\.\/assets\/icons\/icon\.png"\)/,
+    "native_window_icon must embed assets/icons/icon.png at compile time"
+  );
+  assert.match(
+    libRs,
+    /#\[cfg\(any\(target_os = "windows", target_os = "linux"\)\)\]\s*\npub use native_app::native_window_icon;/,
+    "lib.rs must re-export native_window_icon for Windows and Linux"
+  );
+  assert.match(
+    mainRs,
+    /#\[cfg\(any\(target_os = "windows", target_os = "linux"\)\)\]\s*\n\s*let window_icon = gwt::native_window_icon\(\);/,
+    "main.rs must resolve the native_window_icon for Windows and Linux"
+  );
+  assert.match(
+    mainRs,
+    /\.with_window_icon\(window_icon\)/,
+    "main.rs WindowBuilder must call .with_window_icon(window_icon) so Windows and Linux pick up the GWT icon"
+  );
+});
+
 run("macOS app bundle declares and ships the CFBundleIconFile resource", () => {
   const workflow = fs.readFileSync(
     path.join(__dirname, "..", ".github", "workflows", "release.yml"),

--- a/scripts/test_release_assets.cjs
+++ b/scripts/test_release_assets.cjs
@@ -84,6 +84,28 @@ run("release workflow packages gwtd alongside gwt", () => {
   assert.match(workflow, /Contents\/MacOS\/gwtd/);
 });
 
+run("macOS app bundle declares and ships the CFBundleIconFile resource", () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, "..", ".github", "workflows", "release.yml"),
+    "utf8"
+  );
+  assert.match(
+    workflow,
+    /<key>CFBundleIconFile<\/key>\s*\n\s*<string>icon<\/string>/,
+    "build-dmg Info.plist must declare CFBundleIconFile=icon so macOS resolves the bundle icon"
+  );
+  assert.match(
+    workflow,
+    /mkdir -p dist\/GWT\.app\/Contents\/Resources/,
+    "build-dmg must create Contents/Resources before copying icon.icns"
+  );
+  assert.match(
+    workflow,
+    /cp assets\/icons\/icon\.icns dist\/GWT\.app\/Contents\/Resources\/icon\.icns/,
+    "build-dmg must copy assets/icons/icon.icns into Contents/Resources/icon.icns"
+  );
+});
+
 run("package scripts keep the GUI front door and release contract explicit", () => {
   const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8"));
   assert.equal(pkg.bin.gwt, "bin/gwt.cjs");

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,23 @@
 # Lessons Learned
 
+## 2026-05-20 — SPEC の FR で platform scope を限定すると、サイレントな regression を生む（macOS app icon）
+
+### 事象
+
+`v9.38.0` の `/Applications/GWT.app` で Dock / Finder / `⌘Tab` の GWT アイコンが macOS デフォルトに戻っていた。`/Applications/GWT.app/Contents/Info.plist` には `CFBundleIconFile` が無く、`Contents/Resources/` も空だった。`assets/icons/icon.icns` はリポジトリに存在していたが、リリースワークフローが bundle へ wire していなかった（Issue #2799）。
+
+### 原因
+
+旧 Tauri bundler は macOS bundle / icns binding を自動で担当していた。SPEC-1776 で gwt-tauri を削除した時点でこの binding が失われたが、`.github/workflows/release.yml` の手作り `GWT.app` 生成ステップは未追加のまま。後続の SPEC #2041 FR-027 は「**Windows build は**……」と platform を限定して icon assets を再配線したため、Windows 側だけが復活し macOS 側は CI logs にも明示的なエラーが出ないまま落ちたまま継続した。FR の文言から `macOS` の文字が抜けていたことが silent regression を許した直接原因。
+
+### 再発防止策
+
+1. **FR は platform scope を limit するときに必ず明示的に列挙する**: 「Windows build は…」のように一つの platform に限定する FR を書く場合、同じ要件が他の platform でも必要かどうかをレビュー時に必ずチェックする。テンプレートに「OS scope: windows / macos / linux / all」を入れて選択漏れを防ぐ。
+2. **bundle resource を扱う変更は test_release_assets.cjs に静的検証を追加する**: release.yml が macOS bundle に `CFBundleIconFile` を書き、`Contents/Resources/icon.icns` を copy しているかは `node scripts/test_release_assets.cjs` で静的にチェックできる。`assert.match(workflow, /<key>CFBundleIconFile<\/key>\s*\n\s*<string>icon<\/string>/)` の様な regex で CI 回帰防止。
+3. **routing: バグは plain Issue で扱う**: `gwt-spec` ラベルは仕様用なので、FR scope 漏れによる regression のような bug 修正は plain Issue として登録し `gwt-fix-issue` で TDD 修正する。SPEC を再 open するのは「設計判断を伴う」場合のみに限定する（feedback memory: `feedback-spec-is-for-specifications-not-bugs`）。
+
+---
+
 ## 2026-05-20 — `gwtd issue spec create -f <body>` は section マーカーを付けない
 
 ### 事象

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -15,6 +15,7 @@
 1. **FR は platform scope を limit するときに必ず明示的に列挙する**: 「Windows build は…」のように一つの platform に限定する FR を書く場合、同じ要件が他の platform でも必要かどうかをレビュー時に必ずチェックする。テンプレートに「OS scope: windows / macos / linux / all」を入れて選択漏れを防ぐ。
 2. **bundle resource を扱う変更は test_release_assets.cjs に静的検証を追加する**: release.yml が macOS bundle に `CFBundleIconFile` を書き、`Contents/Resources/icon.icns` を copy しているかは `node scripts/test_release_assets.cjs` で静的にチェックできる。`assert.match(workflow, /<key>CFBundleIconFile<\/key>\s*\n\s*<string>icon<\/string>/)` の様な regex で CI 回帰防止。
 3. **routing: バグは plain Issue で扱う**: `gwt-spec` ラベルは仕様用なので、FR scope 漏れによる regression のような bug 修正は plain Issue として登録し `gwt-fix-issue` で TDD 修正する。SPEC を再 open するのは「設計判断を伴う」場合のみに限定する（feedback memory: `feedback-spec-is-for-specifications-not-bugs`）。
+4. **app icon は OS ごとに別経路で配線される。1 OS の修正で完結したと判断しない**: macOS は bundle `Info.plist::CFBundleIconFile` + `Contents/Resources/icon.icns`、Windows は `winresource::set_icon`（.exe 埋込）と `wix/main.wxs` の `<Icon>`（installer / Start Menu / ARP）に加えて runtime の `WindowBuilder::with_window_icon` (HWND `WM_SETICON`)、Linux は X11 / Wayland 用の `WindowBuilder::with_window_icon`。冗長に見えても各経路を独立に配線し、各 OS で table を埋めて配線抜けを目視確認する。
 
 ---
 


### PR DESCRIPTION
## Summary

GWT アプリアイコンが Dock / Finder / Alt+Tab で OS デフォルトに戻って
いた regression を、macOS / Windows / Linux の各経路で再配線する。
`gwt-tauri` 削除以降、各 OS の app icon 配線が部分的に欠けたままで、
SPEC #2041 FR-027 は Windows scope に限定されていたため macOS bundle
icon binding と各 OS の runtime tao window icon が未配線だった。

## Changes

### macOS — DMG bundle icon

- `.github/workflows/release.yml`: `build-dmg` job の `Create app bundle`
  step に `mkdir -p Contents/Resources` を追加し、Info.plist heredoc に
  `<key>CFBundleIconFile</key><string>icon</string>` を埋め込み、
  `cp assets/icons/icon.icns dist/GWT.app/Contents/Resources/icon.icns`
  で bundle に icon resource を同梱。`codesign --deep` は Resources を
  含めて再 hash するため sign / notarize / staple chain は影響なし。

### Windows / Linux — runtime tao window icon

- `crates/gwt/Cargo.toml`: `image` dependency の cfg を
  `target_os = "windows"` から
  `any(target_os = "windows", target_os = "linux")` に拡張。
- `crates/gwt/src/native_app.rs`: `windows_app_icon` を
  `native_window_icon` に rename し、cfg を上記 any に拡張。
  Windows / Linux 用の `#[cfg(test)]` ユニットテストを追加し、
  `assets/icons/icon.png` の embed → `tao::window::Icon` 復号を検証。
- `crates/gwt/src/lib.rs`: `native_window_icon` の re-export を追加。
- `crates/gwt/src/main.rs`: `WindowBuilder` chain に cfg-gated で
  `.with_window_icon(window_icon)` を追加。macOS は bundle
  CFBundleIconFile が canonical source なので tao 経路は呼ばない。

### Regression test (cross-platform)

- `scripts/test_release_assets.cjs`:
  - 「macOS app bundle declares and ships the CFBundleIconFile resource」
    — release.yml が CFBundleIconFile を書き、Contents/Resources を
    作成し、icon.icns をコピーすることを静的に検証。
  - 「native_window_icon wires tao window icon on Windows and Linux」
    — native_app.rs / lib.rs / main.rs が `native_window_icon` を
    定義・再 export・WindowBuilder に注入していることを静的に検証。

### Documentation

- `tasks/lessons.md`: 「FR の platform scope 漏れ防止」「app icon は
  OS ごとに別経路で配線されるので、1 OS の修正で完結したと判断しない」
  などの教訓を記録。

## OS coverage matrix

| OS | Surface | 配線箇所 |
|---|---|---|
| macOS | Dock / Finder / Alt+Tab (bundle icon) | release.yml `build-dmg` Create app bundle step → Info.plist `CFBundleIconFile=icon` + `Contents/Resources/icon.icns` |
| Windows | .exe icon (Explorer / taskbar pin default) | `build.rs::winresource::set_icon("assets/icons/icon.ico")` (SPEC #2041) |
| Windows | MSI installer / ARP / Start Menu shortcut | `wix/main.wxs::<Icon Id="GwtIcon.exe">` (SPEC #2041) |
| Windows | runtime HWND icon (`WM_SETICON`) | `main.rs::WindowBuilder::with_window_icon(native_window_icon())` ← **本 PR で追加** |
| Linux | runtime X11 / Wayland window icon | `main.rs::WindowBuilder::with_window_icon(native_window_icon())` ← **本 PR で追加** |

## Testing

- `bun run test:release-assets`: 17/17 PASS（新 regression test 2 件含む）
- `bun run test:release-flow`: PASS
- `bunx markdownlint-cli tasks/lessons.md`: exit 0
- `cargo fmt -- --check`: PASS
- `cargo clippy -p gwt --all-targets -- -D warnings`: PASS
- `cargo test -p gwt --lib`: 687/687 PASS
- macOS local bundle simulation:
  ```bash
  mkdir -p dist/GWT.app/Contents/{MacOS,Resources}
  # ... (updated heredoc) ...
  cp assets/icons/icon.icns dist/GWT.app/Contents/Resources/icon.icns
  plutil -extract CFBundleIconFile xml1 -o - dist/GWT.app/Contents/Info.plist
  # → <string>icon</string>
  plutil -lint dist/GWT.app/Contents/Info.plist  # → OK
  file dist/GWT.app/Contents/Resources/icon.icns # → Mac OS X icon
  ```

Windows / Linux 側の runtime icon 配線は本リポジトリの darwin host
では実機検証できないため、Rust unit test (cfg-gated) と静的解析
（test_release_assets.cjs）の 2 段で抑えている。CI の Build / Test
ジョブが Windows / Linux でも本テストを実行し、配線が崩れたら fail
する設計。

## Closing Issues

Closes #2799

## Related Issues

- SPEC #2041 (CLOSED): FR-027 で Windows 側 (winresource / wix) の
  配線を完了。本 PR は同 FR の "native window icon に接続する" 文言
  どおりに WindowBuilder への配線を実装し、さらに macOS bundle icon
  と Linux runtime icon を補う。SPEC は再 open しない（feedback
  memory: `gwt-spec` ラベルは仕様用、バグは plain Issue で扱う）。

## Risk / Impact

- 影響範囲: build-dmg job、`crates/gwt/{Cargo.toml,src/lib.rs,src/main.rs,src/native_app.rs}`、`scripts/test_release_assets.cjs`、`tasks/lessons.md`。
- macOS: bundle resource 追加 + plist key 追加。`codesign --deep` で
  再 hash されるため notarize chain は影響なし。
- Windows: `image` crate の compile が追加で発生（既に Windows
  target には依存していたためビルド影響なし）。`with_window_icon` 呼出
  は default fallback の置換であり退行リスクは限定的。
- Linux: `image` crate の compile が新規に発生。実機検証は CI Linux
  Build / Test ジョブで担保。GTK / X11 / Wayland 環境で
  `tao::window::Icon::from_rgba(...)` が失敗した場合は
  `Option<Icon>` の `None` 経路に落ちて icon 配線がないだけで、ウィン
  ドウ起動自体は止まらない。
- macOS の DMG copy-then-swap update path は `.app` 全体を差し替え
  るため、旧 bundle (icns 無し) → 新 bundle (icns 有り) への移行は
  自動。明示的 migration 不要。

## Checklist

- [x] `bun run test:release-assets` PASS (17/17)
- [x] `bun run test:release-flow` PASS
- [x] `bunx markdownlint-cli tasks/lessons.md` PASS
- [x] `cargo fmt -- --check` PASS
- [x] `cargo clippy -p gwt --all-targets -- -D warnings` PASS
- [x] `cargo test -p gwt --lib` PASS (687/687)
- [x] macOS bundle simulation: `plutil -lint` OK / CFBundleIconFile
  extract OK / icns header valid
- [x] release.yml YAML parse OK (`python3 -c yaml.safe_load`)
- [ ] CI Windows / Linux Build / Test の native_window_icon ユニット
  テストが GREEN: CI 完了待ち。
- [ ] 次回 release tag で:
  - macOS DMG マウント時に
    `/Volumes/GWT/GWT.app/Contents/Resources/icon.icns` 存在と
    Dock / Finder の icon 表示
  - Windows MSI install 後にタスクバー / Alt+Tab で GWT アイコン
  - Linux portable install 後に GNOME / KDE のタスクバーで GWT
    アイコン
  をユーザー目視で確認する。
