### PR TITLE
chore(release): v9.40.0

### DIFF
--- a/.claude/skills/gwt-discussion/SKILL.md
+++ b/.claude/skills/gwt-discussion/SKILL.md
@@ -286,7 +286,14 @@ When the discussion stabilizes, update the right artifacts in one batch.
 
 - Use `references/intake.md` for search and routing discipline
 - Use `references/ddd-modeling.md` for Bounded Context and domain modeling
-- Use `references/registration.md` to create or seed `spec.md`
+- **Register the SPEC via `gwt-register-spec`** (sub-skill, SPEC-2784). The
+  caller prepares title + body file from this discussion's outcome; the
+  sub-skill validates, executes the canonical `create` → `--edit spec` →
+  `--section spec` roundtrip safely, and returns the new Issue number. Add
+  `Register Spec` to the Action Bundle. Use `references/registration.md`
+  only when the sub-skill is unavailable; in that case follow its 2-step
+  flow manually and verify `--section spec` returns non-empty content
+  before handoff.
 - Use `references/clarification.md` to remove high-impact
   `[NEEDS CLARIFICATION]` markers
 - Use `references/deepening.md` when the user asks for deeper analysis on an
@@ -334,6 +341,7 @@ Reason: <one sentence>
 - Resume Build Context: <what the implementer must use>
 
 ### Action Bundle
+- Register Spec
 - Update Spec
 - Update Plan
 - Resume Build
@@ -341,6 +349,10 @@ Reason: <one sentence>
 - Write Lesson
 - No Action
 ```
+
+`Register Spec` runs the `gwt-register-spec` sub-skill (SPEC-2784) to
+materialize a new SPEC Issue safely. Use it instead of manual
+`gwtd issue spec create` whenever a fresh SPEC owner is needed.
 
 This final result is the handoff point where the workflow may leave Plan Mode.
 

--- a/.claude/skills/gwt-discussion/references/registration.md
+++ b/.claude/skills/gwt-discussion/references/registration.md
@@ -2,15 +2,38 @@
 
 Detailed logic for the SPEC creation/update phase of gwt-discussion.
 
+> **Preferred path (SPEC-2784):** When this discussion produces a *new*
+> SPEC owner, hand the title + body off to the `gwt-register-spec`
+> sub-skill instead of running `gwtd issue spec create` directly. The
+> sub-skill enforces the 2-step `create` → `--edit spec` → roundtrip
+> verify flow that this reference once documented manually, so the
+> section-marker trap (an empty spec section after a bare `create -f`)
+> cannot occur. Add `Register Spec` to the Action Bundle and let
+> gwt-register-spec own the registration.
+>
+> The rest of this document remains as the recovery / manual path for
+> when the sub-skill is unavailable, or when *updating* an existing SPEC
+> rather than creating a new one.
+
 ## Prerequisites
 
 Phase 3 runs only when Phase 1 routing produced `NEW-SPEC` and Phase 2 domain
 discovery confirmed the scope is right for a SPEC.
 
-## SPEC creation
+## SPEC creation (manual / recovery path)
 
 SPEC の作成・更新は `gwtd issue spec` CLI で行う。
 すべての要約・タイトル・更新説明は current user's language で記述する。
+
+**重要:** `gwtd issue spec create -f <body>` は body file が
+`<!-- artifact:spec BEGIN/END -->` マーカーを含まないと `extract_sections()`
+が空を返し、spec section が空のまま Issue が作成される (SPEC #2780 で発生)。
+manual 経路では必ず以下の 2 段階で実行する:
+
+1. `gwtd issue spec create --title "SPEC: <title>" -f <empty-or-stub>` で器を作成
+2. `gwtd issue spec <n> --edit spec -f <full-body>` で content を投入
+   (`--edit` は section マーカーを自動付与する)
+3. `gwtd issue spec <n> --section spec | head -5` で非空を必ず確認
 
 ### コマンド
 

--- a/.claude/skills/gwt-register-issue/SKILL.md
+++ b/.claude/skills/gwt-register-issue/SKILL.md
@@ -37,7 +37,7 @@ Do not use this for an existing Issue. Use `gwt-fix-issue` instead.
 3. Run duplicate search before creating anything. Search both open Issues and existing SPEC owners, using the visible `gwt-search` surface when possible.
 4. Decide the registration outcome with the `Spec Status` contract below before creating any new owner.
 5. When the request is a narrow bug, docs, chore, or investigation item and the `Spec Status` allows a plain Issue, create it with `gwtd issue create --title ... -f ...`.
-6. When the request reveals a missing or unclear owner SPEC, stop plain-Issue creation and hand off to `gwt-discussion`.
+6. When the request reveals a missing or unclear owner SPEC, stop plain-Issue creation and hand off to `gwt-discussion`. (SPEC-2784: gwt-discussion's Action Bundle now includes `Register Spec` which delegates to the `gwt-register-spec` sub-skill so the SPEC Issue is materialized safely via the canonical create→edit→roundtrip flow. This skill does not create SPEC owners itself.)
 7. Return the chosen owner and next step in the current user's language.
 
 ## Spec Status

--- a/.claude/skills/gwt-register-spec/SKILL.md
+++ b/.claude/skills/gwt-register-spec/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: gwt-register-spec
+description: "Use when gwt-discussion has produced a finished SPEC design and the Action Bundle includes Register Spec. Materializes a SPEC issue safely via create-then-edit with structural + format-quality validation and roundtrip verification."
+---
+
+# gwt-register-spec
+
+Sub-skill called from `gwt-discussion` to materialize an already-decided SPEC
+design into a `gwt-spec` GitHub Issue. Encapsulates the canonical 2-step
+`gwtd issue spec create` → `gwtd issue spec --edit spec` flow so that the
+section-marker trap (an empty spec section because `create -f` does not wrap
+the body in `<!-- artifact:spec BEGIN/END -->` markers) cannot happen.
+
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
+## When to use
+
+- `gwt-discussion` has reached Phase 5 and its Action Bundle includes
+  `Register Spec`.
+- The caller already has the SPEC title (`SPEC: <title>`) and a complete
+  SPEC body file on disk with the 7 canonical sections filled in.
+- A new SPEC owner is needed; an existing SPEC owner has already been ruled
+  out by duplicate search in `gwt-discussion` / `gwt-register-issue`.
+
+Do not use this when the design is still under discussion (use
+`gwt-discussion`), when the request is narrow enough for a plain Issue (use
+`gwt-register-issue`), or when an existing SPEC needs additional sections
+(use `gwt-discussion` followed by `gwtd issue spec <n> --edit <section>` —
+this skill does not edit existing SPECs).
+
+## Ownership
+
+- Validate the provided body against the canonical SPEC contract.
+- Create the GitHub Issue safely (no orphan Issue on validation failure).
+- Inject the spec section via `--edit spec -f <body>` so the section markers
+  are auto-applied.
+- Roundtrip-verify by reading `--section spec` back and asserting non-empty.
+- Hand off the new Issue number to the caller. Plan / tasks sections are the
+  responsibility of `gwt-plan-spec` and are out of scope.
+
+## Inputs
+
+The skill takes two inputs from the caller:
+
+1. `title` — string. Must match `^SPEC: .+$`. Becomes the GitHub Issue title.
+2. `body_path` — filesystem path. Must point to a UTF-8 markdown file with
+   the canonical 7 sections (see `references/body-template.md`). The H1 inside
+   the file must equal `title`.
+
+The caller is responsible for assembling `body_path` from discussion
+artifacts (`.gwt/discussion.md`, Action Delta, plan file). This skill never
+generates content; it only validates and materializes.
+
+## Workflow
+
+Run these steps in order. If any step fails with `validation` or `roundtrip`
+severity, stop immediately and report back. Do not retry silently.
+
+```dot
+digraph register_spec_flow {
+    "start lifecycle" -> "load body";
+    "load body" -> "validate (structural + format-quality)";
+    "validate" -> "report issues" [label="any Structural issue"];
+    "validate" -> "gwtd issue spec create --title <t> -f <stub>" [label="all PASS"];
+    "create" -> "abort: io failure" [label="error"];
+    "create" -> "gwtd issue spec <n> --edit spec -f <body>" [label="issue created"];
+    "edit" -> "recovery report (orphan Issue #N)" [label="edit failure"];
+    "edit" -> "gwtd issue spec <n> --section spec" [label="edit ok"];
+    "section spec" -> "abort: empty spec" [label="empty"];
+    "section spec" -> "complete lifecycle, return Issue #N + URL" [label="non-empty"];
+}
+```
+
+1. **Lifecycle start**: `gwtd register start --spec 0` (placeholder spec id;
+   the real id is recorded via `phase` once the Issue is created).
+2. **Load body**: read `body_path` as UTF-8.
+3. **Validate**: call the validation library (see
+   `references/validation-rules.md`). On any `Structural` or `Format` issue,
+   call `gwtd register abort --spec 0 --reason "validation: <summary>"` and
+   return the issue list to the caller. Do not call any GitHub API.
+4. **Create shell**: `gwtd issue spec create --title "<title>" -f <stub>`
+   where `<stub>` is an empty placeholder file. Capture the new issue
+   number.
+5. **Phase create**: `gwtd register phase --spec <n> --label create` to bind
+   the real spec id and record the milestone.
+6. **Inject body**: `gwtd issue spec <n> --edit spec -f <body_path>`. The
+   `--edit` command auto-applies `<!-- artifact:spec BEGIN/END -->` markers.
+7. **Phase edit**: `gwtd register phase --spec <n> --label edit`.
+8. **Roundtrip verify**: `gwtd issue spec <n> --section spec`. The output
+   must be non-empty and must contain the H1 line of the body file. On
+   failure, follow `references/recovery.md` and abort.
+9. **Phase roundtrip**: `gwtd register phase --spec <n> --label roundtrip`.
+10. **Complete**: `gwtd register complete --spec <n>`. Return `{ issue: <n>,
+    url: "https://github.com/akiojin/gwt/issues/<n>" }` to the caller.
+
+## Validation rules
+
+See `references/validation-rules.md` for the canonical list. Summary:
+
+| Severity | Rule |
+|---|---|
+| Structural | Title matches `^SPEC: .+$` |
+| Structural | H1 in body equals title |
+| Structural | All 7 required sections exist (`背景`, `ユビキタス言語`, `ユーザーシナリオと受け入れシナリオ`, `機能要件`, `成功基準`, `Out of Scope`, `Related Artifacts`) |
+| Structural | `機能要件` contains at least one `FR-NNN` line |
+| Structural | No `[NEEDS CLARIFICATION]` markers anywhere |
+| Format | FR identifiers are contiguous (`FR-001`, `FR-002`, … no gaps) |
+
+Structural issues block create. Format issues also block create in v1
+(hard-fail policy).
+
+## Failure policy
+
+- **Validation failure** → no Issue created. Report each
+  `ValidationIssue { severity, location, message }` to the caller.
+- **Create failure** (network, auth) → no Issue created. Surface the gh / gwtd
+  error verbatim and `register abort`.
+- **Edit failure after create success** → the Issue exists but is empty.
+  Follow `references/recovery.md` to either retry `--edit spec` or open the
+  Issue for manual repair. Always include the orphan Issue number in the
+  recovery report.
+- **Roundtrip empty** → the `--edit` call apparently succeeded but the
+  section is unreadable. Treat as `Edit failure after create success`.
+
+## Recovery
+
+See `references/recovery.md`. The skill never silently retries; the caller
+(and any human reviewer) must see the orphan Issue and act.
+
+## Exit CLI (Stop-block contract)
+
+The skill registers lifecycle events through `gwtd register`:
+
+- `gwtd register start --spec 0` at the beginning (placeholder spec id).
+- `gwtd register phase --spec <n> --label <validation|create|edit|roundtrip>`
+  at each milestone.
+- `gwtd register complete --spec <n>` once the Issue is created and verified.
+- `gwtd register abort --spec <n|0> --reason '<text>'` on any failure.
+
+State file: `<worktree>/.gwt/skill-state/register-spec.json`. The
+`skill-register-spec-stop-check` Stop hook returns
+`{"decision":"block","reason":"..."}` while the state is active, honoring the
+shared `stop_hook_active` fail-safe so each Stop cycle allows at most one
+forced continuation.
+
+## Chain suggestion
+
+On `register complete`, suggest `gwt-plan-spec --spec <n>` as the next step.

--- a/.claude/skills/gwt-register-spec/references/body-template.md
+++ b/.claude/skills/gwt-register-spec/references/body-template.md
@@ -1,0 +1,98 @@
+# SPEC body template
+
+The 7 required sections, in canonical order. Copy this skeleton, fill in
+each section, and pass the resulting file to `gwt-register-spec` via
+`body_path`.
+
+The H1 line MUST equal the GitHub Issue title (the same `SPEC: <title>` you
+pass as `title`). See `validation-rules.md` for the full rule set.
+
+```markdown
+# SPEC: <one-line work name>
+
+## 背景
+
+<Why this work is needed. What problem or constraint prompted it. Reference
+prior incidents, lessons, or upstream decisions. Keep to 3-6 paragraphs.>
+
+## ユビキタス言語
+
+- **<TermA>**: <one-sentence definition that the team agrees on>
+- **<TermB>**: <one-sentence definition>
+- <Add as many entries as needed; this section is the shared vocabulary for
+  the rest of the SPEC. Reviewers should be able to read the rest of the
+  SPEC and know exactly what each named concept refers to.>
+
+## ユーザーシナリオと受け入れシナリオ
+
+### Primary User Story
+
+<One paragraph: which user, what outcome, why it matters.>
+
+### Acceptance Scenarios
+
+1. **<short name>**: <Given / When / Then narrative. Be concrete enough to
+   write a test against it.>
+2. **<short name>**: <...>
+3. **<short name>**: <...>
+
+## 機能要件
+
+- **FR-001**: <First requirement. Use the FR-NNN pattern with contiguous
+  numbers. Each requirement is one declarative sentence the implementation
+  must satisfy.>
+- **FR-002**: <...>
+- **FR-003**: <...>
+<Add as many FRs as needed. The numbering must be contiguous (FR-001,
+FR-002, …) — gaps cause a Format validation issue.>
+
+## 成功基準
+
+- <Concrete verification command or observable outcome. Prefer command +
+  expected result over prose.>
+- <Example: `cargo test -p gwt-github spec_validate::` が GREEN.>
+- <Example: `pnpm lint:skills` が新 SKILL.md frontmatter で通過.>
+
+## Out of Scope (v1)
+
+- <Explicitly excluded behaviors. Use this to prevent scope creep during
+  implementation.>
+- <Items that belong in v2 or in a different SPEC.>
+
+## Related Artifacts
+
+- Plan: `<path to plan file if any>`
+- Discussion state: `.gwt/discussion.md` (Proposal X [chosen] / Evidence
+  Gate complete)
+- Reference: `<related SPEC, docs, code path>`
+```
+
+## Section-by-section guidance
+
+- **背景** — answer "why now". Forward-looking only; do not repeat the
+  ユビキタス言語 definitions here.
+- **ユビキタス言語** — required even for small SPECs. If the work introduces
+  no new terms, list the load-bearing existing terms so reviewers do not
+  have to guess.
+- **ユーザーシナリオと受け入れシナリオ** — `Primary User Story` is one
+  paragraph; `Acceptance Scenarios` is a numbered list. Each scenario
+  should be implementable as a black-box test.
+- **機能要件** — declarative `FR-NNN` lines. Imperative voice ("must …") is
+  fine. Avoid "should" language; ambiguity blocks downstream planning.
+- **成功基準** — prefer commands and observable signals. Subjective bullets
+  ("ユーザー体験が向上する") are not measurable and should be deleted.
+- **Out of Scope (v1)** — required even if empty (write `- なし` if there
+  are no deferred items). Forces the author to think about scope.
+- **Related Artifacts** — paths and links only. No prose summaries here;
+  the SPEC body itself is the canonical narrative.
+
+## Common mistakes
+
+- Listing `FR-001` and `FR-003` but no `FR-002` — Format validation fails.
+- Adding `[NEEDS CLARIFICATION]` markers and forgetting to resolve them
+  before calling `gwt-register-spec`. Use `gwt-discussion` to resolve them
+  first.
+- Using `**Functional Requirements**` or English-only section headings
+  instead of the canonical Japanese names. The validator looks for exact
+  Japanese headings.
+- Forgetting to keep H1 in sync with the GitHub Issue title argument.

--- a/.claude/skills/gwt-register-spec/references/recovery.md
+++ b/.claude/skills/gwt-register-spec/references/recovery.md
@@ -1,0 +1,90 @@
+# Recovery from partial registration
+
+`gwt-register-spec` is designed so the only way to produce a half-baked
+SPEC Issue is for `gwtd issue spec create` to succeed and the subsequent
+`gwtd issue spec <n> --edit spec -f <body>` to fail. (Validation runs
+before any GitHub API call, so a `Structural` or `Format` failure never
+creates an orphan Issue.)
+
+This document covers that single failure mode and the matching recovery
+flow.
+
+## Detect
+
+After `gwtd issue spec create` returns the new Issue number, the skill
+immediately calls `gwtd issue spec <n> --edit spec -f <body>`. If `--edit`
+exits non-zero, the skill stops the lifecycle with:
+
+```
+gwtd register abort --spec <n> --reason 'edit failed: <gh/gwtd error verbatim>'
+```
+
+If the skill reaches the roundtrip step and `gwtd issue spec <n>
+--section spec` reports empty output or the heading does not contain the
+expected H1, the skill aborts with `--reason 'roundtrip empty'`.
+
+In both cases the GitHub Issue still exists with an empty spec section.
+The caller and any human reviewer must see the orphan Issue number.
+
+## Report
+
+The skill returns a structured report to the caller containing at
+minimum:
+
+```json
+{
+  "outcome": "partial",
+  "issue": <n>,
+  "url": "https://github.com/akiojin/gwt/issues/<n>",
+  "failed_step": "edit" | "roundtrip",
+  "error": "<verbatim gh/gwtd error>",
+  "next_action": "manual_edit"
+}
+```
+
+The caller surfaces this back to the user. Do not silently retry — the
+underlying failure (network, auth, GitHub rate limit) usually persists
+and would block the retry too.
+
+## Repair (manual)
+
+Once the upstream failure is understood (e.g. network restored, auth
+refreshed), the human or follow-up agent runs:
+
+```
+gwtd issue spec <n> --edit spec -f <body_path>
+gwtd issue spec <n> --section spec | head -5      # roundtrip verify
+```
+
+If the roundtrip is OK, the SPEC is healed. There is no need to delete
+and re-create the Issue.
+
+## Repair (automated retry, deferred)
+
+In v1 the skill does not auto-retry. Adding bounded retry with
+exponential backoff is a v2 candidate; the open design questions are:
+
+- How many retries before the orphan Issue is reported?
+- Should the skill detect transient errors (HTTP 5xx, network) and
+  retry only those, vs hard-fail on auth?
+- Where does the retry budget live — per-skill-run, per-process, or
+  per-user-session?
+
+These will be revisited if recovery ends up being a frequent operation.
+Until then, the manual flow is intentional: it forces a human to see
+the orphan Issue, which is the safest outcome.
+
+## When the Issue should be abandoned, not repaired
+
+If the SPEC body itself turned out to be wrong (e.g. duplicate of an
+existing SPEC found during a second-pass search), close the GitHub Issue
+with a short comment pointing at the canonical owner. Do not edit the
+spec section to point elsewhere — that pollutes the SPEC search index.
+
+```
+gwtd issue comment <n> -f <comment.md>      # explain why
+# then close the Issue via the UI or `gh issue close <n>` (out of band)
+```
+
+This is the only case where the orphan Issue is intentionally left
+empty.

--- a/.claude/skills/gwt-register-spec/references/validation-rules.md
+++ b/.claude/skills/gwt-register-spec/references/validation-rules.md
@@ -1,0 +1,112 @@
+# Validation rules
+
+`gwt-register-spec` validates the SPEC body before any GitHub API call.
+This document is the canonical list. The Rust implementation lives at
+`crates/gwt-github/src/spec_validate.rs` and exposes
+`validate_spec_body(body: &str, title: &str, rules: &ValidationRules) ->
+Vec<ValidationIssue>`.
+
+## Severity levels
+
+- `Structural` — the body cannot be processed downstream without manual
+  correction. Always hard-fail: no Issue is created.
+- `Format` — the body is processable but does not meet the project's
+  format convention. Also hard-fail in v1 (consistent registration
+  surface). Future opt-in soft-fail is possible behind a `--allow-format`
+  flag, but that is out of scope for v1.
+
+Every issue carries `{ severity, location, message }` where `location` is
+either `"title"`, the section heading (`"## 機能要件"`), or a 1-based line
+offset inside the body.
+
+## Rule table
+
+| ID | Severity | Rule | Failure example |
+|---|---|---|---|
+| R1 | Structural | Title matches `^SPEC: .+$` | `"feat: foo"` → fail |
+| R2 | Structural | First non-blank line of body equals title | H1 says `# something else` |
+| R3 | Structural | Section `## 背景` exists | missing or misspelled |
+| R4 | Structural | Section `## ユビキタス言語` exists | — |
+| R5 | Structural | Section `## ユーザーシナリオと受け入れシナリオ` exists | — |
+| R6 | Structural | Section `## 機能要件` exists | — |
+| R7 | Structural | Section `## 成功基準` exists | — |
+| R8 | Structural | Section `## Out of Scope` exists (case-sensitive prefix; `(v1)` suffix permitted) | `## Out Of Scope` → fail |
+| R9 | Structural | Section `## Related Artifacts` exists | — |
+| R10 | Structural | `機能要件` section contains ≥1 line matching `^- \*\*FR-\d{3}\*\*` | no FR present |
+| R11 | Structural | No occurrence of `[NEEDS CLARIFICATION]` anywhere | unresolved markers |
+| R12 | Format | FR identifiers are contiguous (`FR-001`, `FR-002`, …) | `FR-001, FR-003` |
+
+R8 explicitly permits `## Out of Scope (v1)` so version-suffixed sections
+keep passing validation. Implementation: prefix match on
+`"## Out of Scope"` then optional whitespace + `(...)`.
+
+## Roundtrip check (post-create)
+
+After the GitHub Issue has been created and `--edit spec -f <body>` has
+been called, the skill performs a roundtrip verification:
+
+1. `gwtd issue spec <n> --section spec` must exit 0.
+2. The output must be non-empty.
+3. The output must contain the H1 line of the body (`# SPEC: …`).
+
+If any of these fail, the skill aborts the lifecycle with a
+`roundtrip` reason and surfaces the orphan Issue number per
+`recovery.md`.
+
+## Section heading detection
+
+Headings are recognised by exact `## <Heading>` at the start of a line
+(after optional leading whitespace is rejected — only flush-left
+headings count). The match is on the heading text, not on any anchor or
+slug. The validator does **not** parse markdown into an AST; it operates
+on line patterns to keep the implementation small and predictable.
+
+## What is NOT validated (v1 contract)
+
+- Tense, voice, or style of FR sentences (no NLP).
+- Numbering of acceptance scenarios (any 1-based numeric list is
+  accepted).
+- Existence of plan / tasks sections — those are added later by
+  `gwt-plan-spec`.
+- Section ordering — sections may appear in any order as long as all
+  required headings exist.
+- Internal links to other SPECs — `Related Artifacts` may contain any
+  free-form text.
+
+## Worked example
+
+Given a body with:
+
+```markdown
+# SPEC: Demo
+
+## 背景
+ある。
+
+## ユビキタス言語
+- **X**: y
+
+## ユーザーシナリオと受け入れシナリオ
+### Primary User Story
+hi.
+
+## 機能要件
+- **FR-001**: a
+- **FR-002**: b
+
+## 成功基準
+- ok
+
+## Related Artifacts
+- none
+```
+
+Validation issues returned:
+
+- `Structural` `## ユーザーシナリオと受け入れシナリオ`: missing
+  `### Acceptance Scenarios` is not validated (out of scope), but the
+  section itself is present → no issue.
+- `Structural` `## Out of Scope`: missing → fail.
+- (no other issues)
+
+The caller fixes the missing section, re-runs validation, and proceeds.

--- a/.codex/skills/gwt-register-spec/SKILL.md
+++ b/.codex/skills/gwt-register-spec/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: gwt-register-spec
+description: "Use when gwt-discussion has produced a finished SPEC design and the Action Bundle includes Register Spec. Materializes a SPEC issue safely via create-then-edit with structural + format-quality validation and roundtrip verification."
+---
+
+# gwt-register-spec
+
+Sub-skill called from `gwt-discussion` to materialize an already-decided SPEC
+design into a `gwt-spec` GitHub Issue. Encapsulates the canonical 2-step
+`gwtd issue spec create` → `gwtd issue spec --edit spec` flow so that the
+section-marker trap (an empty spec section because `create -f` does not wrap
+the body in `<!-- artifact:spec BEGIN/END -->` markers) cannot happen.
+
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
+## When to use
+
+- `gwt-discussion` has reached Phase 5 and its Action Bundle includes
+  `Register Spec`.
+- The caller already has the SPEC title (`SPEC: <title>`) and a complete
+  SPEC body file on disk with the 7 canonical sections filled in.
+- A new SPEC owner is needed; an existing SPEC owner has already been ruled
+  out by duplicate search in `gwt-discussion` / `gwt-register-issue`.
+
+Do not use this when the design is still under discussion (use
+`gwt-discussion`), when the request is narrow enough for a plain Issue (use
+`gwt-register-issue`), or when an existing SPEC needs additional sections
+(use `gwt-discussion` followed by `gwtd issue spec <n> --edit <section>` —
+this skill does not edit existing SPECs).
+
+## Ownership
+
+- Validate the provided body against the canonical SPEC contract.
+- Create the GitHub Issue safely (no orphan Issue on validation failure).
+- Inject the spec section via `--edit spec -f <body>` so the section markers
+  are auto-applied.
+- Roundtrip-verify by reading `--section spec` back and asserting non-empty.
+- Hand off the new Issue number to the caller. Plan / tasks sections are the
+  responsibility of `gwt-plan-spec` and are out of scope.
+
+## Inputs
+
+The skill takes two inputs from the caller:
+
+1. `title` — string. Must match `^SPEC: .+$`. Becomes the GitHub Issue title.
+2. `body_path` — filesystem path. Must point to a UTF-8 markdown file with
+   the canonical 7 sections (see `references/body-template.md`). The H1 inside
+   the file must equal `title`.
+
+The caller is responsible for assembling `body_path` from discussion
+artifacts (`.gwt/discussion.md`, Action Delta, plan file). This skill never
+generates content; it only validates and materializes.
+
+## Workflow
+
+Run these steps in order. If any step fails with `validation` or `roundtrip`
+severity, stop immediately and report back. Do not retry silently.
+
+```dot
+digraph register_spec_flow {
+    "start lifecycle" -> "load body";
+    "load body" -> "validate (structural + format-quality)";
+    "validate" -> "report issues" [label="any Structural issue"];
+    "validate" -> "gwtd issue spec create --title <t> -f <stub>" [label="all PASS"];
+    "create" -> "abort: io failure" [label="error"];
+    "create" -> "gwtd issue spec <n> --edit spec -f <body>" [label="issue created"];
+    "edit" -> "recovery report (orphan Issue #N)" [label="edit failure"];
+    "edit" -> "gwtd issue spec <n> --section spec" [label="edit ok"];
+    "section spec" -> "abort: empty spec" [label="empty"];
+    "section spec" -> "complete lifecycle, return Issue #N + URL" [label="non-empty"];
+}
+```
+
+1. **Lifecycle start**: `gwtd register start --spec 0` (placeholder spec id;
+   the real id is recorded via `phase` once the Issue is created).
+2. **Load body**: read `body_path` as UTF-8.
+3. **Validate**: call the validation library (see
+   `references/validation-rules.md`). On any `Structural` or `Format` issue,
+   call `gwtd register abort --spec 0 --reason "validation: <summary>"` and
+   return the issue list to the caller. Do not call any GitHub API.
+4. **Create shell**: `gwtd issue spec create --title "<title>" -f <stub>`
+   where `<stub>` is an empty placeholder file. Capture the new issue
+   number.
+5. **Phase create**: `gwtd register phase --spec <n> --label create` to bind
+   the real spec id and record the milestone.
+6. **Inject body**: `gwtd issue spec <n> --edit spec -f <body_path>`. The
+   `--edit` command auto-applies `<!-- artifact:spec BEGIN/END -->` markers.
+7. **Phase edit**: `gwtd register phase --spec <n> --label edit`.
+8. **Roundtrip verify**: `gwtd issue spec <n> --section spec`. The output
+   must be non-empty and must contain the H1 line of the body file. On
+   failure, follow `references/recovery.md` and abort.
+9. **Phase roundtrip**: `gwtd register phase --spec <n> --label roundtrip`.
+10. **Complete**: `gwtd register complete --spec <n>`. Return `{ issue: <n>,
+    url: "https://github.com/akiojin/gwt/issues/<n>" }` to the caller.
+
+## Validation rules
+
+See `references/validation-rules.md` for the canonical list. Summary:
+
+| Severity | Rule |
+|---|---|
+| Structural | Title matches `^SPEC: .+$` |
+| Structural | H1 in body equals title |
+| Structural | All 7 required sections exist (`背景`, `ユビキタス言語`, `ユーザーシナリオと受け入れシナリオ`, `機能要件`, `成功基準`, `Out of Scope`, `Related Artifacts`) |
+| Structural | `機能要件` contains at least one `FR-NNN` line |
+| Structural | No `[NEEDS CLARIFICATION]` markers anywhere |
+| Format | FR identifiers are contiguous (`FR-001`, `FR-002`, … no gaps) |
+
+Structural issues block create. Format issues also block create in v1
+(hard-fail policy).
+
+## Failure policy
+
+- **Validation failure** → no Issue created. Report each
+  `ValidationIssue { severity, location, message }` to the caller.
+- **Create failure** (network, auth) → no Issue created. Surface the gh / gwtd
+  error verbatim and `register abort`.
+- **Edit failure after create success** → the Issue exists but is empty.
+  Follow `references/recovery.md` to either retry `--edit spec` or open the
+  Issue for manual repair. Always include the orphan Issue number in the
+  recovery report.
+- **Roundtrip empty** → the `--edit` call apparently succeeded but the
+  section is unreadable. Treat as `Edit failure after create success`.
+
+## Recovery
+
+See `references/recovery.md`. The skill never silently retries; the caller
+(and any human reviewer) must see the orphan Issue and act.
+
+## Exit CLI (Stop-block contract)
+
+The skill registers lifecycle events through `gwtd register`:
+
+- `gwtd register start --spec 0` at the beginning (placeholder spec id).
+- `gwtd register phase --spec <n> --label <validation|create|edit|roundtrip>`
+  at each milestone.
+- `gwtd register complete --spec <n>` once the Issue is created and verified.
+- `gwtd register abort --spec <n|0> --reason '<text>'` on any failure.
+
+State file: `<worktree>/.gwt/skill-state/register-spec.json`. The
+`skill-register-spec-stop-check` Stop hook returns
+`{"decision":"block","reason":"..."}` while the state is active, honoring the
+shared `stop_hook_active` fail-safe so each Stop cycle allows at most one
+forced continuation.
+
+## Chain suggestion
+
+On `register complete`, suggest `gwt-plan-spec --spec <n>` as the next step.

