### PR TITLE
fix(issue-cache): keep load_entry strict on malformed SPEC to prevent write_section data loss

### DIFF
--- a/crates/gwt-github/src/cache.rs
+++ b/crates/gwt-github/src/cache.rs
@@ -230,13 +230,11 @@ impl Cache {
             .collect();
         let spec_body = match SpecBody::parse(&snapshot.body, &parsed_comments) {
             Ok(spec_body) => spec_body,
-            Err(_) => SpecBody {
-                // Mirror the lenient policy from `write_snapshot`: any body
-                // that fails to parse as a SPEC (no header, malformed
-                // sections index, missing referenced comment, etc.) is
-                // surfaced as a plain Issue entry rather than silently
-                // dropped. UI consumers always see the cached body and
-                // metadata; only the structured sections map is empty.
+            Err(ParseError::MissingHeader) => SpecBody {
+                // Plain Issue (no `<!-- gwt-spec id=... -->` header at all):
+                // synthesize an empty SpecBody so the entry still surfaces
+                // to UI consumers as a regular Issue. This mirrors the
+                // existing `write_snapshot` path for plain Issues.
                 meta: SpecMeta {
                     id: meta.number.to_string(),
                     version: 1,
@@ -244,6 +242,22 @@ impl Cache {
                 sections_index: crate::body::SectionsIndex::default(),
                 sections: std::collections::BTreeMap::new(),
             },
+            Err(_) => {
+                // Body carries a SPEC header but the structural parse fails
+                // (malformed sections index, missing referenced comment,
+                // etc.). We intentionally do NOT downgrade these to an
+                // empty SpecBody: a subsequent `SpecOps::write_section`
+                // would recompute the routing from the empty section map
+                // and rewrite the body's index, orphaning content stored in
+                // comments referenced only by the original (malformed)
+                // index. Returning `None` keeps such entries out of UI
+                // lists until the next refresh either repairs the body or
+                // proves it is truly a plain Issue. The on-disk cache is
+                // still populated (write_snapshot is lenient), so the
+                // body / meta survive in `~/.gwt/cache/issues/<n>/` for
+                // diagnostics.
+                return None;
+            }
         };
         Some(CacheEntry {
             snapshot,

--- a/crates/gwt-github/tests/cache_test.rs
+++ b/crates/gwt-github/tests/cache_test.rs
@@ -411,8 +411,21 @@ fn apply_phase_change_does_not_disturb_body_or_sections() {
 // `gh issue view` and ends up calling `write_snapshot` with a body whose
 // header parses but whose sections index is malformed. Previously this
 // surfaced as `body parse error: broken index map: ...` and propagated up
-// to the GUI Issue refresh. The cache must now treat such bodies as plain
-// Issues: cache body + meta, leave sections/ empty.
+// to the GUI Issue refresh.
+//
+// The cache layer now splits responsibilities to absorb the regression
+// without introducing a data-loss vector on real SPECs that happen to be
+// transiently malformed:
+//
+// - `write_snapshot` is lenient: it always caches `body.md` and `meta.json`
+//   verbatim. Sections are only materialized when parse succeeds.
+// - `load_entry` is strict for header-present-but-malformed bodies. It
+//   returns `None` so `SpecOps::write_section` never operates on an empty
+//   sections map (which would otherwise rewrite the body's section index
+//   with only the freshly-edited section, orphaning any content stored in
+//   the comments referenced by the malformed index).
+// - `load_entry` still surfaces plain Issues (no header) with an empty
+//   `SpecBody` so the GUI list keeps showing them.
 #[test]
 fn write_snapshot_falls_back_to_plain_when_sections_index_is_malformed() {
     let tmp = TempDir::new().unwrap();
@@ -456,16 +469,47 @@ Rest of the body is human prose, not a real SPEC.\n"
         .collect();
     assert!(
         leftover.is_empty(),
-        "sections/ must be empty for fallback-cached plain Issue (got: {:?})",
+        "sections/ must be empty for fallback-cached entry (got: {:?})",
         leftover.iter().map(|e| e.file_name()).collect::<Vec<_>>()
     );
 
-    // load_entry must still surface the issue (with empty sections),
-    // not silently drop it.
+    // load_entry must NOT surface this entry: the SPEC header is present
+    // but parse failed, so exposing an empty SpecBody would let
+    // `SpecOps::write_section` recompute the routing from scratch and
+    // overwrite the body's sections index, orphaning any content in
+    // comments referenced by the malformed index.
+    assert!(
+        cache.load_entry(IssueNumber(123)).is_none(),
+        "load_entry must hide header-present-but-malformed entries to \
+         prevent SpecOps::write_section from corrupting them"
+    );
+}
+
+// Companion to the previous test: a plain Issue (no `<!-- gwt-spec id=...`
+// header at all) must still surface from `load_entry` with an empty
+// `SpecBody`, so the GUI keeps listing it. Hiding plain Issues by accident
+// would silently drop bug reports / docs / chores from the Issue window.
+#[test]
+fn load_entry_surfaces_plain_issue_with_empty_spec_body() {
+    let tmp = TempDir::new().unwrap();
+    let cache = Cache::new(tmp.path().to_path_buf());
+
+    let body = "Just a plain bug report.\nNo gwt-spec markers here.\n".to_string();
+    let snapshot = IssueSnapshot {
+        number: IssueNumber(456),
+        title: "Plain bug".into(),
+        body: body.clone(),
+        labels: vec!["bug".into()],
+        state: IssueState::Open,
+        updated_at: UpdatedAt::new("t1"),
+        comments: Vec::new(),
+    };
+    cache.write_snapshot(&snapshot).unwrap();
+
     let entry = cache
-        .load_entry(IssueNumber(123))
-        .expect("load_entry must surface a plain-fallback entry");
-    assert_eq!(entry.snapshot.number, IssueNumber(123));
+        .load_entry(IssueNumber(456))
+        .expect("plain Issue must surface from load_entry");
+    assert_eq!(entry.snapshot.number, IssueNumber(456));
     assert_eq!(entry.snapshot.body, body);
     assert!(entry.spec_body.sections.is_empty());
 }


### PR DESCRIPTION
## Summary

Codex P1 review on PR #2806 で指摘されたデータ損失パスを閉じる follow-up 修正です。前 PR は `Cache::load_entry` の SPEC parse fallback も `MissingHeader` 限定から全 parse error に拡張していましたが、`BrokenIndex` / `MissingComment` で `Err(_) => SpecBody { sections: empty }` を返す挙動が、`SpecOps::write_section` が空 section map から routing を再計算して body の `sections:` index を上書きし、既存 comment 参照セクションを orphan させる経路を新たに開いてしまっていました。

このコミットで `Cache::load_entry` を `MissingHeader` 限定の fallback に戻し、それ以外（header あり / 構造不正）では `None` を返すように厳格化します。`write_snapshot` の resilience（refresh が 1 件の malformed Issue で止まらない）は維持。

Codex review thread はこの修正で reply + resolve 済みです。

## Changes

- `crates/gwt-github/src/cache.rs`
  - `Cache::load_entry` の `match` を `Ok(_)` / `Err(MissingHeader) → synthesized empty SpecBody` / `Err(_) → return None` の 3 分岐に再構成
  - `write_snapshot` 側は変更なし（lenient のまま、body+meta+空 sections を必ず書き込む）
  - 動機（write_section の data-loss 防止 / refresh resilience の両立）をコメントに明文化
- `crates/gwt-github/tests/cache_test.rs`
  - 既存 test `write_snapshot_falls_back_to_plain_when_sections_index_is_malformed` を更新: load_entry が `None` を返すことを assert（header あり + parse 失敗 のとき）
  - 新規 test `load_entry_surfaces_plain_issue_with_empty_spec_body` を追加: header なし plain Issue は引き続き empty SpecBody で surface することを保証

## Testing

- `cargo test -p gwt -p gwt-github -p gwt-core --all-features` 全 PASS
- `cargo clippy --all-targets --all-features -- -D warnings` warnings 0
- `cargo fmt --check` clean
- `bunx commitlint --from HEAD~1 --to HEAD` PASS

## Closing Issues

None — PR #2806 の Codex P1 follow-up なので新規 Issue は登録しません。

## Related Issues

- PR #2806 (本 PR の起点。lenient 版のみ auto-merged されたため P1 fix を後追いで送る)
- #2794 (元 bug Issue)
- #2793 (副作用で残った plain bug Issue。header は持つが prose ベース。本 PR の strict load_entry で UI 一覧からは見えなくなる代わりに write_section の data loss は防止される)

## Checklist

- [x] Conventional Commits 準拠
- [x] commitlint PASS
- [x] 既存テスト全 PASS（regression test 更新含む）
- [x] 新規テストで plain Issue surface 担保
- [x] Codex review thread を reply + resolve 済み
- [x] 外科的修正（load_entry の match arm 再構成 + テスト 1 追加 / 1 更新のみ）
- [ ] CI 全 check 完走（push 後フォロー）
