### PR TITLE
fix(issue-cache): cache plain when SPEC body parse fails to absorb is_spec_issue regression

### DIFF
--- a/crates/gwt-github/src/cache.rs
+++ b/crates/gwt-github/src/cache.rs
@@ -153,14 +153,20 @@ impl Cache {
                 }
                 prune_unlisted_files(&sections_dir, &desired_sections)?;
             }
-            Err(ParseError::MissingHeader) => {
-                // Plain GitHub Issues share the same cache root as SPEC Issues
-                // but do not carry gwt-spec section markers. For those entries
-                // we still cache body/meta/comments and simply omit `sections/`.
+            Err(_) => {
+                // Either the body has no gwt-spec header at all (plain Issue),
+                // or it looks like a SPEC but the structural parse failed
+                // (e.g., the body contains prose / code that happens to match
+                // the gwt-spec header pattern, the sections index is malformed,
+                // or a referenced comment is missing). In all such cases the
+                // Issue cannot be safely exposed as a structured SPEC, so we
+                // persist it as a plain Issue: body and meta are cached, but
+                // no per-section files are written. A subsequent refresh that
+                // arrives with a well-formed SPEC body will rewrite the
+                // sections/ tree on the next call.
                 let desired_sections: HashSet<String> = HashSet::new();
                 prune_unlisted_files(&sections_dir, &desired_sections)?;
             }
-            Err(err) => return Err(CacheError::Parse(err)),
         }
 
         // Finally, write meta.json.