--- a/.codex/skills/gwt-register-spec/references/body-template.md
+++ b/.codex/skills/gwt-register-spec/references/body-template.md
@@ -1,0 +1,98 @@
+# SPEC body template
+
+The 7 required sections, in canonical order. Copy this skeleton, fill in
+each section, and pass the resulting file to `gwt-register-spec` via
+`body_path`.
+
+The H1 line MUST equal the GitHub Issue title (the same `SPEC: <title>` you
+pass as `title`). See `validation-rules.md` for the full rule set.
+
+```markdown
+# SPEC: <one-line work name>
+
+## 背景
+
+<Why this work is needed. What problem or constraint prompted it. Reference
+prior incidents, lessons, or upstream decisions. Keep to 3-6 paragraphs.>
+
+## ユビキタス言語
+
+- **<TermA>**: <one-sentence definition that the team agrees on>
+- **<TermB>**: <one-sentence definition>
+- <Add as many entries as needed; this section is the shared vocabulary for
+  the rest of the SPEC. Reviewers should be able to read the rest of the
+  SPEC and know exactly what each named concept refers to.>
+
+## ユーザーシナリオと受け入れシナリオ
+
+### Primary User Story
+
+<One paragraph: which user, what outcome, why it matters.>
+
+### Acceptance Scenarios
+
+1. **<short name>**: <Given / When / Then narrative. Be concrete enough to
+   write a test against it.>
+2. **<short name>**: <...>
+3. **<short name>**: <...>
+
+## 機能要件
+
+- **FR-001**: <First requirement. Use the FR-NNN pattern with contiguous
+  numbers. Each requirement is one declarative sentence the implementation
+  must satisfy.>
+- **FR-002**: <...>
+- **FR-003**: <...>
+<Add as many FRs as needed. The numbering must be contiguous (FR-001,
+FR-002, …) — gaps cause a Format validation issue.>
+
+## 成功基準
+
+- <Concrete verification command or observable outcome. Prefer command +
+  expected result over prose.>
+- <Example: `cargo test -p gwt-github spec_validate::` が GREEN.>
+- <Example: `pnpm lint:skills` が新 SKILL.md frontmatter で通過.>
+
+## Out of Scope (v1)
+
+- <Explicitly excluded behaviors. Use this to prevent scope creep during
+  implementation.>
+- <Items that belong in v2 or in a different SPEC.>
+
+## Related Artifacts
+
+- Plan: `<path to plan file if any>`
+- Discussion state: `.gwt/discussion.md` (Proposal X [chosen] / Evidence
+  Gate complete)
+- Reference: `<related SPEC, docs, code path>`
+```
+
+## Section-by-section guidance
+
+- **背景** — answer "why now". Forward-looking only; do not repeat the
+  ユビキタス言語 definitions here.
+- **ユビキタス言語** — required even for small SPECs. If the work introduces
+  no new terms, list the load-bearing existing terms so reviewers do not
+  have to guess.
+- **ユーザーシナリオと受け入れシナリオ** — `Primary User Story` is one
+  paragraph; `Acceptance Scenarios` is a numbered list. Each scenario
+  should be implementable as a black-box test.
+- **機能要件** — declarative `FR-NNN` lines. Imperative voice ("must …") is
+  fine. Avoid "should" language; ambiguity blocks downstream planning.
+- **成功基準** — prefer commands and observable signals. Subjective bullets
+  ("ユーザー体験が向上する") are not measurable and should be deleted.
+- **Out of Scope (v1)** — required even if empty (write `- なし` if there
+  are no deferred items). Forces the author to think about scope.
+- **Related Artifacts** — paths and links only. No prose summaries here;
+  the SPEC body itself is the canonical narrative.
+
+## Common mistakes
+
+- Listing `FR-001` and `FR-003` but no `FR-002` — Format validation fails.
+- Adding `[NEEDS CLARIFICATION]` markers and forgetting to resolve them
+  before calling `gwt-register-spec`. Use `gwt-discussion` to resolve them
+  first.
+- Using `**Functional Requirements**` or English-only section headings
+  instead of the canonical Japanese names. The validator looks for exact
+  Japanese headings.
+- Forgetting to keep H1 in sync with the GitHub Issue title argument.

--- a/.codex/skills/gwt-register-spec/references/recovery.md
+++ b/.codex/skills/gwt-register-spec/references/recovery.md
@@ -1,0 +1,90 @@
+# Recovery from partial registration
+
+`gwt-register-spec` is designed so the only way to produce a half-baked
+SPEC Issue is for `gwtd issue spec create` to succeed and the subsequent
+`gwtd issue spec <n> --edit spec -f <body>` to fail. (Validation runs
+before any GitHub API call, so a `Structural` or `Format` failure never
+creates an orphan Issue.)
+
+This document covers that single failure mode and the matching recovery
+flow.
+
+## Detect
+
+After `gwtd issue spec create` returns the new Issue number, the skill
+immediately calls `gwtd issue spec <n> --edit spec -f <body>`. If `--edit`
+exits non-zero, the skill stops the lifecycle with:
+
+```
+gwtd register abort --spec <n> --reason 'edit failed: <gh/gwtd error verbatim>'
+```
+
+If the skill reaches the roundtrip step and `gwtd issue spec <n>
+--section spec` reports empty output or the heading does not contain the
+expected H1, the skill aborts with `--reason 'roundtrip empty'`.
+
+In both cases the GitHub Issue still exists with an empty spec section.
+The caller and any human reviewer must see the orphan Issue number.
+
+## Report
+
+The skill returns a structured report to the caller containing at
+minimum:
+
+```json
+{
+  "outcome": "partial",
+  "issue": <n>,
+  "url": "https://github.com/akiojin/gwt/issues/<n>",
+  "failed_step": "edit" | "roundtrip",
+  "error": "<verbatim gh/gwtd error>",
+  "next_action": "manual_edit"
+}
+```
+
+The caller surfaces this back to the user. Do not silently retry — the
+underlying failure (network, auth, GitHub rate limit) usually persists
+and would block the retry too.
+
+## Repair (manual)
+
+Once the upstream failure is understood (e.g. network restored, auth
+refreshed), the human or follow-up agent runs:
+
+```
+gwtd issue spec <n> --edit spec -f <body_path>
+gwtd issue spec <n> --section spec | head -5      # roundtrip verify
+```
+
+If the roundtrip is OK, the SPEC is healed. There is no need to delete
+and re-create the Issue.
+
+## Repair (automated retry, deferred)
+
+In v1 the skill does not auto-retry. Adding bounded retry with
+exponential backoff is a v2 candidate; the open design questions are:
+
+- How many retries before the orphan Issue is reported?
+- Should the skill detect transient errors (HTTP 5xx, network) and
+  retry only those, vs hard-fail on auth?
+- Where does the retry budget live — per-skill-run, per-process, or
+  per-user-session?
+
+These will be revisited if recovery ends up being a frequent operation.
+Until then, the manual flow is intentional: it forces a human to see
+the orphan Issue, which is the safest outcome.
+
+## When the Issue should be abandoned, not repaired
+
+If the SPEC body itself turned out to be wrong (e.g. duplicate of an
+existing SPEC found during a second-pass search), close the GitHub Issue
+with a short comment pointing at the canonical owner. Do not edit the
+spec section to point elsewhere — that pollutes the SPEC search index.
+
+```
+gwtd issue comment <n> -f <comment.md>      # explain why
+# then close the Issue via the UI or `gh issue close <n>` (out of band)
+```
+
+This is the only case where the orphan Issue is intentionally left
+empty.

--- a/.codex/skills/gwt-register-spec/references/validation-rules.md
+++ b/.codex/skills/gwt-register-spec/references/validation-rules.md
@@ -1,0 +1,112 @@
+# Validation rules
+
+`gwt-register-spec` validates the SPEC body before any GitHub API call.
+This document is the canonical list. The Rust implementation lives at
+`crates/gwt-github/src/spec_validate.rs` and exposes
+`validate_spec_body(body: &str, title: &str, rules: &ValidationRules) ->
+Vec<ValidationIssue>`.
+
+## Severity levels
+
+- `Structural` — the body cannot be processed downstream without manual
+  correction. Always hard-fail: no Issue is created.
+- `Format` — the body is processable but does not meet the project's
+  format convention. Also hard-fail in v1 (consistent registration
+  surface). Future opt-in soft-fail is possible behind a `--allow-format`
+  flag, but that is out of scope for v1.
+
+Every issue carries `{ severity, location, message }` where `location` is
+either `"title"`, the section heading (`"## 機能要件"`), or a 1-based line
+offset inside the body.
+
+## Rule table
+
+| ID | Severity | Rule | Failure example |
+|---|---|---|---|
+| R1 | Structural | Title matches `^SPEC: .+$` | `"feat: foo"` → fail |
+| R2 | Structural | First non-blank line of body equals title | H1 says `# something else` |
+| R3 | Structural | Section `## 背景` exists | missing or misspelled |
+| R4 | Structural | Section `## ユビキタス言語` exists | — |
+| R5 | Structural | Section `## ユーザーシナリオと受け入れシナリオ` exists | — |
+| R6 | Structural | Section `## 機能要件` exists | — |
+| R7 | Structural | Section `## 成功基準` exists | — |
+| R8 | Structural | Section `## Out of Scope` exists (case-sensitive prefix; `(v1)` suffix permitted) | `## Out Of Scope` → fail |
+| R9 | Structural | Section `## Related Artifacts` exists | — |
+| R10 | Structural | `機能要件` section contains ≥1 line matching `^- \*\*FR-\d{3}\*\*` | no FR present |
+| R11 | Structural | No occurrence of `[NEEDS CLARIFICATION]` anywhere | unresolved markers |
+| R12 | Format | FR identifiers are contiguous (`FR-001`, `FR-002`, …) | `FR-001, FR-003` |
+
+R8 explicitly permits `## Out of Scope (v1)` so version-suffixed sections
+keep passing validation. Implementation: prefix match on
+`"## Out of Scope"` then optional whitespace + `(...)`.
+
+## Roundtrip check (post-create)
+
+After the GitHub Issue has been created and `--edit spec -f <body>` has
+been called, the skill performs a roundtrip verification:
+
+1. `gwtd issue spec <n> --section spec` must exit 0.
+2. The output must be non-empty.
+3. The output must contain the H1 line of the body (`# SPEC: …`).
+
+If any of these fail, the skill aborts the lifecycle with a
+`roundtrip` reason and surfaces the orphan Issue number per
+`recovery.md`.
+
+## Section heading detection
+
+Headings are recognised by exact `## <Heading>` at the start of a line
+(after optional leading whitespace is rejected — only flush-left
+headings count). The match is on the heading text, not on any anchor or
+slug. The validator does **not** parse markdown into an AST; it operates
+on line patterns to keep the implementation small and predictable.
+
+## What is NOT validated (v1 contract)
+
+- Tense, voice, or style of FR sentences (no NLP).
+- Numbering of acceptance scenarios (any 1-based numeric list is
+  accepted).
+- Existence of plan / tasks sections — those are added later by
+  `gwt-plan-spec`.
+- Section ordering — sections may appear in any order as long as all
+  required headings exist.
+- Internal links to other SPECs — `Related Artifacts` may contain any
+  free-form text.
+
+## Worked example
+
+Given a body with:
+
+```markdown
+# SPEC: Demo
+
+## 背景
+ある。
+
+## ユビキタス言語
+- **X**: y
+
+## ユーザーシナリオと受け入れシナリオ
+### Primary User Story
+hi.
+
+## 機能要件
+- **FR-001**: a
+- **FR-002**: b
+
+## 成功基準
+- ok
+
+## Related Artifacts
+- none
+```
+
+Validation issues returned:
+
+- `Structural` `## ユーザーシナリオと受け入れシナリオ`: missing
+  `### Acceptance Scenarios` is not validated (out of scope), but the
+  section itself is present → no issue.
+- `Structural` `## Out of Scope`: missing → fail.
+- (no other issues)
+
+The caller fixes the missing section, re-runs validation, and proceeds.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,6 +309,7 @@ jobs:
       - name: Create app bundle
         run: |
           mkdir -p dist/GWT.app/Contents/MacOS
+          mkdir -p dist/GWT.app/Contents/Resources
           cat > dist/GWT.app/Contents/Info.plist <<EOF
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -318,6 +319,8 @@ jobs:
             <string>GWT</string>
             <key>CFBundleExecutable</key>
             <string>gwt</string>
+            <key>CFBundleIconFile</key>
+            <string>icon</string>
             <key>CFBundleIdentifier</key>
             <string>io.github.akiojin.gwt</string>
             <key>CFBundleName</key>
@@ -333,6 +336,7 @@ jobs:
           EOF
           cp dist/gwt dist/GWT.app/Contents/MacOS/gwt
           cp dist/gwtd dist/GWT.app/Contents/MacOS/gwtd
+          cp assets/icons/icon.icns dist/GWT.app/Contents/Resources/icon.icns
           chmod +x dist/GWT.app/Contents/MacOS/gwt
           chmod +x dist/GWT.app/Contents/MacOS/gwtd
       - name: Prepare macOS signing keychain

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,10 +99,13 @@
 ##### Step 3: 既存 SPEC が見つからない場合のみ → 新規 SPEC を作成する
 
 - `gwt-discussion` を使って investigation-first で議論し、必要なら DDD ベースで SPEC 設計まで進める（調査 → ドメイン分析 → SPEC 登録/更新 → 仕様明確化）
-- GitHub Issue (`gwt-spec` label) として作成する `spec` section には最低限以下を含める:
-  - ユーザーシナリオとテスト（受け入れシナリオ）
+- SPEC 登録は **`gwt-register-spec` skill 経由** で行う（SPEC-2784）。gwt-discussion の Action Bundle で `Register Spec` を選択し、title + body file を渡せば、skill が validation → `gwtd issue spec create` → `--edit spec` → roundtrip 検証を安全に実行する。直接 `gwtd issue spec create -f` を呼ぶと section マーカー漏れで空 SPEC が作成される（SPEC #2780 で発生、tasks/lessons.md 参照）
+- GitHub Issue (`gwt-spec` label) として作成する `spec` section には最低限以下を含める（gwt-register-spec の validation が強制する 7 セクション）:
+  - 背景 / ユビキタス言語
+  - ユーザーシナリオと受け入れシナリオ
   - 機能要件（FR-\*）
   - 成功基準
+  - Out of Scope / Related Artifacts
 - `gwt-plan-spec` で `plan` / `tasks` section も策定してから実装に入る
 - 新規 SPEC を作成した場合でも、エージェントは自分で新規ブランチや Worktree を作成しない。実装に進む場合は、承認済み SPEC と `gwt-plan-spec` の成果物に基づき、現在起動されている branch/worktree で作業する。
 - Git 環境の作成が必要な場合は、ユーザー操作に基づく gwt の Start Work / Launch materialization が担当する。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,36 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.40.0] - 2026-05-20
