### PR TITLE
fix(gui): resolve embedded_web duplicate + Release Notes window CSS + cursor affordance

### DIFF
--- a/crates/gwt/playwright/tests/release-notes-live.spec.ts
+++ b/crates/gwt/playwright/tests/release-notes-live.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * SPEC #2780 — Release Notes window live E2E.
+ *
+ * Unlike the other release-notes related tests (the gwt-core parser unit
+ * tests and the linkedom DOM tests in `crates/gwt/web/__tests__/`), this
+ * spec runs against a **live** gwt backend over a real WebSocket. It does
+ * NOT use `installEmbeddedRoutes`, because the whole point is to exercise
+ * the `open_release_notes` -> `release_notes_payload` round-trip that the
+ * embedded-route tests skip.
+ *
+ * Required environment:
+ *   GWT_PLAYWRIGHT_BASE_URL=http://127.0.0.1:<port>   # a running gwt server
+ *
+ * The spec auto-skips when the env var is missing so CI runs without
+ * a live backend stay green; the live coverage runs explicitly via
+ * the gwt-verify --mode pre-pr flow once a real server is wired up.
+ */
+import { test, expect } from "@playwright/test";
+
+const BASE = process.env.GWT_PLAYWRIGHT_BASE_URL ?? "";
+
+// `serial` because every test in this file talks to the same live backend.
+// In parallel mode the chromium-dark and chromium-light projects race against
+// each other for the modal-backdrop state and the WebSocket session, which
+// flaps the click interception logic. Sequential execution keeps the spec
+// stable while leaving the rest of `pnpm test:visual` parallel.
+test.describe.serial("Release Notes window (live backend)", () => {
+  test.skip(!BASE, "GWT_PLAYWRIGHT_BASE_URL is not set; live E2E skipped");
+
+  test.beforeEach(async ({ page }) => {
+    // The Operator splash should auto-dismiss after ~1.45s and persists a
+    // sessionStorage flag so subsequent loads skip it entirely. We pre-set
+    // the flag here so the splash is skipped from the first load.
+    //
+    // KNOWN ISSUE (filed separately): in live mode the splash currently
+    // refuses to dismiss even when the sessionStorage flag is set. While
+    // that is open, force-hide the overlay client-side so the rest of the
+    // E2E can still exercise the Release Notes flow. Remove the force-hide
+    // once the splash dismiss bug is closed.
+    await page.addInitScript(() => {
+      try {
+        window.sessionStorage.setItem("gwt:ui:briefing", "1");
+      } catch {
+        /* no-op */
+      }
+    });
+    await page.goto(BASE);
+    // KNOWN ISSUE workarounds (track in follow-up Issue):
+    //  1. Splash overlay refuses to dismiss in live mode even with the
+    //     sessionStorage flag set; force-hide it.
+    //  2. Workspace state can carry over modal backdrops (file-tree picker,
+    //     etc.) that intercept pointer events. Inject a permanent style rule
+    //     that disables `pointer-events` on every modal-backdrop so any
+    //     late-arriving modal cannot steal the click on `#app-version`.
+    await page.addStyleTag({
+      content: `.modal-backdrop, #op-briefing { display: none !important; pointer-events: none !important; }`,
+    });
+    await page.evaluate(() => {
+      const overlay = document.getElementById("op-briefing");
+      if (overlay) overlay.hidden = true;
+    });
+    await expect(page.locator("#op-briefing")).toBeHidden();
+  });
+
+  test("clicking #app-version opens the Release Notes window with current version focused", async ({
+    page,
+  }) => {
+    const label = page.locator("#app-version");
+    await expect(label).toBeVisible();
+    const labelText = (await label.textContent())?.trim() ?? "";
+    const currentVersion = labelText.replace(/^v/, "").split(" -> ")[0];
+    expect(currentVersion).toMatch(/^\d+\.\d+\.\d+$/);
+
+    await label.click();
+
+    const window = page.locator("#release-notes-window");
+    await expect(window).toBeVisible();
+    await expect(window).toHaveAttribute("role", "dialog");
+
+    const selected = window.locator(".release-notes-sidebar-item.is-selected");
+    await expect(selected).toHaveAttribute("data-version", currentVersion);
+
+    // Right pane should render the corresponding entry's H2 (`v<version>`).
+    await expect(
+      window.locator(".release-notes-content h2"),
+    ).toHaveText(`v${currentVersion}`);
+  });
+
+  test("selecting a different version in the sidebar updates the content pane", async ({
+    page,
+  }) => {
+    await page.locator("#app-version").click();
+    const window = page.locator("#release-notes-window");
+    await expect(window).toBeVisible();
+
+    const items = window.locator(".release-notes-sidebar-item");
+    // Pick the second entry so we differ from the default selection.
+    await items.nth(1).click();
+
+    const target = await items.nth(1).getAttribute("data-version");
+    expect(target).toBeTruthy();
+    await expect(
+      window.locator(".release-notes-sidebar-item.is-selected"),
+    ).toHaveAttribute("data-version", target as string);
+    await expect(
+      window.locator(".release-notes-content h2"),
+    ).toHaveText(`v${target}`);
+  });
+
+  test("close button removes the window and isOpen reflects that", async ({
+    page,
+  }) => {
+    await page.locator("#app-version").click();
+    const window = page.locator("#release-notes-window");
+    await expect(window).toBeVisible();
+    await window.locator(".release-notes-close").click();
+    await expect(window).toHaveCount(0);
+  });
+
+  test("keyboard activation (Enter on #app-version) opens the window", async ({
+    page,
+  }) => {
+    const label = page.locator("#app-version");
+    await expect(label).toBeVisible();
+    // Use locator.press so Playwright handles focus + key dispatch atomically;
+    // separate focus()+keyboard.press() races against any element that competes
+    // for focus during workspace boot.
+    await label.press("Enter");
+    await expect(page.locator("#release-notes-window")).toBeVisible();
+  });
+});

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -484,9 +484,7 @@
         const label = formatVersionLabel();
         appVersionLabel.hidden = !label;
         appVersionLabel.textContent = label;