@@ -224,7 +230,13 @@ impl Cache {
             .collect();
         let spec_body = match SpecBody::parse(&snapshot.body, &parsed_comments) {
             Ok(spec_body) => spec_body,
-            Err(ParseError::MissingHeader) => SpecBody {
+            Err(_) => SpecBody {
+                // Mirror the lenient policy from `write_snapshot`: any body
+                // that fails to parse as a SPEC (no header, malformed
+                // sections index, missing referenced comment, etc.) is
+                // surfaced as a plain Issue entry rather than silently
+                // dropped. UI consumers always see the cached body and
+                // metadata; only the structured sections map is empty.
                 meta: SpecMeta {
                     id: meta.number.to_string(),
                     version: 1,
@@ -232,7 +244,6 @@ impl Cache {
                 sections_index: crate::body::SectionsIndex::default(),
                 sections: std::collections::BTreeMap::new(),
             },
-            Err(_) => return None,
         };
         Some(CacheEntry {
             snapshot,

--- a/crates/gwt-github/tests/cache_test.rs
+++ b/crates/gwt-github/tests/cache_test.rs
@@ -404,3 +404,68 @@ fn apply_phase_change_does_not_disturb_body_or_sections() {
     let spec_section = fs::read_to_string(tmp.path().join("11/sections/spec.md")).unwrap();
     assert_eq!(spec_section, "immutable spec");
 }
+
+// Regression: When an Issue body contains gwt-spec marker patterns as prose
+// or code (e.g., a plain bug Issue describing the SPEC format), the loose
+// substring detection in `gwt::issue_cache::is_spec_issue` triggers
+// `gh issue view` and ends up calling `write_snapshot` with a body whose
+// header parses but whose sections index is malformed. Previously this
+// surfaced as `body parse error: broken index map: ...` and propagated up
+// to the GUI Issue refresh. The cache must now treat such bodies as plain
+// Issues: cache body + meta, leave sections/ empty.
+#[test]
+fn write_snapshot_falls_back_to_plain_when_sections_index_is_malformed() {
+    let tmp = TempDir::new().unwrap();
+    let cache = Cache::new(tmp.path().to_path_buf());
+
+    // Body has a structurally valid gwt-spec header but the sections
+    // index is on a single line (as it would be when quoted in prose),
+    // which `parse_index_map` cannot disentangle.
+    let body = "Background:\n\
+<!-- gwt-spec id=42 version=1 -->\n\
+<!-- sections: plan=comment:777 spec=body tasks=body -->\n\
+\n\
+Rest of the body is human prose, not a real SPEC.\n"
+        .to_string();
+    let snapshot = IssueSnapshot {
+        number: IssueNumber(123),
+        title: "Plain Issue with SPEC-looking prose".into(),
+        body: body.clone(),
+        labels: vec!["bug".into()],
+        state: IssueState::Open,
+        updated_at: UpdatedAt::new("t1"),
+        comments: Vec::new(),
+    };
+
+    cache
+        .write_snapshot(&snapshot)
+        .expect("write_snapshot must succeed even when SPEC parse fails");
+
+    // Body and meta should be present and verbatim.
+    let body_on_disk = fs::read_to_string(tmp.path().join("123/body.md")).unwrap();
+    assert_eq!(body_on_disk, body);
+    assert!(tmp.path().join("123/meta.json").is_file());
+
+    // Sections directory must exist but be empty.
+    let sections_dir = tmp.path().join("123/sections");
+    assert!(sections_dir.is_dir());
+    let leftover: Vec<_> = fs::read_dir(&sections_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| !e.file_name().to_string_lossy().starts_with('.'))
+        .collect();
+    assert!(
+        leftover.is_empty(),
+        "sections/ must be empty for fallback-cached plain Issue (got: {:?})",
+        leftover.iter().map(|e| e.file_name()).collect::<Vec<_>>()
+    );
+
+    // load_entry must still surface the issue (with empty sections),
+    // not silently drop it.
+    let entry = cache
+        .load_entry(IssueNumber(123))
+        .expect("load_entry must surface a plain-fallback entry");
+    assert_eq!(entry.snapshot.number, IssueNumber(123));
+    assert_eq!(entry.snapshot.body, body);
+    assert!(entry.spec_body.sections.is_empty());
+}


### PR DESCRIPTION
## Summary

PR #2795 (Closes #2794) で導入した `is_spec_issue` の substring マッチが too loose で、body に SPEC マーカー (`<!-- gwt-spec id=`, `<!-- sections: -->`) をプロース / コードとして literal で含む **plain Issue** でも `gh issue view ... --json comments` 経路に進み、`SpecBody::parse` が `BrokenIndex` を返して GUI の Issue ウィンドウ refresh が `write issue cache: body parse error: broken index map: line 1: invalid comment id '<id> spec=body tasks=body'` で停止する regression を直します。

`Cache::write_snapshot` と `Cache::load_entry` の SPEC parse fallback を `MissingHeader` 限定から **全 parse error** に拡張し、body が SPEC 風に見えても構造的に parse できない場合は plain Issue として cache します（body verbatim / sections 空 / meta あり）。

## Changes

- `crates/gwt-github/src/cache.rs`
  - `Cache::write_snapshot` の `match SpecBody::parse(...)` を、ErrAll → plain fallback に変更（MissingHeader 限定だった graceful path を全 parse error に拡張）
  - `Cache::load_entry` も同方針: parse error 時は synthesized empty SpecBody を返し、UI が silently drop しないようにする
  - 動機・適用ケース・ロールバック条件をコメントで明文化
- `crates/gwt-github/tests/cache_test.rs`
  - 新規テスト `write_snapshot_falls_back_to_plain_when_sections_index_is_malformed`
  - 「gwt-spec header + single-line sections index (`plan=comment:777 spec=body tasks=body`)」という、ユーザー報告と同形の body で write_snapshot が成功し、body verbatim / sections 空 / load_entry が surface することを保証

## Testing

- `cargo test -p gwt -p gwt-github -p gwt-core --all-features` 全 PASS（新規 regression test 含む）
- `cargo clippy -p gwt-github --all-targets --all-features -- -D warnings` warnings 0
- `cargo fmt --check` clean
- `bunx commitlint --from HEAD~1 --to HEAD` PASS
- 手動 GUI: rebuilt binary でローカル `gwt serve` を起動し、Issue ウィンドウ refresh で `broken index map` エラーが出ないことを確認 (URL: http://127.0.0.1:60304/)

## Closing Issues

None — 本 PR は #2794 / PR #2795 で導入した regression を直接修正する fix なので、新しい owner Issue は登録しません（PR #2795 と同じ症状軸の continuation）。

## Related Issues

- #2794 (本 regression の起点となった元 bug Issue)
- PR #2795 (元 fix PR、本 PR の regression 起点)
- #2793 (副作用で GitHub に残ってしまった、body に SPEC marker を literal で含む plain Issue。本 PR の fallback により cache 経路は通るが、Issue 自体の処遇は別判断)

## Checklist

- [x] Conventional Commits 準拠（`fix(issue-cache): ...`）
- [x] commitlint local check PASS
- [x] 既存テスト全 PASS（gwt + gwt-github + gwt-core）
- [x] ユーザー報告と同形のエラー再現テストを RED → GREEN
- [x] 外科的修正（cache.rs の 2 箇所の match arm + 1 テスト追加のみ）
- [x] is_spec_issue 自体は変更せず、cache 層で graceful にする方針を選択（呼び出し側の判断ロジックを壊さないため）
- [ ] CI 全 check 完走（push 後フォロー）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache resilience by handling parsing failures more gracefully, now falling back to storing content as plain issues rather than failing outright.

* **Tests**
  * Added regression test to verify the cache properly handles malformed content without data loss.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->