+
+### Bug Fixes
+
+- **release:** MacOS DMG bundle に icon.icns と CFBundleIconFile を再配線 (#2799)
+- **gui:** Gate Linked issue section to Issue Bridge launches (SPEC-2014)
+- **logging:** Adapt Logs window reader to canonical JSONL shape (SPEC-1924 US-14)
+- **logging:** Disambiguate tracing_subscriber::fmt intra-doc link in reader
+- **issue-cache:** Detect spec issues by body header to keep refresh resilient to label loss
+- **gui:** Register /release-notes-window.js to unblock splash boot
+- **gui:** Register release-notes-window.js in embedded_web allow-list
+- **gui:** Make #app-version look clickable, drop noisy tooltip
+- **gui:** Give .release-notes-window fixed positioning so it actually shows
+- **release:** Windows と Linux も tao window icon を明示配線する (#2799)
+- **issue-cache:** Cache plain when SPEC body parse fails to absorb is_spec_issue regression
+
+### Features
+
+- **skills:** Introduce gwt-register-spec for safe SPEC creation (SPEC-2784)
+- **gui:** Surface server URL in status strip with browser+copy (SPEC-2785)
+- **core:** Introduce ProcessConsoleHub and migrate gh CLI callers (SPEC-1924 / SPEC-2019)
+
+### Refactor
+
+- **cli:** Move parse_register_args into cli/register to honor cli.rs size budget
+
+### Testing
+
+- **playwright:** Add live E2E spec for Release Notes window + lessons
+
 ## [9.39.0] - 2026-05-20
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,6 +1447,7 @@ dependencies = [
  "ignore",
  "notify",
  "notify-debouncer-mini",
+ "regex",
  "reqwest",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.39.0"
+version = "9.40.0"
 dependencies = [
  "ammonia",
  "axum",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.39.0"
+version = "9.40.0"
 dependencies = [
  "chrono",
  "dunce",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.39.0"
+version = "9.40.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.39.0"
+version = "9.40.0"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.39.0"
+version = "9.40.0"
 dependencies = [
  "dirs",
  "serde",
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.39.0"
+version = "9.40.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.39.0"
+version = "9.40.0"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.39.0"
+version = "9.40.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.39.0"
+version = "9.40.0"
 dependencies = [
  "gwt-core",
  "regex",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.39.0"
+version = "9.40.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.39.0"
+version = "9.40.0"
 dependencies = [
  "libc",
  "nix 0.31.3",
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.39.0"
+version = "9.40.0"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.39.0"
+version = "9.40.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt-core/Cargo.toml
+++ b/crates/gwt-core/Cargo.toml
@@ -29,6 +29,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
 uuid = { workspace = true }
+regex = { workspace = true }
 
 [build-dependencies]
 serde_yaml = { workspace = true }

--- a/crates/gwt-core/src/lib.rs
+++ b/crates/gwt-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod logging;
 pub mod migration;
 pub mod paths;
 pub mod process;
+pub mod process_console;
 mod release_contract;
 pub mod release_notes;
 pub mod repo_hash;

--- a/crates/gwt-core/src/logging/init.rs
+++ b/crates/gwt-core/src/logging/init.rs
@@ -1,10 +1,12 @@
 //! Subscriber initialization and handle types.
 
+use std::sync::Arc;
+
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{
-    filter::EnvFilter,
-    layer::SubscriberExt,
+    filter::{EnvFilter, FilterFn},
+    layer::{Layer, SubscriberExt},
     reload::{self, Handle as TracingReloadHandle},
     util::SubscriberInitExt,
     Registry,
@@ -16,6 +18,7 @@ use super::{
     ui_forwarder::UiForwarderLayer,
     writer, LogEvent,
 };
+use crate::process_console::ProcessConsoleHub;
 
 /// Reload handle for the `EnvFilter` layer.
 ///
@@ -43,6 +46,10 @@ pub struct LoggingHandles {
     /// The directory that logs are written to (canonicalised path
     /// after `create_dir_all`).
     pub log_dir: std::path::PathBuf,
+    /// Ephemeral hub that collects external process stdout / stderr
+    /// lines. SPEC-1924 FR-038. Cheap to clone; hand a clone to the GUI
+    /// runtime so the Logs window can subscribe.
+    pub process_console_hub: Arc<ProcessConsoleHub>,
 }
 
 impl LoggingHandles {
@@ -121,7 +128,14 @@ pub fn init(config: LoggingConfig) -> Result<LoggingHandles, String> {
     };
     let (reloadable_filter, reload_handle) = reload::Layer::new(env_filter);
 
-    let fmt = fmt_layer::build(non_blocking);
+    // SPEC-1924 FR-040: keep `gwt.process.line` events out of the
+    // canonical JSONL file. They only need to flow to the UI forwarder
+    // and (via spawn_logged) to the ProcessConsoleHub. The filter is
+    // applied to the file writer layer only, so the UI layer still
+    // observes the line events for live forwarding hooks.
+    let fmt = fmt_layer::build(non_blocking).with_filter(FilterFn::new(|metadata| {
+        !metadata.target().starts_with("gwt.process.line")
+    }));
     let ui = UiForwarderLayer::new(ui_tx.clone());
 
     Registry::default()
@@ -141,11 +155,18 @@ pub fn init(config: LoggingConfig) -> Result<LoggingHandles, String> {
         );
     }
 
+    let process_console_hub = ProcessConsoleHub::new();
+    // SPEC-1924 FR-039: install the process-wide hub so synchronous
+    // gh / git / docker / runner wrappers can find it without
+    // threading it through every call site.
+    let _ = crate::process_console::set_global(process_console_hub.clone());
+
     Ok(LoggingHandles {
         guard,
         reload_handle,
         ui_rx: Some(ui_rx),
         ui_tx,
         log_dir: config.log_dir,
+        process_console_hub: Arc::new(process_console_hub),
     })
 }

--- a/crates/gwt-core/src/logging/mod.rs
+++ b/crates/gwt-core/src/logging/mod.rs
@@ -24,6 +24,7 @@ pub mod event;
 pub mod fmt_layer;
 pub mod housekeep;
 pub mod init;
+pub mod reader;
 pub mod ui_forwarder;
 pub mod writer;
 
@@ -31,4 +32,5 @@ pub use config::{LogLevel, LoggingConfig};
 pub use event::LogEvent;
 pub use housekeep::{housekeep, HousekeepReport};
 pub use init::{apply_log_level_to_handle, init, LoggingHandles, ReloadHandle};
+pub use reader::{read_log_file, LogFileEntry, ReadDiagnostics, ReadOutcome};
 pub use writer::{current_log_file, log_file_for_date, LOG_FILE_BASENAME};

--- a/crates/gwt-core/src/logging/mod.rs
+++ b/crates/gwt-core/src/logging/mod.rs
@@ -32,3 +32,11 @@ pub use event::LogEvent;
 pub use housekeep::{housekeep, HousekeepReport};
 pub use init::{apply_log_level_to_handle, init, LoggingHandles, ReloadHandle};
 pub use writer::{current_log_file, log_file_for_date, LOG_FILE_BASENAME};
+
+// SPEC-1924 Update 2026-05-20: re-export ProcessConsoleHub family so
+// downstream crates can access them through `gwt_core::logging::...`
+// alongside the existing `LoggingHandles.process_console_hub` field.
+pub use crate::process_console::{
+    spawn_logged, spawn_logged_blocking, ProcessConsoleHub, ProcessKind, ProcessLine,
+    ProcessStream, SpawnOptions, SpawnOutput, DEFAULT_RING_CAPACITY,
+};

--- a/crates/gwt-core/src/logging/reader.rs
+++ b/crates/gwt-core/src/logging/reader.rs
@@ -25,7 +25,7 @@
 //! this reader; do not re-implement `serde_json::from_str::<LogEvent>` on
 //! disk lines (SPEC-1924 FR-037 / SC-011).
 //!
-//! See [`tracing_subscriber::fmt`] for the writer side; the relevant
+//! See [`mod@tracing_subscriber::fmt`] for the writer side; the relevant
 //! configuration lives in `crates/gwt-core/src/logging/fmt_layer.rs`.
 
 use std::{

--- a/crates/gwt-core/src/logging/reader.rs
+++ b/crates/gwt-core/src/logging/reader.rs
@@ -1,0 +1,341 @@
+//! Canonical log file reader (SPEC-1924 US-14 / FR-035 / FR-036 / FR-037).
+//!
+//! The structured runtime log file at
+//! `~/.gwt/projects/<repo-hash>/logs/gwt.log.YYYY-MM-DD` is written by
+//! `tracing_subscriber::fmt::layer().json()` (see `fmt_layer.rs`) using the
+//! shape:
+//!
+//! ```json
+//! {"timestamp":"...","level":"INFO","fields":{"message":"...","k":"v"},"target":"..."}
+//! ```
+//!
+//! In-process the UI forwarder produces [`LogEvent`] values with an
+//! auto-assigned `id`, mapped `severity` / `source`, and a hoisted `message`.
+//! These two shapes are intentionally different: the on-disk shape is the
+//! standard `tracing` JSON Lines format (compatible with external tooling)
+//! and `id` is only meaningful inside a single process.
+//!
+//! This module provides the glue: [`LogFileEntry`] mirrors the on-disk shape
+//! exactly, and [`read_log_file`] turns the JSONL file into a
+//! [`Vec<LogEvent>`] suitable for the Logs window snapshot path. Malformed
+//! lines are skipped and counted in [`ReadDiagnostics`] so a single corrupt
+//! flush never blanks the snapshot.
+//!
+//! Logs window, future CLI subcommands, and the daemon must all go through
+//! this reader; do not re-implement `serde_json::from_str::<LogEvent>` on
+//! disk lines (SPEC-1924 FR-037 / SC-011).
+//!
+//! See [`tracing_subscriber::fmt`] for the writer side; the relevant
+//! configuration lives in `crates/gwt-core/src/logging/fmt_layer.rs`.
+
+use std::{
+    io::{self, BufRead, BufReader},
+    path::{Path, PathBuf},
+};
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use super::{LogEvent, LogLevel};
+
+/// Result of [`read_log_file`].
+#[derive(Debug, Clone)]
+pub struct ReadOutcome {
+    /// Successfully decoded log events in source order. `id` is assigned in
+    /// read order starting at `1`.
+    pub entries: Vec<LogEvent>,
+    /// Diagnostic counters describing the read (skipped malformed lines etc.).
+    pub diagnostics: ReadDiagnostics,
+}
+
+/// Diagnostic counters for a single [`read_log_file`] invocation.
+#[derive(Debug, Clone)]
+pub struct ReadDiagnostics {
+    /// Absolute path of the file that was read (so the UI can surface the
+    /// source when warning about skipped lines).
+    pub path: PathBuf,
+    /// Number of non-empty lines that failed JSON / shape validation and were
+    /// skipped. Empty lines do not count.
+    pub skipped: usize,
+}
+
+/// JSON Lines record as emitted by `tracing_subscriber::fmt::json()`.
+///
+/// Top-level fields not listed here (`span`, `spans`, `threadId`, …) are
+/// silently ignored via `#[serde(deny_unknown_fields)]` *not* being set.
+#[derive(Debug, Clone, Deserialize)]
+pub struct LogFileEntry {
+    pub timestamp: DateTime<Utc>,
+    pub level: String,
+    #[serde(default)]
+    pub target: String,
+    #[serde(default)]
+    pub fields: serde_json::Map<String, serde_json::Value>,
+}
+
+impl LogFileEntry {
+    /// Convert this on-disk record into an in-memory [`LogEvent`].
+    ///
+    /// `id` is taken from the caller so that [`read_log_file`] can assign
+    /// monotonically increasing ids in source order without any global state.
+    pub fn into_log_event(mut self, id: u64) -> LogEvent {
+        let severity = parse_level(&self.level);
+
+        let message = take_string(&mut self.fields, "message").unwrap_or_default();
+        let detail = take_string(&mut self.fields, "detail");
+
+        LogEvent {
+            id,
+            severity,
+            source: self.target,
+            message,
+            detail,
+            timestamp: self.timestamp,
+            fields: self.fields,
+        }
+    }
+}
+
+/// Read a canonical structured log file and return the decoded events.
+///
+/// Behavior:
+///
+/// - Returns `Ok(ReadOutcome { entries: vec![], diagnostics: { skipped: 0 } })`
+///   when `path` does not exist (matches the previous GUI behavior: an empty
+///   Logs window is acceptable before any event has been emitted).
+/// - Empty lines and an unterminated trailing line are tolerated and do not
+///   count as `skipped`.
+/// - Lines that fail to decode are skipped and counted in
+///   `diagnostics.skipped`; the rest are returned.
+/// - `id` is assigned in read order starting from `1` and is in-memory only.
+pub fn read_log_file(path: &Path) -> io::Result<ReadOutcome> {
+    let file = match std::fs::File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(ReadOutcome {
+                entries: Vec::new(),
+                diagnostics: ReadDiagnostics {
+                    path: path.to_path_buf(),
+                    skipped: 0,
+                },
+            });
+        }
+        Err(error) => return Err(error),
+    };
+
+    let reader = BufReader::new(file);
+    let mut entries = Vec::new();
+    let mut skipped = 0_usize;
+    let mut next_id: u64 = 1;
+
+    for line in reader.lines() {
+        let line = line?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<LogFileEntry>(trimmed) {
+            Ok(entry) => {
+                entries.push(entry.into_log_event(next_id));
+                next_id += 1;
+            }
+            Err(_) => {
+                skipped += 1;
+            }
+        }
+    }
+
+    Ok(ReadOutcome {
+        entries,
+        diagnostics: ReadDiagnostics {
+            path: path.to_path_buf(),
+            skipped,
+        },
+    })
+}
+
+fn parse_level(level: &str) -> LogLevel {
+    match level.to_ascii_uppercase().as_str() {
+        "ERROR" => LogLevel::Error,
+        "WARN" | "WARNING" => LogLevel::Warn,
+        "INFO" => LogLevel::Info,
+        // tracing emits DEBUG/TRACE — both collapse to Debug to match
+        // `LogLevel::from_tracing`.
+        _ => LogLevel::Debug,
+    }
+}
+
+fn take_string(
+    fields: &mut serde_json::Map<String, serde_json::Value>,
+    key: &str,
+) -> Option<String> {
+    match fields.remove(key)? {
+        serde_json::Value::String(s) => Some(s),
+        // tracing sometimes records `Debug` fields as their `{:?}` string
+        // form which serializes as a JSON string anyway; everything else
+        // (numbers, booleans, objects) is unexpected for `message`/`detail`
+        // and we fall back to its JSON representation rather than dropping
+        // the information silently.
+        other => Some(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn write_lines(lines: &[&str]) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("gwt.log.2026-05-20");
+        let mut file = std::fs::File::create(&path).expect("create");
+        for line in lines {
+            file.write_all(line.as_bytes()).expect("write line");
+            file.write_all(b"\n").expect("write newline");
+        }
+        (dir, path)
+    }
+
+    const PROD_LINE_INFO: &str = r#"{"timestamp":"2026-05-20T09:00:00.015355+09:00","level":"INFO","fields":{"message":"PTY resize completed","cols":72,"rows":24,"outcome":"ok"},"target":"gwt::resize::pty"}"#;
+    const PROD_LINE_WARN: &str = r#"{"timestamp":"2026-05-20T09:00:00.020000+09:00","level":"WARN","fields":{"message":"slow flush","elapsed_ms":120},"target":"gwt::flush"}"#;
+    const PROD_LINE_ERROR: &str = r#"{"timestamp":"2026-05-20T09:00:00.030000+09:00","level":"ERROR","fields":{"message":"git failed","detail":"exit status 128"},"target":"gwt::git"}"#;
+    const PROD_LINE_NO_MESSAGE: &str = r#"{"timestamp":"2026-05-20T09:00:00.040000+09:00","level":"INFO","fields":{"k":"v"},"target":"gwt::nomsg"}"#;
+    const UNKNOWN_FIELD_LINE: &str = r#"{"timestamp":"2026-05-20T09:00:00.050000+09:00","level":"INFO","fields":{"message":"with span"},"target":"gwt::span","span":{"name":"outer"},"spans":[{"name":"outer"}]}"#;
+    const MALFORMED_LINE: &str = r#"{"foo":"bar"}"#;
+
+    #[test]
+    fn reads_production_shape_jsonl_round_trip() {
+        let (_dir, path) = write_lines(&[PROD_LINE_INFO, PROD_LINE_WARN, PROD_LINE_ERROR]);
+
+        let outcome = read_log_file(&path).expect("read ok");
+
+        assert_eq!(outcome.diagnostics.skipped, 0);
+        assert_eq!(outcome.entries.len(), 3);
+
+        // ids are assigned in source order, in-memory only.
+        assert_eq!(outcome.entries[0].id, 1);
+        assert_eq!(outcome.entries[1].id, 2);
+        assert_eq!(outcome.entries[2].id, 3);
+
+        // level -> severity
+        assert_eq!(outcome.entries[0].severity, LogLevel::Info);
+        assert_eq!(outcome.entries[1].severity, LogLevel::Warn);
+        assert_eq!(outcome.entries[2].severity, LogLevel::Error);
+
+        // target -> source, fields.message -> message
+        assert_eq!(outcome.entries[0].source, "gwt::resize::pty");
+        assert_eq!(outcome.entries[0].message, "PTY resize completed");
+
+        // fields.detail -> detail
+        assert_eq!(
+            outcome.entries[2].detail.as_deref(),
+            Some("exit status 128")
+        );
+
+        // residual fields retained, message/detail removed.
+        assert!(!outcome.entries[0].fields.contains_key("message"));
+        assert_eq!(
+            outcome.entries[0].fields.get("outcome"),
+            Some(&serde_json::Value::String("ok".to_string()))
+        );
+        assert!(!outcome.entries[2].fields.contains_key("detail"));
+    }
+
+    #[test]
+    fn skips_malformed_lines_and_returns_remaining_entries() {
+        let (_dir, path) = write_lines(&[PROD_LINE_INFO, MALFORMED_LINE, PROD_LINE_WARN]);
+
+        let outcome = read_log_file(&path).expect("read ok");
+
+        assert_eq!(outcome.entries.len(), 2);
+        assert_eq!(outcome.diagnostics.skipped, 1);
+        assert_eq!(outcome.diagnostics.path, path);
+        // ids are assigned only to successfully decoded entries and remain
+        // monotonic.
+        assert_eq!(outcome.entries[0].id, 1);
+        assert_eq!(outcome.entries[1].id, 2);
+    }
+
+    #[test]
+    fn missing_file_returns_empty_outcome() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("does-not-exist.log");
+
+        let outcome = read_log_file(&path).expect("read ok");
+
+        assert!(outcome.entries.is_empty());
+        assert_eq!(outcome.diagnostics.skipped, 0);
+        assert_eq!(outcome.diagnostics.path, path);
+    }
+
+    #[test]
+    fn empty_file_returns_empty_outcome() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("gwt.log.empty");
+        std::fs::File::create(&path).expect("create");
+
+        let outcome = read_log_file(&path).expect("read ok");
+
+        assert!(outcome.entries.is_empty());
+        assert_eq!(outcome.diagnostics.skipped, 0);
+    }
+
+    #[test]
+    fn ignores_blank_lines_without_counting_as_skipped() {
+        let (_dir, path) = write_lines(&["", "   ", PROD_LINE_INFO, "", PROD_LINE_WARN, "   "]);
+
+        let outcome = read_log_file(&path).expect("read ok");
+
+        assert_eq!(outcome.entries.len(), 2);
+        assert_eq!(outcome.diagnostics.skipped, 0);
+    }
+
+    #[test]
+    fn tolerates_trailing_unterminated_line() {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("gwt.log.trail");
+        let mut file = std::fs::File::create(&path).expect("create");
+        file.write_all(PROD_LINE_INFO.as_bytes()).expect("write");
+        file.write_all(b"\n").expect("write nl");
+        // last line has no trailing newline
+        file.write_all(PROD_LINE_WARN.as_bytes()).expect("write");
+
+        let outcome = read_log_file(&path).expect("read ok");
+
+        assert_eq!(outcome.entries.len(), 2);
+        assert_eq!(outcome.diagnostics.skipped, 0);
+    }
+
+    #[test]
+    fn unknown_top_level_fields_are_ignored() {
+        let (_dir, path) = write_lines(&[UNKNOWN_FIELD_LINE]);
+
+        let outcome = read_log_file(&path).expect("read ok");
+
+        assert_eq!(outcome.entries.len(), 1);
+        assert_eq!(outcome.diagnostics.skipped, 0);
+        assert_eq!(outcome.entries[0].message, "with span");
+        assert_eq!(outcome.entries[0].source, "gwt::span");
+        // span / spans are not mapped to LogEvent and must not leak into
+        // `fields` (those keys are siblings of `fields`, not children).
+        assert!(!outcome.entries[0].fields.contains_key("span"));
+        assert!(!outcome.entries[0].fields.contains_key("spans"));
+    }
+
+    #[test]
+    fn missing_message_field_yields_empty_message() {
+        let (_dir, path) = write_lines(&[PROD_LINE_NO_MESSAGE]);
+
+        let outcome = read_log_file(&path).expect("read ok");
+
+        assert_eq!(outcome.entries.len(), 1);
+        assert_eq!(outcome.entries[0].message, "");
+        assert_eq!(
+            outcome.entries[0].fields.get("k"),
+            Some(&serde_json::Value::String("v".to_string()))
+        );
+    }
+}

--- a/crates/gwt-core/src/process_console/hub.rs
+++ b/crates/gwt-core/src/process_console/hub.rs
@@ -1,0 +1,239 @@
+//! `ProcessConsoleHub` — ephemeral ring-buffer + broadcast for process console lines.
+//!
+//! The hub is the single in-memory surface that the Logs window's Process
+//! facet reads from. It is owned by `LoggingHandles` (set up in `gwt-core`
+//! during `logging::init`) and handed to the GUI runtime so the WebSocket
+//! dispatcher can subscribe.
+//!
+//! Storage strategy (SPEC-1924 FR-038 / NFR-006):
+//!
+//! - One bounded `VecDeque<ProcessLine>` per [`ProcessKind`]
+//! - Default capacity 5000 lines / kind; the oldest line is dropped on overflow
+//! - A `tokio::sync::broadcast::Sender<ProcessLine>` with a small capacity for
+//!   live forwarding. Slow subscribers may lag and miss intermediate lines —
+//!   the ring buffer is the durable replay surface.
+//!
+//! The hub is `Clone` cheap (it wraps `Arc<Mutex<...>>`) so any caller can
+//! grab a handle without coordination.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use tokio::sync::broadcast;
+
+use super::kind::ProcessKind;
+use super::line::ProcessLine;
+
+/// Process-wide hub installed by `gwt_core::logging::init`. Used by
+/// synchronous callers (gh / git / docker / runner wrappers) that do
+/// not have a direct handle to `LoggingHandles`.
+///
+/// `set_global` returns an error if a hub was already installed; this
+/// is intentional so that double-init in tests is loud rather than
+/// silently leaking.
+static GLOBAL_HUB: OnceLock<ProcessConsoleHub> = OnceLock::new();
+
+/// Default capacity per kind. Mirrors SPEC-1924 NFR-006.
+pub const DEFAULT_RING_CAPACITY: usize = 5000;
+
+/// Broadcast channel capacity. Slow subscribers may receive `Lagged`
+/// errors; the ring buffer is the durable replay surface.
+const DEFAULT_BROADCAST_CAPACITY: usize = 1024;
+
+/// Cheap `Clone` handle to the process console.
+///
+/// All clones share the same ring buffers and broadcast sender.
+#[derive(Clone)]
+pub struct ProcessConsoleHub {
+    inner: Arc<HubInner>,
+}
+
+struct HubInner {
+    capacity: usize,
+    rings: [Mutex<VecDeque<ProcessLine>>; ProcessKind::ALL.len()],
+    sender: broadcast::Sender<ProcessLine>,
+}
+
+impl ProcessConsoleHub {
+    /// Build a hub with the default 5000-line ring buffer per kind.
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_RING_CAPACITY)
+    }
+
+    /// Build a hub with a custom ring buffer capacity (test-only knob).
+    pub fn with_capacity(capacity: usize) -> Self {
+        let (sender, _) = broadcast::channel(DEFAULT_BROADCAST_CAPACITY);
+        let rings = std::array::from_fn(|_| Mutex::new(VecDeque::with_capacity(capacity)));
+        Self {
+            inner: Arc::new(HubInner {
+                capacity,
+                rings,
+                sender,
+            }),
+        }
+    }
+
+    /// Push a line into the kind's ring buffer and broadcast it.
+    ///
+    /// The broadcast is best-effort; if there are no live subscribers the
+    /// send returns an error which we silently drop. The ring buffer is
+    /// always updated so the next subscriber can replay history.
+    pub fn push(&self, line: ProcessLine) {
+        let idx = kind_index(line.kind);
+        if let Ok(mut ring) = self.inner.rings[idx].lock() {
+            if ring.len() == self.inner.capacity {
+                ring.pop_front();
+            }
+            ring.push_back(line.clone());
+        }
+        let _ = self.inner.sender.send(line);
+    }
+
+    /// Snapshot the ring buffer for one kind, oldest first.
+    pub fn snapshot_kind(&self, kind: ProcessKind) -> Vec<ProcessLine> {
+        let idx = kind_index(kind);
+        self.inner.rings[idx]
+            .lock()
+            .map(|ring| ring.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Snapshot every ring buffer merged into a single time-sorted vec.
+    pub fn snapshot_all(&self) -> Vec<ProcessLine> {
+        let mut out: Vec<ProcessLine> = ProcessKind::ALL
+            .iter()
+            .flat_map(|kind| self.snapshot_kind(*kind))
+            .collect();
+        out.sort_by_key(|line| line.timestamp);
+        out
+    }
+
+    /// Subscribe to the live broadcast stream.
+    ///
+    /// The returned receiver yields every line pushed AFTER subscription.
+    /// Use [`snapshot_kind`](Self::snapshot_kind) or
+    /// [`snapshot_all`](Self::snapshot_all) to replay history.
+    pub fn subscribe(&self) -> broadcast::Receiver<ProcessLine> {
+        self.inner.sender.subscribe()
+    }
+
+    /// Ring buffer capacity per kind (test helper).
+    pub fn capacity(&self) -> usize {
+        self.inner.capacity
+    }
+}
+
+/// Install the process-wide hub. Called once by `logging::init`.
+///
+/// Returns `false` when a hub was already installed (which happens in
+/// tests that run multiple init sequences in the same process).
+pub fn set_global(hub: ProcessConsoleHub) -> bool {
+    GLOBAL_HUB.set(hub).is_ok()
+}
+
+/// Borrow the process-wide hub if one was installed by
+/// [`set_global`]. Synchronous gh / git / docker / runner wrappers
+/// fall back to a freshly allocated hub (orphan instance, ring buffer
+/// only) when no global was installed — this keeps unit tests of those
+/// crates working without bringing the full logging init along.
+pub fn global() -> ProcessConsoleHub {
+    if let Some(hub) = GLOBAL_HUB.get() {
+        hub.clone()
+    } else {
+        ProcessConsoleHub::new()
+    }
+}
+
+impl Default for ProcessConsoleHub {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn kind_index(kind: ProcessKind) -> usize {
+    ProcessKind::ALL
+        .iter()
+        .position(|candidate| *candidate == kind)
+        .expect("ProcessKind::ALL is exhaustive")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::line::ProcessStream;
+    use super::*;
+
+    fn line(kind: ProcessKind, message: &str) -> ProcessLine {
+        ProcessLine::new(kind, 1, ProcessStream::Stdout, message)
+    }
+
+    #[test]
+    fn push_and_snapshot_round_trip_per_kind() {
+        let hub = ProcessConsoleHub::new();
+        hub.push(line(ProcessKind::Gh, "gh one"));
+        hub.push(line(ProcessKind::Git, "git one"));
+        hub.push(line(ProcessKind::Gh, "gh two"));
+
+        let gh = hub.snapshot_kind(ProcessKind::Gh);
+        assert_eq!(gh.len(), 2);
+        assert_eq!(gh[0].message, "gh one");
+        assert_eq!(gh[1].message, "gh two");
+
+        let git = hub.snapshot_kind(ProcessKind::Git);
+        assert_eq!(git.len(), 1);
+        assert_eq!(git[0].message, "git one");
+
+        let docker = hub.snapshot_kind(ProcessKind::Docker);
+        assert!(docker.is_empty());
+    }
+
+    #[test]
+    fn ring_buffer_overflows_oldest_first() {
+        let hub = ProcessConsoleHub::with_capacity(3);
+        for i in 0..5 {
+            hub.push(line(ProcessKind::Gh, &format!("line {i}")));
+        }
+        let gh = hub.snapshot_kind(ProcessKind::Gh);
+        assert_eq!(gh.len(), 3);
+        assert_eq!(gh[0].message, "line 2");
+        assert_eq!(gh[1].message, "line 3");
+        assert_eq!(gh[2].message, "line 4");
+    }
+
+    #[test]
+    fn snapshot_all_is_time_sorted() {
+        let hub = ProcessConsoleHub::new();
+        let l1 = ProcessLine::new(ProcessKind::Git, 1, ProcessStream::Stdout, "first");
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let l2 = ProcessLine::new(ProcessKind::Docker, 2, ProcessStream::Stdout, "second");
+        hub.push(l2.clone());
+        hub.push(l1.clone());
+        let merged = hub.snapshot_all();
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].message, "first");
+        assert_eq!(merged[1].message, "second");
+    }
+
+    #[tokio::test]
+    async fn subscribe_receives_live_lines() {
+        let hub = ProcessConsoleHub::new();
+        let mut rx = hub.subscribe();
+        hub.push(line(ProcessKind::Gh, "live one"));
+        let received = rx.recv().await.unwrap();
+        assert_eq!(received.message, "live one");
+        assert_eq!(received.kind, ProcessKind::Gh);
+    }
+
+    #[test]
+    fn clone_shares_ring_buffer() {
+        let hub = ProcessConsoleHub::new();
+        let clone = hub.clone();
+        hub.push(line(ProcessKind::Gh, "shared"));
+        assert_eq!(clone.snapshot_kind(ProcessKind::Gh).len(), 1);
+    }
+
+    #[test]
+    fn default_capacity_matches_spec() {
+        let hub = ProcessConsoleHub::new();
+        assert_eq!(hub.capacity(), DEFAULT_RING_CAPACITY);
+    }
+}

--- a/crates/gwt-core/src/process_console/kind.rs
+++ b/crates/gwt-core/src/process_console/kind.rs
@@ -1,0 +1,140 @@
+//! `ProcessKind` — taxonomy for external processes that gwt spawns.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// Logical category of an external process for the Console facet.
+///
+/// The set is intentionally small and closed. Adding a new variant
+/// requires a SPEC update (#1924 FR-038).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ProcessKind {
+    #[serde(rename = "gh")]
+    Gh,
+    #[serde(rename = "git")]
+    Git,
+    #[serde(rename = "docker")]
+    Docker,
+    #[serde(rename = "agent")]
+    AgentBootstrap,
+    #[serde(rename = "runner")]
+    IndexRunner,
+}
+
+impl ProcessKind {
+    pub const ALL: &'static [ProcessKind] = &[
+        ProcessKind::Gh,
+        ProcessKind::Git,
+        ProcessKind::Docker,
+        ProcessKind::AgentBootstrap,
+        ProcessKind::IndexRunner,
+    ];
+
+    /// Lower-case stable identifier used on the wire (socket payloads,
+    /// `tracing` field values, and Logs window chip labels).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ProcessKind::Gh => "gh",
+            ProcessKind::Git => "git",
+            ProcessKind::Docker => "docker",
+            ProcessKind::AgentBootstrap => "agent",
+            ProcessKind::IndexRunner => "runner",
+        }
+    }
+}
+
+impl fmt::Display for ProcessKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for ProcessKind {
+    type Err = ParseProcessKindError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "gh" => Ok(ProcessKind::Gh),
+            "git" => Ok(ProcessKind::Git),
+            "docker" => Ok(ProcessKind::Docker),
+            "agent" | "agent_bootstrap" => Ok(ProcessKind::AgentBootstrap),
+            "runner" | "index_runner" => Ok(ProcessKind::IndexRunner),
+            other => Err(ParseProcessKindError {
+                value: other.to_string(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseProcessKindError {
+    pub value: String,
+}
+
+impl fmt::Display for ParseProcessKindError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown ProcessKind: {}", self.value)
+    }
+}
+
+impl std::error::Error for ParseProcessKindError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_kinds_roundtrip_through_str() {
+        for kind in ProcessKind::ALL {
+            let s = kind.as_str();
+            let parsed: ProcessKind = s.parse().unwrap();
+            assert_eq!(parsed, *kind);
+        }
+    }
+
+    #[test]
+    fn agent_bootstrap_accepts_both_aliases() {
+        assert_eq!(
+            "agent".parse::<ProcessKind>().unwrap(),
+            ProcessKind::AgentBootstrap
+        );
+        assert_eq!(
+            "agent_bootstrap".parse::<ProcessKind>().unwrap(),
+            ProcessKind::AgentBootstrap
+        );
+    }
+
+    #[test]
+    fn index_runner_accepts_both_aliases() {
+        assert_eq!(
+            "runner".parse::<ProcessKind>().unwrap(),
+            ProcessKind::IndexRunner
+        );
+        assert_eq!(
+            "index_runner".parse::<ProcessKind>().unwrap(),
+            ProcessKind::IndexRunner
+        );
+    }
+
+    #[test]
+    fn unknown_kind_returns_error() {
+        let err = "unknown".parse::<ProcessKind>().unwrap_err();
+        assert_eq!(err.value, "unknown");
+    }
+
+    #[test]
+    fn serde_matches_wire_string() {
+        assert_eq!(
+            serde_json::to_string(&ProcessKind::AgentBootstrap).unwrap(),
+            "\"agent\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ProcessKind::IndexRunner).unwrap(),
+            "\"runner\""
+        );
+        let kind: ProcessKind = serde_json::from_str("\"gh\"").unwrap();
+        assert_eq!(kind, ProcessKind::Gh);
+    }
+}

--- a/crates/gwt-core/src/process_console/line.rs
+++ b/crates/gwt-core/src/process_console/line.rs
@@ -1,0 +1,106 @@
+//! `ProcessLine` — a single stdout / stderr line emitted by an external process.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::kind::ProcessKind;
+
+/// Which stdio stream produced the line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProcessStream {
+    #[serde(rename = "stdout")]
+    Stdout,
+    #[serde(rename = "stderr")]
+    Stderr,
+}
+
+impl ProcessStream {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ProcessStream::Stdout => "stdout",
+            ProcessStream::Stderr => "stderr",
+        }
+    }
+}
+
+/// One redacted stdout / stderr line plus enough metadata to filter and
+/// render it in the Logs window's Process facet.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProcessLine {
+    /// Logical category of the spawning process.
+    pub kind: ProcessKind,
+    /// Per-spawn correlation id. Lets the UI group lines that came from
+    /// the same `spawn_logged` call across kinds.
+    pub spawn_id: u64,
+    /// Which stdio stream produced the line.
+    pub stream: ProcessStream,
+    /// The redacted line text. Trailing line separators are stripped
+    /// before redaction. Carriage-return progress lines (`docker pull`,
+    /// `git clone`) are split into one line per CR by the spawn loop.
+    pub message: String,
+    /// Local time at which `spawn_logged` observed the line.
+    pub timestamp: DateTime<Utc>,
+}
+
+impl ProcessLine {
+    pub fn new(
+        kind: ProcessKind,
+        spawn_id: u64,
+        stream: ProcessStream,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            kind,
+            spawn_id,
+            stream,
+            message: message.into(),
+            timestamp: Utc::now(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn process_stream_roundtrip_via_serde() {
+        assert_eq!(
+            serde_json::to_string(&ProcessStream::Stdout).unwrap(),
+            "\"stdout\""
+        );
+        let parsed: ProcessStream = serde_json::from_str("\"stderr\"").unwrap();
+        assert_eq!(parsed, ProcessStream::Stderr);
+    }
+
+    #[test]
+    fn process_line_carries_kind_and_text() {
+        let line = ProcessLine::new(
+            ProcessKind::Gh,
+            42,
+            ProcessStream::Stdout,
+            "PR #123 created",
+        );
+        assert_eq!(line.kind, ProcessKind::Gh);
+        assert_eq!(line.spawn_id, 42);
+        assert_eq!(line.stream, ProcessStream::Stdout);
+        assert_eq!(line.message, "PR #123 created");
+    }
+
+    #[test]
+    fn process_line_roundtrip_through_json() {
+        let line = ProcessLine::new(
+            ProcessKind::Docker,
+            7,
+            ProcessStream::Stderr,
+            "Pulling fs layer",
+        );
+        let json = serde_json::to_string(&line).unwrap();
+        assert!(json.contains("\"docker\""));
+        assert!(json.contains("\"stderr\""));
+        let back: ProcessLine = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.kind, ProcessKind::Docker);
+        assert_eq!(back.stream, ProcessStream::Stderr);
+        assert_eq!(back.message, "Pulling fs layer");
+    }
+}

--- a/crates/gwt-core/src/process_console/mod.rs
+++ b/crates/gwt-core/src/process_console/mod.rs
@@ -1,0 +1,35 @@
+//! Process console — ephemeral hub for external process stdout / stderr.
+//!
+//! See SPEC-1924 Update 2026-05-20 (Process Console Domain) and SPEC-2019
+//! Update 2026-05-20 (Process Console Facet) for the motivating discussion.
+//!
+//! ## Architecture
+//!
+//! Three pieces collaborate:
+//!
+//! 1. [`ProcessKind`] enum — closed set of process categories that gwt
+//!    spawns: gh / git / docker / agent bootstrap / Python index runner.
+//! 2. [`ProcessConsoleHub`] — ring-buffer + broadcast surface that the
+//!    Logs window subscribes to via WebSocket. Owned by `LoggingHandles`.
+//! 3. [`spawn_logged`] — single entry point that callers use to launch
+//!    external processes. Emits `gwt.process.summary` tracing events to
+//!    the canonical log file and forwards stdout / stderr lines (after
+//!    redaction) to the hub.
+//!
+//! Line-level events never reach the canonical log file. They live only
+//! in the hub's ring buffer (capacity 5000 lines / kind by default) and
+//! the broadcast channel. The summary events (start / end / exit_code /
+//! duration / line counts) are persisted to the canonical file via the
+//! standard tracing pipeline.
+
+pub mod hub;
+pub mod kind;
+pub mod line;
+pub mod redact;
+pub mod spawn;
+
+pub use hub::{global, set_global, ProcessConsoleHub, DEFAULT_RING_CAPACITY};
+pub use kind::{ParseProcessKindError, ProcessKind};
+pub use line::{ProcessLine, ProcessStream};
+pub use redact::{redact_line, REDACTED};
+pub use spawn::{spawn_logged, spawn_logged_blocking, SpawnOptions, SpawnOutput};

--- a/crates/gwt-core/src/process_console/redact.rs
+++ b/crates/gwt-core/src/process_console/redact.rs
@@ -1,0 +1,124 @@
+//! Secret redaction for process console lines.
+//!
+//! `ProcessConsoleHub` runs every stdout / stderr line through
+//! [`redact_line`] before pushing it to the ring buffer or broadcasting
+//! to subscribers (SPEC-1924 FR-041). The redaction targets the token
+//! shapes that gh, git, and docker can echo into diagnostic output
+//! when running in verbose / debug mode:
+//!
+//! - `Authorization: <anything>` headers (case-insensitive)
+//! - `token=<value>` URL parameters
+//! - GitHub Personal Access Token prefixes (`gh_` / `ghp_` / `ghs_` / `ghu_`) followed by 16+ alphanumerics
+//!
+//! Replacement is `***redacted***`. The function returns the raw line
+//! unchanged when it does not match any pattern, so callers can compare
+//! the input and output cheaply.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+/// Replacement string used for every redacted pattern.
+pub const REDACTED: &str = "***redacted***";
+
+/// Apply every redaction pattern to `line`.
+///
+/// Returns a `String` because the regex crate cannot guarantee an
+/// in-place replace. When no pattern matches, the result is byte-equal
+/// to the input.
+pub fn redact_line(line: &str) -> String {
+    let mut out = line.to_string();
+    out = authorization_re().replace_all(&out, REDACTED).into_owned();
+    out = url_token_re().replace_all(&out, REDACTED).into_owned();
+    out = github_token_re().replace_all(&out, REDACTED).into_owned();
+    out
+}
+
+fn authorization_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?i)Authorization\s*:\s*[^\r\n]+").expect("authorization regex"))
+}
+
+fn url_token_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"(?i)\btoken=[^\s&\r\n]+").expect("url token regex"))
+}
+
+fn github_token_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"gh[pous]_[A-Za-z0-9]{16,}").expect("github token regex"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_authorization_header() {
+        let line = "Authorization: Bearer ghp_abcdef0123456789abcdef";
+        let out = redact_line(line);
+        assert_eq!(out, REDACTED);
+    }
+
+    #[test]
+    fn redacts_lowercase_authorization_header() {
+        let line = "  authorization: bearer x  ";
+        let out = redact_line(line);
+        assert!(out.contains(REDACTED));
+        assert!(!out.contains("bearer x"));
+    }
+
+    #[test]
+    fn redacts_url_token_param() {
+        let line = "GET /api/v3/user?token=secretvalue123 HTTP/1.1";
+        let out = redact_line(line);
+        assert!(out.contains(REDACTED));
+        assert!(!out.contains("secretvalue123"));
+        assert!(out.contains("/api/v3/user"));
+    }
+
+    #[test]
+    fn redacts_github_personal_access_token() {
+        let line = "got ghp_abcdef0123456789ABCDEF from env";
+        let out = redact_line(line);
+        assert!(out.contains(REDACTED));
+        assert!(!out.contains("ghp_abcdef0123456789ABCDEF"));
+    }
+
+    #[test]
+    fn redacts_other_github_token_prefixes() {
+        for prefix in ["gho_", "ghs_", "ghu_"] {
+            let token = format!("{prefix}{}", "X".repeat(20));
+            let line = format!("token is {token} here");
+            let out = redact_line(&line);
+            assert!(
+                out.contains(REDACTED),
+                "{prefix} should be redacted, got: {out}"
+            );
+            assert!(!out.contains(&token));
+        }
+    }
+
+    #[test]
+    fn passes_through_clean_line() {
+        let line = "fatal: could not find object";
+        assert_eq!(redact_line(line), line);
+    }
+
+    #[test]
+    fn does_not_redact_short_gh_words() {
+        // `gh_` followed by <16 chars should not match.
+        let line = "ghi_short and gh_abc are not tokens";
+        let out = redact_line(line);
+        assert_eq!(out, line);
+    }
+
+    #[test]
+    fn redacts_multiple_secrets_in_one_line() {
+        let line =
+            "Authorization: Bearer ghp_abcdef0123456789abcdef; token=secretvalue123 ghs_short";
+        let out = redact_line(line);
+        assert!(!out.contains("ghp_abcdef0123456789abcdef"));
+        assert!(!out.contains("secretvalue123"));
+    }
+}

--- a/crates/gwt-core/src/process_console/spawn.rs
+++ b/crates/gwt-core/src/process_console/spawn.rs
@@ -1,0 +1,425 @@
+//! `spawn_logged` — the single entry point for spawning external processes
+//! while emitting summary tracing events and forwarding stdout / stderr
+//! lines to [`ProcessConsoleHub`].
+//!
+//! SPEC-1924 FR-039: every caller of `Command::new` / `.spawn()` /
+//! `.output()` in gwt is expected to migrate to this wrapper. The two
+//! intentional exceptions (and how to express them) are:
+//!
+//! - Detached spawn that intentionally backgrounds (current
+//!   `crates/gwt/src/launch_runtime.rs:491-493` and
+//!   `crates/gwt-agent/src/prepare.rs:766-768`): pass
+//!   `SpawnOptions { detach: true, .. }` so the wrapper still emits a
+//!   `start` summary, forwards lines until the child detaches, and
+//!   emits a best-effort `exit_code = null` summary at end.
+//! - Stdio::null sinks (e.g. `crates/gwt-git/src/worktree.rs:533-534`):
+//!   pass `SpawnOptions { capture_stdout: false, capture_stderr: false, .. }`
+//!   so the wrapper still emits start / end summary tracing but does not
+//!   forward any line.
+
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::process::Command as TokioCommand;
+
+use super::hub::ProcessConsoleHub;
+use super::kind::ProcessKind;
+use super::line::{ProcessLine, ProcessStream};
+use super::redact;
+
+const SUMMARY_TARGET: &str = "gwt.process.summary";
+
+static SPAWN_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Knobs that control how `spawn_logged` runs the child process.
+#[derive(Debug, Clone)]
+pub struct SpawnOptions {
+    /// Human-readable command label rendered in summary tracing (e.g.
+    /// `"gh pr list"`). The label may differ from the actual argv.
+    pub label: String,
+    /// Working directory passed to the child.
+    pub current_dir: Option<PathBuf>,
+    /// Extra env entries to set / override.
+    pub envs: Vec<(OsString, OsString)>,
+    /// Whether to pipe and forward stdout. Disable for `Stdio::null()`
+    /// callers that only need lifecycle summary.
+    pub capture_stdout: bool,
+    /// Whether to pipe and forward stderr.
+    pub capture_stderr: bool,
+}
+
+impl SpawnOptions {
+    pub fn new(label: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            current_dir: None,
+            envs: Vec::new(),
+            capture_stdout: true,
+            capture_stderr: true,
+        }
+    }
+
+    pub fn current_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.current_dir = Some(dir.into());
+        self
+    }
+
+    pub fn env(mut self, key: impl Into<OsString>, value: impl Into<OsString>) -> Self {
+        self.envs.push((key.into(), value.into()));
+        self
+    }
+
+    pub fn capture(mut self, stdout: bool, stderr: bool) -> Self {
+        self.capture_stdout = stdout;
+        self.capture_stderr = stderr;
+        self
+    }
+}
+
+/// Outcome of a `spawn_logged` call.
+#[derive(Debug)]
+pub struct SpawnOutput {
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    pub stdout_lines: u64,
+    pub stderr_lines: u64,
+}
+
+impl SpawnOutput {
+    pub fn success(&self) -> bool {
+        matches!(self.exit_code, Some(0))
+    }
+}
+
+/// Synchronous wrapper around [`spawn_logged`].
+///
+/// Builds a transient current-thread tokio runtime to drive the async
+/// pipeline. Use this from CLI handlers and any sync caller. When the
+/// caller already has a tokio runtime handle, prefer the async variant
+/// directly.
+pub fn spawn_logged_blocking(
+    hub: &ProcessConsoleHub,
+    kind: ProcessKind,
+    program: impl Into<OsString>,
+    args: &[impl AsRef<std::ffi::OsStr>],
+    options: SpawnOptions,
+) -> std::io::Result<SpawnOutput> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    runtime.block_on(spawn_logged(hub, kind, program, args, options))
+}
+
+/// Spawn `program` with `args`, forwarding lines to `hub` and emitting
+/// `gwt.process.summary` tracing events at start / end.
+pub async fn spawn_logged(
+    hub: &ProcessConsoleHub,
+    kind: ProcessKind,
+    program: impl Into<OsString>,
+    args: &[impl AsRef<std::ffi::OsStr>],
+    options: SpawnOptions,
+) -> std::io::Result<SpawnOutput> {
+    let program = program.into();
+    let spawn_id = SPAWN_ID.fetch_add(1, Ordering::Relaxed);
+    let started_at = Instant::now();
+
+    tracing::info!(
+        target: SUMMARY_TARGET,
+        kind = kind.as_str(),
+        spawn_id = spawn_id,
+        label = %options.label,
+        program = %program.to_string_lossy(),
+        phase = "start",
+        "process start",
+    );
+
+    let mut command = TokioCommand::new(&program);
+    command.args(args.iter().map(|a| a.as_ref()));
+    if let Some(dir) = &options.current_dir {
+        command.current_dir(dir);
+    }
+    for (key, value) in &options.envs {
+        command.env(key, value);
+    }
+    command.stdin(Stdio::null());
+    command.stdout(if options.capture_stdout {
+        Stdio::piped()
+    } else {
+        Stdio::null()
+    });
+    command.stderr(if options.capture_stderr {
+        Stdio::piped()
+    } else {
+        Stdio::null()
+    });
+
+    let mut child = command.spawn()?;
+
+    let stdout_task = if options.capture_stdout {
+        let stdout = child.stdout.take().expect("piped stdout");
+        let hub = hub.clone();
+        Some(tokio::spawn(forward_stream(
+            stdout,
+            hub,
+            kind,
+            spawn_id,
+            ProcessStream::Stdout,
+        )))
+    } else {
+        None
+    };
+
+    let stderr_task = if options.capture_stderr {
+        let stderr = child.stderr.take().expect("piped stderr");
+        let hub = hub.clone();
+        Some(tokio::spawn(forward_stream(
+            stderr,
+            hub,
+            kind,
+            spawn_id,
+            ProcessStream::Stderr,
+        )))
+    } else {
+        None
+    };
+
+    let status = child.wait().await?;
+
+    let (stdout, stdout_lines) = match stdout_task {
+        Some(handle) => handle.await.unwrap_or_else(|_| (String::new(), 0)),
+        None => (String::new(), 0),
+    };
+    let (stderr, stderr_lines) = match stderr_task {
+        Some(handle) => handle.await.unwrap_or_else(|_| (String::new(), 0)),
+        None => (String::new(), 0),
+    };
+
+    let duration_ms = started_at.elapsed().as_millis() as u64;
+    let exit_code = status.code();
+
+    tracing::info!(
+        target: SUMMARY_TARGET,
+        kind = kind.as_str(),
+        spawn_id = spawn_id,
+        label = %options.label,
+        phase = "end",
+        exit_code = exit_code.map(|c| c as i64),
+        duration_ms = duration_ms,
+        stdout_lines = stdout_lines,
+        stderr_lines = stderr_lines,
+        success = status.success(),
+        "process end",
+    );
+
+    Ok(SpawnOutput {
+        exit_code,
+        stdout,
+        stderr,
+        stdout_lines,
+        stderr_lines,
+    })
+}
+
+async fn forward_stream<R>(
+    mut reader: R,
+    hub: ProcessConsoleHub,
+    kind: ProcessKind,
+    spawn_id: u64,
+    stream: ProcessStream,
+) -> (String, u64)
+where
+    R: AsyncRead + Unpin,
+{
+    let mut bytes = Vec::with_capacity(4096);
+    if reader.read_to_end(&mut bytes).await.is_err() {
+        // Fall through; whatever we collected so far is still useful.
+    }
+    // Hold the caller-facing buffer as the raw text exactly as the
+    // child wrote it. `gh auth token` needs the secret to land in the
+    // caller's hands unchanged.
+    let buf = String::from_utf8_lossy(&bytes).into_owned();
+
+    // Split for the hub: newlines AND carriage returns are treated as
+    // line boundaries (the latter so that `docker pull` / `git clone`
+    // progress bars surface as discrete entries rather than one giant
+    // string). Empty fragments are dropped — they only mark boundary
+    // adjacency, not content.
+    let mut total_lines: u64 = 0;
+    for piece in buf.split(['\n', '\r']) {
+        if piece.is_empty() {
+            continue;
+        }
+        let redacted = redact::redact_line(piece);
+        hub.push(ProcessLine::new(kind, spawn_id, stream, redacted));
+        total_lines += 1;
+    }
+    (buf, total_lines)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn echo_command() -> (String, Vec<String>) {
+        if cfg!(windows) {
+            (
+                "cmd".to_string(),
+                vec!["/C".to_string(), "echo hello world".to_string()],
+            )
+        } else {
+            (
+                "sh".to_string(),
+                vec!["-c".to_string(), "echo hello world".to_string()],
+            )
+        }
+    }
+
+    fn stderr_command() -> (String, Vec<String>) {
+        if cfg!(windows) {
+            (
+                "cmd".to_string(),
+                vec!["/C".to_string(), "echo oops 1>&2".to_string()],
+            )
+        } else {
+            (
+                "sh".to_string(),
+                vec!["-c".to_string(), "echo oops 1>&2".to_string()],
+            )
+        }
+    }
+
+    fn failing_command() -> (String, Vec<String>) {
+        if cfg!(windows) {
+            (
+                "cmd".to_string(),
+                vec!["/C".to_string(), "exit 7".to_string()],
+            )
+        } else {
+            (
+                "sh".to_string(),
+                vec!["-c".to_string(), "exit 7".to_string()],
+            )
+        }
+    }
+
+    #[tokio::test]
+    async fn spawn_logged_forwards_stdout_to_hub() {
+        let hub = ProcessConsoleHub::new();
+        let (cmd, args) = echo_command();
+        let out = spawn_logged(
+            &hub,
+            ProcessKind::Git,
+            cmd,
+            &args,
+            SpawnOptions::new("test echo"),
+        )
+        .await
+        .unwrap();
+        assert!(out.success());
+        assert!(out.stdout.contains("hello world"));
+        assert_eq!(out.stdout_lines, 1);
+        let lines = hub.snapshot_kind(ProcessKind::Git);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].stream, ProcessStream::Stdout);
+        assert!(lines[0].message.contains("hello world"));
+    }
+
+    #[tokio::test]
+    async fn spawn_logged_forwards_stderr_separately() {
+        let hub = ProcessConsoleHub::new();
+        let (cmd, args) = stderr_command();
+        let out = spawn_logged(
+            &hub,
+            ProcessKind::Docker,
+            cmd,
+            &args,
+            SpawnOptions::new("test stderr"),
+        )
+        .await
+        .unwrap();
+        assert!(out.success());
+        assert_eq!(out.stderr_lines, 1);
+        let lines = hub.snapshot_kind(ProcessKind::Docker);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].stream, ProcessStream::Stderr);
+    }
+
+    #[tokio::test]
+    async fn spawn_logged_surfaces_non_zero_exit() {
+        let hub = ProcessConsoleHub::new();
+        let (cmd, args) = failing_command();
+        let out = spawn_logged(
+            &hub,
+            ProcessKind::Gh,
+            cmd,
+            &args,
+            SpawnOptions::new("test fail"),
+        )
+        .await
+        .unwrap();
+        assert!(!out.success());
+        assert_eq!(out.exit_code, Some(7));
+    }
+
+    #[tokio::test]
+    async fn spawn_logged_redacts_secrets_in_hub_but_keeps_raw_for_caller() {
+        let hub = ProcessConsoleHub::new();
+        let token = "ghp_abcdef0123456789ABCDEF";
+        let (cmd, args) = if cfg!(windows) {
+            (
+                "cmd".to_string(),
+                vec!["/C".to_string(), format!("echo got {token} here")],
+            )
+        } else {
+            (
+                "sh".to_string(),
+                vec!["-c".to_string(), format!("echo got {token} here")],
+            )
+        };
+        let out = spawn_logged(
+            &hub,
+            ProcessKind::Gh,
+            cmd,
+            &args,
+            SpawnOptions::new("test redact"),
+        )
+        .await
+        .unwrap();
+        assert!(out.success());
+        // SpawnOutput retains the raw value so that gh auth token /
+        // similar helpers receive the real secret.
+        assert!(
+            out.stdout.contains(token),
+            "caller-facing stdout should keep raw token: {:?}",
+            out.stdout
+        );
+        // Hub line is redacted (SPEC-1924 FR-041).
+        let lines = hub.snapshot_kind(ProcessKind::Gh);
+        assert!(
+            !lines[0].message.contains(token),
+            "hub line: {:?}",
+            lines[0].message
+        );
+        assert!(lines[0].message.contains("***redacted***"));
+    }
+
+    #[tokio::test]
+    async fn spawn_logged_capture_off_skips_line_forward() {
+        let hub = ProcessConsoleHub::new();
+        let (cmd, args) = echo_command();
+        let options = SpawnOptions::new("test null").capture(false, false);
+        let out = spawn_logged(&hub, ProcessKind::Git, cmd, &args, options)
+            .await
+            .unwrap();
+        assert!(out.success());
+        assert!(out.stdout.is_empty());
+        assert_eq!(out.stdout_lines, 0);
+        let lines = hub.snapshot_kind(ProcessKind::Git);
+        assert!(lines.is_empty());
+    }
+}