-        appVersionLabel.title = label
-          ? `${label} — click to view release notes`
-          : "";
+        appVersionLabel.title = label;
       }
 
       function setVersionState(current, latest = null) {

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1579,6 +1579,141 @@ kbd.op-kbd {
   border-color: var(--color-accent, var(--color-text-muted));
 }
 
+/* SPEC-2780 — Release Notes floating window. Without explicit fixed
+   positioning the element flows in document order and ends up below the
+   viewport when appended to document.body (observed live: y=741, mounted
+   but invisible to the user). */
+.release-notes-window {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 10050;
+  display: flex;
+  flex-direction: column;
+  width: min(880px, 92vw);
+  height: min(640px, 86vh);
+  background: var(--color-surface, #1c1f24);
+  color: var(--color-text, #e8eaed);
+  border: 1px solid var(--color-border, #3a3f47);
+  border-radius: 8px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+}
+.release-notes-window-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--color-border, #3a3f47);
+  flex: 0 0 auto;
+}
+.release-notes-window-header h1 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-muted, #aab0b8);
+}
+.release-notes-close {
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted, #aab0b8);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+.release-notes-close:hover,
+.release-notes-close:focus-visible {
+  background: var(--color-surface-elevated, #2a2e35);
+  color: var(--color-text, #e8eaed);
+}
+.release-notes-body {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.release-notes-sidebar {
+  flex: 0 0 200px;
+  border-right: 1px solid var(--color-border, #3a3f47);
+  overflow-y: auto;
+  padding: 8px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.release-notes-sidebar-item {
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-left: 3px solid transparent;
+  color: var(--color-text, #e8eaed);
+  cursor: pointer;
+  text-align: left;
+  padding: 6px 14px;
+  font: inherit;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.release-notes-sidebar-item:hover,
+.release-notes-sidebar-item:focus-visible {
+  background: var(--color-surface-elevated, #2a2e35);
+}
+.release-notes-sidebar-item.is-selected {
+  background: var(--color-surface-elevated, #2a2e35);
+  border-left-color: var(--color-accent, #7aa2f7);
+}
+.release-notes-sidebar-version {
+  font-weight: 600;
+}
+.release-notes-sidebar-date {
+  font-size: 11px;
+  color: var(--color-text-muted, #aab0b8);
+}
+.release-notes-content {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 16px 22px;
+}
+.release-notes-content h2 {
+  margin: 0 0 4px 0;
+  font-size: 18px;
+  display: inline-block;
+}
+.release-notes-version-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.release-notes-date {
+  color: var(--color-text-muted, #aab0b8);
+  font-size: 12px;
+}
+.release-notes-content h3 {
+  margin: 14px 0 6px 0;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted, #aab0b8);
+}
+.release-notes-content ul {
+  margin: 0;
+  padding-left: 20px;
+}
+.release-notes-content li {
+  margin: 2px 0;
+  line-height: 1.5;
+}
+.release-notes-empty {
+  padding: 24px;
+  color: var(--color-text-muted, #aab0b8);
+}
+
 :root[data-theme] .hint {
   color: var(--color-text-muted);
   background: color-mix(in oklab, var(--color-surface) 80%, transparent);

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1513,6 +1513,17 @@ kbd.op-kbd {
   border-color: var(--color-border);
 }
 
+/* SPEC-2780 — Release Notes window trigger affordance. The version badge
+   doubles as a button so make the cursor + hover state reflect that. */
+.app-version[role="button"] {
+  cursor: pointer;
+}
+:root[data-theme] .app-version[role="button"]:hover,
+:root[data-theme] .app-version[role="button"]:focus-visible {
+  color: var(--color-text);
+  border-color: var(--color-accent, var(--color-text-muted));
+}
+
 :root[data-theme] .hint {
   color: var(--color-text-muted);
   background: color-mix(in oklab, var(--color-surface) 80%, transparent);

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,41 @@
 # Lessons Learned
 
+## 2026-05-20 — Unit / Playwright snapshot tests は E2E ではない
+
+### 事象
+
+SPEC #2780 (Release Notes Window) 実装で、以下のテストが全て GREEN だった:
+
+- gwt-core release_notes::tests 12 件 PASS (parser unit)
+- protocol round-trip 5 件 PASS (serde 単体)
+- pnpm test:frontend-unit 507 件 PASS (linkedom + node:test の DOM 単体)
+- pnpm test:visual 34 件 PASS (Playwright snapshot、20 件は skip)
+- cargo clippy / fmt CLEAN
+- CI 全 13 check SUCCESS、auto-merge で v9.39.0 として release
+
+それにもかかわらず、production では **release-notes-window.js が 404 で配信されず、機能完全に死んでいた**。ユーザーが GUI を起動して確認するまで誰も気付かなかった。
+
+### 原因
+
+1. **crates/gwt/src/embedded_web.rs に新 JS module の RootJsModuleAsset エントリを追加し忘れた**。embedded server は allow-list ベースで asset を配信する設計だが、新規 web/ ファイルを追加した際に embedded_web.rs への登録が必須であることが workflow / spec / 既存テストのいずれでも強制されていなかった。
+2. **既存の Playwright spec で `GWT_PLAYWRIGHT_BASE_URL` 必須の live-mode tests (theme-toggle 等) は CI で env var が未設定のため全て skip されていた**。誰も live mode で動作確認していなかった。`pnpm test:visual` の "34 passed / 20 skipped" の "20 skipped" は全てこのカテゴリ。
+3. **Playwright snapshot tests は `installEmbeddedRoutes()` で frontend を route 経由で直接配信するため、embedded_web.rs の allow-list を経由しない**。つまり embedded server の asset routing は test されていない。
+
+### 再発防止策
+
+1. **新規 `crates/gwt/web/*.js` モジュール追加時は、必ず `crates/gwt/src/embedded_web.rs` に `RootJsModuleAsset` エントリと `pub fn <name>_js() -> &'static str` を追加する**。コンパイル時に検出できるよう、app.js の import 一覧と embedded_web.rs の RootJsModuleAsset を突き合わせる integration test を `crates/gwt/tests/embedded_web_routing_test.rs` として追加することを検討する（follow-up Issue）。
+2. **live mode E2E spec を最低 1 件は CI で実行する**。`gwt serve` を background で起動して `GWT_PLAYWRIGHT_BASE_URL` を設定する CI step を追加する（follow-up Issue）。
+3. **UI 変更を PR にする前に、`cargo run -p gwt --bin gwt` で実際に起動して manual smoke を実施する**。AGENTS.md「For UI or frontend changes, start the dev server and use the feature in a browser before reporting the task as complete」を厳守する。「Playwright tests 通った = 動く」と勘違いしない。
+4. **PR body の checklist で「目視確認はレビュアー側で実施」と書いて user に押し付けない**。テストカバレッジに穴がある場合は明示的に "I cannot verify the live UI in this environment" と書き、leaving-it-to-reviewer の責務逃れをしない。
+5. **同じ trap が広範に存在する**: `crates/gwt/web/__tests__/playwright-embedded-routes.test.mjs` は app.js の import を `installEmbeddedRoutes` の ROOT_MODULES と突き合わせるが、embedded_web.rs の RootJsModuleAsset との突き合わせは存在しない。すべての route 配信経路を相互検証する skeleton test が要る。
+
+### 検証
+
+- `crates/gwt/playwright/tests/release-notes-live.spec.ts` を新規追加 (live backend、`installEmbeddedRoutes` 不使用)。最初は 8/8 RED で embedded_web.rs の欠落と splash auto-dismiss bug を可視化。embedded_web.rs 修正後、8/8 GREEN (chromium-dark 4 + chromium-light 4、serial)。
+- embedded_web.rs 本体の fix は **別 agent の PR #2797** (work/20260520-0409 / cb25afc1) が canonical。並行調査していて重複検出した。PR #2797 は `every_root_js_module_import_in_app_assets_is_registered` 回帰防止 unit test を含む。私の PR #2798 は live E2E spec と本 lessons の追記のみに縮小して PR #2797 の補完に位置付けた (#2797 が merge されるまで、私の branch では embedded_web.rs を local change なしで動くことを確認する)。
+
+---
+
 ## 2026-05-20 — `gwtd issue spec create -f <body>` は section マーカーを付けない
 
 ### 事象


### PR DESCRIPTION
## Summary

PR #2797 と #2798 が parallel に develop へ merge され、`crates/gwt/src/embedded_web.rs` に **`release_notes_window_js` 関数 + `/release-notes-window.js` RootJsModuleAsset の重複定義** が残っていて develop が compile error 状態になっています。同時に SPEC-2780 の UX 問題（version label が button に見えない + Release Notes window が `position: static` で画面外に落ちる）を実機検証で発見したのでまとめて修正します。

## Changes

- `crates/gwt/src/embedded_web.rs`: 重複した `release_notes_window_js` 関数定義と RootJsModuleAsset エントリを 1 つに統合（PR #2797 の comment 付きバージョンを正本として残す）。
- `crates/gwt/web/app.js`: SPEC-2780 で追加していた `appVersionLabel.title = "${label} — click to view release notes"` ツールチップを撤去（user feedback「ツールチップは不要」）。title は label のみに戻す。
- `crates/gwt/web/styles/components.css`:
  - `.app-version[role="button"]` に `cursor: pointer` + hover / focus-visible 状態を追加（user feedback「単なるテキスト領域です」への最小 affordance）。
  - **`.release-notes-window` 一式の CSS を新規追加**: `position: fixed` で画面中央、`z-index: 10050`、sidebar / content pane / sidebar item selected / hover / empty state まで完備。それ以前は CSS 0 行で `position: static` のため document flow で画面外 (`y=741`) に落ちていた（実機 Playwright probe で確認）。
- `crates/gwt/playwright/tests/release-notes-live.spec.ts`: live backend に対する 4 tests（click / sidebar 切替 / close / keyboard Enter）。`installEmbeddedRoutes` 不使用で WebSocket round-trip を検証。
- `tasks/lessons.md`: 「unit + Playwright snapshot tests は E2E ではない」事象、原因、再発防止策を記録。

## Testing

- [x] `cargo build -p gwt --bin gwt` — OK（重複定義解消後）
- [x] live E2E `GWT_PLAYWRIGHT_BASE_URL=… pnpm exec playwright test release-notes-live.spec.ts` — 4 tests PASS (chromium-dark)
- [x] 手動 E2E: `./target/debug/gwt serve --no-open` 起動 → user がブラウザで version badge クリック → Release Notes window が画面中央に表示・sidebar で別バージョンに切替可能を確認
- [x] window 位置 probe: `{x:200, y:50, w:880, h:619, position:"fixed", zIndex:"10050"}` (1280x720 viewport で中央)
- [ ] CI: 全 matrix を auto-merge ワークフローに任せる

## Closing Issues

- None (develop の compile error 修正と SPEC-2780 の実機 UX retraction のうち最小限を含む hotfix)

## Related Issues / Links

- Refs SPEC-2780（trigger / window 表示の retraction 対象）
- Refs #2802（entry point の根本見直し: 「label を button overload するのは不味い」UX issue。本 PR は最小 affordance のみで根本見直しは別 Issue）
- Refs #2796（Operator splash auto-dismiss bug。E2E spec で workaround 中）
- PR #2797 / PR #2798（先行 merge で重複定義を生じさせた両 PR）

## Checklist

- [x] Tests added/updated（live E2E spec 4 件）
- [x] Lint/format passed（`cargo clippy`、`cargo fmt`、`pnpm lint:skills` は直前に CLEAN を確認）
- [x] Documentation updated（lessons.md に詳細記録）
- [x] Migration/backfill plan — N/A
- [x] CHANGELOG impact considered — `fix(gui):` で patch bump

## Context

ユーザーの実機検証フィードバックから 3 段階の問題を順次発見:

1. **embedded_web.rs allow-list 漏れ** (PR #2797 / 私の merged PR #2798 の embedded_web.rs 部分で対応済み)
2. **version label がボタンに見えない** (本 PR で cursor:pointer + tooltip 撤去)
3. **Release Notes window が CSS 不足で画面外に mount される** (本 PR で `.release-notes-window` の CSS を追加)

unit + Playwright snapshot tests + CI が全 GREEN だった SPEC-2780 が production v9.39.0 で完全に死んでいたという事実は、tasks/lessons.md に詳細記録済み。本 PR の live E2E spec は同種の retraction を CI で検出するための skeleton。

## Risk / Impact

- **Affected areas**: embedded_web.rs の重複解消、app.js の tooltip 行、components.css への新規 CSS 追加、Playwright 新 spec 追加、lessons.md。既存 routing / 既存テストへの後退影響なし。
- **Rollback plan**: develop が compile error 状態なので revert は実質不可。本 PR を merge することで初めて develop が compile 可能になる。
- **Production への即時影響**: 本 PR を merge して新 release が出るまで v9.39.0 ユーザーは Release Notes window を見ることができない (cursor も pointer にならない、window が出ても見えない)。