--- a/crates/gwt-core/tests/logging_init.rs
+++ b/crates/gwt-core/tests/logging_init.rs
@@ -8,7 +8,7 @@
 
 use std::time::{Duration, Instant};
 
-use gwt_core::logging::{current_log_file, init, LogLevel, LoggingConfig};
+use gwt_core::logging::{current_log_file, init, read_log_file, LogLevel, LoggingConfig};
 
 #[test]
 fn init_writes_tracing_events_as_jsonl_to_gwt_log() {
@@ -66,5 +66,30 @@ fn init_writes_tracing_events_as_jsonl_to_gwt_log() {
     assert!(
         content.contains("warning sample"),
         "expected warn event in log file"
+    );
+
+    // SPEC-1924 US-14 / T-LFR-006: the on-disk JSONL produced by the live
+    // writer must be replayable by the new reader without any skipped lines.
+    let outcome = read_log_file(&log_path).expect("read_log_file should succeed");
+    assert_eq!(
+        outcome.diagnostics.skipped, 0,
+        "writer/reader shape mismatch: read_log_file skipped {} line(s)",
+        outcome.diagnostics.skipped
+    );
+    assert!(
+        outcome
+            .entries
+            .iter()
+            .any(|e| e.message == "hello from test" && e.source == "gwt_core::logging::test"),
+        "expected hello event to round-trip via read_log_file, got: {:?}",
+        outcome.entries
+    );
+    assert!(
+        outcome
+            .entries
+            .iter()
+            .any(|e| e.message == "warning sample"
+                && e.severity == gwt_core::logging::LogLevel::Warn),
+        "expected warn event to round-trip via read_log_file with Warn severity"
     );
 }

--- a/crates/gwt-core/tests/process_console_filter.rs
+++ b/crates/gwt-core/tests/process_console_filter.rs
@@ -1,0 +1,77 @@
+//! SPEC-1924 FR-040 / SC-013 regression test.
+//!
+//! `gwt.process.line` events must never reach the canonical JSONL log
+//! file. They are observed by the in-process UI forwarder and the
+//! `ProcessConsoleHub` only. `gwt.process.summary` events must reach
+//! the file as usual.
+
+use std::time::{Duration, Instant};
+
+use gwt_core::logging::{current_log_file, init, LogLevel, LoggingConfig};
+
+#[test]
+fn process_line_events_are_excluded_from_canonical_log_file() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let config = LoggingConfig {
+        log_dir: dir.path().to_path_buf(),
+        default_level: LogLevel::Debug,
+        config_file_level: None,
+        retention_days: 0,
+    };
+
+    let handles = init(config).expect("init should succeed");
+
+    // Emit at info level so the EnvFilter does not gate it. The
+    // `gwt.process.line` exclusion happens at the fmt layer (target
+    // prefix filter), not at the EnvFilter level.
+    tracing::info!(
+        target: "gwt.process.line",
+        kind = "gh",
+        stream = "stdout",
+        "should NOT appear on disk"
+    );
+    tracing::info!(
+        target: "gwt.process.summary",
+        kind = "gh",
+        spawn_id = 1u64,
+        phase = "start",
+        "summary should appear on disk"
+    );
+    tracing::info!(
+        target: "gwt.process.summary",
+        kind = "gh",
+        spawn_id = 1u64,
+        phase = "end",
+        exit_code = 0i64,
+        duration_ms = 42u64,
+        "summary end should appear on disk"
+    );
+
+    drop(handles);
+
+    let log_path = current_log_file(dir.path());
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let mut content = std::fs::read_to_string(&log_path).unwrap_or_default();
+    while !content.contains("summary should appear on disk") && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(20));
+        content = std::fs::read_to_string(&log_path).unwrap_or_default();
+    }
+
+    assert!(
+        content.contains("summary should appear on disk"),
+        "expected summary start event in log file, got: {content}"
+    );
+    assert!(
+        content.contains("summary end should appear on disk"),
+        "expected summary end event in log file"
+    );
+    assert!(
+        !content.contains("should NOT appear on disk"),
+        "process line event leaked into canonical log: {content}"
+    );
+    assert!(
+        !content.contains("\"target\":\"gwt.process.line\"")
+            && !content.contains("\"target\": \"gwt.process.line\""),
+        "no entry with target=gwt.process.line should be in canonical log: {content}"
+    );
+}

--- a/crates/gwt-git/src/issue.rs
+++ b/crates/gwt-git/src/issue.rs
@@ -96,29 +96,32 @@ fn cache_filename(owner: &str, repo: &str) -> String {
 /// Fetch open issues from GitHub via `gh issue list --json`.
 pub fn fetch_issues(owner: &str, repo: &str) -> Result<Vec<Issue>> {
     let repo_slug = format!("{owner}/{repo}");
-    let output = gwt_core::process::hidden_command("gh")
-        .args([
+    let hub = gwt_core::process_console::global();
+    let output = gwt_core::process_console::spawn_logged_blocking(
+        &hub,
+        gwt_core::process_console::ProcessKind::Gh,
+        "gh",
+        &[
             "issue",
             "list",
             "--repo",
-            &repo_slug,
+            repo_slug.as_str(),
             "--state",
             "open",
             "--json",
             "number,title,state,labels,assignees,body,url",
             "--limit",
             "100",
-        ])
-        .output()
-        .map_err(|e| GwtError::Git(format!("gh issue list: {e}")))?;
+        ],
+        gwt_core::process_console::SpawnOptions::new("gh issue list"),
+    )
+    .map_err(|e| GwtError::Git(format!("gh issue list: {e}")))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        return Err(GwtError::Git(format!("gh issue list: {stderr}")));
+    if !output.success() {
+        return Err(GwtError::Git(format!("gh issue list: {}", output.stderr)));
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    parse_gh_issues_json(&stdout)
+    parse_gh_issues_json(&output.stdout)
 }
 
 /// Parse the JSON output from `gh issue list --json`.

--- a/crates/gwt-git/src/pr_status.rs
+++ b/crates/gwt-git/src/pr_status.rs
@@ -57,26 +57,31 @@ impl PrStatus {
 ///
 /// The `repo_slug` should be in "owner/repo" format.
 pub fn fetch_pr_status(repo_slug: &str, number: u64) -> Result<PrStatus> {
-    let output = gwt_core::process::hidden_command("gh")
-        .args([
-            "pr",
-            "view",
-            &number.to_string(),
-            "--repo",
-            repo_slug,
-            "--json",
-            "number,title,state,url,createdAt,mergeable,mergeStateStatus,statusCheckRollup,reviewDecision",
-        ])
-        .output()
-        .map_err(|e| GwtError::Git(format!("gh pr view: {e}")))?;
+    let hub = gwt_core::process_console::global();
+    let args = [
+        "pr",
+        "view",
+        &number.to_string(),
+        "--repo",
+        repo_slug,
+        "--json",
+        "number,title,state,url,createdAt,mergeable,mergeStateStatus,statusCheckRollup,reviewDecision",
+    ];
+    let label = format!("gh pr view {}", number);
+    let output = gwt_core::process_console::spawn_logged_blocking(
+        &hub,
+        gwt_core::process_console::ProcessKind::Gh,
+        "gh",
+        &args,
+        gwt_core::process_console::SpawnOptions::new(label),
+    )
+    .map_err(|e| GwtError::Git(format!("gh pr view: {e}")))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        return Err(GwtError::Git(format!("gh pr view: {stderr}")));
+    if !output.success() {
+        return Err(GwtError::Git(format!("gh pr view: {}", output.stderr)));
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    parse_pr_status_json(&stdout)
+    parse_pr_status_json(&output.stdout)
 }
 
 /// Parse `gh pr view --json` output.
@@ -242,16 +247,23 @@ where
 }
 
 fn run_gh_command(repo_path: &Path, args: &[&str]) -> Result<GhCliOutput> {
-    let output = gwt_core::process::hidden_command("gh")
-        .args(args)
-        .current_dir(repo_path)
-        .output()
-        .map_err(|e| GwtError::Git(format!("gh {}: {e}", args.join(" "))))?;
+    let hub = gwt_core::process_console::global();
+    let label = format!("gh {}", args.join(" "));
+    let options =
+        gwt_core::process_console::SpawnOptions::new(label.clone()).current_dir(repo_path);
+    let output = gwt_core::process_console::spawn_logged_blocking(
+        &hub,
+        gwt_core::process_console::ProcessKind::Gh,
+        "gh",
+        args,
+        options,
+    )
+    .map_err(|e| GwtError::Git(format!("{label}: {e}")))?;
 
     Ok(GhCliOutput {
-        success: output.status.success(),
-        stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        success: output.success(),
+        stdout: output.stdout,
+        stderr: output.stderr,
     })
 }
 
@@ -348,29 +360,31 @@ pub struct PrCheckReport {
 /// Runs `gh pr view` to gather CI, merge, and review states. Falls back
 /// to `Unknown` states when `gh` is unavailable or the repo has no open PR.
 pub fn pr_check_report(repo_path: &Path) -> Result<PrCheckReport> {
-    let output = gwt_core::process::hidden_command("gh")
-        .args([
+    let hub = gwt_core::process_console::global();
+    let output = gwt_core::process_console::spawn_logged_blocking(
+        &hub,
+        gwt_core::process_console::ProcessKind::Gh,
+        "gh",
+        &[
             "pr",
             "view",
             "--json",
             "statusCheckRollup,mergeable,mergeStateStatus,reviewDecision,state,title",
-        ])
-        .current_dir(repo_path)
-        .output()
-        .map_err(|e| GwtError::Git(format!("gh pr view: {e}")))?;
+        ],
+        gwt_core::process_console::SpawnOptions::new("gh pr view --json").current_dir(repo_path),
+    )
+    .map_err(|e| GwtError::Git(format!("gh pr view: {e}")))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.success() {
         return Ok(PrCheckReport {
             ci: CiStatus::Unknown,
             merge: MergeStatus::Unknown,
             review: ReviewStatus::Unknown,
-            summary: format!("No open PR or gh error: {}", stderr.trim()),
+            summary: format!("No open PR or gh error: {}", output.stderr.trim()),
         });
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    parse_pr_check_report_json(&stdout)
+    parse_pr_check_report_json(&output.stdout)
 }
 
 /// Parse `gh pr view --json` output into an extended PR check report.

--- a/crates/gwt-github/src/cache.rs
+++ b/crates/gwt-github/src/cache.rs
@@ -230,13 +230,11 @@ impl Cache {
             .collect();
         let spec_body = match SpecBody::parse(&snapshot.body, &parsed_comments) {
             Ok(spec_body) => spec_body,
-            Err(_) => SpecBody {
-                // Mirror the lenient policy from `write_snapshot`: any body
-                // that fails to parse as a SPEC (no header, malformed
-                // sections index, missing referenced comment, etc.) is
-                // surfaced as a plain Issue entry rather than silently
-                // dropped. UI consumers always see the cached body and
-                // metadata; only the structured sections map is empty.
+            Err(ParseError::MissingHeader) => SpecBody {
+                // Plain Issue (no `<!-- gwt-spec id=... -->` header at all):
+                // synthesize an empty SpecBody so the entry still surfaces
+                // to UI consumers as a regular Issue. This mirrors the
+                // existing `write_snapshot` path for plain Issues.
                 meta: SpecMeta {
                     id: meta.number.to_string(),
                     version: 1,
@@ -244,6 +242,22 @@ impl Cache {
                 sections_index: crate::body::SectionsIndex::default(),
                 sections: std::collections::BTreeMap::new(),
             },
+            Err(_) => {
+                // Body carries a SPEC header but the structural parse fails
+                // (malformed sections index, missing referenced comment,
+                // etc.). We intentionally do NOT downgrade these to an
+                // empty SpecBody: a subsequent `SpecOps::write_section`
+                // would recompute the routing from the empty section map
+                // and rewrite the body's index, orphaning content stored in
+                // comments referenced only by the original (malformed)
+                // index. Returning `None` keeps such entries out of UI
+                // lists until the next refresh either repairs the body or
+                // proves it is truly a plain Issue. The on-disk cache is
+                // still populated (write_snapshot is lenient), so the
+                // body / meta survive in `~/.gwt/cache/issues/<n>/` for
+                // diagnostics.
+                return None;
+            }
         };
         Some(CacheEntry {
             snapshot,

--- a/crates/gwt-github/src/cache.rs
+++ b/crates/gwt-github/src/cache.rs
@@ -153,14 +153,20 @@ impl Cache {
                 }
                 prune_unlisted_files(&sections_dir, &desired_sections)?;
             }
-            Err(ParseError::MissingHeader) => {
-                // Plain GitHub Issues share the same cache root as SPEC Issues
-                // but do not carry gwt-spec section markers. For those entries
-                // we still cache body/meta/comments and simply omit `sections/`.
+            Err(_) => {
+                // Either the body has no gwt-spec header at all (plain Issue),
+                // or it looks like a SPEC but the structural parse failed
+                // (e.g., the body contains prose / code that happens to match
+                // the gwt-spec header pattern, the sections index is malformed,
+                // or a referenced comment is missing). In all such cases the
+                // Issue cannot be safely exposed as a structured SPEC, so we
+                // persist it as a plain Issue: body and meta are cached, but
+                // no per-section files are written. A subsequent refresh that
+                // arrives with a well-formed SPEC body will rewrite the
+                // sections/ tree on the next call.
                 let desired_sections: HashSet<String> = HashSet::new();
                 prune_unlisted_files(&sections_dir, &desired_sections)?;
             }
-            Err(err) => return Err(CacheError::Parse(err)),
         }
 
         // Finally, write meta.json.
@@ -224,7 +230,13 @@ impl Cache {
             .collect();
         let spec_body = match SpecBody::parse(&snapshot.body, &parsed_comments) {
             Ok(spec_body) => spec_body,
-            Err(ParseError::MissingHeader) => SpecBody {
+            Err(_) => SpecBody {
+                // Mirror the lenient policy from `write_snapshot`: any body
+                // that fails to parse as a SPEC (no header, malformed
+                // sections index, missing referenced comment, etc.) is
+                // surfaced as a plain Issue entry rather than silently
+                // dropped. UI consumers always see the cached body and
+                // metadata; only the structured sections map is empty.
                 meta: SpecMeta {
                     id: meta.number.to_string(),
                     version: 1,
@@ -232,7 +244,6 @@ impl Cache {
                 sections_index: crate::body::SectionsIndex::default(),
                 sections: std::collections::BTreeMap::new(),
             },
-            Err(_) => return None,
         };
         Some(CacheEntry {
             snapshot,

--- a/crates/gwt-github/src/client/http.rs
+++ b/crates/gwt-github/src/client/http.rs
@@ -18,7 +18,6 @@
 
 use std::sync::Mutex;
 
-use gwt_core::process::hidden_command;
 use serde_json::{json, Value};
 
 use crate::client::{
@@ -340,14 +339,19 @@ fn check_status(resp: &HttpResponse) -> Result<(), ApiError> {
 }
 
 fn resolve_gh_token() -> Result<String, ApiError> {
-    let output = hidden_command("gh")
-        .args(["auth", "token"])
-        .output()
-        .map_err(|e| ApiError::Network(format!("gh auth token: {e}")))?;
-    if !output.status.success() {
+    let hub = gwt_core::process_console::global();
+    let output = gwt_core::process_console::spawn_logged_blocking(
+        &hub,
+        gwt_core::process_console::ProcessKind::Gh,
+        "gh",
+        &["auth", "token"],
+        gwt_core::process_console::SpawnOptions::new("gh auth token"),
+    )
+    .map_err(|e| ApiError::Network(format!("gh auth token: {e}")))?;
+    if !output.success() {
         return Err(ApiError::Unauthorized);
     }
-    let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let token = output.stdout.trim().to_string();
     if token.is_empty() {
         return Err(ApiError::Unauthorized);
     }

--- a/crates/gwt-github/src/lib.rs
+++ b/crates/gwt-github/src/lib.rs
@@ -22,6 +22,7 @@ pub mod migration;
 pub mod routing;
 pub mod sections;
 pub mod spec_ops;
+pub mod spec_validate;
 
 pub use body::{ParseError as BodyParseError, SectionLocation, SectionsIndex, SpecBody, SpecMeta};
 pub use cache::{Cache, CacheEntry, CacheError, CacheMeta};

--- a/crates/gwt-github/src/spec_validate.rs
+++ b/crates/gwt-github/src/spec_validate.rs
@@ -1,0 +1,293 @@
+//! SPEC body validation for `gwt-register-spec` (SPEC-2784).
+//!
+//! Pure validation of a SPEC body string against the 7-section canonical
+//! contract. Returns a list of issues rather than `Result<_, _>` so the
+//! caller can present every problem at once instead of fix-one-then-rerun.
+
+use serde::{Deserialize, Serialize};
+
+/// Severity of a single validation finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Severity {
+    /// Cannot be processed downstream without a manual fix.
+    Structural,
+    /// Processable but does not meet the project's format convention.
+    Format,
+}
+
+/// One validation finding. `location` is either `"title"`, the section
+/// heading (`"## 機能要件"`), or a free-form line / span hint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidationIssue {
+    pub severity: Severity,
+    pub location: String,
+    pub message: String,
+}
+
+/// Validation configuration. `default_rules()` returns the canonical
+/// 7-section / FR-NNN rule set used by `gwt-register-spec`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidationRules {
+    pub title_prefix: &'static str,
+    pub required_sections: &'static [&'static str],
+    pub frbidden_marker: &'static str,
+}
+
+/// Canonical rules: `SPEC: ` prefix, 7 sections, no `[NEEDS CLARIFICATION]`.
+pub fn default_rules() -> ValidationRules {
+    ValidationRules {
+        title_prefix: "SPEC: ",
+        required_sections: &[
+            "## 背景",
+            "## ユビキタス言語",
+            "## ユーザーシナリオと受け入れシナリオ",
+            "## 機能要件",
+            "## 成功基準",
+            "## Out of Scope",
+            "## Related Artifacts",
+        ],
+        frbidden_marker: "[NEEDS CLARIFICATION]",
+    }
+}
+
+/// Validate the body against the rules. Empty `Vec` means PASS.
+pub fn validate_spec_body(
+    body: &str,
+    title: &str,
+    rules: &ValidationRules,
+) -> Vec<ValidationIssue> {
+    let mut issues = Vec::new();
+
+    if !title.starts_with(rules.title_prefix) || title.len() <= rules.title_prefix.len() {
+        issues.push(ValidationIssue {
+            severity: Severity::Structural,
+            location: "title".into(),
+            message: format!(
+                "title must match `^{}.+$`, got: {}",
+                rules.title_prefix, title
+            ),
+        });
+    }
+
+    let expected_h1 = format!("# {title}");
+    let first_h1 = body
+        .lines()
+        .find(|line| line.starts_with("# "))
+        .unwrap_or("");
+    if first_h1 != expected_h1 {
+        issues.push(ValidationIssue {
+            severity: Severity::Structural,
+            location: "h1".into(),
+            message: format!("body H1 must equal `{expected_h1}`, got: `{first_h1}`"),
+        });
+    }
+
+    for required in rules.required_sections {
+        if !body
+            .lines()
+            .any(|line| line == *required || line.starts_with(&format!("{required} (")))
+        {
+            issues.push(ValidationIssue {
+                severity: Severity::Structural,
+                location: (*required).into(),
+                message: format!("required section `{required}` is missing"),
+            });
+        }
+    }
+
+    let fr_section = extract_section(body, "## 機能要件");
+    let fr_numbers = collect_fr_numbers(&fr_section);
+    if fr_numbers.is_empty() {
+        issues.push(ValidationIssue {
+            severity: Severity::Structural,
+            location: "## 機能要件".into(),
+            message: "at least one `- **FR-NNN**: ...` line is required".into(),
+        });
+    } else {
+        for (i, &n) in fr_numbers.iter().enumerate() {
+            let expected = (i + 1) as u32;
+            if n != expected {
+                issues.push(ValidationIssue {
+                    severity: Severity::Format,
+                    location: "## 機能要件".into(),
+                    message: format!(
+                        "FR identifiers must be contiguous starting at FR-001; \
+                         expected FR-{expected:03}, found FR-{n:03}"
+                    ),
+                });
+                break;
+            }
+        }
+    }
+
+    if body.contains(rules.frbidden_marker) {
+        issues.push(ValidationIssue {
+            severity: Severity::Structural,
+            location: "body".into(),
+            message: format!(
+                "`{}` markers must be resolved before registration",
+                rules.frbidden_marker
+            ),
+        });
+    }
+
+    issues
+}
+
+fn extract_section(body: &str, heading_prefix: &str) -> String {
+    let mut out = String::new();
+    let mut inside = false;
+    for line in body.lines() {
+        if inside {
+            if line.starts_with("## ") {
+                break;
+            }
+            out.push_str(line);
+            out.push('\n');
+        } else if line == heading_prefix || line.starts_with(&format!("{heading_prefix} (")) {
+            inside = true;
+        }
+    }
+    out
+}
+
+fn collect_fr_numbers(section: &str) -> Vec<u32> {
+    let mut numbers = Vec::new();
+    for line in section.lines() {
+        let trimmed = line.trim_start();
+        let rest = match trimmed.strip_prefix("- **FR-") {
+            Some(rest) => rest,
+            None => continue,
+        };
+        let digits: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+        if digits.is_empty() {
+            continue;
+        }
+        if let Ok(n) = digits.parse::<u32>() {
+            numbers.push(n);
+        }
+    }
+    numbers
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn good_body() -> String {
+        r#"# SPEC: Demo Feature
+
+## 背景
+
+The why.
+
+## ユビキタス言語
+
+- **Term**: meaning
+
+## ユーザーシナリオと受け入れシナリオ
+
+### Primary User Story
+
+A story.
+
+### Acceptance Scenarios
+
+1. Scenario one.
+
+## 機能要件
+
+- **FR-001**: first
+- **FR-002**: second
+
+## 成功基準
+
+- All tests pass.
+
+## Out of Scope (v1)
+
+- nothing
+
+## Related Artifacts
+
+- none
+"#
+        .to_string()
+    }
+
+    #[test]
+    fn passes_a_well_formed_body() {
+        let issues = validate_spec_body(&good_body(), "SPEC: Demo Feature", &default_rules());
+        assert!(issues.is_empty(), "expected no issues, got: {issues:#?}");
+    }
+
+    #[test]
+    fn flags_title_without_spec_prefix() {
+        let issues = validate_spec_body(&good_body(), "feat: missing prefix", &default_rules());
+        assert!(issues
+            .iter()
+            .any(|i| i.location == "title" && i.severity == Severity::Structural));
+    }
+
+    #[test]
+    fn flags_h1_mismatch() {
+        let issues = validate_spec_body(&good_body(), "SPEC: Different Title", &default_rules());
+        assert!(issues
+            .iter()
+            .any(|i| i.location == "h1" && i.severity == Severity::Structural));
+    }
+
+    #[test]
+    fn flags_missing_section() {
+        let body = good_body().replace("## Out of Scope (v1)", "## OutOfScope (typo)");
+        let issues = validate_spec_body(&body, "SPEC: Demo Feature", &default_rules());
+        assert!(issues.iter().any(|i| i.location.contains("Out of Scope")));
+    }
+
+    #[test]
+    fn flags_no_fr_lines() {
+        let body = good_body().replace("- **FR-001**: first\n- **FR-002**: second", "- something");
+        let issues = validate_spec_body(&body, "SPEC: Demo Feature", &default_rules());
+        assert!(issues
+            .iter()
+            .any(|i| i.location == "## 機能要件" && i.severity == Severity::Structural));
+    }
+
+    #[test]
+    fn flags_non_contiguous_fr_numbers() {
+        let body = good_body().replace("- **FR-002**: second", "- **FR-003**: third");
+        let issues = validate_spec_body(&body, "SPEC: Demo Feature", &default_rules());
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.severity == Severity::Format && i.location == "## 機能要件"),
+            "expected Format issue for FR gap, got: {issues:#?}"
+        );
+    }
+
+    #[test]
+    fn flags_needs_clarification_marker() {
+        let body = good_body().replace("The why.", "The why. [NEEDS CLARIFICATION]");
+        let issues = validate_spec_body(&body, "SPEC: Demo Feature", &default_rules());
+        assert!(issues
+            .iter()
+            .any(|i| i.message.contains("NEEDS CLARIFICATION")));
+    }
+
+    #[test]
+    fn empty_body_reports_multiple_issues() {
+        let issues = validate_spec_body("", "SPEC: Empty", &default_rules());
+        // At least missing H1 + every required section + missing FR.
+        assert!(issues.len() >= 8, "expected many issues, got: {issues:#?}");
+    }
+
+    #[test]
+    fn out_of_scope_without_version_suffix_passes() {
+        let body = good_body().replace("## Out of Scope (v1)", "## Out of Scope");
+        let issues = validate_spec_body(&body, "SPEC: Demo Feature", &default_rules());
+        assert!(
+            issues.is_empty(),
+            "`## Out of Scope` alone should pass, got: {issues:#?}"
+        );
+    }
+}

--- a/crates/gwt-github/tests/cache_test.rs
+++ b/crates/gwt-github/tests/cache_test.rs
@@ -411,8 +411,21 @@ fn apply_phase_change_does_not_disturb_body_or_sections() {
 // `gh issue view` and ends up calling `write_snapshot` with a body whose
 // header parses but whose sections index is malformed. Previously this
 // surfaced as `body parse error: broken index map: ...` and propagated up
-// to the GUI Issue refresh. The cache must now treat such bodies as plain
-// Issues: cache body + meta, leave sections/ empty.
+// to the GUI Issue refresh.
+//
+// The cache layer now splits responsibilities to absorb the regression
+// without introducing a data-loss vector on real SPECs that happen to be
+// transiently malformed:
+//
+// - `write_snapshot` is lenient: it always caches `body.md` and `meta.json`
+//   verbatim. Sections are only materialized when parse succeeds.
+// - `load_entry` is strict for header-present-but-malformed bodies. It
+//   returns `None` so `SpecOps::write_section` never operates on an empty
+//   sections map (which would otherwise rewrite the body's section index
+//   with only the freshly-edited section, orphaning any content stored in
+//   the comments referenced by the malformed index).
+// - `load_entry` still surfaces plain Issues (no header) with an empty
+//   `SpecBody` so the GUI list keeps showing them.
 #[test]
 fn write_snapshot_falls_back_to_plain_when_sections_index_is_malformed() {
     let tmp = TempDir::new().unwrap();
@@ -456,16 +469,47 @@ Rest of the body is human prose, not a real SPEC.\n"
         .collect();
     assert!(
         leftover.is_empty(),
-        "sections/ must be empty for fallback-cached plain Issue (got: {:?})",
+        "sections/ must be empty for fallback-cached entry (got: {:?})",
         leftover.iter().map(|e| e.file_name()).collect::<Vec<_>>()
     );
 
-    // load_entry must still surface the issue (with empty sections),
-    // not silently drop it.
+    // load_entry must NOT surface this entry: the SPEC header is present
+    // but parse failed, so exposing an empty SpecBody would let
+    // `SpecOps::write_section` recompute the routing from scratch and
+    // overwrite the body's sections index, orphaning any content in
+    // comments referenced by the malformed index.
+    assert!(
+        cache.load_entry(IssueNumber(123)).is_none(),
+        "load_entry must hide header-present-but-malformed entries to \
+         prevent SpecOps::write_section from corrupting them"
+    );
+}
+
+// Companion to the previous test: a plain Issue (no `<!-- gwt-spec id=...`
+// header at all) must still surface from `load_entry` with an empty
+// `SpecBody`, so the GUI keeps listing it. Hiding plain Issues by accident
+// would silently drop bug reports / docs / chores from the Issue window.
+#[test]
+fn load_entry_surfaces_plain_issue_with_empty_spec_body() {
+    let tmp = TempDir::new().unwrap();
+    let cache = Cache::new(tmp.path().to_path_buf());
+
+    let body = "Just a plain bug report.\nNo gwt-spec markers here.\n".to_string();
+    let snapshot = IssueSnapshot {
+        number: IssueNumber(456),
+        title: "Plain bug".into(),
+        body: body.clone(),
+        labels: vec!["bug".into()],
+        state: IssueState::Open,
+        updated_at: UpdatedAt::new("t1"),
+        comments: Vec::new(),
+    };
+    cache.write_snapshot(&snapshot).unwrap();
+
     let entry = cache
-        .load_entry(IssueNumber(123))
-        .expect("load_entry must surface a plain-fallback entry");
-    assert_eq!(entry.snapshot.number, IssueNumber(123));
+        .load_entry(IssueNumber(456))
+        .expect("plain Issue must surface from load_entry");
+    assert_eq!(entry.snapshot.number, IssueNumber(456));
     assert_eq!(entry.snapshot.body, body);
     assert!(entry.spec_body.sections.is_empty());
 }

--- a/crates/gwt-github/tests/cache_test.rs
+++ b/crates/gwt-github/tests/cache_test.rs
@@ -404,3 +404,68 @@ fn apply_phase_change_does_not_disturb_body_or_sections() {
     let spec_section = fs::read_to_string(tmp.path().join("11/sections/spec.md")).unwrap();
     assert_eq!(spec_section, "immutable spec");
 }
+
+// Regression: When an Issue body contains gwt-spec marker patterns as prose
+// or code (e.g., a plain bug Issue describing the SPEC format), the loose
+// substring detection in `gwt::issue_cache::is_spec_issue` triggers
+// `gh issue view` and ends up calling `write_snapshot` with a body whose
+// header parses but whose sections index is malformed. Previously this
+// surfaced as `body parse error: broken index map: ...` and propagated up
+// to the GUI Issue refresh. The cache must now treat such bodies as plain
+// Issues: cache body + meta, leave sections/ empty.
+#[test]
+fn write_snapshot_falls_back_to_plain_when_sections_index_is_malformed() {
+    let tmp = TempDir::new().unwrap();
+    let cache = Cache::new(tmp.path().to_path_buf());
+
+    // Body has a structurally valid gwt-spec header but the sections
+    // index is on a single line (as it would be when quoted in prose),
+    // which `parse_index_map` cannot disentangle.
+    let body = "Background:\n\
+<!-- gwt-spec id=42 version=1 -->\n\
+<!-- sections: plan=comment:777 spec=body tasks=body -->\n\
+\n\
+Rest of the body is human prose, not a real SPEC.\n"
+        .to_string();
+    let snapshot = IssueSnapshot {
+        number: IssueNumber(123),
+        title: "Plain Issue with SPEC-looking prose".into(),
+        body: body.clone(),
+        labels: vec!["bug".into()],
+        state: IssueState::Open,
+        updated_at: UpdatedAt::new("t1"),
+        comments: Vec::new(),
+    };
+
+    cache
+        .write_snapshot(&snapshot)
+        .expect("write_snapshot must succeed even when SPEC parse fails");
+
+    // Body and meta should be present and verbatim.
+    let body_on_disk = fs::read_to_string(tmp.path().join("123/body.md")).unwrap();
+    assert_eq!(body_on_disk, body);
+    assert!(tmp.path().join("123/meta.json").is_file());
+
+    // Sections directory must exist but be empty.
+    let sections_dir = tmp.path().join("123/sections");
+    assert!(sections_dir.is_dir());
+    let leftover: Vec<_> = fs::read_dir(&sections_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| !e.file_name().to_string_lossy().starts_with('.'))
+        .collect();
+    assert!(
+        leftover.is_empty(),
+        "sections/ must be empty for fallback-cached plain Issue (got: {:?})",
+        leftover.iter().map(|e| e.file_name()).collect::<Vec<_>>()
+    );
+
+    // load_entry must still surface the issue (with empty sections),
+    // not silently drop it.
+    let entry = cache
+        .load_entry(IssueNumber(123))
+        .expect("load_entry must surface a plain-fallback entry");
+    assert_eq!(entry.snapshot.number, IssueNumber(123));
+    assert_eq!(entry.snapshot.body, body);
+    assert!(entry.spec_body.sections.is_empty());
+}

--- a/crates/gwt/Cargo.toml
+++ b/crates/gwt/Cargo.toml
@@ -63,7 +63,7 @@ libc = { workspace = true }
 [target.'cfg(target_os = "macos")'.dependencies]
 muda = "0.19"
 
-[target.'cfg(target_os = "windows")'.dependencies]
+[target.'cfg(any(target_os = "windows", target_os = "linux"))'.dependencies]
 image.workspace = true
 
 [target.'cfg(target_os = "windows")'.build-dependencies]

--- a/crates/gwt/playwright/tests/release-notes-live.spec.ts
+++ b/crates/gwt/playwright/tests/release-notes-live.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * SPEC #2780 — Release Notes window live E2E.
+ *
+ * Unlike the other release-notes related tests (the gwt-core parser unit
+ * tests and the linkedom DOM tests in `crates/gwt/web/__tests__/`), this
+ * spec runs against a **live** gwt backend over a real WebSocket. It does
+ * NOT use `installEmbeddedRoutes`, because the whole point is to exercise
+ * the `open_release_notes` -> `release_notes_payload` round-trip that the
+ * embedded-route tests skip.
+ *
+ * Required environment:
+ *   GWT_PLAYWRIGHT_BASE_URL=http://127.0.0.1:<port>   # a running gwt server
+ *
+ * The spec auto-skips when the env var is missing so CI runs without
+ * a live backend stay green; the live coverage runs explicitly via
+ * the gwt-verify --mode pre-pr flow once a real server is wired up.
+ */
+import { test, expect } from "@playwright/test";
+
+const BASE = process.env.GWT_PLAYWRIGHT_BASE_URL ?? "";
+
+// `serial` because every test in this file talks to the same live backend.
+// In parallel mode the chromium-dark and chromium-light projects race against
+// each other for the modal-backdrop state and the WebSocket session, which
+// flaps the click interception logic. Sequential execution keeps the spec
+// stable while leaving the rest of `pnpm test:visual` parallel.
+test.describe.serial("Release Notes window (live backend)", () => {
+  test.skip(!BASE, "GWT_PLAYWRIGHT_BASE_URL is not set; live E2E skipped");
+
+  test.beforeEach(async ({ page }) => {
+    // The Operator splash should auto-dismiss after ~1.45s and persists a
+    // sessionStorage flag so subsequent loads skip it entirely. We pre-set
+    // the flag here so the splash is skipped from the first load.
+    //
+    // KNOWN ISSUE (filed separately): in live mode the splash currently
+    // refuses to dismiss even when the sessionStorage flag is set. While
+    // that is open, force-hide the overlay client-side so the rest of the
+    // E2E can still exercise the Release Notes flow. Remove the force-hide
+    // once the splash dismiss bug is closed.
+    await page.addInitScript(() => {
+      try {
+        window.sessionStorage.setItem("gwt:ui:briefing", "1");
+      } catch {
+        /* no-op */
+      }
+    });
+    await page.goto(BASE);
+    // KNOWN ISSUE workarounds (track in follow-up Issue):
+    //  1. Splash overlay refuses to dismiss in live mode even with the
+    //     sessionStorage flag set; force-hide it.
+    //  2. Workspace state can carry over modal backdrops (file-tree picker,
+    //     etc.) that intercept pointer events. Inject a permanent style rule
+    //     that disables `pointer-events` on every modal-backdrop so any
+    //     late-arriving modal cannot steal the click on `#app-version`.
+    await page.addStyleTag({
+      content: `.modal-backdrop, #op-briefing { display: none !important; pointer-events: none !important; }`,
+    });
+    await page.evaluate(() => {
+      const overlay = document.getElementById("op-briefing");
+      if (overlay) overlay.hidden = true;
+    });
+    await expect(page.locator("#op-briefing")).toBeHidden();
+  });
+
+  test("clicking #app-version opens the Release Notes window with current version focused", async ({
+    page,
+  }) => {
+    const label = page.locator("#app-version");
+    await expect(label).toBeVisible();
+    const labelText = (await label.textContent())?.trim() ?? "";
+    const currentVersion = labelText.replace(/^v/, "").split(" -> ")[0];
+    expect(currentVersion).toMatch(/^\d+\.\d+\.\d+$/);
+
+    await label.click();
+
+    const window = page.locator("#release-notes-window");
+    await expect(window).toBeVisible();
+    await expect(window).toHaveAttribute("role", "dialog");
+
+    const selected = window.locator(".release-notes-sidebar-item.is-selected");
+    await expect(selected).toHaveAttribute("data-version", currentVersion);
+
+    // Right pane should render the corresponding entry's H2 (`v<version>`).
+    await expect(
+      window.locator(".release-notes-content h2"),
+    ).toHaveText(`v${currentVersion}`);
+  });
+
+  test("selecting a different version in the sidebar updates the content pane", async ({
+    page,
+  }) => {
+    await page.locator("#app-version").click();
+    const window = page.locator("#release-notes-window");
+    await expect(window).toBeVisible();
+
+    const items = window.locator(".release-notes-sidebar-item");
+    // Pick the second entry so we differ from the default selection.
+    await items.nth(1).click();
+
+    const target = await items.nth(1).getAttribute("data-version");
+    expect(target).toBeTruthy();
+    await expect(
+      window.locator(".release-notes-sidebar-item.is-selected"),
+    ).toHaveAttribute("data-version", target as string);
+    await expect(
+      window.locator(".release-notes-content h2"),
+    ).toHaveText(`v${target}`);
+  });
+
+  test("close button removes the window and isOpen reflects that", async ({
+    page,
+  }) => {
+    await page.locator("#app-version").click();
+    const window = page.locator("#release-notes-window");
+    await expect(window).toBeVisible();
+    await window.locator(".release-notes-close").click();
+    await expect(window).toHaveCount(0);
+  });
+
+  test("keyboard activation (Enter on #app-version) opens the window", async ({
+    page,
+  }) => {
+    const label = page.locator("#app-version");
+    await expect(label).toBeVisible();
+    // Use locator.press so Playwright handles focus + key dispatch atomically;
+    // separate focus()+keyboard.press() races against any element that competes
+    // for focus during workspace boot.
+    await label.press("Enter");
+    await expect(page.locator("#release-notes-window")).toBeVisible();
+  });
+});

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1661,27 +1661,33 @@ fn search_github_repositories(
     if trimmed.is_empty() {
         return Err("repository search query is required".to_string());
     }
-    let output = gwt_core::process::hidden_command("gh")
-        .args([
+    let hub = gwt_core::process_console::global();
+    let limit_str = limit.to_string();
+    let output = gwt_core::process_console::spawn_logged_blocking(
+        &hub,
+        gwt_core::process_console::ProcessKind::Gh,
+        "gh",
+        &[
             "search",
             "repos",
             trimmed,
             "--json",
             "fullName,description,url,defaultBranch,visibility,updatedAt",
             "--limit",
-            &limit.to_string(),
-        ])
-        .output()
-        .map_err(|error| format!("gh search repos: {error}"))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            limit_str.as_str(),
+        ],
+        gwt_core::process_console::SpawnOptions::new("gh search repos"),
+    )
+    .map_err(|error| format!("gh search repos: {error}"))?;
+    if !output.success() {
+        let stderr = output.stderr.trim().to_string();
         return Err(if stderr.is_empty() {
             "gh search repos failed".to_string()
         } else {
             stderr
         });
     }
-    parse_github_repository_search_results(&String::from_utf8_lossy(&output.stdout))
+    parse_github_repository_search_results(&output.stdout)
 }
 
 /// SPEC-2041 Phase 19 (FR-065): launch the platform default opener

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -3985,13 +3985,24 @@ impl AppRuntime {
         }
 
         match load_log_entries_from_dir(&self.log_dir) {
-            Ok(entries) => vec![OutboundEvent::reply(
-                client_id,
-                BackendEvent::LogEntries {
-                    id: id.to_string(),
-                    entries,
-                },
-            )],
+            Ok(outcome) => {
+                let mut events = vec![OutboundEvent::reply(
+                    client_id,
+                    BackendEvent::LogEntries {
+                        id: id.to_string(),
+                        entries: outcome.entries,
+                    },
+                )];
+                if outcome.diagnostics.skipped > 0 {
+                    events.push(OutboundEvent::reply(
+                        client_id,
+                        BackendEvent::LogEntryAppended {
+                            entry: skipped_lines_warning(&outcome.diagnostics),
+                        },
+                    ));
+                }
+                events
+            }
             Err(error) => vec![OutboundEvent::reply(
                 client_id,
                 BackendEvent::LogError {
@@ -4629,43 +4640,35 @@ impl AppRuntime {
     }
 }
 
-fn load_log_entries_from_dir(log_dir: &Path) -> Result<Vec<gwt_core::logging::LogEvent>, String> {
+/// Read the active canonical log file via the SPEC-1924 FR-035 reader.
+///
+/// Returns the decoded snapshot together with `ReadDiagnostics` so the caller
+/// can surface a non-blocking warning when malformed lines were skipped
+/// (FR-036 / SC-010). IO errors other than `NotFound` are forwarded as a
+/// human-readable message so the Logs window can switch to an error state
+/// without crashing the agent.
+fn load_log_entries_from_dir(log_dir: &Path) -> Result<gwt_core::logging::ReadOutcome, String> {
     let path = gwt_core::logging::current_log_file(log_dir);
-    let file = match std::fs::File::open(&path) {
-        Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
-        Err(error) => {
-            return Err(format!(
-                "Failed to open log file {}: {error}",
-                path.display()
-            ))
-        }
-    };
-    let reader = std::io::BufReader::new(file);
-    let mut entries = Vec::new();
-    for (index, line) in std::io::BufRead::lines(reader).enumerate() {
-        let line = line.map_err(|error| {
-            format!(
-                "Failed to read log line {} from {}: {error}",
-                index + 1,
-                path.display()
-            )
-        })?;
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let entry =
-            serde_json::from_str::<gwt_core::logging::LogEvent>(trimmed).map_err(|error| {
-                format!(
-                    "Failed to parse log line {} from {}: {error}",
-                    index + 1,
-                    path.display()
-                )
-            })?;
-        entries.push(entry);
-    }
-    Ok(entries)
+    gwt_core::logging::read_log_file(&path)
+        .map_err(|error| format!("Failed to read log file {}: {error}", path.display()))
+}
+
+/// Build the synthetic warning event surfaced when `read_log_file` skipped
+/// malformed lines. Keeps the message phrasing consistent with the Logs
+/// window expectation of a single notice per load (FR-036 / SC-010).
+fn skipped_lines_warning(
+    diagnostics: &gwt_core::logging::ReadDiagnostics,
+) -> gwt_core::logging::LogEvent {
+    let count = diagnostics.skipped;
+    let plural = if count == 1 { "line" } else { "lines" };
+    gwt_core::logging::LogEvent::new(
+        gwt_core::logging::LogLevel::Warn,
+        "gwt_core::logging::reader",
+        format!(
+            "Skipped {count} malformed {plural} while reading {}",
+            diagnostics.path.display()
+        ),
+    )
 }
 
 fn spawn_branch_cleanup_async(
@@ -6487,7 +6490,7 @@ mod tests {
             coordination_events_path, load_snapshot, post_entry, AuthorKind, BoardAudienceScope,
             BoardEntry, BoardEntryKind, BoardMention, BoardMentionTargetKind, CoordinationEvent,
         },
-        logging::{current_log_file, LogEvent, LogLevel},
+        logging::{current_log_file, LogLevel},
         paths::gwt_cache_dir,
         repo_hash::detect_repo_hash,
     };
@@ -11806,14 +11809,16 @@ exit 1
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let window_id = combined_window_id("tab-1", "logs-1");
         let log_path = current_log_file(&runtime.log_dir);
-        let entry =
-            LogEvent::new(LogLevel::Warn, "pty", "runtime stalled").with_detail("retrying read");
+        // Write the canonical on-disk JSONL shape produced by
+        // `tracing_subscriber::fmt::layer().json()` (see
+        // `crates/gwt-core/src/logging/fmt_layer.rs`) so the reader exercises
+        // the production format end-to-end (SPEC-1924 FR-035).
         fs::write(
             &log_path,
-            format!(
-                "{}\n",
-                serde_json::to_string(&entry).expect("serialize log event")
-            ),
+            "{\"timestamp\":\"2026-05-20T09:00:00.000000+00:00\",\
+             \"level\":\"WARN\",\
+             \"fields\":{\"message\":\"runtime stalled\",\"detail\":\"retrying read\"},\
+             \"target\":\"pty\"}\n",
         )
         .expect("write log snapshot");
 
@@ -11833,8 +11838,80 @@ exit 1
                 && id == &window_id
                 && entries.len() == 1
                 && entries[0].message == "runtime stalled"
+                && entries[0].detail.as_deref() == Some("retrying read")
+                && entries[0].source == "pty"
                 && matches!(entries[0].severity, LogLevel::Warn)
         ));
+    }
+
+    /// SPEC-1924 US-14 / FR-036 / SC-010 — when canonical log file contains
+    /// malformed lines, the Logs window receives the surviving entries plus
+    /// exactly one Warning notice via `LogEntryAppended`.
+    #[test]
+    fn app_runtime_load_logs_emits_warning_for_skipped_lines() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "logs-1",
+            repo,
+            WindowPreset::Logs,
+            WindowProcessStatus::Ready,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "logs-1");
+        let log_path = current_log_file(&runtime.log_dir);
+        let good = "{\"timestamp\":\"2026-05-20T09:00:00.000000+00:00\",\
+            \"level\":\"INFO\",\"fields\":{\"message\":\"ok\"},\"target\":\"gwt\"}";
+        let malformed = "{\"foo\":\"bar\"}";
+        fs::write(&log_path, format!("{good}\n{malformed}\n{good}\n")).expect("write log snapshot");
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::LoadLogs {
+                id: window_id.clone(),
+            },
+        );
+
+        assert_eq!(
+            events.len(),
+            2,
+            "expected LogEntries + LogEntryAppended for skipped notice, got {:?}",
+            events
+        );
+
+        let entries_match = matches!(
+            &events[0],
+            OutboundEvent {
+                target: DispatchTarget::Client(client_id),
+                event: BackendEvent::LogEntries { id, entries },
+            } if client_id == "client-1"
+                && id == &window_id
+                && entries.len() == 2
+                && entries.iter().all(|e| e.message == "ok")
+        );
+        assert!(
+            entries_match,
+            "first event must be LogEntries: {:?}",
+            events[0]
+        );
+
+        let warning_match = matches!(
+            &events[1],
+            OutboundEvent {
+                target: DispatchTarget::Client(client_id),
+                event: BackendEvent::LogEntryAppended { entry },
+            } if client_id == "client-1"
+                && entry.severity == LogLevel::Warn
+                && entry.source == "gwt_core::logging::reader"
+                && entry.message.contains("Skipped 1 malformed line")
+        );
+        assert!(
+            warning_match,
+            "second event must be a Warn LogEntryAppended notice: {:?}",
+            events[1]
+        );
     }
 
     #[test]
@@ -14889,5 +14966,86 @@ exit 1
                 .map(|i| (i.id.clone(), i.status_category.clone()))
                 .collect::<Vec<_>>()
         );
+    }
+
+    // SPEC-1924 US-14 FR-035 / FR-036 / SC-010 / SC-011 — verify the Logs
+    // window snapshot reader goes through `gwt_core::logging::read_log_file`
+    // and that the synthetic warning event is well-formed when malformed
+    // lines are skipped.
+
+    const PROD_LINE_INFO: &str = r#"{"timestamp":"2026-05-20T09:00:00.015355+09:00","level":"INFO","fields":{"message":"PTY resize completed","outcome":"ok"},"target":"gwt::resize::pty"}"#;
+    const MALFORMED_LINE: &str = r#"{"foo":"bar"}"#;
+
+    fn write_canonical_log_file(log_dir: &Path, lines: &[&str]) {
+        fs::create_dir_all(log_dir).expect("create log dir");
+        let log_path = current_log_file(log_dir);
+        let mut file = fs::File::create(&log_path).expect("create log file");
+        for line in lines {
+            file.write_all(line.as_bytes()).expect("write line");
+            file.write_all(b"\n").expect("write newline");
+        }
+    }
+
+    #[test]
+    fn load_log_entries_from_dir_returns_outcome_with_no_skipped_lines() {
+        let dir = tempdir().expect("tempdir");
+        write_canonical_log_file(dir.path(), &[PROD_LINE_INFO]);
+
+        let outcome = super::load_log_entries_from_dir(dir.path()).expect("read ok");
+
+        assert_eq!(outcome.entries.len(), 1);
+        assert_eq!(outcome.entries[0].message, "PTY resize completed");
+        assert_eq!(outcome.diagnostics.skipped, 0);
+    }
+
+    #[test]
+    fn load_log_entries_from_dir_counts_skipped_lines() {
+        let dir = tempdir().expect("tempdir");
+        write_canonical_log_file(
+            dir.path(),
+            &[PROD_LINE_INFO, MALFORMED_LINE, PROD_LINE_INFO],
+        );
+
+        let outcome = super::load_log_entries_from_dir(dir.path()).expect("read ok");
+
+        assert_eq!(outcome.entries.len(), 2);
+        assert_eq!(outcome.diagnostics.skipped, 1);
+    }
+
+    #[test]
+    fn load_log_entries_from_dir_returns_empty_outcome_when_file_missing() {
+        let dir = tempdir().expect("tempdir");
+
+        let outcome = super::load_log_entries_from_dir(dir.path()).expect("read ok");
+
+        assert!(outcome.entries.is_empty());
+        assert_eq!(outcome.diagnostics.skipped, 0);
+    }
+
+    #[test]
+    fn skipped_lines_warning_is_warn_severity_and_includes_count_and_path() {
+        let diagnostics = gwt_core::logging::ReadDiagnostics {
+            path: PathBuf::from("/tmp/gwt.log.2026-05-20"),
+            skipped: 3,
+        };
+
+        let event = super::skipped_lines_warning(&diagnostics);
+
+        assert_eq!(event.severity, LogLevel::Warn);
+        assert_eq!(event.source, "gwt_core::logging::reader");
+        assert!(event.message.contains("Skipped 3 malformed lines"));
+        assert!(event.message.contains("/tmp/gwt.log.2026-05-20"));
+    }
+
+    #[test]
+    fn skipped_lines_warning_singular_for_one_line() {
+        let diagnostics = gwt_core::logging::ReadDiagnostics {
+            path: PathBuf::from("/tmp/x.log"),
+            skipped: 1,
+        };
+
+        let event = super::skipped_lines_warning(&diagnostics);
+
+        assert!(event.message.contains("Skipped 1 malformed line "));
     }
 }

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1684,6 +1684,48 @@ fn search_github_repositories(
     parse_github_repository_search_results(&String::from_utf8_lossy(&output.stdout))
 }
 
+/// SPEC-2785 FR-E: exact same-origin match between the embedded server's
+/// bound URL and a frontend-supplied URL. Used as the pre-spawn gate by
+/// [`AppRuntime::open_server_url_events`] so a renderer compromise cannot
+/// smuggle an arbitrary URL into the OS opener.
+///
+/// Comparison is byte-exact. Trailing-slash and case differences are NOT
+/// normalized — the frontend derives its URL from `window.location.origin`
+/// so the two strings are always produced by the same source and any drift
+/// is a bug worth surfacing rather than papering over.
+fn validate_server_url(allowed: Option<&str>, requested: &str) -> bool {
+    matches!(allowed, Some(value) if value == requested)
+}
+
+/// SPEC-2785 FR-C / FR-E: launch the platform default browser for a URL
+/// argument (analogous to [`open_path_with_os_default`] but reserved for URLs
+/// that have already cleared [`validate_server_url`]). The opener receives
+/// the URL via argv directly, never through a shell, so URL contents cannot
+/// trigger shell metacharacter expansion.
+fn open_url_with_os_default(url: &str) -> Result<(), std::io::Error> {
+    use std::process::Command;
+    let child = if cfg!(target_os = "macos") {
+        let mut cmd = Command::new("open");
+        cmd.arg(url);
+        cmd.spawn()?
+    } else if cfg!(target_os = "windows") {
+        let mut cmd = Command::new("cmd");
+        // The empty "" before the URL is required by `start` so that a URL
+        // beginning with quoted text is not interpreted as a window title.
+        cmd.args(["/C", "start", "", url]);
+        cmd.spawn()?
+    } else {
+        let mut cmd = Command::new("xdg-open");
+        cmd.arg(url);
+        cmd.spawn()?
+    };
+    std::thread::spawn(move || {
+        let mut child = child;
+        let _ = child.wait();
+    });
+    Ok(())
+}
+
 /// SPEC-2041 Phase 19 (FR-065): launch the platform default opener
 /// (`open` on macOS, `xdg-open` on Linux, `explorer` on Windows). Errors are
 /// silently dropped so the modal does not surface noise; the path is logged
@@ -1810,6 +1852,12 @@ pub struct AppRuntime {
     /// windows. Reset every time the user reopens the picker, so this is a
     /// transient in-memory map and is not persisted with the session state.
     pub(crate) file_tree_worktree_roots: HashMap<String, PathBuf>,
+    /// SPEC-2785 FR-E: embedded server URL captured after the axum bind so
+    /// `open_server_url_events` can reject requests whose origin differs from
+    /// the bound URL. `None` before the server is started (e.g. during early
+    /// AppRuntime construction or unit tests that never call
+    /// `set_server_url`).
+    pub(crate) server_url: Option<String>,
 }
 
 impl ProjectTabRuntime {
@@ -1892,6 +1940,7 @@ impl AppRuntime {
             pty_writers,
             persist_dispatcher,
             file_tree_worktree_roots: HashMap::new(),
+            server_url: None,
         };
         app.rebuild_window_lookup();
         app.seed_window_pty_statuses();
@@ -1956,6 +2005,13 @@ impl AppRuntime {
 
     pub(crate) fn set_hook_forward_target(&mut self, target: HookForwardTarget) {
         self.hook_forward_target = Some(target);
+    }
+
+    /// SPEC-2785 FR-E: capture the embedded server URL after the axum bind
+    /// completes so `open_server_url_events` can reject mismatched origin
+    /// requests before invoking the OS opener.
+    pub(crate) fn set_server_url(&mut self, url: String) {
+        self.server_url = Some(url);
     }
 
     pub(crate) fn handle_frontend_event(
@@ -2266,6 +2322,7 @@ impl AppRuntime {
             FrontendEvent::OpenUpdateLog { log_path } => {
                 self.open_update_log_events(&client_id, log_path)
             }
+            FrontendEvent::OpenServerUrl { url } => self.open_server_url_events(&client_id, url),
             FrontendEvent::ListCustomAgents => vec![OutboundEvent::reply(
                 client_id,
                 gwt::custom_agents_dispatch::list_event(),
@@ -2661,6 +2718,34 @@ impl AppRuntime {
                 ),
             )],
         }
+    }
+
+    /// SPEC-2785 US-1 / FR-C / FR-E: user clicked the server URL cell in the
+    /// status strip. The renderer-supplied `url` is treated as untrusted and
+    /// is only forwarded to [`open_url_with_os_default`] when it matches the
+    /// embedded server's bound URL captured by [`Self::set_server_url`].
+    /// Mismatched origins (or an unset server URL) are dropped with a trace
+    /// log so a compromised renderer cannot redirect the OS opener to an
+    /// arbitrary URL. The handler returns no outbound events; the click is a
+    /// side-effect only.
+    fn open_server_url_events(&self, _client_id: &str, url: String) -> Vec<OutboundEvent> {
+        if validate_server_url(self.server_url.as_deref(), &url) {
+            if let Err(error) = open_url_with_os_default(&url) {
+                tracing::trace!(
+                    target: "gwt::open_server_url",
+                    %error,
+                    "failed to spawn OS browser opener"
+                );
+            }
+        } else {
+            tracing::trace!(
+                target: "gwt::open_server_url",
+                requested = %url,
+                allowed = ?self.server_url,
+                "rejected open_server_url request: origin mismatch"
+            );
+        }
+        Vec::new()
     }
 
     /// SPEC-2041 Phase 19 (FR-065): user pressed `Open log` on the failed
@@ -7254,6 +7339,7 @@ exit 1
             pty_writers,
             persist_dispatcher,
             file_tree_worktree_roots: HashMap::new(),
+            server_url: None,
         };
         runtime.rebuild_window_lookup();
         runtime.seed_window_pty_statuses();
@@ -14688,6 +14774,78 @@ exit 1
         let missing = logs_root.path().join("does-not-exist.log");
         let resolved = super::validate_update_log_path(missing.to_str().unwrap(), logs_root.path());
         assert!(resolved.is_none(), "missing files must be rejected");
+    }
+
+    // SPEC-2785 FR-E: open_server_url requests must be gated by an exact
+    // same-origin match against the embedded server's bound URL. The shared
+    // validator function is reused by `AppRuntime::open_server_url_events`
+    // so a mismatched origin cannot smuggle an arbitrary URL into the OS
+    // opener.
+    #[test]
+    fn validate_server_url_accepts_exact_bound_url() {
+        let allowed = Some("http://127.0.0.1:54321/");
+        assert!(super::validate_server_url(
+            allowed,
+            "http://127.0.0.1:54321/"
+        ));
+    }
+
+    #[test]
+    fn validate_server_url_rejects_different_port() {
+        let allowed = Some("http://127.0.0.1:54321/");
+        assert!(!super::validate_server_url(
+            allowed,
+            "http://127.0.0.1:54322/"
+        ));
+    }
+
+    #[test]
+    fn validate_server_url_rejects_different_scheme() {
+        let allowed = Some("http://127.0.0.1:54321/");
+        assert!(!super::validate_server_url(
+            allowed,
+            "https://127.0.0.1:54321/"
+        ));
+    }
+
+    #[test]
+    fn validate_server_url_rejects_when_allowed_is_none() {
+        assert!(!super::validate_server_url(None, "http://127.0.0.1:54321/"));
+    }
+
+    #[test]
+    fn validate_server_url_rejects_external_origin() {
+        let allowed = Some("http://127.0.0.1:54321/");
+        assert!(!super::validate_server_url(allowed, "http://evil.example/"));
+    }
+
+    // SPEC-2785 SC-4: `open_server_url_events` returns an empty event list and
+    // performs no OS opener side effect when the requested URL does not match
+    // the configured server URL. The state mutation guard is `server_url`
+    // being None or unequal to the request.
+    #[test]
+    fn open_server_url_events_rejects_mismatched_origin() {
+        let temp = tempdir().expect("tempdir");
+        let (mut runtime, _events) = sample_runtime_with_events(temp.path(), Vec::new(), None);
+        runtime.set_server_url("http://127.0.0.1:54321/".to_string());
+        let outbound =
+            runtime.open_server_url_events("client-1", "http://evil.example/".to_string());
+        assert!(
+            outbound.is_empty(),
+            "mismatched origin must yield no outbound events"
+        );
+    }
+
+    #[test]
+    fn open_server_url_events_rejects_when_server_url_unset() {
+        let temp = tempdir().expect("tempdir");
+        let (runtime, _events) = sample_runtime_with_events(temp.path(), Vec::new(), None);
+        let outbound =
+            runtime.open_server_url_events("client-1", "http://127.0.0.1:54321/".to_string());
+        assert!(
+            outbound.is_empty(),
+            "unset server URL must reject any open request"
+        );
     }
 
     #[test]

--- a/crates/gwt/src/bin/gwtd.rs
+++ b/crates/gwt/src/bin/gwtd.rs
@@ -67,6 +67,7 @@ fn print_help() {
     println!("  discuss     gwt-discussion exit CLI (SPEC-1935)");
     println!("  plan        gwt-plan-spec exit CLI (SPEC-1935)");
     println!("  build       gwt-build-spec exit CLI (SPEC-1935)");
+    println!("  register    gwt-register-spec exit CLI (SPEC-2784)");
     println!("  pane        Inspect and control live agent panes");
     println!("  workspace   Update Workspace current projection and summary journal");
     println!("  update      Check / apply gwt updates");
@@ -86,6 +87,7 @@ fn family_help(family: &str) -> Option<String> {
         "discuss" => Some(format_discuss_help()),
         "plan" => Some(format_plan_help()),
         "build" => Some(format_build_help()),
+        "register" => Some(format_register_help()),
         "pane" => Some(format_pane_help()),
         "workspace" => Some(format_workspace_help()),
         "update" => Some(format_update_help()),
@@ -247,6 +249,7 @@ fn format_hook_help() -> String {
         "  skill-discussion-stop-check             Stop-check for gwt-discussion",
         "  skill-plan-spec-stop-check              Stop-check for gwt-plan-spec",
         "  skill-build-spec-stop-check             Stop-check for gwt-build-spec",
+        "  skill-register-spec-stop-check          Stop-check for gwt-register-spec",
         "",
         "Stdin: hooks read JSON from stdin per the Claude Code hook contract.",
         "",
@@ -312,6 +315,22 @@ fn format_build_help() -> String {
         "  phase --spec <n> --label <stage>       Mark a phase milestone (red/green/...)",
         "  complete --spec <n>                    Mark build-spec complete",
         "  abort --spec <n> [--reason <text>]     Abort build-spec",
+        "",
+    ]
+    .join("\n")
+}
+
+fn format_register_help() -> String {
+    [
+        "gwtd register — gwt-register-spec exit CLI (SPEC-2784).",
+        "",
+        "Usage: gwtd register <action> --spec <n> [...]",
+        "",
+        "Actions:",
+        "  start --spec <n>                       Mark register-spec started (use --spec 0 if id unknown)",
+        "  phase --spec <n> --label <stage>       Milestone: validation/create/edit/roundtrip",
+        "  complete --spec <n>                    Mark register-spec complete",
+        "  abort --spec <n> [--reason <text>]     Abort register-spec",
         "",
     ]
     .join("\n")

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -33,7 +33,7 @@ mod issue_spec;
 mod pane;
 mod plan;
 mod pr;
-mod register;
+pub(crate) mod register;
 pub mod serve;
 mod skill_state_runtime;
 #[cfg(test)]
@@ -378,10 +378,8 @@ pub type PlanCommand = SkillStateAction;
 /// SPEC-1942 family enum for `gwtd build ...`. Backed by [`SkillStateAction`].
 pub type BuildCommand = SkillStateAction;
 
-/// SPEC-2784 family enum for `gwtd register ...`. Backed by
-/// [`SkillStateAction`] — same lifecycle pattern as `plan` and `build`.
+/// SPEC-2784 family enum for `gwtd register ...`. Same skill-state lifecycle.
 pub type RegisterCommand = SkillStateAction;
-
 /// SPEC-1935 / Issue #2529: canonical CLI surface for `gwt-agent` pane
 /// inspection and lifecycle operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -682,12 +680,7 @@ pub fn parse_build_args(args: &[String]) -> Result<CliCommand, CliParseError> {
     parse_skill_state_args(args).map(CliCommand::Build)
 }
 
-/// Parse `gwtd register <action> --spec <n> [...]` (SPEC-2784).
-pub fn parse_register_args(args: &[String]) -> Result<CliCommand, CliParseError> {
-    parse_skill_state_args(args).map(CliCommand::Register)
-}
-
-fn parse_skill_state_args(args: &[String]) -> Result<SkillStateAction, CliParseError> {
+pub(crate) fn parse_skill_state_args(args: &[String]) -> Result<SkillStateAction, CliParseError> {
     let (head, rest) = args.split_first().ok_or(CliParseError::Usage)?;
     match head.as_str() {
         "start" => {

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -33,6 +33,7 @@ mod issue_spec;
 mod pane;
 mod plan;
 mod pr;
+mod register;
 pub mod serve;
 mod skill_state_runtime;
 #[cfg(test)]
@@ -152,6 +153,8 @@ pub enum CliCommand {
     Plan(PlanCommand),
     /// `gwtd build ...` — gwt-build-spec exit CLI.
     Build(BuildCommand),
+    /// `gwtd register ...` — gwt-register-spec exit CLI (SPEC-2784).
+    Register(RegisterCommand),
     /// `gwtd update [...]` and `gwtd __internal {apply-update,run-installer} ...`.
     Update(UpdateCommand),
     /// `gwtd daemon ...` — long-running runtime daemon (SPEC-2077).
@@ -375,6 +378,10 @@ pub type PlanCommand = SkillStateAction;
 /// SPEC-1942 family enum for `gwtd build ...`. Backed by [`SkillStateAction`].
 pub type BuildCommand = SkillStateAction;
 
+/// SPEC-2784 family enum for `gwtd register ...`. Backed by
+/// [`SkillStateAction`] — same lifecycle pattern as `plan` and `build`.
+pub type RegisterCommand = SkillStateAction;
+
 /// SPEC-1935 / Issue #2529: canonical CLI surface for `gwt-agent` pane
 /// inspection and lifecycle operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -555,6 +562,7 @@ pub fn should_dispatch_cli(args: &[String]) -> bool {
                     | "discuss"
                     | "plan"
                     | "build"
+                    | "register"
                     | "daemon"
                     | "workspace"
                     | "pane"
@@ -674,6 +682,11 @@ pub fn parse_build_args(args: &[String]) -> Result<CliCommand, CliParseError> {
     parse_skill_state_args(args).map(CliCommand::Build)
 }
 
+/// Parse `gwtd register <action> --spec <n> [...]` (SPEC-2784).
+pub fn parse_register_args(args: &[String]) -> Result<CliCommand, CliParseError> {
+    parse_skill_state_args(args).map(CliCommand::Register)
+}
+
 fn parse_skill_state_args(args: &[String]) -> Result<SkillStateAction, CliParseError> {
     let (head, rest) = args.split_first().ok_or(CliParseError::Usage)?;
     match head.as_str() {
@@ -746,6 +759,7 @@ pub fn run<E: CliEnv>(env: &mut E, cmd: CliCommand) -> Result<i32, SpecOpsError>
         CliCommand::Discuss(action) => discuss::run(env, action, &mut out)?,
         CliCommand::Plan(action) => plan::run(env, action, &mut out)?,
         CliCommand::Build(action) => build::run(env, action, &mut out)?,
+        CliCommand::Register(action) => register::run(env, action, &mut out)?,
         CliCommand::Hook(HookCommand::Run { name, rest }) => {
             return hook::run_hook(env, &name, &rest);
         }

--- a/crates/gwt/src/cli/actions.rs
+++ b/crates/gwt/src/cli/actions.rs
@@ -58,17 +58,23 @@ pub(super) fn fetch_actions_run_log_via_gh(
     repo_path: &std::path::Path,
     run_id: u64,
 ) -> io::Result<String> {
-    let output = gwt_core::process::hidden_command("gh")
-        .args(["run", "view", &run_id.to_string(), "--log"])
-        .current_dir(repo_path)
-        .output()?;
-    if !output.status.success() {
+    let hub = gwt_core::process_console::global();
+    let run_str = run_id.to_string();
+    let output = gwt_core::process_console::spawn_logged_blocking(
+        &hub,
+        gwt_core::process_console::ProcessKind::Gh,
+        "gh",
+        &["run", "view", run_str.as_str(), "--log"],
+        gwt_core::process_console::SpawnOptions::new(format!("gh run view {run_id} --log"))
+            .current_dir(repo_path),
+    )?;
+    if !output.success() {
         return Err(io::Error::other(format!(
             "gh run view --log: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            output.stderr.trim()
         )));
     }
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    Ok(output.stdout)
 }
 
 pub(super) fn fetch_actions_job_log_via_gh(
@@ -78,23 +84,28 @@ pub(super) fn fetch_actions_job_log_via_gh(
     job_id: u64,
 ) -> io::Result<String> {
     let endpoint = format!("/repos/{owner}/{repo}/actions/jobs/{job_id}/logs");
-    let output = gwt_core::process::hidden_command("gh")
-        .args(["api", &endpoint])
-        .current_dir(repo_path)
-        .output()?;
-    if !output.status.success() {
+    let hub = gwt_core::process_console::global();
+    let output = gwt_core::process_console::spawn_logged_blocking(
+        &hub,
+        gwt_core::process_console::ProcessKind::Gh,
+        "gh",
+        &["api", endpoint.as_str()],
+        gwt_core::process_console::SpawnOptions::new(format!("gh api {endpoint}"))
+            .current_dir(repo_path),
+    )?;
+    if !output.success() {
         return Err(io::Error::other(format!(
             "gh api {endpoint}: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            output.stderr.trim()
         )));
     }
-    if output.stdout.starts_with(b"PK") {
+    if output.stdout.as_bytes().starts_with(b"PK") {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             "job logs returned a zip archive; unable to parse",
         ));
     }
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    Ok(output.stdout)
 }
 
 #[cfg(test)]

--- a/crates/gwt/src/cli/env/mod.rs
+++ b/crates/gwt/src/cli/env/mod.rs
@@ -185,6 +185,7 @@ pub fn dispatch<E: CliEnv>(env: &mut E, args: &[String]) -> i32 {
         "discuss" => super::parse_discuss_args(&rest),
         "plan" => super::parse_plan_args(&rest),
         "build" => super::parse_build_args(&rest),
+        "register" => super::parse_register_args(&rest),
         "daemon" => super::parse_daemon_args(&rest),
         "workspace" => super::parse_workspace_args(&rest),
         "pane" => parse_pane_args(&rest),

--- a/crates/gwt/src/cli/env/mod.rs
+++ b/crates/gwt/src/cli/env/mod.rs
@@ -185,7 +185,7 @@ pub fn dispatch<E: CliEnv>(env: &mut E, args: &[String]) -> i32 {
         "discuss" => super::parse_discuss_args(&rest),
         "plan" => super::parse_plan_args(&rest),
         "build" => super::parse_build_args(&rest),
-        "register" => super::parse_register_args(&rest),
+        "register" => super::register::parse_args(&rest),
         "daemon" => super::parse_daemon_args(&rest),
         "workspace" => super::parse_workspace_args(&rest),
         "pane" => parse_pane_args(&rest),

--- a/crates/gwt/src/cli/hook/event_dispatcher.rs
+++ b/crates/gwt/src/cli/hook/event_dispatcher.rs
@@ -9,7 +9,8 @@ use std::{path::Path, time::Instant};
 
 use super::{
     board_reminder, diagnostics, skill_build_spec_stop_check, skill_discussion_stop_check,
-    skill_plan_spec_stop_check, workflow_policy, workspace_identity, HookError, HookOutput,
+    skill_plan_spec_stop_check, skill_register_spec_stop_check, workflow_policy,
+    workspace_identity, HookError, HookOutput,
 };
 
 pub fn handle_with_input(
@@ -120,6 +121,9 @@ fn handle_stop(
         }),
         run_value(event, "skill-build-spec-stop-check", || {
             skill_build_spec_stop_check::handle_with_input(worktree_root, input, current_session)
+        }),
+        run_value(event, "skill-register-spec-stop-check", || {
+            skill_register_spec_stop_check::handle_with_input(worktree_root, input, current_session)
         }),
     ] {
         if matches!(output, HookOutput::StopBlock { .. }) {

--- a/crates/gwt/src/cli/hook/mod.rs
+++ b/crates/gwt/src/cli/hook/mod.rs
@@ -29,6 +29,7 @@ pub mod segments;
 pub mod skill_build_spec_stop_check;
 pub mod skill_discussion_stop_check;
 pub mod skill_plan_spec_stop_check;
+pub mod skill_register_spec_stop_check;
 pub mod workflow_policy;
 mod workspace_identity;
 pub mod worktree;
@@ -60,6 +61,7 @@ pub enum HookKind {
     SkillDiscussionStopCheck,
     SkillPlanSpecStopCheck,
     SkillBuildSpecStopCheck,
+    SkillRegisterSpecStopCheck,
 }
 
 impl HookKind {
@@ -81,6 +83,7 @@ impl HookKind {
             "skill-discussion-stop-check" => Some(Self::SkillDiscussionStopCheck),
             "skill-plan-spec-stop-check" => Some(Self::SkillPlanSpecStopCheck),
             "skill-build-spec-stop-check" => Some(Self::SkillBuildSpecStopCheck),
+            "skill-register-spec-stop-check" => Some(Self::SkillRegisterSpecStopCheck),
             _ => None,
         }
     }
@@ -239,8 +242,8 @@ pub fn run_daemon_hook<E: CliEnv>(
 ) -> Result<i32, SpecOpsError> {
     use crate::cli::hook::{
         block_bash_policy, event_dispatcher, provider_event, skill_build_spec_stop_check,
-        skill_discussion_stop_check, skill_plan_spec_stop_check, workflow_policy, HookKind,
-        HookOutput,
+        skill_discussion_stop_check, skill_plan_spec_stop_check, skill_register_spec_stop_check,
+        workflow_policy, HookKind, HookOutput,
     };
 
     let Some(kind) = HookKind::from_name(name) else {
@@ -405,6 +408,16 @@ pub fn run_daemon_hook<E: CliEnv>(
             let cwd = env.repo_path().to_path_buf();
             let current_session = std::env::var(gwt_agent::GWT_SESSION_ID_ENV).ok();
             let output = skill_build_spec_stop_check::handle_with_input(
+                &cwd,
+                &stdin,
+                current_session.as_deref(),
+            );
+            Ok(emit_hook_output(env, &output))
+        }
+        HookKind::SkillRegisterSpecStopCheck => {
+            let cwd = env.repo_path().to_path_buf();
+            let current_session = std::env::var(gwt_agent::GWT_SESSION_ID_ENV).ok();
+            let output = skill_register_spec_stop_check::handle_with_input(
                 &cwd,
                 &stdin,
                 current_session.as_deref(),

--- a/crates/gwt/src/cli/hook/skill_register_spec_stop_check.rs
+++ b/crates/gwt/src/cli/hook/skill_register_spec_stop_check.rs
@@ -1,0 +1,101 @@
+//! `gwtd hook skill-register-spec-stop-check` — Stop-block handler for the
+//! `gwt-register-spec` skill (SPEC-2784).
+//!
+//! Identical decision body to `skill-plan-spec-stop-check` and
+//! `skill-build-spec-stop-check`: read `.gwt/skill-state/register-spec.json`,
+//! return `HookOutput::StopBlock` while the state is `active: true` for the
+//! current session, honour `stop_hook_active` to cap forced continuation at
+//! one per Stop cycle, and stay silent on every other path.
+
+use std::{
+    io::{self, Read},
+    path::Path,
+};
+
+use gwt_agent::GWT_SESSION_ID_ENV;
+
+use super::{HookError, HookOutput};
+
+pub const SKILL_NAME: &str = "register-spec";
+pub const SKILL_DISPLAY: &str = "gwt-register-spec";
+
+pub fn handle() -> Result<HookOutput, HookError> {
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+    let cwd = std::env::current_dir()?;
+    let current_session = std::env::var(GWT_SESSION_ID_ENV).ok();
+    Ok(handle_with_input(&cwd, &input, current_session.as_deref()))
+}
+
+pub fn handle_with_input(
+    worktree: &Path,
+    input: &str,
+    current_session_id: Option<&str>,
+) -> HookOutput {
+    super::skill_plan_spec_stop_check::decide(
+        worktree,
+        input,
+        current_session_id,
+        SKILL_NAME,
+        SKILL_DISPLAY,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use gwt_core::skill_state::{save, SkillState};
+
+    fn active_state(session: &str, phase: &str) -> SkillState {
+        SkillState {
+            active: true,
+            owner_spec: Some(2784),
+            started_at: Utc.with_ymd_and_hms(2026, 5, 20, 9, 0, 0).unwrap(),
+            phase: Some(phase.to_string()),
+            session_id: session.to_string(),
+        }
+    }
+
+    #[test]
+    fn blocks_while_register_state_is_active() {
+        let dir = tempfile::tempdir().unwrap();
+        save(dir.path(), SKILL_NAME, &active_state("sess-1", "create")).unwrap();
+        match handle_with_input(dir.path(), "{}", Some("sess-1")) {
+            HookOutput::StopBlock { reason } => {
+                assert!(reason.contains("gwt-register-spec"));
+                assert!(reason.contains("create"));
+            }
+            other => panic!("expected StopBlock, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn silent_when_state_file_is_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            handle_with_input(dir.path(), "{}", Some("sess-1")),
+            HookOutput::Silent,
+        );
+    }
+
+    #[test]
+    fn silent_when_session_id_does_not_match() {
+        let dir = tempfile::tempdir().unwrap();
+        save(dir.path(), SKILL_NAME, &active_state("sess-other", "edit")).unwrap();
+        assert_eq!(
+            handle_with_input(dir.path(), "{}", Some("sess-1")),
+            HookOutput::Silent,
+        );
+    }
+
+    #[test]
+    fn silent_when_stop_hook_active_is_true() {
+        let dir = tempfile::tempdir().unwrap();
+        save(dir.path(), SKILL_NAME, &active_state("sess-1", "create")).unwrap();
+        assert_eq!(
+            handle_with_input(dir.path(), r#"{"stop_hook_active":true}"#, Some("sess-1"),),
+            HookOutput::Silent,
+        );
+    }
+}

--- a/crates/gwt/src/cli/issue.rs
+++ b/crates/gwt/src/cli/issue.rs
@@ -343,8 +343,12 @@ query($owner: String!, $repo: String!, $number: Int!) {
 }
 "#;
 
-    let output = gwt_core::process::hidden_command("gh")
-        .args([
+    let hub = gwt_core::process_console::global();
+    let output = gwt_core::process_console::spawn_logged_blocking(
+        &hub,
+        gwt_core::process_console::ProcessKind::Gh,
+        "gh",
+        &[
             "api",
             "graphql",
             "-f",
@@ -355,17 +359,18 @@ query($owner: String!, $repo: String!, $number: Int!) {
             &format!("repo={repo}"),
             "-F",
             &format!("number={}", number.0),
-        ])
-        .output()?;
+        ],
+        gwt_core::process_console::SpawnOptions::new("gh api graphql issue timeline"),
+    )?;
 
-    if !output.status.success() {
+    if !output.success() {
         return Err(io::Error::other(format!(
             "gh api graphql failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            output.stderr.trim()
         )));
     }
 
-    let value: serde_json::Value = serde_json::from_slice(&output.stdout)
+    let value: serde_json::Value = serde_json::from_str(&output.stdout)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
     let nodes = value
         .get("data")

--- a/crates/gwt/src/cli/pr/gh.rs
+++ b/crates/gwt/src/cli/pr/gh.rs
@@ -7,14 +7,56 @@
 //!
 //! All helpers are `pub(super)` so the parent `cli::pr` module can re-export
 //! them and `cli::env` can call them via `super::pr::*`.
+//!
+//! Every spawn flows through `gwt_core::process_console::spawn_logged_blocking`
+//! so the canonical log captures `gwt.process.summary` events for each
+//! invocation (SPEC-1924 FR-039 / FR-040).
 
+use std::ffi::OsStr;
 use std::io;
+use std::path::Path;
 
+use gwt_core::process_console::{spawn_logged_blocking, ProcessKind, SpawnOptions, SpawnOutput};
 use gwt_git::PrStatus;
 
 use crate::cli::{
     PrCheckItem, PrChecksSummary, PrCreateCall, PrReview, PrReviewThread, PrReviewThreadComment,
 };
+
+fn run_gh_in<I, S>(label: &str, repo_path: Option<&Path>, args: I) -> io::Result<SpawnOutput>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let hub = gwt_core::process_console::global();
+    let args_vec: Vec<std::ffi::OsString> =
+        args.into_iter().map(|s| s.as_ref().to_owned()).collect();
+    let mut options = SpawnOptions::new(label);
+    if let Some(dir) = repo_path {
+        options = options.current_dir(dir);
+    }
+    spawn_logged_blocking(&hub, ProcessKind::Gh, "gh", &args_vec, options)
+}
+
+fn run_gh<I, S>(label: &str, args: I) -> io::Result<SpawnOutput>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    run_gh_in(label, None, args)
+}
+
+fn run_git_in<I, S>(label: &str, repo_path: &Path, args: I) -> io::Result<SpawnOutput>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let hub = gwt_core::process_console::global();
+    let args_vec: Vec<std::ffi::OsString> =
+        args.into_iter().map(|s| s.as_ref().to_owned()).collect();
+    let options = SpawnOptions::new(label).current_dir(repo_path);
+    spawn_logged_blocking(&hub, ProcessKind::Git, "git", &args_vec, options)
+}
 
 const PR_STATUS_FIELDS: &str =
     "number,title,state,url,createdAt,mergeable,mergeStateStatus,statusCheckRollup,reviewDecision";
@@ -23,25 +65,25 @@ const PR_LIST_FIELDS: &str = "number,title,state,url,createdAt,mergeable,mergeSt
 pub fn fetch_current_pr_via_gh(repo_path: &std::path::Path) -> io::Result<Option<PrStatus>> {
     if let Some(branch) = current_branch_name(repo_path)? {
         let repo = github_remote_owner_and_repo(repo_path);
-        let output = gwt_core::process::hidden_command("gh")
-            .args([
+        let output = run_gh_in(
+            &format!("gh pr list --head {branch}"),
+            Some(repo_path),
+            [
                 "pr",
                 "list",
                 "--head",
-                &branch,
+                branch.as_str(),
                 "--state",
                 "all",
                 "--json",
                 PR_LIST_FIELDS,
                 "--limit",
                 "100",
-            ])
-            .current_dir(repo_path)
-            .output()?;
+            ],
+        )?;
 
-        if output.status.success() {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            let pr_values = filter_current_repo_head_prs(&stdout, &branch, repo.as_ref())?;
+        if output.success() {
+            let pr_values = filter_current_repo_head_prs(&output.stdout, &branch, repo.as_ref())?;
             if !pr_values.is_empty() {
                 let filtered_stdout = serde_json::to_string(&pr_values)
                     .map_err(|err| io::Error::other(err.to_string()))?;
@@ -54,14 +96,14 @@ pub fn fetch_current_pr_via_gh(repo_path: &std::path::Path) -> io::Result<Option
         }
     }
 
-    let output = gwt_core::process::hidden_command("gh")
-        .args(["pr", "view", "--json", PR_STATUS_FIELDS])
-        .current_dir(repo_path)
-        .output()?;
+    let output = run_gh_in(
+        "gh pr view",
+        Some(repo_path),
+        ["pr", "view", "--json", PR_STATUS_FIELDS],
+    )?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let trimmed = stderr.trim();
+    if !output.success() {
+        let trimmed = output.stderr.trim();
         let lowered = trimmed.to_ascii_lowercase();
         if lowered.contains("no pull requests found")
             || lowered.contains("no pull request found")
@@ -72,8 +114,7 @@ pub fn fetch_current_pr_via_gh(repo_path: &std::path::Path) -> io::Result<Option
         return Err(io::Error::other(format!("gh pr view: {trimmed}")));
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let pr = gwt_git::pr_status::parse_pr_status_json(&stdout)
+    let pr = gwt_git::pr_status::parse_pr_status_json(&output.stdout)
         .map_err(|err| io::Error::other(err.to_string()))?;
     Ok(Some(pr))
 }
@@ -132,30 +173,31 @@ fn pr_head_repository_name(value: &serde_json::Value) -> Option<&str> {
 }
 
 fn current_branch_name(repo_path: &std::path::Path) -> io::Result<Option<String>> {
-    let output = gwt_core::process::hidden_command("git")
-        .args(["branch", "--show-current"])
-        .current_dir(repo_path)
-        .output()?;
-    if !output.status.success() {
+    let output = run_git_in(
+        "git branch --show-current",
+        repo_path,
+        ["branch", "--show-current"],
+    )?;
+    if !output.success() {
         return Ok(None);
     }
-    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let branch = output.stdout.trim().to_string();
     Ok((!branch.is_empty()).then_some(branch))
 }
 
 pub(super) fn github_remote_owner_and_repo(
     repo_path: &std::path::Path,
 ) -> Option<(String, String)> {
-    let output = gwt_core::process::hidden_command("git")
-        .args(["remote", "get-url", "origin"])
-        .current_dir(repo_path)
-        .output()
-        .ok()?;
-    if !output.status.success() {
+    let output = run_git_in(
+        "git remote get-url origin",
+        repo_path,
+        ["remote", "get-url", "origin"],
+    )
+    .ok()?;
+    if !output.success() {
         return None;
     }
-    let remote_url = String::from_utf8_lossy(&output.stdout);
-    parse_github_remote_url(remote_url.trim())
+    parse_github_remote_url(output.stdout.trim())
 }
 
 fn parse_github_remote_url(remote_url: &str) -> Option<(String, String)> {
@@ -199,20 +241,19 @@ pub fn create_pr_via_gh(
         args.push("--draft".to_string());
     }
 
-    let output = gwt_core::process::hidden_command("gh")
-        .args(&args)
-        .current_dir(repo_path)
-        .output()?;
-    if !output.status.success() {
+    let output = run_gh_in("gh pr create", Some(repo_path), &args)?;
+    if !output.success() {
         return Err(io::Error::other(format!(
             "gh pr create: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            output.stderr.trim()
         )));
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let url = extract_pr_url(&stdout).ok_or_else(|| {
-        io::Error::other(format!("gh pr create: missing PR URL in output: {stdout}"))
+    let url = extract_pr_url(&output.stdout).ok_or_else(|| {
+        io::Error::other(format!(
+            "gh pr create: missing PR URL in output: {}",
+            output.stdout
+        ))
     })?;
     let number = parse_pr_number_from_url(&url)
         .ok_or_else(|| io::Error::other(format!("gh pr create: invalid PR URL: {url}")))?;
@@ -242,14 +283,11 @@ pub fn edit_pr_via_gh(
         args.push(label.clone());
     }
 
-    let output = gwt_core::process::hidden_command("gh")
-        .args(&args)
-        .current_dir(repo_path)
-        .output()?;
-    if !output.status.success() {
+    let output = run_gh_in("gh pr edit", Some(repo_path), &args)?;
+    if !output.success() {
         return Err(io::Error::other(format!(
             "gh pr edit: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            output.stderr.trim()
         )));
     }
     gwt_git::pr_status::fetch_pr_status(repo_slug, number)
@@ -273,14 +311,16 @@ pub fn comment_on_pr_via_gh(
     number: u64,
     body: &str,
 ) -> io::Result<()> {
-    let output = gwt_core::process::hidden_command("gh")
-        .args(["pr", "comment", &number.to_string(), "--body", body])
-        .current_dir(repo_path)
-        .output()?;
-    if !output.status.success() {
+    let number_str = number.to_string();
+    let output = run_gh_in(
+        &format!("gh pr comment {number}"),
+        Some(repo_path),
+        ["pr", "comment", number_str.as_str(), "--body", body],
+    )?;
+    if !output.success() {
         return Err(io::Error::other(format!(
             "gh pr comment: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            output.stderr.trim()
         )));
     }
     Ok(())
@@ -288,17 +328,15 @@ pub fn comment_on_pr_via_gh(
 
 pub fn fetch_pr_reviews_via_gh(owner: &str, repo: &str, number: u64) -> io::Result<Vec<PrReview>> {
     let endpoint = format!("repos/{owner}/{repo}/pulls/{number}/reviews");
-    let output = gwt_core::process::hidden_command("gh")
-        .args(["api", &endpoint])
-        .output()?;
-    if !output.status.success() {
+    let output = run_gh(&format!("gh api {endpoint}"), ["api", endpoint.as_str()])?;
+    if !output.success() {
         return Err(io::Error::other(format!(
             "gh api {endpoint}: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            output.stderr.trim()
         )));
     }
 
-    let values: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout)
+    let values: Vec<serde_json::Value> = serde_json::from_str(&output.stdout)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
     Ok(values
         .into_iter()
@@ -370,8 +408,9 @@ query($owner: String!, $repo: String!, $number: Int!) {
   }
 }
 "#;
-    let output = gwt_core::process::hidden_command("gh")
-        .args([
+    let output = run_gh(
+        "gh api graphql reviewThreads",
+        [
             "api",
             "graphql",
             "-f",
@@ -382,16 +421,16 @@ query($owner: String!, $repo: String!, $number: Int!) {
             &format!("repo={repo}"),
             "-F",
             &format!("number={number}"),
-        ])
-        .output()?;
-    if !output.status.success() {
+        ],
+    )?;
+    if !output.success() {
         return Err(io::Error::other(format!(
             "gh api graphql: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
+            output.stderr.trim()
         )));
     }
 
-    let value: serde_json::Value = serde_json::from_slice(&output.stdout)
+    let value: serde_json::Value = serde_json::from_str(&output.stdout)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
     let nodes = value
         .get("data")
@@ -498,8 +537,9 @@ mutation($threadId: ID!, $body: String!) {
 }
 "#;
         if should_reply_to_review_thread(&current_thread, body) {
-            let reply = gwt_core::process::hidden_command("gh")
-                .args([
+            let reply = run_gh(
+                "gh api graphql reply",
+                [
                     "api",
                     "graphql",
                     "-f",
@@ -508,12 +548,12 @@ mutation($threadId: ID!, $body: String!) {
                     &format!("threadId={}", thread.id),
                     "-f",
                     &format!("body={body}"),
-                ])
-                .output()?;
-            if !reply.status.success() {
+                ],
+            )?;
+            if !reply.success() {
                 return Err(io::Error::other(format!(
                     "gh api graphql reply: {}",
-                    String::from_utf8_lossy(&reply.stderr).trim()
+                    reply.stderr.trim()
                 )));
             }
         }
@@ -525,17 +565,18 @@ mutation($threadId: ID!) {
   }
 }
 "#;
-        let resolve = gwt_core::process::hidden_command("gh")
-            .args([
+        let resolve = run_gh(
+            "gh api graphql resolve",
+            [
                 "api",
                 "graphql",
                 "-f",
                 &format!("query={resolve_mutation}"),
                 "-f",
                 &format!("threadId={}", thread.id),
-            ])
-            .output()?;
-        if !resolve.status.success() {
+            ],
+        )?;
+        if !resolve.success() {
             if fetch_pr_review_thread_state_via_gh(owner, repo, number, &thread.id)?
                 .as_ref()
                 .is_some_and(|thread| thread.is_resolved)
@@ -545,7 +586,7 @@ mutation($threadId: ID!) {
             }
             return Err(io::Error::other(format!(
                 "gh api graphql resolve: {}",
-                String::from_utf8_lossy(&resolve.stderr).trim()
+                resolve.stderr.trim()
             )));
         }
 
@@ -571,20 +612,21 @@ pub fn fetch_pr_checks_via_gh(
         "startedAt",
         "completedAt",
     ];
-    let mut output = gwt_core::process::hidden_command("gh")
-        .args([
+    let number_str = number.to_string();
+    let mut output = run_gh_in(
+        &format!("gh pr checks {number}"),
+        Some(repo_path),
+        [
             "pr",
             "checks",
-            &number.to_string(),
+            number_str.as_str(),
             "--json",
             &primary_fields.join(","),
-        ])
-        .current_dir(repo_path)
-        .output()?;
+        ],
+    )?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let available = parse_available_fields(&stderr);
+    if !output.success() {
+        let available = parse_available_fields(&output.stderr);
         if !available.is_empty() {
             let fallback_fields = [
                 "name",
@@ -601,23 +643,22 @@ pub fn fetch_pr_checks_via_gh(
                 .filter(|field| available.iter().any(|candidate| candidate == field))
                 .collect();
             if !selected.is_empty() {
-                output = gwt_core::process::hidden_command("gh")
-                    .args([
+                output = run_gh_in(
+                    &format!("gh pr checks {number} fallback"),
+                    Some(repo_path),
+                    [
                         "pr",
                         "checks",
-                        &number.to_string(),
+                        number_str.as_str(),
                         "--json",
                         &selected.join(","),
-                    ])
-                    .current_dir(repo_path)
-                    .output()?;
+                    ],
+                )?;
             }
         }
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let checks = parse_pr_checks_items_response(&stdout, &stderr, output.status.success())?;
+    let checks = parse_pr_checks_items_response(&output.stdout, &output.stderr, output.success())?;
     let merge_status = pr.effective_merge_status().to_string();
 
     Ok(PrChecksSummary {

--- a/crates/gwt/src/cli/register.rs
+++ b/crates/gwt/src/cli/register.rs
@@ -16,7 +16,12 @@
 use gwt_github::SpecOpsError;
 
 use super::skill_state_runtime;
-use crate::cli::{CliEnv, SkillStateAction};
+use crate::cli::{parse_skill_state_args, CliCommand, CliEnv, CliParseError, SkillStateAction};
+
+/// Parse `gwtd register <action> --spec <n> [...]` (SPEC-2784).
+pub fn parse_args(args: &[String]) -> Result<CliCommand, CliParseError> {
+    parse_skill_state_args(args).map(CliCommand::Register)
+}
 
 pub const SKILL_NAME: &str = "register-spec";
 pub const SKILL_DISPLAY: &str = "gwt-register-spec";

--- a/crates/gwt/src/cli/register.rs
+++ b/crates/gwt/src/cli/register.rs
@@ -1,0 +1,31 @@
+//! `gwtd register <start|phase|complete|abort> --spec <n> [...]`
+//!
+//! Exit CLI for the `gwt-register-spec` skill (SPEC-2784). Writes
+//! `.gwt/skill-state/register-spec.json` via [`gwt_core::skill_state`].
+//!
+//! The lifecycle mirrors `gwt-plan-spec` and `gwt-build-spec`: `start` is
+//! called when the skill begins materializing a SPEC, `phase` records each
+//! milestone (`validation`, `create`, `edit`, `roundtrip`), and
+//! `complete` / `abort` flip `active: false` so the Stop-block handler stops
+//! forcing continuation.
+//!
+//! Because the SPEC id is not known until `gwtd issue spec create` returns,
+//! `gwt-register-spec` may legitimately call `start --spec 0` and then
+//! re-emit `phase --spec <real-id>` once the Issue is created.
+
+use gwt_github::SpecOpsError;
+
+use super::skill_state_runtime;
+use crate::cli::{CliEnv, SkillStateAction};
+
+pub const SKILL_NAME: &str = "register-spec";
+pub const SKILL_DISPLAY: &str = "gwt-register-spec";
+pub const VERB: &str = "register";
+
+pub(super) fn run<E: CliEnv>(
+    env: &mut E,
+    action: SkillStateAction,
+    out: &mut String,
+) -> Result<i32, SpecOpsError> {
+    skill_state_runtime::run(env, action, SKILL_NAME, SKILL_DISPLAY, VERB, out)
+}

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -58,6 +58,10 @@ pub fn update_cta_js() -> &'static str {
     include_str!("../web/update-cta.js")
 }
 
+pub fn release_notes_window_js() -> &'static str {
+    include_str!("../web/release-notes-window.js")
+}
+
 pub fn terminal_context_menu_js() -> &'static str {
     include_str!("../web/terminal-context-menu.js")
 }
@@ -231,6 +235,11 @@ pub const ROOT_JS_MODULE_ASSETS: &[RootJsModuleAsset] = &[
         path: "/update-cta.js",
         source: update_cta_js,
         marker: "createUpdateCtaController",
+    },
+    RootJsModuleAsset {
+        path: "/release-notes-window.js",
+        source: release_notes_window_js,
+        marker: "createReleaseNotesWindow",
     },
     RootJsModuleAsset {
         path: "/terminal-context-menu.js",

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -186,6 +186,15 @@ pub fn custom_agent_env_editor_js() -> &'static str {
     include_str!("../web/custom-agent-env-editor.js")
 }
 
+// SPEC-2780 — release notes window with version selector. app.js imports this
+// via `import { createReleaseNotesWindow } from "/release-notes-window.js"` at
+// module top level. Missing this route causes the ES module load to fail and
+// the splash to hang because none of the boot wiring (mission briefing,
+// WebSocket connect, operator shell) runs.
+pub fn release_notes_window_js() -> &'static str {
+    include_str!("../web/release-notes-window.js")
+}
+
 pub const ROOT_JS_MODULE_ASSETS: &[RootJsModuleAsset] = &[
     RootJsModuleAsset {
         path: "/branch-cleanup-modal.js",
@@ -331,6 +340,11 @@ pub const ROOT_JS_MODULE_ASSETS: &[RootJsModuleAsset] = &[
         path: "/custom-agent-env-editor.js",
         source: custom_agent_env_editor_js,
         marker: "renderCustomAgentEnvEditor",
+    },
+    RootJsModuleAsset {
+        path: "/release-notes-window.js",
+        source: release_notes_window_js,
+        marker: "createReleaseNotesWindow",
     },
 ];
 
@@ -1106,6 +1120,87 @@ mod tests {
                 asset.path,
                 asset.marker,
             );
+        }
+    }
+
+    /// SPEC-2780 follow-up — every top-level `import ... from "/x.js"` in any
+    /// shipped JS module must be registered in `ROOT_JS_MODULE_ASSETS` or the
+    /// embedded server returns 404 at runtime, the ES module load aborts, and
+    /// the splash hangs because no boot wiring runs. We learned this the hard
+    /// way when `/release-notes-window.js` was added to `app.js` without a
+    /// matching route; assert here so the regression cannot recur silently.
+    #[test]
+    fn every_root_js_module_import_in_app_assets_is_registered() {
+        use std::collections::BTreeSet;
+
+        // Crawl every embedded JS source registered with the server plus
+        // `app.js` (the entrypoint) for `from "/X.js"` patterns.
+        let mut imports: BTreeSet<String> = BTreeSet::new();
+        let mut sources: Vec<(&str, &str)> = vec![("/app.js", app_js())];
+        for asset in root_js_module_assets() {
+            sources.push((asset.path, (asset.source)()));
+        }
+
+        for (origin, source) in &sources {
+            collect_root_js_imports(source, origin, &mut imports);
+        }
+
+        let registered: BTreeSet<String> = root_js_module_assets()
+            .iter()
+            .map(|asset| asset.path.to_string())
+            .collect();
+
+        let missing: Vec<String> = imports
+            .difference(&registered)
+            .filter(|path| *path != "/app.js")
+            .cloned()
+            .collect();
+
+        assert!(
+            missing.is_empty(),
+            "embedded JS modules import these paths but they are not registered \
+             in ROOT_JS_MODULE_ASSETS (will 404 at runtime and freeze splash): {:?}",
+            missing,
+        );
+    }
+
+    fn collect_root_js_imports(
+        source: &str,
+        origin: &str,
+        out: &mut std::collections::BTreeSet<String>,
+    ) {
+        // Tolerant scanner for top-level absolute-path module imports of the
+        // shape `from "/something.js"` or `from '/something.js'`. We do not
+        // need a full JS parser here; the goal is to catch obvious 404 traps.
+        for line in source.lines() {
+            let trimmed = line.trim_start();
+            if !trimmed.starts_with("import")
+                && !trimmed.starts_with("} from")
+                && !trimmed.contains(" from ")
+            {
+                continue;
+            }
+            for quote in ['"', '\''] {
+                let mut rest = line;
+                while let Some(idx) = rest.find(quote) {
+                    let after = &rest[idx + 1..];
+                    if let Some(end) = after.find(quote) {
+                        let candidate = &after[..end];
+                        if candidate.starts_with('/') && candidate.ends_with(".js") {
+                            // Ignore the entrypoint itself; app.js is served by
+                            // a dedicated handler, not via root_js_module_assets.
+                            if candidate != "/app.js" {
+                                out.insert(candidate.to_string());
+                            }
+                        }
+                        rest = &after[end + 1..];
+                    } else {
+                        break;
+                    }
+                }
+            }
+            // Suppress the unused-variable lint when no match path is taken.
+            let _ = origin;
         }
     }
 

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -2545,8 +2545,36 @@ mod tests {
         );
         assert!(
             html.contains("showSetupForms && launchWizard.show_branch_controls !== false")
-                && html.contains("showSetupForms && launchWizard.show_agent_settings"),
-            "expected branch and linked issue controls to be gated to setup forms",
+                && html.contains("showSetupForms && launchWizard.show_linked_issue"),
+            "expected branch and linked issue controls to be gated to setup forms \
+             (linked issue uses dedicated show_linked_issue flag per SPEC-2014 FR-057)",
+        );
+    }
+
+    // SPEC-2014 Amendment 2026-05-20 (US-25 / FR-057-059 / SC-032)
+    // The Launch Wizard "Linked issue" section must render through the
+    // `show_linked_issue` gate and must not contain an editable input that
+    // dispatches `set_linked_issue` / `clear_linked_issue` from the UI. The
+    // value is rendered as static read-only text.
+    #[test]
+    fn embedded_web_launch_wizard_linked_issue_is_readonly_for_issue_bridge() {
+        let html = frontend_bundle_source();
+
+        assert!(
+            html.contains("showSetupForms && launchWizard.show_linked_issue"),
+            "expected Linked issue section to be gated by show_linked_issue (FR-057)",
+        );
+        assert!(
+            !html.contains(r#"kind: "set_linked_issue""#),
+            "expected the frontend to stop dispatching set_linked_issue from the wizard UI (FR-058)",
+        );
+        assert!(
+            !html.contains(r#"kind: "clear_linked_issue""#),
+            "expected the frontend to stop dispatching clear_linked_issue from the wizard UI (FR-058)",
+        );
+        assert!(
+            html.contains("launchWizard.linked_issue_number") && html.contains("Issue number"),
+            "expected the Linked issue section to render the issue number as static read-only text",
         );
     }
 

--- a/crates/gwt/src/issue_cache.rs
+++ b/crates/gwt/src/issue_cache.rs
@@ -21,6 +21,12 @@ use serde_json::Value;
 
 const DETACHED_REPO_CACHE_DIR: &str = "__detached__";
 const SPEC_LABEL: &str = "gwt-spec";
+/// Substring that uniquely identifies a SPEC body header. We do not run the
+/// full regex here because callers only need to decide whether to fetch
+/// comments — a positive substring match is enough to trigger the comment
+/// fetch path. The actual structural parse still happens later in
+/// [`gwt_github::body::SpecBody::parse`].
+const SPEC_BODY_HEADER_MARKER: &str = "<!-- gwt-spec id=";
 const ISSUE_CACHE_REFRESH_META_FILE: &str = "refresh-meta.json";
 pub const ISSUE_CACHE_TTL: Duration = Duration::from_secs(15 * 60);
 
@@ -95,11 +101,7 @@ pub fn sync_issue_cache_from_remote(repo_path: &Path, cache_root: &Path) -> Resu
 
     let cache = Cache::new(cache_root.to_path_buf());
     for listed_snapshot in &snapshots {
-        let snapshot = if listed_snapshot
-            .labels
-            .iter()
-            .any(|label| label == SPEC_LABEL)
-        {
+        let snapshot = if is_spec_issue(listed_snapshot) {
             fetch_issue_snapshot(repo_path, listed_snapshot.number)?
         } else {
             listed_snapshot.clone()
@@ -126,6 +128,18 @@ pub fn issue_cache_has_entries(cache_root: &Path) -> bool {
                 .to_str()
                 .is_some_and(|name| name.parse::<u64>().is_ok())
     })
+}
+
+/// Decide whether an Issue should be fetched as a SPEC (with comments) during
+/// `sync_issue_cache_from_remote`. The label `gwt-spec` is the primary signal,
+/// but the body header is also authoritative — without this fallback, an
+/// Issue whose `gwt-spec` label has been removed (or was never applied) but
+/// whose body still carries section markers referencing comments would be
+/// cached without those comments, and the next [`gwt_github::cache::Cache::write_snapshot`]
+/// would fail with `MissingComment`.
+fn is_spec_issue(snapshot: &IssueSnapshot) -> bool {
+    snapshot.labels.iter().any(|label| label == SPEC_LABEL)
+        || snapshot.body.contains(SPEC_BODY_HEADER_MARKER)
 }
 
 fn gh_executable() -> std::ffi::OsString {
@@ -397,7 +411,7 @@ fn parse_issue_list_snapshots(json: &str) -> Result<Vec<IssueSnapshot>, String> 
 
 #[cfg(test)]
 mod tests {
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "windows", unix))]
     use std::env;
     use std::fs;
 
@@ -607,6 +621,84 @@ exit /b 1\r\n",
             Some(value) => env::set_var("GWT_TEST_GH", value),
             None => env::remove_var("GWT_TEST_GH"),
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sync_remote_detects_spec_via_body_header_when_label_missing() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = crate::cli::fake_gh_test_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let temp = tempdir().expect("tempdir");
+        let repo_path = temp.path().join("repo");
+        let cache_root = temp.path().join("cache");
+        fs::create_dir_all(&repo_path).expect("create repo path");
+
+        let body_escaped = "<!-- gwt-spec id=42 version=1 -->\\n\
+            <!-- sections:\\nplan=comment:777\\nspec=body\\ntasks=body\\n-->\\n\\n\
+            <!-- artifact:spec BEGIN -->\\nSpec body\\n<!-- artifact:spec END -->\\n\\n\
+            <!-- artifact:tasks BEGIN -->\\n- [ ] T-001\\n<!-- artifact:tasks END -->";
+        let list_json = format!(
+            r#"[{{"number":42,"title":"Stripped label spec","body":"{body_escaped}","labels":[],"state":"OPEN","url":"https://example.test/issues/42","updatedAt":"2026-05-20T00:00:00Z"}}]"#,
+        );
+        let view_json = format!(
+            r#"{{"number":42,"title":"Stripped label spec","body":"{body_escaped}","labels":[],"state":"OPEN","updatedAt":"2026-05-20T00:00:00Z","comments":[{{"id":"IC_kwDOTest","url":"https://github.com/example/repo/issues/42#issuecomment-777","body":"<!-- artifact:plan BEGIN -->\nPlan body for stripped\n<!-- artifact:plan END -->","createdAt":"2026-05-20T00:00:00Z"}}]}}"#,
+        );
+        let fake_gh = repo_path.join("fake-gh");
+        let script = format!(
+            "#!/bin/sh\n\
+if [ \"$1 $2\" = \"issue list\" ]; then\n\
+  cat <<'JSON'\n\
+{list_json}\n\
+JSON\n\
+  exit 0\n\
+fi\n\
+if [ \"$1 $2\" = \"issue view\" ]; then\n\
+  cat <<'JSON'\n\
+{view_json}\n\
+JSON\n\
+  exit 0\n\
+fi\n\
+echo \"unexpected gh invocation $*\" >&2\n\
+exit 1\n",
+        );
+        fs::write(&fake_gh, script).expect("write fake gh");
+        fs::set_permissions(&fake_gh, fs::Permissions::from_mode(0o755)).expect("chmod fake gh");
+
+        gwt_core::process::hidden_command("git")
+            .args(["init", "-b", "main"])
+            .current_dir(&repo_path)
+            .status()
+            .expect("git init");
+
+        let old_gh = env::var_os("GWT_TEST_GH");
+        env::set_var("GWT_TEST_GH", &fake_gh);
+
+        let result = sync_issue_cache_from_remote(&repo_path, &cache_root);
+
+        match old_gh {
+            Some(value) => env::set_var("GWT_TEST_GH", value),
+            None => env::remove_var("GWT_TEST_GH"),
+        }
+
+        result.expect("sync should succeed when body header marks the issue as a spec");
+
+        let cache = Cache::new(cache_root);
+        let entry = cache
+            .load_entry(IssueNumber(42))
+            .expect("cached entry must exist");
+        assert_eq!(
+            entry
+                .spec_body
+                .sections
+                .get(&gwt_github::SectionName("plan".to_string())),
+            Some(&"Plan body for stripped".to_string()),
+            "plan section content from comment must be present even without gwt-spec label"
+        );
+        assert_eq!(entry.snapshot.comments.len(), 1);
+        assert_eq!(entry.snapshot.comments[0].id, gwt_github::CommentId(777));
     }
 
     #[test]

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -225,6 +225,10 @@ pub struct LaunchWizardView {
     pub show_branch_controls: bool,
     pub show_manual_setup: bool,
     pub show_runtime_confirmation: bool,
+    // SPEC-2014 Amendment 2026-05-20 (FR-057): gate the Linked issue section
+    // so it only renders when the wizard was opened through the Knowledge
+    // Issue Bridge (linked_issue_kind == Some(Issue) AND number is some).
+    pub show_linked_issue: bool,
     pub runtime_resolution_pending: bool,
     pub runtime_resolution_message: Option<String>,
     pub primary_action_label: String,
@@ -1006,6 +1010,10 @@ impl LaunchWizardState {
             show_branch_controls: show_manual_setup && self.wizard_mode == LaunchWizardMode::Branch,
             show_manual_setup,
             show_runtime_confirmation,
+            show_linked_issue: matches!(
+                self.context.linked_issue_kind,
+                Some(LinkedIssueKind::Issue)
+            ) && self.linked_issue_number.is_some(),
             runtime_resolution_pending: self.runtime_resolution_pending,
             runtime_resolution_message: self.runtime_resolution_message.clone(),
             primary_action_label: self.primary_action_label(),
@@ -6099,6 +6107,69 @@ mod tests {
         let config = state.build_launch_config().expect("config");
 
         assert_eq!(config.linked_issue_number, Some(1234));
+    }
+
+    // SPEC-2014 Amendment 2026-05-20 (US-25 / FR-057 / SC-031)
+    // Launch Wizard view should gate the "Linked issue" section so it only
+    // appears when the wizard was opened through the Knowledge Issue Bridge
+    // (`linked_issue_kind == Some(Issue)` AND `linked_issue_number.is_some()`).
+    // SPEC Bridge, Active Work Add-Agent, Workspace Resume, and Branches paths
+    // must hide the section.
+    #[test]
+    fn view_shows_linked_issue_only_for_issue_kind() {
+        // Case 1: Knowledge Issue Bridge — kind=Issue + number=Some => true.
+        let issue_state = LaunchWizardState::open_with(
+            context_with_linked_issue(branch("develop"), "develop", LinkedIssueKind::Issue, 1938),
+            sample_agent_options(),
+            Vec::new(),
+        );
+        assert!(
+            issue_state.view().show_linked_issue,
+            "Issue Bridge (kind=Issue, number=Some) should set show_linked_issue=true"
+        );
+        assert_eq!(issue_state.view().linked_issue_number, Some(1938));
+
+        // Case 2: Knowledge SPEC Bridge — kind=Spec + number=Some => false.
+        let spec_state = LaunchWizardState::open_with(
+            context_with_linked_issue(branch("develop"), "develop", LinkedIssueKind::Spec, 2014),
+            sample_agent_options(),
+            Vec::new(),
+        );
+        assert!(
+            !spec_state.view().show_linked_issue,
+            "SPEC Bridge (kind=Spec) should set show_linked_issue=false"
+        );
+
+        // Case 3: Active Work Add-Agent / Workspace Resume — kind=None + number=Some => false.
+        let mut active_ctx = context(branch("develop"), "develop");
+        active_ctx.linked_issue_number = Some(1234);
+        let active_state =
+            LaunchWizardState::open_with(active_ctx, sample_agent_options(), Vec::new());
+        assert!(
+            !active_state.view().show_linked_issue,
+            "kind=None pre-fill (Active Work / Workspace Resume) should set show_linked_issue=false"
+        );
+
+        // Case 4: No number at all => false even for nominal Issue kind.
+        let mut no_number_ctx = context(branch("develop"), "develop");
+        no_number_ctx.linked_issue_kind = Some(LinkedIssueKind::Issue);
+        let no_number_state =
+            LaunchWizardState::open_with(no_number_ctx, sample_agent_options(), Vec::new());
+        assert!(
+            !no_number_state.view().show_linked_issue,
+            "linked_issue_number=None should always set show_linked_issue=false"
+        );
+
+        // Case 5: Default empty context (Branches / direct launch) => false.
+        let empty_state = LaunchWizardState::open_with(
+            context(branch("develop"), "develop"),
+            sample_agent_options(),
+            Vec::new(),
+        );
+        assert!(
+            !empty_state.view().show_linked_issue,
+            "default context (Branches / direct launch) should set show_linked_issue=false"
+        );
     }
 
     #[test]

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -91,6 +91,8 @@ pub use managed_assets::{
     refresh_existing_managed_gwt_assets_for_worktree, refresh_managed_gwt_assets_for_agent,
     refresh_managed_gwt_assets_for_worktree,
 };
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+pub use native_app::native_window_icon;
 #[cfg(target_os = "macos")]
 pub use native_app::MacosNativeMenu;
 pub use native_app::{

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -6027,11 +6027,14 @@ fn main() -> wry::Result<()> {
     // renders into. Binding the pair in a tuple keeps the Rust ownership of
     // `Window` until the closure (and therefore the process) ends.
     let webview_surface: Option<(Window, wry::WebView)> = if serve_args.is_none() {
-        let window = WindowBuilder::new()
+        let builder = WindowBuilder::new()
             .with_title(APP_NAME)
-            .with_inner_size(tao::dpi::LogicalSize::new(1440.0, 920.0))
-            .build(&event_loop)
-            .expect("window");
+            .with_inner_size(tao::dpi::LogicalSize::new(1440.0, 920.0));
+        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        let window_icon = gwt::native_window_icon();
+        #[cfg(any(target_os = "windows", target_os = "linux"))]
+        let builder = builder.with_window_icon(window_icon);
+        let window = builder.build(&event_loop).expect("window");
         let builder = WebViewBuilder::new().with_url(front_door.webview_url);
 
         #[cfg(any(

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1939,6 +1939,7 @@ mod tests {
             pty_writers: Arc::new(RwLock::new(HashMap::new())),
             persist_dispatcher,
             file_tree_worktree_roots: HashMap::new(),
+            server_url: None,
         };
         runtime.rebuild_window_lookup();
         runtime.seed_window_pty_statuses();
@@ -5988,6 +5989,11 @@ fn main() -> wry::Result<()> {
     .expect("embedded server");
     app.set_hook_forward_target(server.hook_forward_target());
     let front_door = gui_front_door_launch_surface(server.url());
+    // SPEC-2785 FR-E: hand the bound URL to AppRuntime so
+    // `open_server_url_events` can gate `OpenServerUrl` requests against it.
+    // Must run before the WebView surface boots; the first frontend message
+    // is `FrontendReady` which does not exercise this code path.
+    app.set_server_url(front_door.browser_url.to_string());
     eprintln!("gwt browser URL: {}", front_door.browser_url);
     if serve_args.is_some() {
         eprintln!("gwt serve: press Ctrl-C to stop");

--- a/crates/gwt/src/native_app.rs
+++ b/crates/gwt/src/native_app.rs
@@ -51,12 +51,26 @@ pub fn native_menu_command_for_id(menu_id: &str) -> Option<NativeMenuCommand> {
     }
 }
 
-#[cfg(target_os = "windows")]
-pub fn windows_app_icon() -> Option<tao::window::Icon> {
+#[cfg(any(target_os = "windows", target_os = "linux"))]
+pub fn native_window_icon() -> Option<tao::window::Icon> {
     let image = image::load_from_memory(include_bytes!("../../../assets/icons/icon.png")).ok()?;
     let image = image.into_rgba8();
     let (width, height) = image.dimensions();
     tao::window::Icon::from_rgba(image.into_raw(), width, height).ok()
+}
+
+#[cfg(all(test, any(target_os = "windows", target_os = "linux")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_window_icon_loads_embedded_png() {
+        let icon = native_window_icon();
+        assert!(
+            icon.is_some(),
+            "native_window_icon must decode assets/icons/icon.png at build time"
+        );
+    }
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -405,6 +405,14 @@ pub enum FrontendEvent {
     OpenUpdateLog {
         log_path: Option<String>,
     },
+    /// SPEC-2785 US-1 / FR-C: user clicked the server URL cell in the status
+    /// strip. Backend opens the URL in the OS default browser only when it
+    /// matches the embedded server's bound URL (FR-E same-origin gate). The
+    /// renderer-supplied `url` is treated as untrusted and validated against
+    /// `AppRuntime::server_url` before any opener is spawned.
+    OpenServerUrl {
+        url: String,
+    },
     /// Settings > Custom Agents: list every stored custom agent. Response is
     /// [`BackendEvent::CustomAgentList`].
     ListCustomAgents,
@@ -2200,6 +2208,22 @@ mod tests {
             matches!(event, FrontendEvent::OpenStartWork),
             "Start Work must be a global command, not a Branches window event"
         );
+    }
+
+    // SPEC-2785 US-1 AS-1 / FR-C: frontend → backend WS payload contract for
+    // opening the server URL in the OS default browser.
+    #[test]
+    fn frontend_event_accepts_open_server_url() {
+        let event: FrontendEvent = serde_json::from_value(serde_json::json!({
+            "kind": "open_server_url",
+            "url": "http://127.0.0.1:54321/"
+        }))
+        .expect("deserialize open_server_url");
+
+        assert!(matches!(
+            event,
+            FrontendEvent::OpenServerUrl { ref url } if url == "http://127.0.0.1:54321/"
+        ));
     }
 
     #[test]

--- a/crates/gwt/tests/serve_mode_test.rs
+++ b/crates/gwt/tests/serve_mode_test.rs
@@ -136,6 +136,36 @@ fn serve_mode_starts_server_without_opening_webview() {
         "default serve mode must bind to 127.0.0.1, got {url}",
     );
 
+    // SPEC-2785 US-2 AS-2 / FR-F: `gwt serve` must announce the Ctrl-C
+    // shutdown contract on stderr so headless operators know how to stop
+    // the server gracefully. We drain stderr a little further to confirm
+    // the line, bounded by a small follow-up budget so this test never
+    // blocks indefinitely on a quiet stderr.
+    let mut saw_ctrl_c_hint = false;
+    let ctrl_c_deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < ctrl_c_deadline {
+        match rx.recv_timeout(Duration::from_millis(500)) {
+            Ok(line) => {
+                transcript.push(line.clone());
+                if line.contains("gwt serve: press Ctrl-C to stop") {
+                    saw_ctrl_c_hint = true;
+                    break;
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    if !saw_ctrl_c_hint {
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = reader_handle.join();
+        panic!(
+            "expected 'gwt serve: press Ctrl-C to stop' on stderr after URL line. transcript:\n{}",
+            transcript.join("\n")
+        );
+    }
+
     let healthz = format!("{url}healthz");
     let client = reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(5))
@@ -152,4 +182,114 @@ fn serve_mode_starts_server_without_opening_webview() {
     // verifies that the wait completed successfully — that is, we did not
     // leak the child process.
     let _ = status;
+}
+
+/// SPEC-2785 US-2 AS-3 / FR-F: `GWT_BROWSER_URL_FILE` is the canonical
+/// non-stderr handoff channel for CI / Playwright. Setting it to a writable
+/// path must persist the bound URL there so harnesses can consume the URL
+/// without parsing stderr.
+#[test]
+#[ignore = "Spawns the full gwt binary and requires a warm ~/.gwt; opt in with --ignored"]
+fn serve_mode_writes_browser_url_to_handoff_file_when_env_set() {
+    let temp_cwd = tempfile::tempdir().expect("temp cwd");
+    let handoff_dir = tempfile::tempdir().expect("handoff dir");
+    let handoff_path = handoff_dir.path().join("gwt-browser-url.txt");
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_gwt"))
+        .arg("serve")
+        .arg("--port")
+        .arg("0")
+        .arg("--no-open")
+        .env("GWT_FORCE_NEW_INSTANCE", "1")
+        .env("GWT_BROWSER_URL_FILE", &handoff_path)
+        .current_dir(temp_cwd.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn gwt serve");
+
+    let stderr = child.stderr.take().expect("stderr handle");
+    let (tx, rx) = mpsc::channel::<String>();
+    let reader_handle = thread::Builder::new()
+        .name("gwt-serve-stderr-reader".to_string())
+        .spawn(move || {
+            let reader = BufReader::new(stderr);
+            for line in reader.lines().map_while(Result::ok) {
+                if tx.send(line).is_err() {
+                    break;
+                }
+            }
+        })
+        .expect("spawn stderr reader thread");
+
+    // Wait for the URL line so we know the embedded server has started and
+    // the handoff file has been written by the parent process.
+    let started = Instant::now();
+    let timeout = Duration::from_secs(180);
+    let mut url: Option<String> = None;
+    let mut transcript: Vec<String> = Vec::new();
+    loop {
+        let remaining = match timeout.checked_sub(started.elapsed()) {
+            Some(remaining) if !remaining.is_zero() => remaining,
+            _ => break,
+        };
+        match rx.recv_timeout(remaining.min(Duration::from_secs(1))) {
+            Ok(line) => {
+                transcript.push(line.clone());
+                if let Some(rest) = line.strip_prefix("gwt browser URL: ") {
+                    url = Some(rest.trim().to_string());
+                    break;
+                }
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+    let url = match url {
+        Some(value) => value,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = reader_handle.join();
+            panic!(
+                "did not observe 'gwt browser URL:' on stderr within {timeout:?}. transcript:\n{}",
+                transcript.join("\n")
+            );
+        }
+    };
+
+    // The handoff file is written by the parent immediately after the
+    // stderr announcement, but the two are independent syscalls; tolerate
+    // a tiny race by polling for a short while before failing.
+    let mut file_contents = String::new();
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while Instant::now() < deadline {
+        if let Ok(text) = std::fs::read_to_string(&handoff_path) {
+            if !text.trim().is_empty() {
+                file_contents = text;
+                break;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = reader_handle.join();
+
+    assert!(
+        !file_contents.is_empty(),
+        "GWT_BROWSER_URL_FILE must be populated; path={}",
+        handoff_path.display()
+    );
+    assert_eq!(
+        file_contents.trim(),
+        url.trim(),
+        "handoff file contents must match the stderr URL line",
+    );
+    assert!(
+        file_contents.trim().starts_with("http://127.0.0.1:"),
+        "handoff URL must point at the local embedded server, got {file_contents:?}"
+    );
 }

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1449,10 +1449,13 @@ test("Launch wizard runtime confirmation shows summary without setup forms", () 
     /if\s*\(\s*showSetupForms\s*&&[\s\S]*?launchWizard\.show_codex_fast_mode[\s\S]*?\)\s*\{[\s\S]*?createLaunchSection\(\s*"Launch settings"/,
     "expected Launch settings controls to be part of setup forms only",
   );
+  // SPEC-2014 Amendment 2026-05-20 (FR-057): Linked issue is gated by its
+  // dedicated `show_linked_issue` flag so it only appears when the wizard
+  // was opened through the Knowledge Issue Bridge.
   assert.match(
     appSource,
-    /if\s*\(\s*showSetupForms\s*&&\s*launchWizard\.show_agent_settings\s*\)/,
-    "expected Linked issue controls to be part of setup forms only",
+    /if\s*\(\s*showSetupForms\s*&&\s*launchWizard\.show_linked_issue\s*\)/,
+    "expected Linked issue controls to be gated by show_linked_issue and setup forms",
   );
 });
 
@@ -1698,9 +1701,13 @@ test("Dynamically-created form fields without surrounding <label> have aria-labe
   // so screen readers announce their purpose instead of just "edit text"
   // (input/textarea) or the first option (select). This audit covers
   // the launch wizard and profile editor surfaces.
+  // SPEC-2014 Amendment 2026-05-20 (FR-058): the wizard "Issue number"
+  // field is now rendered as static read-only text (no <input>), so its
+  // accessibility name is conveyed by the surrounding launch-field label
+  // instead of a per-input aria-label. The audit entry is removed
+  // accordingly.
   const expected = [
     { selector: 'input\\.setAttribute\\("aria-label", "Branch name"\\)', desc: "wizard branch name" },
-    { selector: 'input\\.setAttribute\\("aria-label", "Issue number"\\)', desc: "wizard issue number" },
     { selector: 'keyInput\\.setAttribute\\("aria-label", `Env var key, row ', desc: "env var key" },
     { selector: 'valueInput\\.setAttribute\\("aria-label", `Env var value, row ', desc: "env var value" },
     { selector: 'keyInput\\.setAttribute\\("aria-label", `Disabled env key, row ', desc: "disabled env key" },

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -6864,35 +6864,23 @@
           panel.appendChild(section);
         }
 
-        if (showSetupForms && launchWizard.show_agent_settings) {
+        // SPEC-2014 Amendment 2026-05-20 (FR-057 / FR-058):
+        // The Linked issue section renders only when the wizard was opened
+        // through the Knowledge Issue Bridge. The issue number is shown as
+        // read-only text instead of an editable input.
+        if (showSetupForms && launchWizard.show_linked_issue) {
           const section = createLaunchSection(
             "Linked issue",
-            "Optional: Link an issue to this launch session.",
+            "Read-only: this agent will be linked to the originating issue.",
           );
           const grid = createNode("div", "launch-form-grid");
           const field = createLaunchField("Issue number", false);
-          const input = createNode("input", "launch-input");
-          input.type = "number";
-          input.min = "1";
-          // SPEC-2356 — see createLaunchField comment: aria-label is the
-          // programmatic name since launch-field labels are non-<label> divs.
-          input.setAttribute("aria-label", "Issue number");
-          input.value = launchWizard.linked_issue_number
-            ? launchWizard.linked_issue_number.toString()
-            : "";
-          input.placeholder = "e.g., 1938";
-          input.addEventListener("change", () => {
-            const value = input.value.trim();
-            if (value) {
-              sendWizardAction({
-                kind: "set_linked_issue",
-                issue_number: parseInt(value, 10),
-              });
-            } else {
-              sendWizardAction({ kind: "clear_linked_issue" });
-            }
-          });
-          field.appendChild(input);
+          // The launch-field label already announces "Issue number"; the
+          // static value div is read alongside that label so SR users hear
+          // "Issue number, #N" without needing a per-value aria-label.
+          const value = createNode("div", "launch-static-value");
+          value.textContent = `#${launchWizard.linked_issue_number}`;
+          field.appendChild(value);
           grid.appendChild(field);
           section.appendChild(grid);
           panel.appendChild(section);

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -484,9 +484,7 @@
         const label = formatVersionLabel();
         appVersionLabel.hidden = !label;
         appVersionLabel.textContent = label;
-        appVersionLabel.title = label
-          ? `${label} — click to view release notes`
-          : "";
+        appVersionLabel.title = label;
       }
 
       function setVersionState(current, latest = null) {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -615,6 +615,81 @@
         });
       }
 
+      // SPEC-2785 US-1 / FR-A〜G: server URL cell in op-status-strip. URL is
+      // derived from `window.location` (frontend is always loaded from the
+      // bound URL, so this is the canonical source) and matches the backend
+      // `AppRuntime::server_url` exactly. Clicking the URL value forwards an
+      // `OpenServerUrl` event to the backend which performs an exact
+      // same-origin check before invoking the OS opener. Clicking the copy
+      // glyph writes the URL to the clipboard with a transient `Copied`
+      // affordance; clipboard rejection downgrades to an inline error state
+      // (no modal) and logs to console for diagnostics.
+      const serverUrlValue = document.getElementById("op-strip-server-url");
+      const serverUrlCopy = document.getElementById("op-strip-server-url-copy");
+      if (serverUrlValue && !serverUrlValue.dataset.serverUrlBound) {
+        serverUrlValue.dataset.serverUrlBound = "true";
+        const serverUrl = new URL("/", window.location.href).toString();
+        serverUrlValue.textContent = serverUrl;
+        serverUrlValue.title = serverUrl;
+        if (serverUrlCopy) {
+          serverUrlCopy.dataset.url = serverUrl;
+        }
+        const openServerUrlInBrowser = () => {
+          send({ kind: "open_server_url", url: serverUrl });
+        };
+        serverUrlValue.addEventListener("click", openServerUrlInBrowser);
+        serverUrlValue.addEventListener("keydown", (event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            openServerUrlInBrowser();
+          }
+        });
+
+        if (serverUrlCopy && !serverUrlCopy.dataset.serverUrlBound) {
+          serverUrlCopy.dataset.serverUrlBound = "true";
+          let copyResetTimer = 0;
+          const flashCopyState = (state, baseLabel) => {
+            serverUrlCopy.dataset.state = state;
+            serverUrlValue.dataset.state = state;
+            if (baseLabel) {
+              serverUrlCopy.setAttribute("aria-label", baseLabel);
+            }
+            if (copyResetTimer) {
+              window.clearTimeout(copyResetTimer);
+            }
+            copyResetTimer = window.setTimeout(() => {
+              serverUrlCopy.removeAttribute("data-state");
+              serverUrlValue.removeAttribute("data-state");
+              serverUrlCopy.setAttribute("aria-label", "Copy server URL");
+              copyResetTimer = 0;
+            }, 1500);
+          };
+          const copyServerUrl = () => {
+            if (!navigator.clipboard?.writeText) {
+              console.warn(
+                "navigator.clipboard.writeText unavailable; cannot copy server URL",
+              );
+              flashCopyState("error", "Copy failed; clipboard unavailable");
+              return;
+            }
+            navigator.clipboard
+              .writeText(serverUrl)
+              .then(() => flashCopyState("copied", "Copied server URL"))
+              .catch((error) => {
+                console.warn("clipboard.writeText rejected", error);
+                flashCopyState("error", "Copy failed; permission denied");
+              });
+          };
+          serverUrlCopy.addEventListener("click", copyServerUrl);
+          serverUrlCopy.addEventListener("keydown", (event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              copyServerUrl();
+            }
+          });
+        }
+      }
+
       const updateCtaController = createUpdateCtaController({
         document,
         send,

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -295,6 +295,24 @@
             <span class="op-status-strip__live-dot" aria-hidden="true"></span>
             <span class="op-status-strip__label">LIVE</span>
           </div>
+          <div class="op-status-strip__cell op-status-strip__cell--server-url">
+            <span class="op-status-strip__label">URL</span>
+            <span
+              class="op-status-strip__value op-status-strip__server-url-value"
+              id="op-strip-server-url"
+              role="button"
+              tabindex="0"
+              aria-label="Open server URL in browser"
+              title=""
+            >—</span>
+            <button
+              type="button"
+              class="op-status-strip__server-url-copy"
+              id="op-strip-server-url-copy"
+              aria-label="Copy server URL"
+              title="Copy URL"
+            >&#x29C9;</button>
+          </div>
           <div class="op-status-strip__cell op-status-strip__cell--active">
             <span class="op-status-strip__label">ACTIVE</span>
             <span class="op-status-strip__value" id="op-strip-active" aria-label="Active agents">0</span>

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -875,6 +875,61 @@ body::after {
   color: var(--color-state-blocked);
 }
 
+/* SPEC-2785 FR-A / FR-B / FR-G: server URL cell sits immediately right of
+   the LIVE indicator with the full http://host:port/ URL. The value is
+   clickable (opens external browser via backend IPC) and a sibling copy
+   icon writes the URL to the clipboard. The value is constrained with
+   ellipsis so a long URL cannot crowd out the other status cells. */
+.op-status-strip__cell--server-url {
+  min-width: 0;
+}
+
+.op-status-strip__server-url-value {
+  color: var(--color-state-active);
+  cursor: pointer;
+  max-width: 28ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  outline: none;
+}
+
+.op-status-strip__server-url-value:hover,
+.op-status-strip__server-url-value:focus-visible {
+  text-decoration: underline;
+}
+
+.op-status-strip__server-url-value[data-state="copied"] {
+  color: var(--color-state-idle);
+}
+
+.op-status-strip__server-url-copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: var(--space-1);
+  padding: 0 var(--space-1);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: color-mix(in oklab, var(--color-status-strip-fg) 75%, transparent);
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
+}
+
+.op-status-strip__server-url-copy:hover,
+.op-status-strip__server-url-copy:focus-visible {
+  border-color: color-mix(in oklab, var(--color-status-strip-fg) 40%, transparent);
+  color: var(--color-status-strip-fg);
+  outline: none;
+}
+
+.op-status-strip__server-url-copy[data-state="copied"] {
+  color: var(--color-state-active);
+  border-color: color-mix(in oklab, var(--color-state-active) 60%, transparent);
+}
+
 /* ============================================================
    Canvas area — Operator overrides on existing layout
    ============================================================ */

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1579,6 +1579,141 @@ kbd.op-kbd {
   border-color: var(--color-accent, var(--color-text-muted));
 }
 
+/* SPEC-2780 — Release Notes floating window. Without explicit fixed
+   positioning the element flows in document order and ends up below the
+   viewport when appended to document.body (observed live: y=741, mounted
+   but invisible to the user). */
+.release-notes-window {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 10050;
+  display: flex;
+  flex-direction: column;
+  width: min(880px, 92vw);
+  height: min(640px, 86vh);
+  background: var(--color-surface, #1c1f24);
+  color: var(--color-text, #e8eaed);
+  border: 1px solid var(--color-border, #3a3f47);
+  border-radius: 8px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+}
+.release-notes-window-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--color-border, #3a3f47);
+  flex: 0 0 auto;
+}
+.release-notes-window-header h1 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-muted, #aab0b8);
+}
+.release-notes-close {
+  background: transparent;
+  border: none;
+  color: var(--color-text-muted, #aab0b8);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+.release-notes-close:hover,
+.release-notes-close:focus-visible {
+  background: var(--color-surface-elevated, #2a2e35);
+  color: var(--color-text, #e8eaed);
+}
+.release-notes-body {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.release-notes-sidebar {
+  flex: 0 0 200px;
+  border-right: 1px solid var(--color-border, #3a3f47);
+  overflow-y: auto;
+  padding: 8px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.release-notes-sidebar-item {
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-left: 3px solid transparent;
+  color: var(--color-text, #e8eaed);
+  cursor: pointer;
+  text-align: left;
+  padding: 6px 14px;
+  font: inherit;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.release-notes-sidebar-item:hover,
+.release-notes-sidebar-item:focus-visible {
+  background: var(--color-surface-elevated, #2a2e35);
+}
+.release-notes-sidebar-item.is-selected {
+  background: var(--color-surface-elevated, #2a2e35);
+  border-left-color: var(--color-accent, #7aa2f7);
+}
+.release-notes-sidebar-version {
+  font-weight: 600;
+}
+.release-notes-sidebar-date {
+  font-size: 11px;
+  color: var(--color-text-muted, #aab0b8);
+}
+.release-notes-content {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 16px 22px;
+}
+.release-notes-content h2 {
+  margin: 0 0 4px 0;
+  font-size: 18px;
+  display: inline-block;
+}
+.release-notes-version-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.release-notes-date {
+  color: var(--color-text-muted, #aab0b8);
+  font-size: 12px;
+}
+.release-notes-content h3 {
+  margin: 14px 0 6px 0;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted, #aab0b8);
+}
+.release-notes-content ul {
+  margin: 0;
+  padding-left: 20px;
+}
+.release-notes-content li {
+  margin: 2px 0;
+  line-height: 1.5;
+}
+.release-notes-empty {
+  padding: 24px;
+  color: var(--color-text-muted, #aab0b8);
+}
+
 :root[data-theme] .hint {
   color: var(--color-text-muted);
   background: color-mix(in oklab, var(--color-surface) 80%, transparent);

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1513,6 +1513,17 @@ kbd.op-kbd {
   border-color: var(--color-border);
 }
 
+/* SPEC-2780 — Release Notes window trigger affordance. The version badge
+   doubles as a button so make the cursor + hover state reflect that. */
+.app-version[role="button"] {
+  cursor: pointer;
+}
+:root[data-theme] .app-version[role="button"]:hover,
+:root[data-theme] .app-version[role="button"]:focus-visible {
+  color: var(--color-text);
+  border-color: var(--color-accent, var(--color-text-muted));
+}
+
 :root[data-theme] .hint {
   color: var(--color-text-muted);
   background: color-mix(in oklab, var(--color-surface) 80%, transparent);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akiojin/gwt",
-  "version": "9.39.0",
+  "version": "9.40.0",
   "description": "Desktop GUI for Git worktree management and coding agent launch",
   "type": "module",
   "bin": {

--- a/scripts/test_release_assets.cjs
+++ b/scripts/test_release_assets.cjs
@@ -84,6 +84,47 @@ run("release workflow packages gwtd alongside gwt", () => {
   assert.match(workflow, /Contents\/MacOS\/gwtd/);
 });
 
+run("native_window_icon wires tao window icon on Windows and Linux", () => {
+  const nativeApp = fs.readFileSync(
+    path.join(__dirname, "..", "crates", "gwt", "src", "native_app.rs"),
+    "utf8"
+  );
+  const mainRs = fs.readFileSync(
+    path.join(__dirname, "..", "crates", "gwt", "src", "main.rs"),
+    "utf8"
+  );
+  const libRs = fs.readFileSync(
+    path.join(__dirname, "..", "crates", "gwt", "src", "lib.rs"),
+    "utf8"
+  );
+
+  assert.match(
+    nativeApp,
+    /#\[cfg\(any\(target_os = "windows", target_os = "linux"\)\)\]\s*\npub fn native_window_icon\(\) -> Option<tao::window::Icon>/,
+    "native_app.rs must expose native_window_icon() for Windows and Linux"
+  );
+  assert.match(
+    nativeApp,
+    /include_bytes!\("\.\.\/\.\.\/\.\.\/assets\/icons\/icon\.png"\)/,
+    "native_window_icon must embed assets/icons/icon.png at compile time"
+  );
+  assert.match(
+    libRs,
+    /#\[cfg\(any\(target_os = "windows", target_os = "linux"\)\)\]\s*\npub use native_app::native_window_icon;/,
+    "lib.rs must re-export native_window_icon for Windows and Linux"
+  );
+  assert.match(
+    mainRs,
+    /#\[cfg\(any\(target_os = "windows", target_os = "linux"\)\)\]\s*\n\s*let window_icon = gwt::native_window_icon\(\);/,
+    "main.rs must resolve the native_window_icon for Windows and Linux"
+  );
+  assert.match(
+    mainRs,
+    /\.with_window_icon\(window_icon\)/,
+    "main.rs WindowBuilder must call .with_window_icon(window_icon) so Windows and Linux pick up the GWT icon"
+  );
+});
+
 run("macOS app bundle declares and ships the CFBundleIconFile resource", () => {
   const workflow = fs.readFileSync(
     path.join(__dirname, "..", ".github", "workflows", "release.yml"),

--- a/scripts/test_release_assets.cjs
+++ b/scripts/test_release_assets.cjs
@@ -84,6 +84,28 @@ run("release workflow packages gwtd alongside gwt", () => {
   assert.match(workflow, /Contents\/MacOS\/gwtd/);
 });
 
+run("macOS app bundle declares and ships the CFBundleIconFile resource", () => {
+  const workflow = fs.readFileSync(
+    path.join(__dirname, "..", ".github", "workflows", "release.yml"),
+    "utf8"
+  );
+  assert.match(
+    workflow,
+    /<key>CFBundleIconFile<\/key>\s*\n\s*<string>icon<\/string>/,
+    "build-dmg Info.plist must declare CFBundleIconFile=icon so macOS resolves the bundle icon"
+  );
+  assert.match(
+    workflow,
+    /mkdir -p dist\/GWT\.app\/Contents\/Resources/,
+    "build-dmg must create Contents/Resources before copying icon.icns"
+  );
+  assert.match(
+    workflow,
+    /cp assets\/icons\/icon\.icns dist\/GWT\.app\/Contents\/Resources\/icon\.icns/,
+    "build-dmg must copy assets/icons/icon.icns into Contents/Resources/icon.icns"
+  );
+});
+
 run("package scripts keep the GUI front door and release contract explicit", () => {
   const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json"), "utf8"));
   assert.equal(pkg.bin.gwt, "bin/gwt.cjs");

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,41 @@
 # Lessons Learned
 
+## 2026-05-20 — Unit / Playwright snapshot tests は E2E ではない
+
+### 事象
+
+SPEC #2780 (Release Notes Window) 実装で、以下のテストが全て GREEN だった:
+
+- gwt-core release_notes::tests 12 件 PASS (parser unit)
+- protocol round-trip 5 件 PASS (serde 単体)
+- pnpm test:frontend-unit 507 件 PASS (linkedom + node:test の DOM 単体)
+- pnpm test:visual 34 件 PASS (Playwright snapshot、20 件は skip)
+- cargo clippy / fmt CLEAN
+- CI 全 13 check SUCCESS、auto-merge で v9.39.0 として release
+
+それにもかかわらず、production では **release-notes-window.js が 404 で配信されず、機能完全に死んでいた**。ユーザーが GUI を起動して確認するまで誰も気付かなかった。
+
+### 原因
+
+1. **crates/gwt/src/embedded_web.rs に新 JS module の RootJsModuleAsset エントリを追加し忘れた**。embedded server は allow-list ベースで asset を配信する設計だが、新規 web/ ファイルを追加した際に embedded_web.rs への登録が必須であることが workflow / spec / 既存テストのいずれでも強制されていなかった。
+2. **既存の Playwright spec で `GWT_PLAYWRIGHT_BASE_URL` 必須の live-mode tests (theme-toggle 等) は CI で env var が未設定のため全て skip されていた**。誰も live mode で動作確認していなかった。`pnpm test:visual` の "34 passed / 20 skipped" の "20 skipped" は全てこのカテゴリ。
+3. **Playwright snapshot tests は `installEmbeddedRoutes()` で frontend を route 経由で直接配信するため、embedded_web.rs の allow-list を経由しない**。つまり embedded server の asset routing は test されていない。
+
+### 再発防止策
+
+1. **新規 `crates/gwt/web/*.js` モジュール追加時は、必ず `crates/gwt/src/embedded_web.rs` に `RootJsModuleAsset` エントリと `pub fn <name>_js() -> &'static str` を追加する**。コンパイル時に検出できるよう、app.js の import 一覧と embedded_web.rs の RootJsModuleAsset を突き合わせる integration test を `crates/gwt/tests/embedded_web_routing_test.rs` として追加することを検討する（follow-up Issue）。
+2. **live mode E2E spec を最低 1 件は CI で実行する**。`gwt serve` を background で起動して `GWT_PLAYWRIGHT_BASE_URL` を設定する CI step を追加する（follow-up Issue）。
+3. **UI 変更を PR にする前に、`cargo run -p gwt --bin gwt` で実際に起動して manual smoke を実施する**。AGENTS.md「For UI or frontend changes, start the dev server and use the feature in a browser before reporting the task as complete」を厳守する。「Playwright tests 通った = 動く」と勘違いしない。
+4. **PR body の checklist で「目視確認はレビュアー側で実施」と書いて user に押し付けない**。テストカバレッジに穴がある場合は明示的に "I cannot verify the live UI in this environment" と書き、leaving-it-to-reviewer の責務逃れをしない。
+5. **同じ trap が広範に存在する**: `crates/gwt/web/__tests__/playwright-embedded-routes.test.mjs` は app.js の import を `installEmbeddedRoutes` の ROOT_MODULES と突き合わせるが、embedded_web.rs の RootJsModuleAsset との突き合わせは存在しない。すべての route 配信経路を相互検証する skeleton test が要る。
+
+### 検証
+
+- `crates/gwt/playwright/tests/release-notes-live.spec.ts` を新規追加 (live backend、`installEmbeddedRoutes` 不使用)。最初は 8/8 RED で embedded_web.rs の欠落と splash auto-dismiss bug を可視化。embedded_web.rs 修正後、8/8 GREEN (chromium-dark 4 + chromium-light 4、serial)。
+- embedded_web.rs 本体の fix は **別 agent の PR #2797** (work/20260520-0409 / cb25afc1) が canonical。並行調査していて重複検出した。PR #2797 は `every_root_js_module_import_in_app_assets_is_registered` 回帰防止 unit test を含む。私の PR #2798 は live E2E spec と本 lessons の追記のみに縮小して PR #2797 の補完に位置付けた (#2797 が merge されるまで、私の branch では embedded_web.rs を local change なしで動くことを確認する)。
+
+---
+
 ## 2026-05-20 — `gwtd issue spec create -f <body>` は section マーカーを付けない
 
 ### 事象

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,23 @@
 # Lessons Learned
 
+## 2026-05-20 — SPEC の FR で platform scope を限定すると、サイレントな regression を生む（macOS app icon）
+
+### 事象
+
+`v9.38.0` の `/Applications/GWT.app` で Dock / Finder / `⌘Tab` の GWT アイコンが macOS デフォルトに戻っていた。`/Applications/GWT.app/Contents/Info.plist` には `CFBundleIconFile` が無く、`Contents/Resources/` も空だった。`assets/icons/icon.icns` はリポジトリに存在していたが、リリースワークフローが bundle へ wire していなかった（Issue #2799）。
+
+### 原因
+
+旧 Tauri bundler は macOS bundle / icns binding を自動で担当していた。SPEC-1776 で gwt-tauri を削除した時点でこの binding が失われたが、`.github/workflows/release.yml` の手作り `GWT.app` 生成ステップは未追加のまま。後続の SPEC #2041 FR-027 は「**Windows build は**……」と platform を限定して icon assets を再配線したため、Windows 側だけが復活し macOS 側は CI logs にも明示的なエラーが出ないまま落ちたまま継続した。FR の文言から `macOS` の文字が抜けていたことが silent regression を許した直接原因。
+
+### 再発防止策
+
+1. **FR は platform scope を limit するときに必ず明示的に列挙する**: 「Windows build は…」のように一つの platform に限定する FR を書く場合、同じ要件が他の platform でも必要かどうかをレビュー時に必ずチェックする。テンプレートに「OS scope: windows / macos / linux / all」を入れて選択漏れを防ぐ。
+2. **bundle resource を扱う変更は test_release_assets.cjs に静的検証を追加する**: release.yml が macOS bundle に `CFBundleIconFile` を書き、`Contents/Resources/icon.icns` を copy しているかは `node scripts/test_release_assets.cjs` で静的にチェックできる。`assert.match(workflow, /<key>CFBundleIconFile<\/key>\s*\n\s*<string>icon<\/string>/)` の様な regex で CI 回帰防止。
+3. **routing: バグは plain Issue で扱う**: `gwt-spec` ラベルは仕様用なので、FR scope 漏れによる regression のような bug 修正は plain Issue として登録し `gwt-fix-issue` で TDD 修正する。SPEC を再 open するのは「設計判断を伴う」場合のみに限定する（feedback memory: `feedback-spec-is-for-specifications-not-bugs`）。
+
+---
+
 ## 2026-05-20 — `gwtd issue spec create -f <body>` は section マーカーを付けない
 
 ### 事象

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,40 @@
 # Lessons Learned
 
+## 2026-05-20 — Unit / Playwright snapshot tests は E2E ではない
+
+### 事象
+
+SPEC #2780 (Release Notes Window) 実装で、以下のテストが全て GREEN だった:
+
+- gwt-core release_notes::tests 12 件 PASS (parser unit)
+- protocol round-trip 5 件 PASS (serde 単体)
+- pnpm test:frontend-unit 507 件 PASS (linkedom + node:test の DOM 単体)
+- pnpm test:visual 34 件 PASS (Playwright snapshot、20 件は skip)
+- cargo clippy / fmt CLEAN
+- CI 全 13 check SUCCESS、auto-merge で v9.39.0 として release
+
+それにもかかわらず、production では **release-notes-window.js が 404 で配信されず、機能完全に死んでいた**。ユーザーが GUI を起動して確認するまで誰も気付かなかった。
+
+### 原因
+
+1. **crates/gwt/src/embedded_web.rs に新 JS module の RootJsModuleAsset エントリを追加し忘れた**。embedded server は allow-list ベースで asset を配信する設計だが、新規 web/ ファイルを追加した際に embedded_web.rs への登録が必須であることが workflow / spec / 既存テストのいずれでも強制されていなかった。
+2. **既存の Playwright spec で `GWT_PLAYWRIGHT_BASE_URL` 必須の live-mode tests (theme-toggle 等) は CI で env var が未設定のため全て skip されていた**。誰も live mode で動作確認していなかった。`pnpm test:visual` の "34 passed / 20 skipped" の "20 skipped" は全てこのカテゴリ。
+3. **Playwright snapshot tests は `installEmbeddedRoutes()` で frontend を route 経由で直接配信するため、embedded_web.rs の allow-list を経由しない**。つまり embedded server の asset routing は test されていない。
+
+### 再発防止策
+
+1. **新規 `crates/gwt/web/*.js` モジュール追加時は、必ず `crates/gwt/src/embedded_web.rs` に `RootJsModuleAsset` エントリと `pub fn <name>_js() -> &'static str` を追加する**。コンパイル時に検出できるよう、app.js の import 一覧と embedded_web.rs の RootJsModuleAsset を突き合わせる integration test を `crates/gwt/tests/embedded_web_routing_test.rs` として追加することを検討する（follow-up Issue）。
+2. **live mode E2E spec を最低 1 件は CI で実行する**。`gwt serve` を background で起動して `GWT_PLAYWRIGHT_BASE_URL` を設定する CI step を追加する（follow-up Issue）。
+3. **UI 変更を PR にする前に、`cargo run -p gwt --bin gwt` で実際に起動して manual smoke を実施する**。AGENTS.md「For UI or frontend changes, start the dev server and use the feature in a browser before reporting the task as complete」を厳守する。「Playwright tests 通った = 動く」と勘違いしない。
+4. **PR body の checklist で「目視確認はレビュアー側で実施」と書いて user に押し付けない**。テストカバレッジに穴がある場合は明示的に "I cannot verify the live UI in this environment" と書き、leaving-it-to-reviewer の責務逃れをしない。
+5. **同じ trap が広範に存在する**: `crates/gwt/web/__tests__/playwright-embedded-routes.test.mjs` は app.js の import を `installEmbeddedRoutes` の ROOT_MODULES と突き合わせるが、embedded_web.rs の RootJsModuleAsset との突き合わせは存在しない。すべての route 配信経路を相互検証する skeleton test が要る。
+
+### 検証
+
+- `crates/gwt/playwright/tests/release-notes-live.spec.ts` を新規追加 (live backend、`installEmbeddedRoutes` 不使用)。最初は 8/8 RED で embedded_web.rs の欠落と splash auto-dismiss bug を可視化。embedded_web.rs を修正後、4/4 GREEN。
+
+---
+
 ## 2026-05-20 — `gwtd issue spec create -f <body>` は section マーカーを付けない
 
 ### 事象

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -15,6 +15,7 @@
 1. **FR は platform scope を limit するときに必ず明示的に列挙する**: 「Windows build は…」のように一つの platform に限定する FR を書く場合、同じ要件が他の platform でも必要かどうかをレビュー時に必ずチェックする。テンプレートに「OS scope: windows / macos / linux / all」を入れて選択漏れを防ぐ。
 2. **bundle resource を扱う変更は test_release_assets.cjs に静的検証を追加する**: release.yml が macOS bundle に `CFBundleIconFile` を書き、`Contents/Resources/icon.icns` を copy しているかは `node scripts/test_release_assets.cjs` で静的にチェックできる。`assert.match(workflow, /<key>CFBundleIconFile<\/key>\s*\n\s*<string>icon<\/string>/)` の様な regex で CI 回帰防止。
 3. **routing: バグは plain Issue で扱う**: `gwt-spec` ラベルは仕様用なので、FR scope 漏れによる regression のような bug 修正は plain Issue として登録し `gwt-fix-issue` で TDD 修正する。SPEC を再 open するのは「設計判断を伴う」場合のみに限定する（feedback memory: `feedback-spec-is-for-specifications-not-bugs`）。
+4. **app icon は OS ごとに別経路で配線される。1 OS の修正で完結したと判断しない**: macOS は bundle `Info.plist::CFBundleIconFile` + `Contents/Resources/icon.icns`、Windows は `winresource::set_icon`（.exe 埋込）と `wix/main.wxs` の `<Icon>`（installer / Start Menu / ARP）に加えて runtime の `WindowBuilder::with_window_icon` (HWND `WM_SETICON`)、Linux は X11 / Wayland 用の `WindowBuilder::with_window_icon`。冗長に見えても各経路を独立に配線し、各 OS で table を埋めて配線抜けを目視確認する。
 
 ---
 


### PR DESCRIPTION
## Summary

GUI / CLI / SPEC ワークフローに新機能と複数のバグ修正を導入したマイナーリリース。SPEC 作成パスを `gwt-register-spec` で安全化し、GUI ステータスストリップにサーバー URL とブラウザ起動 + クリップボードコピー UI を追加。`gh` CLI 呼び出しを `ProcessConsoleHub` に統合した。Release Notes ウィンドウの起動経路と CSS 配置を修正し、release バンドルの window icon 配線も全 OS で復旧している。

## Changes

### Features

- **skills:** Introduce `gwt-register-spec` for safe SPEC creation (SPEC-2784)
- **gui:** Surface server URL in status strip with browser open + copy affordance (SPEC-2785)
- **core:** Introduce `ProcessConsoleHub` and migrate `gh` CLI callers (SPEC-1924 / SPEC-2019)

### Bug Fixes

- **release:** macOS DMG bundle に `icon.icns` と `CFBundleIconFile` を再配線 (#2799)
- **release:** Windows と Linux も `tao` window icon を明示配線する (#2799)
- **gui:** Gate Linked issue section to Issue Bridge launches (SPEC-2014)
- **gui:** Register `/release-notes-window.js` to unblock splash boot
- **gui:** Register `release-notes-window.js` in `embedded_web` allow-list
- **gui:** Give `.release-notes-window` fixed positioning so it actually shows
- **gui:** Make `#app-version` look clickable, drop noisy tooltip
- **logging:** Adapt Logs window reader to canonical JSONL shape (SPEC-1924 US-14)
- **logging:** Disambiguate `tracing_subscriber::fmt` intra-doc link in reader
- **issue-cache:** Detect spec issues by body header to keep refresh resilient to label loss
- **issue-cache:** Cache plain when SPEC body parse fails to absorb `is_spec_issue` regression

### Refactor

- **cli:** Move `parse_register_args` into `cli/register` to honor `cli.rs` size budget

### Testing

- **playwright:** Add live E2E spec for Release Notes window + lessons

## Version

`v9.40.0` (minor bump from `v9.39.0`)

## Closing Issues

Closes #2794
Closes #2795
Closes #2799

## Related Issues / Links

- #2014
- #2780
- #2784
- #2785
- #2796
- #2797
- #2798
- #2802
