### PR TITLE
feat(skills): gwt-verify を project-agnostic 化しユーザー確認フェーズを追加

### DIFF
--- a/.claude/skills/gwt-build-spec/SKILL.md
+++ b/.claude/skills/gwt-build-spec/SKILL.md
@@ -121,21 +121,28 @@ All other changes require the TDD loop.
 ## Phase 3: Verification
 
 Delegate environment-aware verification to `gwt-verify --mode full`. The
-sub-skill classifies the changed surfaces per
-`.claude/skills/gwt-verify/references/test-matrix.md`, runs the appropriate
-matrix per surface (cargo for Rust crates, `pnpm test:frontend-*` for frontend
-JS, `pnpm test:visual` only for WebView/browser UI surfaces, `pnpm
-test:release-*` only for release-system changes, `pnpm lint:skills` for skill
-asset changes), and returns an evidence bundle in `## Verification Report`
-form. Do not hard-code a static cargo command list here — the right matrix is
-determined by what actually changed.
+sub-skill is a project-agnostic Generic Verification Contract: it classifies
+the changed surfaces against `.claude/skills/gwt-verify/references/surface-taxonomy.md`,
+detects the host project's actual test runners from manifests
+(Cargo.toml / package.json / pyproject.toml / go.mod / ProjectSettings /
+*.sln / etc.) per `.claude/skills/gwt-verify/references/runner-detection.md`,
+runs the appropriate unit / integration / E2E / visual tests, emits a
+**Test Inventory** that names which tests were executed, and hands off to
+the user via a 4-step 導線 + Check Items before finalizing
+`## Verification Report`. The right matrix is determined by what actually
+changed and which runners the project ships; do not hard-code a static
+cargo / pnpm / Playwright command list here.
 
-The skill is considered green when:
+The skill is considered green when **all** of the following hold:
 
 - `gwt-verify --mode full` exits with `Overall: PASS`
 - the evidence bundle records no `failed: tooling-missing` entry
-- no Playwright snapshot diff is unresolved (visual regression must be
+- no visual / UI snapshot diff is unresolved (visual regression must be
   triaged before declaring PASS, not silently regenerated)
+- `User Verification Result` is one of `confirmed`, `n/a`, or
+  `skipped(<reason>)`. `pending` is not acceptable; `rejected(<reason>)`
+  forces `Overall: FAIL` and the implementation returns to Phase 2 (TDD
+  loop). The user's reason is preserved in the evidence bundle.
 
 In SPEC mode, also verify:
 

--- a/.claude/skills/gwt-build-spec/references/completion-gate.md
+++ b/.claude/skills/gwt-build-spec/references/completion-gate.md
@@ -37,16 +37,25 @@ In SPEC mode, it reconciles all artifacts. In standalone mode, it verifies user 
 ### 5. Code verification
 
 Delegate to `gwt-verify --mode full` and require `Overall: PASS` in the
-evidence bundle. The sub-skill picks the matrix per changed surface (see
-`.claude/skills/gwt-verify/references/test-matrix.md`) — cargo for Rust
-crates, `pnpm test:frontend-*` for frontend JS, `pnpm test:visual` for
-WebView/browser UI surfaces only (Playwright is not invoked for non-browser
-surfaces), `pnpm test:release-*` for release-system changes, and
-`pnpm lint:skills` for skill assets.
+evidence bundle. The sub-skill is project-agnostic: it autodetects the host
+project's test runners from manifests (Cargo.toml / package.json /
+pyproject.toml / go.mod / ProjectSettings / *.sln / etc.), runs the
+appropriate unit / integration / E2E / visual tests for each changed
+surface, emits a Test Inventory naming the executed tests, and hands off
+to the user with a 4-step 導線 + Check Items before finalizing the
+report. The matrix is determined by what actually changed and the
+runners the project ships, not by a hard-coded cargo / pnpm / Playwright
+recipe. Project-local AGENTS.md / README instructions always take
+precedence over the generic matrix.
 
-If `gwt-verify` returns `Overall: FAIL` or `failed: tooling-missing`, the
-gate fails. Do not declare completion. Route the failure for repair per
-the failure-handling section below.
+The gate **fails** when any of:
+
+- `gwt-verify` returns `Overall: FAIL`
+- `failed: tooling-missing` is recorded
+- `User Verification Result` is `pending` (handoff never completed) or
+  `rejected(<reason>)` (user declined). The user's reason is preserved
+  in the evidence bundle; route the failure for repair per the
+  failure-handling section below.
 
 ## Standalone mode checks
 

--- a/.claude/skills/gwt-manage-pr/SKILL.md
+++ b/.claude/skills/gwt-manage-pr/SKILL.md
@@ -85,19 +85,30 @@ impossible.**
 
 Before any push, PR create, or PR update operation, invoke
 `gwt-verify --mode pre-pr` and require `Overall: PASS` in the evidence
-bundle. This guarantees the right test matrix has run for the changed
-surfaces — cargo for Rust crates, `pnpm test:frontend-*` for frontend JS,
-`pnpm test:visual` for WebView/browser UI surfaces only (Playwright is not
-invoked for non-browser surfaces), `pnpm test:release-*` for release-system
-changes, and `pnpm lint:skills` for skill assets.
+bundle. `gwt-verify` is a project-agnostic Generic Verification Contract:
+it autodetects the host project's test runners (Cargo.toml /
+package.json / pyproject.toml / go.mod / ProjectSettings / *.sln / etc.),
+runs the appropriate unit / integration / E2E / visual tests for the
+changed surfaces, emits a Test Inventory naming exactly which tests
+were executed, and hands off to the user with a 4-step 導線 + Check
+Items before finalizing the report. Project-local AGENTS.md / README
+testing instructions always take precedence over the generic matrix.
 
-If `gwt-verify --mode pre-pr` returns `Overall: FAIL` or
-`failed: tooling-missing`, do not push, do not create a PR, and do not
-update an existing PR. Route the failure for repair (back to the TDD loop
-or `gwt-discussion`) and re-run pre-pr verification before retrying.
+The push / PR-write gate **fails** when any of:
+
+- `gwt-verify --mode pre-pr` returns `Overall: FAIL`
+- `failed: tooling-missing` is recorded
+- `User Verification Result` is `pending` (handoff never completed) or
+  `rejected(<reason>)` (user declined). The user's reason is preserved
+  in the evidence bundle.
+
+On failure, do not push, do not create a PR, and do not update an
+existing PR. Route the failure for repair (back to the TDD loop or
+`gwt-discussion`) and re-run pre-pr verification before retrying.
 
 This applies equally to Create and Fix modes — every code-changing
-re-push must be preceded by a fresh `gwt-verify --mode pre-pr` PASS.
+re-push must be preceded by a fresh `gwt-verify --mode pre-pr` PASS
+with a satisfied `User Verification Result`.
 
 ## Mode: Create
 

--- a/.claude/skills/gwt-verify/SKILL.md
+++ b/.claude/skills/gwt-verify/SKILL.md
@@ -1,59 +1,113 @@
 ---
 name: gwt-verify
-description: "Use when implementation work needs verification before completion or before opening a PR. Selects the correct test matrix per changed surface (cargo for Rust crates, pnpm for frontend JS, Playwright only for WebView/browser UI, release scripts only for release-system changes) and runs them with evidence-bundle output. Triggers: 'verify', 'run tests', 'pre-PR check', 'gwt-verify'."
+description: "Use when implementation needs verification before completion or before opening a PR. Defines a project-agnostic Generic Verification Contract: classify changed surfaces, autodetect the project's test runners from manifests (Cargo.toml / package.json / pyproject.toml / go.mod / ProjectSettings / *.sln / etc.), run the appropriate unit / integration / E2E / visual tests for the project, emit an evidence bundle that lists exactly which tests were executed, then hand off to the user with a 4-step 導線 (build → launch → navigate → observe) and check items before declaring Overall: PASS. Triggers: 'verify', 'run tests', 'pre-PR check', 'gwt-verify'."
 ---
 
 # gwt-verify
 
-Environment-aware verification skill. Inspects the changed surfaces in the
-current worktree, selects the correct test matrix per surface, runs the
-selected commands, and returns an evidence bundle.
+Project-agnostic verification skill. `gwt-verify` is bundled into every gwt-managed
+worktree, including Rust, Node, Unity, Visual Studio / .NET, Python, Go, and any other
+project type gwt opens. It defines a **Generic Verification Contract** — what to verify,
+how to report, and how to involve the user — without hard-coding any particular test
+runner or build tool.
 
-This skill owns "verification time" for the gwt project. `gwt-build-spec`
-Phase 3 delegates to `gwt-verify --mode full`; `gwt-manage-pr` requires
-`gwt-verify --mode pre-pr` before opening or updating a PR; users may also
-invoke it directly through `/gwt:gwt-verify`.
+This skill owns "verification time" for the active project. `gwt-build-spec` Phase 3
+delegates to `gwt-verify --mode full`; `gwt-manage-pr` requires `gwt-verify --mode pre-pr`
+before opening or updating a PR; users may also invoke it directly through
+`/gwt:gwt-verify`.
 
-Playwright is invoked **only** for WebView/browser UI surfaces. Non-browser
-surfaces (Rust crates, the gwtd CLI, backend domain code, and release
-scripts) do not invoke Playwright — they each have their own dedicated
-execution path documented in `references/test-matrix.md`.
+## Contract overview
+
+`gwt-verify` is **project-agnostic**. It does not own a fixed cargo / pnpm /
+Playwright recipe. Instead it executes the following four-part contract:
+
+1. **Change Classification** — bucket changed files into abstract surfaces
+   (UI surface / interactive CLI / business logic / build-release pipeline /
+   docs / config / skill-asset / external-binding). See
+   `references/surface-taxonomy.md`.
+2. **Appropriate Test Selection** — detect the project's actual test runners
+   from its manifests (Cargo.toml, package.json, pyproject.toml, go.mod,
+   ProjectSettings/ProjectVersion.txt, *.sln / *.csproj, Gemfile, pom.xml,
+   build.gradle, Makefile) and choose the right unit / integration / E2E /
+   visual commands for each changed surface. See
+   `references/runner-detection.md`.
+3. **Test Inventory Emission** — extract the actual test names / scenarios /
+   suite paths from each runner's structured output and list them in the
+   evidence bundle so the user can see **what was tested**, not just a pass /
+   fail count.
+4. **User Verification Handoff** — after automated tests pass, present a
+   surface-specific checklist plus a 4-step 導線 ("How to access": build →
+   launch → navigate → observe) and ask the user to confirm or reject. See
+   `references/user-verification-guide.md`.
+
+Project-local rules always win. If the project root has an AGENTS.md / README
+section describing its own testing approach (e.g., "run `make verify`",
+"use Unity Editor batch mode test runner"), the agent follows that instead of
+the generic matrix in this skill. The matrix here is the fallback frame.
 
 ## Modes
 
 | Mode | When to use | Scope |
 |---|---|---|
-| `--mode quick` (default) | TDD loop, narrow check during implementation | Only the surface(s) touched by uncommitted/working-tree changes; minimum useful subset (e.g. single-crate `cargo test`, single-suite `pnpm test:frontend-unit`). |
-| `--mode full` | gwt-build-spec Phase 3, standalone completion gate | Full matrix per changed surface (cargo test/clippy/fmt, all relevant `pnpm test:frontend-*`, `pnpm test:visual` headless when UI surface changed, skill lint when skill assets changed). |
-| `--mode pre-pr` | gwt-manage-pr before PR create/update | `full` matrix + release-flow tests when release surface changed; visual regression always included for any UI surface. |
-| `--headed` (flag) | Manual UI/design verification | When supplied alongside any mode that runs Playwright, Chromium starts headed. Default is headless to match CI. |
+| `--mode quick` (default) | TDD loop, narrow check during implementation | Only surfaces touched by uncommitted / working-tree changes; the narrowest representative command per runner (e.g. single-package test invocation). Skip heavy integration / E2E / visual unless the diff explicitly touches them. |
+| `--mode full` | gwt-build-spec Phase 3, standalone completion gate | Full matched matrix per changed surface, including integration / E2E / visual when a UI surface changed. User Verification Handoff is required (see below). |
+| `--mode pre-pr` | gwt-manage-pr before PR create / update | `full` matrix + release-flow tests when a release surface changed; visual / UI regression always included if any UI surface changed. User Verification Handoff is required. |
+| `--headed` (flag) | Manual UI / design verification | When supplied alongside any mode that runs a browser-based test runner (Playwright / Cypress / Selenium / WinAppDriver / Unity Editor headed), launch the runner in headed mode so the user can watch. Default is headless to match CI. |
+
+Additional flag:
+
+- `--skip-user-check` — explicitly opt out of the User Verification Handoff
+  phase for non-interactive runs (CI smoke, automated regression sweeps).
+  Default is **off**; `--mode full` and `--mode pre-pr` require user
+  verification unless this flag is set. The reason is recorded in the
+  evidence bundle as `User Verification: skipped(--skip-user-check)`.
 
 ## Invocation Sequence
 
 ```text
-agent → /gwt:gwt-verify [--mode quick|full|pre-pr] [--headed]
+agent → /gwt:gwt-verify [--mode quick|full|pre-pr] [--headed] [--skip-user-check]
   ↓
 gwt-verify
-  1. Collect changed files via
+  1. Establish baseline:
        git diff --name-only $(git merge-base HEAD origin/develop)..HEAD
-     (fall back to origin/main when origin/develop is absent). For `--mode
-     quick` also include `git diff --name-only` (working tree).
-  2. Classify each path into a surface category using
-     references/test-matrix.md.
-  3. Apply mode-specific filtering (quick → minimum subset; full → all matched
-     commands; pre-pr → full + release-flow + always include visual when any
-     UI surface changed).
-  4. Tooling presence check: cargo, pnpm, node_modules, Playwright Chromium.
-     Missing entries follow references/tooling-bootstrap.md (auto-install
-     attempt, otherwise exit with `failed: tooling-missing`).
-  5. Run each selected command sequentially. Capture stdout/stderr and exit
-     code. For Playwright commands also start the GUI server per
-     references/playwright-runbook.md and inject `GWT_PLAYWRIGHT_BASE_URL`.
-  6. Emit the evidence bundle described below.
+     (fall back to origin/main when origin/develop is absent). For
+     `--mode quick` also include `git diff --name-only` (working tree).
+  2. Classify each path into an abstract surface using
+     `references/surface-taxonomy.md`.
+  3. Discover the project's test runners from its manifests using
+     `references/runner-detection.md` (Cargo.toml → cargo,
+     package.json → npm / pnpm / yarn scripts, pyproject.toml → pytest,
+     go.mod → go test, ProjectSettings/ProjectVersion.txt → Unity Editor
+     batch test runner, *.sln / *.csproj → dotnet test, Gemfile → rspec
+     / minitest, pom.xml / build.gradle → mvn / gradle test,
+     Makefile → make test targets). Multiple runners may coexist
+     (e.g. Cargo + pnpm).
+  4. Select appropriate test commands per changed surface. Record the
+     selection rationale in the evidence bundle's `Plan` section. Honor
+     project-local AGENTS.md / README testing instructions when present;
+     the generic matrix is the fallback.
+  5. Tooling presence check: verify each chosen runner / browser / editor
+     is installed. Missing entries follow `references/tooling-bootstrap.md`
+     (best-effort install attempt for runners with auto-install paths;
+     otherwise exit with `failed: tooling-missing`).
+  6. Run each selected command sequentially. Capture stdout / stderr /
+     exit code. For browser-based UI runners, bring up the application
+     server per `references/playwright-runbook.md` before invoking the
+     runner. When the runner supports a structured reporter (JSON / TAP /
+     list / JUnit XML), use it so test-level results can be extracted.
+  7. Extract a Test Inventory from each runner's output: test name,
+     describe block, scenario / snapshot title, lint rule name, etc.
+     If extraction fails for a runner, record
+     `(inventory unavailable: <reason>)` rather than silently degrading.
+  8. Emit the evidence bundle described below, then run the User
+     Verification Handoff phase (unless skipped per the rules above) and
+     finalize Overall once the user response is recorded.
 ```
 
-The skill does **not** invoke Playwright when no WebView/browser UI surface
-changed. This is a hard contract from SPEC-1935 FR-124.
+The skill does not invoke Playwright when no WebView / browser UI surface
+changed. This is a hard contract from SPEC-1935 FR-124. The same restraint
+applies to other UI runners (Cypress / Selenium / WinAppDriver / Unity Editor
+headed): they are only invoked when a UI surface is in scope.
 
 ## Evidence Bundle
 
@@ -61,24 +115,120 @@ Output to stdout in the following shape (Markdown):
 
 ```text
 ## Verification Report
+
 Mode: <quick|full|pre-pr>
 Baseline: merge-base HEAD..origin/develop (<N> commits, <M> files)
-Changed surfaces: <comma-separated list>
+Changed surfaces: <abstract surface list>
 
-Executed:
-- <command>: PASS|FAIL (<short detail, e.g., test count + duration>)
-
-Skipped / not-applicable:
+### Plan
+Detected runners: <e.g. Cargo, pnpm, Playwright | Unity Test Framework | dotnet test | pytest | go test>
+Selected commands per surface:
+- <surface>: <command> — <selection reason>
+Skipped (no matching surface or not applicable):
 - <command>: <reason>
+
+### Executed
+- <command>: PASS|FAIL (<short metric, e.g. test count + duration>)
+
+### Test Inventory
+<command>:
+- PASS  <suite> :: <test name / scenario>
+- FAIL  <suite> :: <test name>  -> <short failure>
+- SKIP  <suite> :: <test name>  -> <reason>
+(inventory unavailable: <reason>)  # when extraction failed for a runner
+
+### User Verification
+Status: required | recommended | skipped(<reason>)
+Surfaces requiring user check: <list>
+
+#### 導線 (How to access the changed behavior)
+1. build:     <project-specific build command>
+2. launch:    <how to start the app / open the editor / run the binary>
+3. navigate:  <how to reach the changed feature inside the running app>
+4. observe:   <what the user should look at / interact with>
+
+#### Check Items
+- [ ] <expected behavior — the representative happy path>
+- [ ] <edge case / failure handling — at least one>
+- [ ] <adjacent feature regression sanity — at least one>
+
+Expected: <one-line summary of the intended behavior>
+Observed: <user response slot>
+User Verification Result: pending | confirmed | rejected(<reason>) | n/a
 
 Headed verification: <yes|no>
 Tooling installed during run: <list, or "none">
+
 Overall: PASS|FAIL
 ```
 
-If any executed command fails, `Overall: FAIL` and the failing command's
-detail block is captured verbatim. `gwt-build-spec` treats `FAIL` and any
-`failed: tooling-missing` entry as a hard completion blocker.
+Rules:
+
+- `Overall: PASS` requires **both** every entry in `Executed` reporting `PASS`
+  **and** `User Verification Result ∈ {confirmed, n/a, skipped(<reason>)}`.
+  `pending` must never resolve to `PASS`.
+- If any executed command fails, `Overall: FAIL` and the failing command's
+  detail block is captured verbatim.
+- If the user rejects, `Overall: FAIL` and the reason is preserved.
+- `failed: tooling-missing` remains a hard completion blocker — callers
+  (`gwt-build-spec`, `gwt-manage-pr`) treat it as such.
+
+## Surface → User-Check Matrix (abstract)
+
+The matrix below is **abstract** so it applies to any project type. For
+project-specific specialization, see `references/surface-taxonomy.md`.
+
+| Abstract Surface | User Check | 導線 generation guidance |
+|---|---|---|
+| UI surface (visible markup / theme / layout / interactive controls) | **Required** | Launch the application using the project's normal launch path → present the entry point (URL / editor Play mode / GUI binary / TUI screen) → list the click / keystroke / navigation steps to reach the changed feature → describe what the user should look at. |
+| Interactive CLI / TUI surface | **Required** | Build the CLI → run a representative subcommand example → compare against expected output / screen state. |
+| Build / Release pipeline | **Required** | Generate the release artifact → manually unpack / install / launch it once → verify the artifact behaves as expected. |
+| Business logic (no observable surface) | **Recommended** | If there is any observable mouth (CLI, log, UI) where the change manifests, present that; otherwise mark as Optional. |
+| External binding / 3rd-party integration | **Recommended** | Show a representative outbound call and expected response shape. |
+| Skill asset / agent config | **Recommended** | Describe the trigger phrase or scenario that should activate the modified skill / agent, plus the expected effect. |
+| Docs / config-only (markdownlint clean) | **Skipped(docs-only)** | Automated checks are sufficient. |
+
+## User Verification Handoff (post-Executed)
+
+When `Overall` would otherwise be `PASS` (every `Executed` entry passed) and
+`--mode full` or `--mode pre-pr` is active and `--skip-user-check` was not
+supplied:
+
+1. Compute the `User Verification` block:
+   - `Status: required` if any changed surface is marked Required above.
+   - `Status: recommended` if only Recommended surfaces changed.
+   - `Status: skipped(<reason>)` for `--mode quick`, `Changed surfaces:
+     (none)`, docs-only changes, `--skip-user-check`, or any explicit
+     skip rule above. The reason must be human-readable and specific.
+2. Generate the 4-step 導線 ("How to access the changed behavior") using the
+   project's build / launch conventions. The structure is fixed across all
+   project types — **always exactly four labelled steps in this order**:
+   1. **build** — the project's build command for the smallest target that
+      exercises the change.
+   2. **launch** — how to start the running artifact (binary / server /
+      editor / interpreter / web page).
+   3. **navigate** — how to reach the changed feature from the entry point.
+   4. **observe** — what the user should look at, click, or interact with to
+      confirm the change.
+   See `references/user-verification-guide.md` for project-type-specific
+   launch patterns (Rust CLI / WebView / Unity Editor / .NET WPF / Python
+   service / generic TUI / long-running service).
+3. Produce a **Check Items** list with **three categories minimum**:
+   (1) expected happy-path behavior, (2) at least one edge case or failure
+   path, (3) at least one adjacent-feature regression sanity check.
+4. Ask the user via the platform's selection question tool
+   (`AskUserQuestionTool` for Claude Code, `request_user_input` for Codex,
+   the closest equivalent for other runtimes) to choose one of:
+   - `Confirmed` — observed behavior matches expectations; record
+     `User Verification Result: confirmed`.
+   - `Rejected(<reason>)` — observed behavior does not match; downgrade
+     `Overall: FAIL` and preserve the user's reason.
+   - `Skip with reason(<reason>)` — user defers verification with an
+     explicit justification; record `User Verification Result:
+     skipped(<reason>)`.
+
+If no selection UI exists in the current runtime, fall back to plain-text
+prompting but keep the same three-option discipline.
 
 ## Stop Conditions
 
@@ -88,12 +238,27 @@ Stop and surface a blocker to the caller when:
   cannot establish a baseline.
 - Tooling bootstrap exhausts auto-install options (see
   `references/tooling-bootstrap.md`) and emits `failed: tooling-missing`.
-- A required Playwright snapshot diff is non-zero in `--mode full` /
+- A required visual / UI snapshot diff is non-zero in `--mode full` /
   `--mode pre-pr` — agent must triage rather than silently regenerate
   snapshots.
-- The agent attempts to invoke Playwright for a surface not listed under the
-  "Browser (Playwright)" column of `references/test-matrix.md`. This is a
-  contract violation, not a runtime error.
+- The agent attempts to invoke Playwright (or any other browser UI runner)
+  for a surface not classified as a UI surface under
+  `references/surface-taxonomy.md`. This is a contract violation, not a
+  runtime error.
+- The User Verification phase is required but no platform question tool
+  and no plain-text channel are available to ask the user.
+
+## Project-local AGENTS.md takes precedence
+
+This skill is distributed into every gwt-managed worktree. The host project
+defines its own testing reality. When the project root holds an AGENTS.md /
+CLAUDE.md / README with a "ローカル検証" / "Testing" / "Verification" section,
+the agent must read those instructions and prefer them over the generic
+matrix in this skill. Use the generic matrix only to fill gaps.
+
+This mirrors the broader gwt rule: gwt's own AGENTS.md is project-local to
+the gwt repo, and any other project gwt opens has its own AGENTS.md as the
+authority.
 
 ## gwtd resolution
 
@@ -104,20 +269,33 @@ exists, stop with `gwtd not found`.
 
 ## References
 
-- `references/test-matrix.md` — canonical surface→execution-system table.
-- `references/playwright-runbook.md` — Chromium project selection, GUI
-  server bring-up, baseURL handoff, headed/headless toggling, snapshot
-  baseline policy.
-- `references/tooling-bootstrap.md` — pnpm / node_modules / Playwright
-  Chromium auto-install contract and `failed: tooling-missing` shape.
+- `references/surface-taxonomy.md` — abstract surface classification and
+  per-project path-pattern examples.
+- `references/runner-detection.md` — manifest → test-runner detection
+  table (Rust / Node / Python / Go / .NET / Unity / Ruby / Java / Make /
+  generic).
+- `references/user-verification-guide.md` — 4-step 導線 generation guide
+  with project-type-specific launch patterns and Check Items rules.
+- `references/test-matrix.md` — example matrix for the gwt repo itself,
+  referenced as a worked example of how to specialize the generic
+  contract.
+- `references/playwright-runbook.md` — operational details for browser /
+  WebView UI runners (Playwright is the canonical example; the same
+  pattern applies to Cypress / Selenium / WinAppDriver / Unity Editor
+  headed).
+- `references/tooling-bootstrap.md` — best-effort installer contract and
+  the `failed: tooling-missing` shape.
 
 ## Chain Suggestion
 
 On `Overall: PASS`, the caller proceeds:
 
-- `gwt-build-spec` Phase 3 → Phase 4 (PR Flow via `gwt-manage-pr`).
-- `gwt-manage-pr` → PR create/update.
-- Manual invocation → return evidence bundle to the user.
+- `gwt-build-spec` Phase 3 → Phase 4 (PR Flow via `gwt-manage-pr`), provided
+  `User Verification Result ∈ {confirmed, n/a, skipped(<reason>)}`.
+- `gwt-manage-pr` → PR create / update, provided the same User Verification
+  Result gate is satisfied.
+- Manual invocation → return the evidence bundle to the user.
 
-On `Overall: FAIL`, the caller stays in their current phase and routes the
-failure for repair (typically back into the TDD loop or `gwt-discussion`).
+On `Overall: FAIL` (including `User Verification Result: rejected(...)`),
+the caller stays in their current phase and routes the failure for repair
+(typically back into the TDD loop or `gwt-discussion`).

--- a/.claude/skills/gwt-verify/references/playwright-runbook.md
+++ b/.claude/skills/gwt-verify/references/playwright-runbook.md
@@ -1,32 +1,53 @@
-# Playwright Runbook
+# Browser / WebView UI Runner Runbook
 
-`gwt-verify` invokes Playwright **only** for WebView/browser UI surfaces (see
-`test-matrix.md`). This document covers the operational details required to
-run `pnpm test:visual` correctly in both headless (default) and headed
-(`--headed`) modes.
+`gwt-verify` invokes a browser-based UI runner **only** for WebView /
+browser UI surfaces (see `surface-taxonomy.md`). Playwright is the
+canonical example documented here; the same operational pattern applies
+to Cypress, Selenium WebDriver, WinAppDriver, and Unity Editor headed.
+For non-UI surfaces, this runbook does not apply — the runner is not
+invoked at all.
 
-## Project Layout
+The contract is the same regardless of the specific runner:
 
-The Playwright project lives under `crates/gwt/playwright/`:
+1. The application under test must be running and reachable before the
+   runner starts.
+2. The runner receives the application's base URL / executable path
+   through an environment variable agreed with the test harness.
+3. The runner runs **headless by default** (CI conditions). Headed mode
+   is opt-in via the `--headed` flag passed to `gwt-verify`.
+4. Snapshot or screenshot diffs are FAIL signals; the skill never
+   regenerates baselines silently.
 
-- `playwright.config.ts` — Chromium dark + Chromium light projects, snapshot
-  template `{snapshotDir}/{testFilePath}/{projectName}/{platform}/{arg}{ext}`.
-- `tests/*.spec.ts` — visual / interaction tests against the embedded gwt
-  frontend.
+## Project Layout (Playwright example, from the gwt repo)
+
+In the gwt repository, the Playwright project lives under
+`crates/gwt/playwright/`:
+
+- `playwright.config.ts` — Chromium dark + Chromium light projects,
+  snapshot template `{snapshotDir}/{testFilePath}/{projectName}/{platform}/{arg}{ext}`.
+- `tests/*.spec.ts` — visual / interaction tests against the embedded
+  gwt frontend.
 - `snapshots/` — committed baseline images.
-- `fixtures/` — WS server responses used by individual tests.
+- `fixtures/` — WebSocket server responses used by individual tests.
 
-## GUI Server Bring-up
+Other projects place their UI tests wherever their convention dictates
+(`tests/e2e/`, `cypress/e2e/`, `tests/playwright/`, `tests/integration/`,
+`Assets/Tests/PlayMode/` for Unity, `test/ui/` for .NET, etc.). The skill
+discovers the location through the project's runner-detection signals.
 
-`pnpm test:visual` expects a running gwt WebView server at the URL declared
-by `GWT_PLAYWRIGHT_BASE_URL`. The skill is responsible for getting that
-server ready before invoking Playwright.
+## Application Bring-up
+
+The runner expects the application under test to be reachable at the URL
+or path declared by its baseURL environment variable. The skill is
+responsible for bringing the application up before invoking the runner.
 
 ```bash
+# Playwright + WebView example (gwt repo):
+
 # 1. Build (debug mode is fine for verify runs)
 cargo build -p gwt --bin gwt
 
-# 2. Start the GUI server in the background
+# 2. Start the application server in the background
 ./target/debug/gwt &
 gui_pid=$!
 
@@ -37,58 +58,78 @@ gui_pid=$!
 # 6. Run Playwright
 pnpm test:visual
 
-# 7. Stop the GUI server
+# 7. Stop the application server
 kill "$gui_pid"
 ```
 
-If `GWT_PLAYWRIGHT_BASE_URL` is already set in the environment (e.g. by a
-preceding test harness) the skill must reuse it instead of spawning a new
-server, to avoid port collisions.
+If the baseURL environment variable is already set in the environment
+(e.g. by a preceding test harness) the skill must reuse it instead of
+spawning a new server, to avoid port collisions.
+
+For other UI runner pairings the same pattern applies:
+
+| Runner | Baseline env var | Application start pattern |
+|---|---|---|
+| Playwright (web / WebView) | `PLAYWRIGHT_BASE_URL` / project-specific (`GWT_PLAYWRIGHT_BASE_URL` in gwt repo) | Start the application server, wait for HTTP 200 |
+| Cypress | `CYPRESS_BASE_URL` | Same as Playwright |
+| Selenium WebDriver | `SELENIUM_BASE_URL` / per-test fixture | Same as Playwright; ensure driver process is running |
+| WinAppDriver (.NET / WPF / WinForms) | `WINAPPDRIVER_TARGET_APP` | Launch the app exe; WinAppDriver attaches by path |
+| Unity Editor headed (PlayMode) | `UNITY_PROJECT_PATH` | Unity Editor launched with `-projectPath` and `-runTests -testPlatform PlayMode` |
 
 ## Headless vs Headed
 
 | Invocation | Behavior |
 |---|---|
-| `pnpm test:visual` (default) | Headless Chromium dark + light projects. Same conditions as CI. |
-| `pnpm test:visual --headed` | Headed Chromium. Used only when the caller passed `--headed` to `gwt-verify`. The skill must surface the GUI URL to the user so they can also inspect the running app. |
-| `pnpm test:visual --update-snapshots` | Snapshot baseline update. **Not** part of `gwt-verify` — the caller must run it explicitly as a separate manual step. |
+| Default (no `--headed`) | Run headless. Same conditions as CI. |
+| `--headed` (passed to `gwt-verify`) | Run headed. The runner must surface the application URL / window so the user can also inspect the running app. Used only when the caller passed `--headed` to `gwt-verify`. |
+| Update-baseline invocation (e.g. `playwright test --update-snapshots`, `cypress test --update`) | **Not** part of `gwt-verify`. The caller must run baseline updates explicitly as a separate manual step, with intent, and commit the new baselines for PR review. |
 
-## Snapshot Diff Policy
+## Snapshot / Diff Policy
 
-- Visual regression failures are evidence-bundle FAIL, not snapshot
-  regeneration triggers.
-- The skill never passes `--update-snapshots` automatically. Baseline updates
-  must be performed by a human-driven step with intent, then committed
-  separately so the change shows up in the PR review.
-- `maxDiffPixelRatio: 0.005` in `playwright.config.ts` is the canonical
-  tolerance; the skill does not override it.
+- Visual / interaction regression failures are evidence-bundle FAIL, not
+  baseline regeneration triggers.
+- The skill never passes `--update-snapshots` (or any equivalent
+  baseline-rewrite flag) automatically. Baseline updates must be
+  performed by a human-driven step with intent, then committed
+  separately so the change appears in PR review.
+- Per-runner tolerance configuration (`maxDiffPixelRatio: 0.005` in
+  `playwright.config.ts`, `cypress-image-snapshot` `failureThreshold`,
+  etc.) is the canonical tolerance; the skill does not override it.
 
-## Project Selection
+## Project Selection (Playwright example)
 
-Both `chromium-dark` and `chromium-light` projects run by default. To narrow
-during quick iteration, the operator may run `pnpm test:visual --project
-chromium-dark` manually; the skill itself always runs both so coverage
-matches CI.
+Both `chromium-dark` and `chromium-light` projects run by default in the
+gwt repo. To narrow during quick iteration, the operator may run
+`pnpm test:visual --project chromium-dark` manually; the skill itself
+always runs both so coverage matches CI.
 
-## Common Failure Modes
+Other UI runners may expose similar narrowing flags (`cypress
+--browser`, `winappdriver` device-specific config). Default to the full
+matrix; narrow only when the operator asks explicitly.
+
+## Common Failure Modes (Playwright example, generalizes)
 
 | Symptom | Likely cause | Action |
 |---|---|---|
-| `Error: connect ECONNREFUSED 127.0.0.1:<port>` | GUI server not yet ready | Re-check the HTTP 200 wait step before invoking Playwright. |
+| `Error: connect ECONNREFUSED 127.0.0.1:<port>` | Application server not yet ready | Re-check the HTTP 200 wait step before invoking the runner. |
 | `Snapshot doesn't match` | Real UI regression OR legitimate redesign | Treat as FAIL; do not auto-regenerate snapshots. Triage in `gwt-discussion` or escalate to the user. |
 | Headed mode shows no window | Running inside a headless host (CI, container) | Detect missing display and downgrade to `Overall: FAIL` with `Headed verification: refused (no display)`. Do not silently fall back to headless. |
-| `browserType.launch: Executable doesn't exist` | Chromium not installed for current Playwright version | Trigger the tooling-bootstrap path (`pnpm exec playwright install --with-deps chromium`). |
+| `browserType.launch: Executable doesn't exist` | Browser not installed for current runner version | Trigger the tooling-bootstrap path (e.g. `pnpm exec playwright install --with-deps chromium`). |
+| WinAppDriver: `Cannot find a matching application` | The target binary is stale or in a different location | Rebuild and update `WINAPPDRIVER_TARGET_APP` before retrying. |
+| Unity PlayMode test: editor freezes | Scene or test code has a synchronous wait | Treat as FAIL; the operator must triage in the Editor, not the skill. |
 
-## Boundary
+## Boundary (do not invoke for non-UI surfaces)
 
-Playwright is for WebView/browser UI verification. Never invoke it for:
+UI runners are for browser / WebView / desktop GUI verification. Never
+invoke them for:
 
-- Pure Rust changes (`crates/*` outside `crates/gwt/web/**` and
-  `crates/gwt/playwright/**`).
-- gwtd CLI smoke (use `cargo run -p gwt --bin gwtd -- --version` instead).
-- Backend domain logic (use `cargo test -p <crate>`).
-- Release scripts (use `pnpm test:release-flow` / `test:release-assets`).
+- Pure backend / library / business-logic changes (use the project's
+  unit / integration test runners instead).
+- CLI smoke (use the project's CLI runner directly,
+  e.g. `cargo run --bin <bin> -- --version`).
+- Release scripts (use the project's release-flow / artifact tests).
 - Documentation-only changes (markdownlint only).
 
-This boundary is enforced by `gwt-verify` at command-selection time per the
-canonical surface table.
+This boundary is enforced by `gwt-verify` at command-selection time per
+`surface-taxonomy.md`. The same restraint applies to all UI runner
+families above, not just Playwright.

--- a/.claude/skills/gwt-verify/references/runner-detection.md
+++ b/.claude/skills/gwt-verify/references/runner-detection.md
@@ -1,0 +1,91 @@
+# Test-Runner Detection (project-agnostic)
+
+`gwt-verify` autodetects the host project's test runners from manifest
+signals before selecting any commands. A project may expose multiple
+runners (e.g. a Rust workspace that also contains a pnpm-driven web
+frontend); the agent picks one per surface based on which runner owns
+that surface's files.
+
+The host project's own AGENTS.md / CLAUDE.md / README always takes
+precedence. Use this table only when the project did not state a testing
+approach explicitly.
+
+## Manifest → Runner Table
+
+| Manifest / signal at project root | Primary runner family | Typical test invocation | Structured-output flag for inventory |
+|---|---|---|---|
+| `Cargo.toml` (workspace or single-crate) | Rust / `cargo test` (optionally `cargo nextest`) | `cargo test -p <crate>` for surface-narrow; `cargo test --workspace` for full | `--format=json` (unstable) or `cargo nextest run --message-format libtest-json` (preferred) |
+| `package.json` with `scripts.test` | Node — read scripts to identify Jest / Vitest / Mocha / Playwright / Cypress / Storybook test | `pnpm test` (or `npm test` / `yarn test`) for the script named in `scripts.test`; surface-specific scripts (`test:unit`, `test:integration`, `test:visual`, `test:e2e`) when present | Jest / Vitest: `--reporter=json`; Mocha: `--reporter=json`; Playwright: `--reporter=json,list`; Cypress: `--reporter=mocha-junit-reporter` |
+| `pyproject.toml` or `setup.cfg` / `setup.py` | Python — pytest / unittest / tox | `pytest -q` (surface-narrow with `-k <pattern>`); `tox -e <env>` when tox is present | `pytest --json-report` (via `pytest-json-report`) or `--junitxml=<file>` |
+| `go.mod` | Go — `go test` | `go test ./<pkg>/...` for surface-narrow; `go test ./...` for full | `go test -json` |
+| `*.sln` / `*.csproj` (and no Unity ProjectSettings) | .NET — `dotnet test` | `dotnet test <Project.csproj>` for surface-narrow; `dotnet test <Solution.sln>` for full | `--logger "trx;LogFileName=test_results.trx"` or `--logger "console;verbosity=detailed"` |
+| `ProjectSettings/ProjectVersion.txt` (presence) | Unity — Editor batch test runner | `Unity -batchmode -runTests -projectPath <path> -testPlatform <EditMode\|PlayMode> -testResults <result.xml> -quit` | NUnit XML at `-testResults` |
+| `Gemfile` | Ruby — RSpec / Minitest | `bundle exec rspec` or `bundle exec rake test` | `--format json` (RSpec) |
+| `pom.xml` | Java / Kotlin — Maven Surefire / Failsafe | `mvn test` (unit), `mvn verify` (integration) | Surefire writes `target/surefire-reports/*.xml` (JUnit XML) |
+| `build.gradle` / `build.gradle.kts` | Gradle — JUnit / Spek | `gradle test` or `gradle check` | `--scan` for build scans; per-task JUnit XML under `build/test-results/` |
+| `Makefile` exposing a `test` target | Project-defined wrapper | `make test` (also check for `make verify` / `make check`) | Depends on wrapped runner |
+| `pubspec.yaml` | Flutter / Dart | `flutter test` (unit) / `flutter test integration_test` | `--reporter json` |
+| `composer.json` | PHP — PHPUnit / Pest | `vendor/bin/phpunit` or `vendor/bin/pest` | `--log-junit` |
+| Standalone `tsconfig.json` without `package.json` (rare) | Likely embedded inside another project — defer to that project's runner | — | — |
+| No recognized manifest | Fallback: read the project's AGENTS.md / README for instructions; otherwise emit `failed: tooling-missing` with rationale | — | — |
+
+## Selection rules
+
+1. **Multi-runner projects.** A workspace may declare more than one
+   manifest (e.g. `Cargo.toml` + `package.json`). Detect all of them, then
+   assign each changed surface to the runner whose manifest owns the
+   surface's path. For example, in a Rust workspace with a pnpm-driven
+   `web/` subdirectory, web changes go to pnpm-driven runners and Rust
+   crate changes go to cargo.
+
+2. **Prefer scripts over inferred conventions.** If `package.json`
+   declares `scripts.test` and surface-specific scripts (`test:unit`,
+   `test:integration`, `test:visual`, `test:release-*`), use the script
+   names as they appear instead of guessing. Same for `Makefile` targets.
+
+3. **Visual / UI runners.** Playwright / Cypress / Selenium /
+   WinAppDriver / Unity Editor headed are only invoked when a UI surface
+   is in scope. Even if the manifest is present, do not invoke a UI
+   runner for non-UI changes.
+
+4. **Long-running runners and `--mode quick`.** Some runners (Unity Editor
+   batch, large `mvn verify`, full `dotnet test` solution) take many
+   minutes. In `--mode quick`, narrow the invocation to a single
+   project / module / `-k` filter relevant to the changed surface, or
+   skip the runner with a recorded `skipped(quick-mode-budget)` reason.
+
+5. **Plugin / module testing in Unity.** If the project ships under
+   `Packages/<id>` Unity package layout, prefer scoping the test runner
+   to that package's assemblies (`-testCategory` / `-testFilter`) instead
+   of running the entire Editor test suite.
+
+6. **Custom wrappers.** When the project defines a `make verify` /
+   `make check` / `scripts/verify.sh` / `bin/check` wrapper, that wrapper
+   is the canonical entry point. Use it instead of bypassing it; the
+   wrapper exists precisely so contributors do not have to remember the
+   runner-specific flags.
+
+7. **Generic fallback.** When no manifest is recognized, surface the
+   uncertainty: emit `failed: tooling-missing — no recognized test runner
+   manifest found at <project root>` and stop. Do not invent commands.
+
+## Inventory extraction hints
+
+The `Test Inventory` section of the evidence bundle lists the actual
+test names / scenarios / suite paths the runner executed. To populate it,
+prefer the runner's structured output flag (the rightmost column in the
+table above) and parse the following fields, in this order of preference:
+
+1. Test identifier — fully qualified name when available
+   (`module::path::test_name` for cargo; `describe > it` for Jest /
+   Vitest / Mocha / Playwright; `ClassName.MethodName` for JUnit /
+   NUnit / xUnit).
+2. Outcome (`PASS` / `FAIL` / `SKIP`).
+3. One-line failure summary (first line of the runner's error message
+   when `FAIL`).
+4. Skip reason when `SKIP`.
+
+When extraction is not feasible (no structured output, parsing failure,
+custom wrapper that swallows stdout), record
+`(inventory unavailable: <reason>)` for that command and continue. Do not
+silently degrade.

--- a/.claude/skills/gwt-verify/references/surface-taxonomy.md
+++ b/.claude/skills/gwt-verify/references/surface-taxonomy.md
@@ -1,0 +1,70 @@
+# Surface Taxonomy (project-agnostic)
+
+`gwt-verify` classifies every changed file into one of the abstract surfaces
+below. The surface determines (a) which test runners are relevant and (b)
+whether the User Verification Handoff is Required, Recommended, or Skipped.
+
+This taxonomy is intentionally project-agnostic. The patterns column shows
+**typical** signals for common project types; treat them as hints, not as
+exhaustive rules. If the host project's AGENTS.md / README defines a
+different classification, that wins.
+
+## Abstract Surfaces
+
+| Surface | Typical signals (any of) | User Check |
+|---|---|---|
+| **UI surface** — anything the end user sees rendered: markup, theme, layout, interactive controls, motion, accessibility affordances. | `*.html`, `*.css`, `*.scss`, `*.tsx` / `*.jsx` rendered components, `theme*.{js,ts}`, Unity `Assets/**/*.{prefab,uxml,uss,asset}` for UI, `.NET` XAML / WinForms designer files, Flutter `*.dart` widget files, Qt `*.ui` files, web assets under any `web/**`, `frontend/**`, `client/**`, `ui/**`, `static/**`. | **Required** |
+| **Interactive CLI / TUI surface** — a command-line or terminal UI a human invokes directly. | CLI entry points (`src/bin/*.rs`, `cmd/**/main.go`, `bin/*`, `scripts/cli.*`), ratatui / blessed / urwid / Bubble Tea TUI files, argparse / clap / cobra / commander definitions when the diff changes user-visible flags, help text, or output formatting. | **Required** |
+| **Business logic (no observable surface)** — pure functions, services, parsers, models, computation. | Source under `src/**` / `lib/**` / `internal/**` / `crates/**` excluding UI and CLI entry points; backend services without UI rendering. | **Recommended** |
+| **Build / Release pipeline** — code that produces or publishes the distributable. | `Dockerfile*`, `Containerfile`, GitHub Actions `release` workflows, `scripts/release-*.{sh,cjs,ps1}`, `goreleaser.yaml`, `Cargo.toml` `[package]` version bumps, `package.json` version bumps, installer specs (`*.iss`, `*.nsi`, `*.wxs`), Unity build scripts. | **Required** |
+| **External binding / 3rd-party integration** — code that crosses a network or process boundary to a service we don't own. | HTTP / gRPC client modules, SDK wrappers, message-broker producers / consumers, OAuth flows, webhook senders. | **Recommended** |
+| **Skill asset / agent config** — agent skills, prompts, hooks, slash-command files. | `.claude/skills/**`, `.codex/skills/**`, `.claude/commands/**`, `.gemini/**`, `.cursor/**`, `AGENTS.md` sections specifically describing agent behavior. | **Recommended** |
+| **Docs / config-only** — documentation, formatting, dependency bumps with no behavior change. | `*.md` outside skill assets, `*.txt`, `LICENSE*`, `CHANGELOG.md`, `.editorconfig`, lint config (`.eslintrc*`, `clippy.toml`), formatter config, no-op dependency bumps. | **Skipped(docs-only)** |
+
+## Selection Rules
+
+1. **A file may match multiple surfaces.** Pick the most user-visible
+   surface (UI > CLI > business logic > docs).
+2. **`ui` / `web` / `frontend` / `client` directories** default to UI surface
+   regardless of file extension when the diff touches files the user
+   ultimately renders. Pure build-config files inside those directories
+   (e.g. `webpack.config.js`) classify as Build / Release pipeline.
+3. **CLI entry-point logic changes** classify as Interactive CLI surface only
+   when the user-visible behavior (flags, output, error messages) changes.
+   Pure internal refactors of the CLI plumbing classify as Business logic.
+4. **Skill assets do not require Playwright** — they are agent-facing only.
+   Their User Check is Recommended (trigger sanity check), not Required.
+5. **Multiple surfaces → take the highest user-check tier across all
+   matched surfaces.** Required > Recommended > Skipped.
+6. **No changed files** → `Changed surfaces: (none)` and User Verification
+   is `skipped(no-change)`.
+
+## Per-project specialization hints
+
+Concrete projects may need finer-grained mappings. The host project's
+AGENTS.md may publish its own table; in that case, prefer the project table
+and use this taxonomy only as a fallback for files the project table does
+not mention. Example: the gwt repo's own example matrix lives in
+`test-matrix.md` alongside this file.
+
+For Unity projects, treat any change under `Assets/**` that is referenced by
+a `Scene` or a `Canvas` as UI surface even when the file is a `.cs` script;
+the rendered behavior is user-visible. Pure `Editor/**` scripts that only
+affect the Unity Editor classify as Build / Release pipeline.
+
+For .NET projects with WPF / WinForms, `*.xaml`, `*.Designer.cs`, and any
+code-behind files for windows / pages classify as UI surface. Backend
+service projects without windows classify as Business logic.
+
+For Web / SPA projects, route definitions, layout shells, and shared
+component libraries classify as UI surface. API route handlers without
+rendering classify as Business logic; if they expose schema visible to a
+human (OpenAPI specs, error responses), bump to External binding.
+
+## Non-Goals
+
+- This taxonomy does not pick the runner. That is `runner-detection.md`.
+- This taxonomy does not regenerate snapshots. Visual regression is FAIL,
+  not auto-update.
+- This taxonomy does not enumerate every file pattern; it gives enough
+  signal for the agent to classify confidently.

--- a/.claude/skills/gwt-verify/references/test-matrix.md
+++ b/.claude/skills/gwt-verify/references/test-matrix.md
@@ -1,54 +1,97 @@
-# Surface → Test Matrix (canonical)
+# Test Matrix (worked example for the gwt repo)
 
-This is the single source of truth for `gwt-verify` surface classification.
-The skill must not invoke Playwright for any row whose "Browser (Playwright)"
-column is empty — that contract comes from SPEC-1935 FR-124 and was reinforced
-by the user during the gwt-discussion that produced Phase 17.
+`gwt-verify` is project-agnostic. The canonical surface classification
+lives in `surface-taxonomy.md` and the manifest-to-runner mapping lives
+in `runner-detection.md`. This file documents the **gwt repository's
+own** specialization of that contract as a worked example. Other
+projects (Unity, .NET, Python, Go, Java, …) should document their own
+matrix in their project AGENTS.md / README and rely on the generic
+contract here as a fallback frame.
 
-## Matrix
+When agents run `gwt-verify` inside the gwt repository, this matrix is
+the project-specific recipe.
 
-| Surface (changed path pattern) | Non-browser execution | Browser (Playwright) |
-|---|---|---|
-| `crates/*/src/**`, `crates/*/tests/**` | `cargo test -p <crate>`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt -- --check` | — |
-| `crates/gwt/src/bin/gwtd*`, `crates/gwt/src/bin/gwt*` | cargo (as above) + bin smoke (`cargo run -p gwt --bin gwtd -- --version`) | — |
-| `crates/gwt/web/**/*.js` (logic only — no UI surface) | `pnpm test:frontend-bundle`, `pnpm test:frontend-unit`, `pnpm test:frontend-smoke` | — |
-| `crates/gwt/web/**` (UI / CSS / HTML / theme assets) | as above | `pnpm test:visual` |
-| `crates/gwt/playwright/**` | — | `pnpm test:visual` |
-| `scripts/check-release-flow.sh`, `scripts/test_release_assets.cjs`, release scripts | `pnpm test:release-flow`, `pnpm test:release-assets` | — |
-| `.claude/skills/**`, `.codex/skills/**`, `crates/gwt-skills/**` | `pnpm lint:skills`, `cargo test -p gwt-skills` | — |
-| `AGENTS.md`, `CLAUDE.md`, `README*.md`, `docs/**` | `markdownlint` (when available) | — |
+## Project: gwt repo (Rust workspace + pnpm-driven WebView frontend)
 
-## Selection Rules
+### Detected runners
 
-1. **Multiple surfaces match** — run the union of all matched commands. Skip
-   duplicates (e.g. only run `cargo clippy --all-targets` once per invocation).
-2. **Browser column is empty → do not invoke Playwright.** This is the user's
-   strong constraint: ブラウザ起動前提のシステムだけが Playwright 対象.
+- `Cargo.toml` workspace at the repo root → `cargo test`,
+  `cargo clippy --all-targets --all-features -- -D warnings`,
+  `cargo fmt -- --check`.
+- `package.json` at `crates/gwt/web/` (and root) → `pnpm` scripts
+  including `test:frontend-bundle`, `test:frontend-unit`,
+  `test:frontend-smoke`, `test:visual`, `test:release-flow`,
+  `test:release-assets`, `lint:skills`.
+- `crates/gwt/playwright/playwright.config.ts` → Playwright project
+  for WebView visual / interaction tests.
+
+### Surface → Command matrix (gwt repo specialization)
+
+| Surface (changed path pattern) | Non-browser execution | Browser (Playwright) | User Check |
+|---|---|---|---|
+| `crates/*/src/**`, `crates/*/tests/**` | `cargo test -p <crate>`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt -- --check` | — | Recommended (business logic) |
+| `crates/gwt/src/bin/gwtd*`, `crates/gwt/src/bin/gwt*` | cargo (as above) + bin smoke (`cargo run -p gwt --bin gwtd -- --version`) | — | Required (interactive CLI) |
+| `crates/gwt/web/**/*.js` (logic only — no UI surface) | `pnpm test:frontend-bundle`, `pnpm test:frontend-unit`, `pnpm test:frontend-smoke` | — | Recommended (business logic) |
+| `crates/gwt/web/**` (UI / CSS / HTML / theme assets) | as above | `pnpm test:visual` | **Required** (UI surface) |
+| `crates/gwt/playwright/**` | — | `pnpm test:visual` | **Required** (UI surface) |
+| `scripts/check-release-flow.sh`, `scripts/test_release_assets.cjs`, release scripts | `pnpm test:release-flow`, `pnpm test:release-assets` | — | **Required** (Build / Release pipeline) |
+| `.claude/skills/**`, `.codex/skills/**`, `crates/gwt-skills/**` | `pnpm lint:skills`, `cargo test -p gwt-skills` | — | Recommended (skill asset) |
+| `AGENTS.md`, `CLAUDE.md`, `README*.md`, `docs/**` | `markdownlint` (when available) | — | Skipped(docs-only) |
+
+### Selection Rules (gwt repo)
+
+1. **Multiple surfaces match** — run the union of all matched commands.
+   Skip duplicates (e.g. only run `cargo clippy --all-targets` once per
+   invocation).
+2. **Browser column is empty → do not invoke Playwright.** This is the
+   strong constraint inherited from SPEC-1935 FR-124: only WebView /
+   browser UI surfaces are eligible for Playwright. The same rule applies
+   to any other UI runner (Cypress / Selenium / WinAppDriver) in
+   future-arriving projects.
 3. **`crates/gwt/web/**` ambiguity** — if any of `*.html`, `*.css`,
-   `theme-*.js`, or visible UI assets changed, treat the surface as "UI / CSS
-   / HTML" and include `pnpm test:visual`. If only non-visual JS logic
-   changed, exclude `pnpm test:visual`.
-4. **`docs/**` only** — markdownlint is non-blocking when markdownlint is
-   absent on the system; the evidence bundle records this as `skipped:
-   markdownlint-not-installed`.
+   `theme-*.js`, or visible UI assets changed, treat the surface as
+   "UI / CSS / HTML" and include `pnpm test:visual`. If only non-visual
+   JS logic changed, exclude `pnpm test:visual`.
+4. **`docs/**` only** — markdownlint is non-blocking when markdownlint
+   is absent on the system; the evidence bundle records this as
+   `skipped: markdownlint-not-installed`.
 5. **No changed files** — evidence bundle is `Overall: PASS` with
-   `Changed surfaces: (none)` and no executed commands. The caller decides
-   whether that means "nothing to verify" or "baseline drift".
+   `Changed surfaces: (none)` and no executed commands. User
+   Verification is `skipped(no-change)`. The caller decides whether
+   that means "nothing to verify" or "baseline drift".
 
-## Mode → Subset
+### Mode → Subset (gwt repo)
 
 | Mode | Behavior |
 |---|---|
-| `quick` | Run the narrowest representative command per matched surface (e.g. `cargo test -p <single crate>`, `pnpm test:frontend-unit` only — skip bundle/smoke). Skip Playwright entirely unless the working tree explicitly carries a `.spec.ts` change under `crates/gwt/playwright/tests/**`. |
-| `full` | Run the full matched list per surface, including `pnpm test:visual` headless when the Browser column is non-empty. |
-| `pre-pr` | `full` plus release-flow tests whenever any release-system file is in the baseline diff. Visual regression is always included if any UI surface changed (no `quick` fallback). |
+| `quick` | Run the narrowest representative command per matched surface (e.g. `cargo test -p <single crate>`, `pnpm test:frontend-unit` only — skip bundle/smoke). Skip Playwright entirely unless the working tree explicitly carries a `.spec.ts` change under `crates/gwt/playwright/tests/**`. User Verification is `skipped(quick-mode)`. |
+| `full` | Run the full matched list per surface, including `pnpm test:visual` headless when the Browser column is non-empty. User Verification is required for Required surfaces. |
+| `pre-pr` | `full` plus release-flow tests whenever any release-system file is in the baseline diff. Visual regression is always included if any UI surface changed (no `quick` fallback). User Verification is required for Required surfaces. |
 | `--headed` | When a matched command would invoke Playwright, run it with `pnpm test:visual --headed` so Chromium starts headed. Default is headless to match CI. |
 
-## Non-Goals
+### Non-Goals (gwt repo)
 
 - `gwt-verify` does **not** mutate snapshots. Snapshot baseline updates
   remain a manual `pnpm test:visual --update-snapshots` step outside the
   skill (caller must run it explicitly with intent).
 - `gwt-verify` does **not** chase external CI. The skill answers "is the
-  local workspace in a verifiable state right now?" — CI verdicts are still
-  the responsibility of `gwt-manage-pr`.
+  local workspace in a verifiable state right now?" — CI verdicts are
+  still the responsibility of `gwt-manage-pr`.
+
+## Adapting this matrix for another project
+
+The matrix above is the gwt repo's specialization. To bring `gwt-verify`
+to a different project type, document a similar matrix in that project's
+AGENTS.md / README that:
+
+1. Lists the project's detected runners (per `runner-detection.md`).
+2. Maps each `surface-taxonomy.md` surface to the runner commands that
+   exercise it.
+3. Marks the User Check tier per surface (Required / Recommended /
+   Skipped).
+4. Describes mode-specific subsets if the project benefits from
+   `quick` vs `full` vs `pre-pr` narrowing.
+
+The skill follows the project's matrix when present; otherwise it
+relies on `surface-taxonomy.md` + `runner-detection.md` as the
+fallback frame.

--- a/.claude/skills/gwt-verify/references/tooling-bootstrap.md
+++ b/.claude/skills/gwt-verify/references/tooling-bootstrap.md
@@ -1,40 +1,64 @@
-# Tooling Bootstrap
+# Tooling Bootstrap (project-agnostic)
 
-`gwt-verify` checks for required tooling before running the selected
-commands. Missing tools follow a bounded auto-install path. When the
-auto-install path is exhausted, the skill records `failed: tooling-missing`
-in the evidence bundle and the caller (typically `gwt-build-spec` Phase 3)
-treats that as a hard completion blocker.
+`gwt-verify` checks that the test runners chosen via `runner-detection.md`
+are actually installed before invoking them. When a runner is missing, the
+skill follows a bounded best-effort auto-install path. If the auto-install
+path is exhausted, the skill records `failed: tooling-missing: <component>`
+in the evidence bundle. Callers (`gwt-build-spec` Phase 3,
+`gwt-manage-pr` Pre-PR) treat that as a hard completion blocker.
 
-## Auto-install Contract
+This contract is the same regardless of project language. The auto-install
+attempts and detection heuristics differ per runner but the *shape* of the
+contract (single attempt, no sudo, no OS package managers, deterministic
+failure mode) is identical.
 
-| Missing | Auto-install attempt | On failure |
-|---|---|---|
-| `pnpm` not on PATH | `corepack enable pnpm` | `failed: tooling-missing: pnpm` |
-| `node_modules` absent or stale | `pnpm install --frozen-lockfile` | `failed: tooling-missing: node_modules` |
-| Playwright Chromium browser absent | `pnpm exec playwright install --with-deps chromium` | `failed: tooling-missing: playwright-chromium` |
-| `cargo` not on PATH | — (pre-existing project requirement) | `failed: tooling-missing: cargo` |
-| `git` not on PATH or repo not initialized | — | `failed: tooling-missing: git` |
-| `markdownlint` not installed (for docs-only runs) | — | `skipped: markdownlint-not-installed` (non-blocking) |
+## Auto-install Contract (per runner family)
+
+The skill attempts the install paths in the rightmost column at most once
+per invocation. On failure, `failed: tooling-missing: <component>` is
+recorded. The component name should be the canonical runner identifier so
+callers can react.
+
+| Runner family | Missing tool detection | Best-effort install attempt | On failure |
+|---|---|---|---|
+| Node-based (npm / pnpm / yarn scripts) | `command -v <pm>` fails; or `node_modules` is absent | For pnpm: `corepack enable pnpm` then `pnpm install --frozen-lockfile`. For yarn: `corepack enable yarn` then `yarn install --frozen-lockfile`. For npm: `npm ci`. | `failed: tooling-missing: <pm>` or `<pm>-dependencies` |
+| Browser UI runner (Playwright / Cypress / WebDriver-based) | Runner CLI present but browsers / drivers absent | Playwright: `pnpm exec playwright install --with-deps <browser>`. Cypress: `pnpm exec cypress install`. WebDriver: rely on the project's own setup script if present. | `failed: tooling-missing: <runner>-browsers` |
+| Rust (`cargo`) | `command -v cargo` fails | — (not auto-installed; this is a developer environment requirement) | `failed: tooling-missing: cargo` |
+| Python (`pytest`, `tox`, runner declared in `pyproject.toml`) | `python -c "import <runner>"` fails | When a `requirements*.txt` / `pyproject.toml` declares dev dependencies, attempt `python -m pip install -r requirements-dev.txt` *only when running inside an active virtualenv*. Never install into a non-venv interpreter. | `failed: tooling-missing: <runner>` |
+| Go (`go test`) | `command -v go` fails | — | `failed: tooling-missing: go` |
+| .NET (`dotnet test`) | `command -v dotnet` fails, or `dotnet --list-sdks` is empty | — | `failed: tooling-missing: dotnet-sdk` |
+| Unity Editor batch runner | The detected Unity Editor executable is missing or version mismatch with `ProjectSettings/ProjectVersion.txt` | — (Unity Editor is provisioned out-of-band) | `failed: tooling-missing: unity-editor-<version>` |
+| Ruby (`bundle exec rspec`) | `command -v bundle` fails | — | `failed: tooling-missing: bundler` |
+| Java / Kotlin (`mvn` / `gradle`) | `command -v mvn` / `command -v gradle` fails | — | `failed: tooling-missing: maven` / `gradle` |
+| Lint / docs (`markdownlint`, etc.) | `command -v markdownlint` fails | — | `skipped: markdownlint-not-installed` (non-blocking) |
+| `git` | `git rev-parse --show-toplevel` fails | — | `failed: tooling-missing: git` |
 
 ## Guardrails
 
 - **No sudo.** The skill must not invoke `sudo` or any privilege escalation.
 - **No OS package managers.** Do not call `apt`, `brew`, `pacman`,
-  `dnf`, `pkg`, `pip`, `choco`, `winget`. The contract is limited to
-  `corepack`, `pnpm install`, and `pnpm exec playwright install`.
-- **No global mutations.** Installations target the worktree (`node_modules`,
-  Playwright cache under `~/.cache/ms-playwright` / `~/Library/Caches/ms-playwright`)
-  and must not modify other repositories.
-- **Cache reuse.** When the Playwright cache already contains the needed
-  Chromium build, the skill must reuse it instead of forcing a reinstall.
+  `dnf`, `pkg`, `pip` (outside an active virtualenv), `choco`, `winget`.
+- **No global mutations.** Installations target the worktree
+  (`node_modules`, `Pipfile.lock`-managed venvs, browser caches under
+  the standard per-user cache directories) and must not modify other
+  repositories.
+- **Cache reuse.** When the runner's browser / driver / package cache
+  already contains the needed version, the skill reuses it instead of
+  forcing a reinstall.
 - **No retries.** Each auto-install attempt runs at most once per
   `gwt-verify` invocation. Repeated transient failures escalate to
   `failed: tooling-missing`.
+- **Project wrapper precedence.** When the project ships its own setup
+  wrapper (`make setup`, `scripts/bootstrap.sh`, `bin/setup`,
+  `package.json` `scripts.bootstrap`), prefer it over invoking the
+  runner-specific install path.
 
 ## Evidence Bundle Shape on Failure
 
-When `failed: tooling-missing` is produced, the evidence bundle MUST include:
+When `failed: tooling-missing` is produced, the evidence bundle MUST
+include the per-attempt status so the caller can distinguish "the
+project's tests are broken" from "the local environment isn't ready to
+run any tests at all":
 
 ```text
 Tooling installed during run:
@@ -44,30 +68,33 @@ Overall: FAIL
 failed: tooling-missing: <component>
 ```
 
-So that the caller can distinguish "the project's tests are broken" from
-"the local environment isn't ready to run any tests at all".
-
-## Detection Heuristics
+## Detection Heuristics (recap)
 
 | Tool | Detection |
 |---|---|
-| `pnpm` | `command -v pnpm` succeeds and `pnpm --version` returns a string. |
-| `node_modules` | `package.json` exists AND `.pnpm-lock-hash` (if present) matches the lockfile, OR a marker file under `node_modules/.modules.yaml` matches the lockfile hash. Heuristic — when in doubt, run `pnpm install --frozen-lockfile` (idempotent when already satisfied). |
-| Playwright Chromium | `pnpm exec playwright --version` succeeds AND the Chromium revision listed in the Playwright version's bundled `browsers.json` is present under the OS-specific Playwright cache. Heuristic — when in doubt, run `pnpm exec playwright install --with-deps chromium --dry-run` and look for "browsers already installed". |
-| `cargo` | `command -v cargo` succeeds. |
+| `pnpm` / `npm` / `yarn` | `command -v <pm>` succeeds and `<pm> --version` returns a string. |
+| Node `node_modules` | `package.json` exists AND a marker file (`node_modules/.modules.yaml` for pnpm, `node_modules/.package-lock.json` for npm, `.yarn/install-state.gz` for yarn) matches the lockfile. When in doubt, run the project's frozen-lockfile install (idempotent). |
+| Playwright browsers | `pnpm exec playwright --version` succeeds AND the bundled `browsers.json` version matches the cache under `~/.cache/ms-playwright` / `~/Library/Caches/ms-playwright` / `%LOCALAPPDATA%\\ms-playwright`. When in doubt, dry-run `pnpm exec playwright install --with-deps <browser> --dry-run`. |
+| Cypress browsers | `pnpm exec cypress info` succeeds and lists at least one browser. |
+| `cargo` / `rustc` | `command -v cargo` succeeds. |
+| `python` runner libraries | `python -c "import <runner>"` succeeds inside the project's interpreter. |
+| `go` | `command -v go` and `go version` succeed. |
+| `dotnet` | `command -v dotnet` and `dotnet --list-sdks` returns ≥ 1 line. |
+| Unity Editor | The path resolved by the project's `ProjectSettings/ProjectVersion.txt` exists and reports the expected version when run with `-version`. |
 | `git` | `git rev-parse --show-toplevel` succeeds inside the worktree. |
 | `markdownlint` | `command -v markdownlint` (or `npx markdownlint --version`) succeeds. |
 
 ## Container / CI Notes
 
-In container environments where the Playwright Chromium cache may be
-pre-baked, the detection heuristic for "browsers already installed" is the
-primary path; the auto-install attempt should short-circuit immediately when
-the dry-run shows everything present.
+In container environments where caches may be pre-baked (Playwright
+browsers, `node_modules`, `~/.cargo`, Go module cache, Unity Editor
+install), the detection heuristics above are the primary path; the
+auto-install attempts should short-circuit immediately when the dry-run
+shows everything is present.
 
-If the environment is hermetic (no internet), the auto-install attempts will
-fail fast and the skill records `failed: tooling-missing` with the network
-error preserved verbatim in the evidence bundle. The caller may either:
+If the environment is hermetic (no internet), the auto-install attempts
+fail fast and the skill records `failed: tooling-missing` with the
+network error preserved verbatim. The caller may either:
 
 - Treat it as a hard block (default behavior in `gwt-build-spec` Phase 3).
 - Override with an explicit `gwtd build abort --reason ...` and have the

--- a/.claude/skills/gwt-verify/references/user-verification-guide.md
+++ b/.claude/skills/gwt-verify/references/user-verification-guide.md
@@ -1,0 +1,162 @@
+# User Verification Guide (4-step 導線 + Check Items)
+
+After automated tests pass, `gwt-verify` hands off to the user for manual
+confirmation when `--mode full` or `--mode pre-pr` is active and the
+changed surfaces include any `Required` or `Recommended` user-check
+entries (per `surface-taxonomy.md`).
+
+The handoff has two halves:
+
+1. **導線** — a fixed 4-step path that walks the user from a clean state
+   to the changed feature.
+2. **Check Items** — a checklist with three required categories of things
+   to verify.
+
+## The 4-step 導線
+
+The 4 steps are **always present and always in this order**, regardless of
+project type:
+
+| # | Label    | What it contains | Examples by project type |
+|---|----------|------------------|---|
+| 1 | **build**    | The project's smallest build command that exercises the change. Skip if the project does not require a build step. | Rust: `cargo build -p <crate>`. Node: `pnpm build` or `pnpm dev` if hot-reload covers the change. Unity: Unity Editor batch build, or "Open Unity Editor and load project" when no headless build exists. .NET: `dotnet build <Solution.sln>`. Python: skip when the script runs directly. Go: `go build ./...`. Mobile: `flutter build apk --debug` / `xcodebuild -scheme <app>`. |
+| 2 | **launch**   | How to start the running artifact. | Rust CLI: `./target/debug/<bin>`. Web/WebView: launch the application server and surface the URL line (e.g., `gwt browser URL: http://127.0.0.1:<port>/`); confirm HTTP 200 with `curl -fsS -I <URL>` before sharing. Unity: Press Play in the Editor on `<Scene>.unity`. .NET: `dotnet run --project <Project>` or launch the built exe. Python service: `python -m <module>` or `uvicorn app:main --reload`. Mobile: open simulator and install the build. Long-running daemon: `<bin> --serve` and tail its log. |
+| 3 | **navigate** | The user-visible steps from launch to the changed feature. | "Click Logs in the top bar → select Process chip → choose `gh`." "Run `<cli> issue spec list --spec 1935` and read the output." "In Unity Editor, open `Hierarchy → MainCanvas → ReleaseNotesWindow`." "In the running .NET app, open menu `Help → About` then close → reopen." |
+| 4 | **observe**  | Exactly what the user should look at, click, or interact with to confirm. | "Verify only `gh`-tagged log lines appear in the table." "Confirm `Closed:` field matches Issue state." "Verify the release-notes window snaps to the top-right and survives a `Ctrl+R` reload." "Confirm the About dialog's version string matches `package.json`." |
+
+Rules:
+
+- Use concrete commands, file paths, and UI affordance names that exist
+  in **this** project. Do not invent paths.
+- Always tell the user what HTTP / WS URL or local port to open when the
+  app is a server; confirm reachability (`curl -fsS -I`) before sharing.
+- Each step is one bullet or short sentence. If a step needs more than 2
+  sentences, the navigation step list is too long — split into
+  sub-bullets but keep the four parent labels.
+- When the project's AGENTS.md / README describes a project-specific
+  launch ritual (e.g., the gwt repo's `gwt browser URL` line at
+  `AGENTS.md` L187), reuse that ritual verbatim.
+
+## Check Items (three required categories)
+
+Every User Verification handoff must include **at least one** check item
+in each of these three categories:
+
+1. **Expected — the representative happy path.** What the change is
+   supposed to do, stated as the user would notice it.
+2. **Edge case / failure handling.** What the user should look at to
+   confirm a boundary, empty input, error response, or unusual size /
+   environment is handled correctly. Pick the most plausible failure
+   mode for this change.
+3. **Adjacent feature regression sanity.** A nearby feature the user
+   should briefly try to confirm nothing else broke. For UI changes,
+   this is usually a sibling screen or widget; for CLI, an adjacent
+   subcommand; for release pipeline, the previously-released artifact's
+   smoke test.
+
+Format each item as a Markdown checkbox so the user can tick it off:
+
+```markdown
+- [ ] Expected: <one-line description of expected behavior>
+- [ ] Edge: <one-line description of edge case to confirm>
+- [ ] Regression: <one-line description of adjacent feature sanity>
+```
+
+You may add more items beyond the three categories, but never fewer.
+
+## Selection question
+
+Ask the user via the platform's selection question tool
+(`AskUserQuestionTool` for Claude Code, `request_user_input` for Codex,
+the closest equivalent for other runtimes) with these three options:
+
+| Label | Effect on `User Verification Result` |
+|---|---|
+| `Confirmed` | `confirmed` — `Overall: PASS` (provided automated tests also passed) |
+| `Rejected(<reason>)` | `rejected(<reason>)` — `Overall: FAIL`; caller routes back to TDD loop or `gwt-discussion` |
+| `Skip with reason(<reason>)` | `skipped(<reason>)` — `Overall: PASS` is allowed but the skip reason is preserved in the evidence bundle for traceability |
+
+When no selection UI is available, ask the same three options in plain
+text and parse the user's free-form reply into one of the three states.
+
+## Rejection escalation
+
+When the user selects `Rejected`:
+
+1. Preserve the user's free-text reason in the evidence bundle's
+   `User Verification Result: rejected(<reason>)` line.
+2. The caller (`gwt-build-spec` Phase 3 / `gwt-manage-pr` Pre-PR) treats
+   this as `Overall: FAIL` and does not advance.
+3. If the rejection points at a spec / design gap rather than an
+   implementation bug, route to `gwt-discussion` to renegotiate scope.
+   Otherwise return to the TDD Red → Green → Refactor loop.
+
+## Skip rules
+
+The handoff is **automatically skipped** (no user prompt) when:
+
+- `--mode quick` is in effect (TDD mid-iteration).
+- `Changed surfaces: (none)` — nothing to verify.
+- All changed surfaces are `docs-only` per `surface-taxonomy.md`.
+- The caller passed `--skip-user-check` for an explicit non-interactive
+  run.
+
+In every skip case, the reason is recorded as
+`User Verification: skipped(<reason>)` so reviewers can audit why no user
+confirmation was requested.
+
+## Worked examples
+
+### Example A — gwt repo, Logs window filter changes
+
+```text
+User Verification: required
+Surfaces requiring user check: UI surface
+
+導線 (How to access):
+1. build:     cargo build -p gwt --bin gwt
+2. launch:    ./target/debug/gwt — note the published `gwt browser URL: http://127.0.0.1:<port>/` and confirm 200 with `curl -fsS -I <URL>`
+3. navigate:  Open the URL in a browser → click `Logs` in the top bar → choose `gh` from the Process chip filter
+4. observe:   Only `gh`-tagged lines should appear; non-`gh` processes are hidden
+
+Check Items:
+- [ ] Expected: `gh`-tagged lines are visible; other process lines are hidden
+- [ ] Edge: selecting "All" restores the unfiltered view without a reload
+- [ ] Regression: the adjacent "Severity" filter still filters as before
+```
+
+### Example B — Unity package, in-game settings menu
+
+```text
+User Verification: required
+Surfaces requiring user check: UI surface
+
+導線 (How to access):
+1. build:     Open Unity Editor on the project (no headless build required)
+2. launch:    Press Play on `Assets/Scenes/Main.unity`
+3. navigate:  In the running scene, open menu `Pause → Settings → Display`
+4. observe:   The new `Render Scale` slider appears under `Quality` and reflects the saved value
+
+Check Items:
+- [ ] Expected: slider moves smoothly and updates the runtime render scale
+- [ ] Edge: setting the slider to 0.5 and quitting Play mode persists the value across reloads
+- [ ] Regression: the existing `Master Volume` slider beside it still functions
+```
+
+### Example C — .NET WPF desktop application
+
+```text
+User Verification: required
+Surfaces requiring user check: UI surface
+
+導線 (How to access):
+1. build:     dotnet build src/App/App.csproj
+2. launch:    dotnet run --project src/App/App.csproj
+3. navigate:  In the running app, click `Help → About`
+4. observe:   The About dialog now lists the new `Build SHA` field below `Version`
+
+Check Items:
+- [ ] Expected: `Build SHA` shows the current commit short hash
+- [ ] Edge: closing and reopening the About dialog keeps the value (no flicker / blank state)
+- [ ] Regression: the existing `Check for updates` button still launches the update flow
+```

--- a/.codex/skills/gwt-build-spec/SKILL.md
+++ b/.codex/skills/gwt-build-spec/SKILL.md
@@ -139,21 +139,28 @@ All other changes require the TDD loop.
 ## Phase 3: Verification
 
 Delegate environment-aware verification to `gwt-verify --mode full`. The
-sub-skill classifies the changed surfaces per
-`.codex/skills/gwt-verify/references/test-matrix.md`, runs the appropriate
-matrix per surface (cargo for Rust crates, `pnpm test:frontend-*` for frontend
-JS, `pnpm test:visual` only for WebView/browser UI surfaces, `pnpm
-test:release-*` only for release-system changes, `pnpm lint:skills` for skill
-asset changes), and returns an evidence bundle in `## Verification Report`
-form. Do not hard-code a static cargo command list here — the right matrix is
-determined by what actually changed.
+sub-skill is a project-agnostic Generic Verification Contract: it classifies
+the changed surfaces against `.codex/skills/gwt-verify/references/surface-taxonomy.md`,
+detects the host project's actual test runners from manifests
+(Cargo.toml / package.json / pyproject.toml / go.mod / ProjectSettings /
+*.sln / etc.) per `.codex/skills/gwt-verify/references/runner-detection.md`,
+runs the appropriate unit / integration / E2E / visual tests, emits a
+**Test Inventory** that names which tests were executed, and hands off to
+the user via a 4-step 導線 + Check Items before finalizing
+`## Verification Report`. The right matrix is determined by what actually
+changed and which runners the project ships; do not hard-code a static
+cargo / pnpm / Playwright command list here.
 
-The skill is considered green when:
+The skill is considered green when **all** of the following hold:
 
 - `gwt-verify --mode full` exits with `Overall: PASS`
 - the evidence bundle records no `failed: tooling-missing` entry
-- no Playwright snapshot diff is unresolved (visual regression must be
+- no visual / UI snapshot diff is unresolved (visual regression must be
   triaged before declaring PASS, not silently regenerated)
+- `User Verification Result` is one of `confirmed`, `n/a`, or
+  `skipped(<reason>)`. `pending` is not acceptable; `rejected(<reason>)`
+  forces `Overall: FAIL` and the implementation returns to Phase 2 (TDD
+  loop). The user's reason is preserved in the evidence bundle.
 
 In SPEC mode, also verify:
 

--- a/.codex/skills/gwt-build-spec/references/completion-gate.md
+++ b/.codex/skills/gwt-build-spec/references/completion-gate.md
@@ -37,16 +37,25 @@ In SPEC mode, it reconciles all artifacts. In standalone mode, it verifies user 
 ### 5. Code verification
 
 Delegate to `gwt-verify --mode full` and require `Overall: PASS` in the
-evidence bundle. The sub-skill picks the matrix per changed surface (see
-`.codex/skills/gwt-verify/references/test-matrix.md`) — cargo for Rust
-crates, `pnpm test:frontend-*` for frontend JS, `pnpm test:visual` for
-WebView/browser UI surfaces only (Playwright is not invoked for non-browser
-surfaces), `pnpm test:release-*` for release-system changes, and
-`pnpm lint:skills` for skill assets.
+evidence bundle. The sub-skill is project-agnostic: it autodetects the host
+project's test runners from manifests (Cargo.toml / package.json /
+pyproject.toml / go.mod / ProjectSettings / *.sln / etc.), runs the
+appropriate unit / integration / E2E / visual tests for each changed
+surface, emits a Test Inventory naming the executed tests, and hands off
+to the user with a 4-step 導線 + Check Items before finalizing the
+report. The matrix is determined by what actually changed and the
+runners the project ships, not by a hard-coded cargo / pnpm / Playwright
+recipe. Project-local AGENTS.md / README instructions always take
+precedence over the generic matrix.
 
-If `gwt-verify` returns `Overall: FAIL` or `failed: tooling-missing`, the
-gate fails. Do not declare completion. Route the failure for repair per
-the failure-handling section below.
+The gate **fails** when any of:
+
+- `gwt-verify` returns `Overall: FAIL`
+- `failed: tooling-missing` is recorded
+- `User Verification Result` is `pending` (handoff never completed) or
+  `rejected(<reason>)` (user declined). The user's reason is preserved
+  in the evidence bundle; route the failure for repair per the
+  failure-handling section below.
 
 ## Standalone mode checks
 

--- a/.codex/skills/gwt-manage-pr/SKILL.md
+++ b/.codex/skills/gwt-manage-pr/SKILL.md
@@ -127,19 +127,30 @@ impossible.**
 
 Before any push, PR create, or PR update operation, invoke
 `gwt-verify --mode pre-pr` and require `Overall: PASS` in the evidence
-bundle. This guarantees the right test matrix has run for the changed
-surfaces — cargo for Rust crates, `pnpm test:frontend-*` for frontend JS,
-`pnpm test:visual` for WebView/browser UI surfaces only (Playwright is not
-invoked for non-browser surfaces), `pnpm test:release-*` for release-system
-changes, and `pnpm lint:skills` for skill assets.
+bundle. `gwt-verify` is a project-agnostic Generic Verification Contract:
+it autodetects the host project's test runners (Cargo.toml /
+package.json / pyproject.toml / go.mod / ProjectSettings / *.sln / etc.),
+runs the appropriate unit / integration / E2E / visual tests for the
+changed surfaces, emits a Test Inventory naming exactly which tests
+were executed, and hands off to the user with a 4-step 導線 + Check
+Items before finalizing the report. Project-local AGENTS.md / README
+testing instructions always take precedence over the generic matrix.
 
-If `gwt-verify --mode pre-pr` returns `Overall: FAIL` or
-`failed: tooling-missing`, do not push, do not create a PR, and do not
-update an existing PR. Route the failure for repair (back to the TDD loop
-or `gwt-discussion`) and re-run pre-pr verification before retrying.
+The push / PR-write gate **fails** when any of:
+
+- `gwt-verify --mode pre-pr` returns `Overall: FAIL`
+- `failed: tooling-missing` is recorded
+- `User Verification Result` is `pending` (handoff never completed) or
+  `rejected(<reason>)` (user declined). The user's reason is preserved
+  in the evidence bundle.
+
+On failure, do not push, do not create a PR, and do not update an
+existing PR. Route the failure for repair (back to the TDD loop or
+`gwt-discussion`) and re-run pre-pr verification before retrying.
 
 This applies equally to Create and Fix modes — every code-changing
-re-push must be preceded by a fresh `gwt-verify --mode pre-pr` PASS.
+re-push must be preceded by a fresh `gwt-verify --mode pre-pr` PASS
+with a satisfied `User Verification Result`.
 
 ## Mode: Create
 

--- a/.codex/skills/gwt-verify/SKILL.md
+++ b/.codex/skills/gwt-verify/SKILL.md
@@ -1,59 +1,113 @@
 ---
 name: gwt-verify
-description: "Use when implementation work needs verification before completion or before opening a PR. Selects the correct test matrix per changed surface (cargo for Rust crates, pnpm for frontend JS, Playwright only for WebView/browser UI, release scripts only for release-system changes) and runs them with evidence-bundle output. Triggers: 'verify', 'run tests', 'pre-PR check', 'gwt-verify'."
+description: "Use when implementation needs verification before completion or before opening a PR. Defines a project-agnostic Generic Verification Contract: classify changed surfaces, autodetect the project's test runners from manifests (Cargo.toml / package.json / pyproject.toml / go.mod / ProjectSettings / *.sln / etc.), run the appropriate unit / integration / E2E / visual tests for the project, emit an evidence bundle that lists exactly which tests were executed, then hand off to the user with a 4-step 導線 (build → launch → navigate → observe) and check items before declaring Overall: PASS. Triggers: 'verify', 'run tests', 'pre-PR check', 'gwt-verify'."
 ---
 
 # gwt-verify
 
-Environment-aware verification skill. Inspects the changed surfaces in the
-current worktree, selects the correct test matrix per surface, runs the
-selected commands, and returns an evidence bundle.
+Project-agnostic verification skill. `gwt-verify` is bundled into every gwt-managed
+worktree, including Rust, Node, Unity, Visual Studio / .NET, Python, Go, and any other
+project type gwt opens. It defines a **Generic Verification Contract** — what to verify,
+how to report, and how to involve the user — without hard-coding any particular test
+runner or build tool.
 
-This skill owns "verification time" for the gwt project. `gwt-build-spec`
-Phase 3 delegates to `gwt-verify --mode full`; `gwt-manage-pr` requires
-`gwt-verify --mode pre-pr` before opening or updating a PR; users may also
-invoke it directly through `/gwt:gwt-verify`.
+This skill owns "verification time" for the active project. `gwt-build-spec` Phase 3
+delegates to `gwt-verify --mode full`; `gwt-manage-pr` requires `gwt-verify --mode pre-pr`
+before opening or updating a PR; users may also invoke it directly through
+`/gwt:gwt-verify`.
 
-Playwright is invoked **only** for WebView/browser UI surfaces. Non-browser
-surfaces (Rust crates, the gwtd CLI, backend domain code, and release
-scripts) do not invoke Playwright — they each have their own dedicated
-execution path documented in `references/test-matrix.md`.
+## Contract overview
+
+`gwt-verify` is **project-agnostic**. It does not own a fixed cargo / pnpm /
+Playwright recipe. Instead it executes the following four-part contract:
+
+1. **Change Classification** — bucket changed files into abstract surfaces
+   (UI surface / interactive CLI / business logic / build-release pipeline /
+   docs / config / skill-asset / external-binding). See
+   `references/surface-taxonomy.md`.
+2. **Appropriate Test Selection** — detect the project's actual test runners
+   from its manifests (Cargo.toml, package.json, pyproject.toml, go.mod,
+   ProjectSettings/ProjectVersion.txt, *.sln / *.csproj, Gemfile, pom.xml,
+   build.gradle, Makefile) and choose the right unit / integration / E2E /
+   visual commands for each changed surface. See
+   `references/runner-detection.md`.
+3. **Test Inventory Emission** — extract the actual test names / scenarios /
+   suite paths from each runner's structured output and list them in the
+   evidence bundle so the user can see **what was tested**, not just a pass /
+   fail count.
+4. **User Verification Handoff** — after automated tests pass, present a
+   surface-specific checklist plus a 4-step 導線 ("How to access": build →
+   launch → navigate → observe) and ask the user to confirm or reject. See
+   `references/user-verification-guide.md`.
+
+Project-local rules always win. If the project root has an AGENTS.md / README
+section describing its own testing approach (e.g., "run `make verify`",
+"use Unity Editor batch mode test runner"), the agent follows that instead of
+the generic matrix in this skill. The matrix here is the fallback frame.
 
 ## Modes
 
 | Mode | When to use | Scope |
 |---|---|---|
-| `--mode quick` (default) | TDD loop, narrow check during implementation | Only the surface(s) touched by uncommitted/working-tree changes; minimum useful subset (e.g. single-crate `cargo test`, single-suite `pnpm test:frontend-unit`). |
-| `--mode full` | gwt-build-spec Phase 3, standalone completion gate | Full matrix per changed surface (cargo test/clippy/fmt, all relevant `pnpm test:frontend-*`, `pnpm test:visual` headless when UI surface changed, skill lint when skill assets changed). |
-| `--mode pre-pr` | gwt-manage-pr before PR create/update | `full` matrix + release-flow tests when release surface changed; visual regression always included for any UI surface. |
-| `--headed` (flag) | Manual UI/design verification | When supplied alongside any mode that runs Playwright, Chromium starts headed. Default is headless to match CI. |
+| `--mode quick` (default) | TDD loop, narrow check during implementation | Only surfaces touched by uncommitted / working-tree changes; the narrowest representative command per runner (e.g. single-package test invocation). Skip heavy integration / E2E / visual unless the diff explicitly touches them. |
+| `--mode full` | gwt-build-spec Phase 3, standalone completion gate | Full matched matrix per changed surface, including integration / E2E / visual when a UI surface changed. User Verification Handoff is required (see below). |
+| `--mode pre-pr` | gwt-manage-pr before PR create / update | `full` matrix + release-flow tests when a release surface changed; visual / UI regression always included if any UI surface changed. User Verification Handoff is required. |
+| `--headed` (flag) | Manual UI / design verification | When supplied alongside any mode that runs a browser-based test runner (Playwright / Cypress / Selenium / WinAppDriver / Unity Editor headed), launch the runner in headed mode so the user can watch. Default is headless to match CI. |
+
+Additional flag:
+
+- `--skip-user-check` — explicitly opt out of the User Verification Handoff
+  phase for non-interactive runs (CI smoke, automated regression sweeps).
+  Default is **off**; `--mode full` and `--mode pre-pr` require user
+  verification unless this flag is set. The reason is recorded in the
+  evidence bundle as `User Verification: skipped(--skip-user-check)`.
 
 ## Invocation Sequence
 
 ```text
-agent → /gwt:gwt-verify [--mode quick|full|pre-pr] [--headed]
+agent → /gwt:gwt-verify [--mode quick|full|pre-pr] [--headed] [--skip-user-check]
   ↓
 gwt-verify
-  1. Collect changed files via
+  1. Establish baseline:
        git diff --name-only $(git merge-base HEAD origin/develop)..HEAD
-     (fall back to origin/main when origin/develop is absent). For `--mode
-     quick` also include `git diff --name-only` (working tree).
-  2. Classify each path into a surface category using
-     references/test-matrix.md.
-  3. Apply mode-specific filtering (quick → minimum subset; full → all matched
-     commands; pre-pr → full + release-flow + always include visual when any
-     UI surface changed).
-  4. Tooling presence check: cargo, pnpm, node_modules, Playwright Chromium.
-     Missing entries follow references/tooling-bootstrap.md (auto-install
-     attempt, otherwise exit with `failed: tooling-missing`).
-  5. Run each selected command sequentially. Capture stdout/stderr and exit
-     code. For Playwright commands also start the GUI server per
-     references/playwright-runbook.md and inject `GWT_PLAYWRIGHT_BASE_URL`.
-  6. Emit the evidence bundle described below.
+     (fall back to origin/main when origin/develop is absent). For
+     `--mode quick` also include `git diff --name-only` (working tree).
+  2. Classify each path into an abstract surface using
+     `references/surface-taxonomy.md`.
+  3. Discover the project's test runners from its manifests using
+     `references/runner-detection.md` (Cargo.toml → cargo,
+     package.json → npm / pnpm / yarn scripts, pyproject.toml → pytest,
+     go.mod → go test, ProjectSettings/ProjectVersion.txt → Unity Editor
+     batch test runner, *.sln / *.csproj → dotnet test, Gemfile → rspec
+     / minitest, pom.xml / build.gradle → mvn / gradle test,
+     Makefile → make test targets). Multiple runners may coexist
+     (e.g. Cargo + pnpm).
+  4. Select appropriate test commands per changed surface. Record the
+     selection rationale in the evidence bundle's `Plan` section. Honor
+     project-local AGENTS.md / README testing instructions when present;
+     the generic matrix is the fallback.
+  5. Tooling presence check: verify each chosen runner / browser / editor
+     is installed. Missing entries follow `references/tooling-bootstrap.md`
+     (best-effort install attempt for runners with auto-install paths;
+     otherwise exit with `failed: tooling-missing`).
+  6. Run each selected command sequentially. Capture stdout / stderr /
+     exit code. For browser-based UI runners, bring up the application
+     server per `references/playwright-runbook.md` before invoking the
+     runner. When the runner supports a structured reporter (JSON / TAP /
+     list / JUnit XML), use it so test-level results can be extracted.
+  7. Extract a Test Inventory from each runner's output: test name,
+     describe block, scenario / snapshot title, lint rule name, etc.
+     If extraction fails for a runner, record
+     `(inventory unavailable: <reason>)` rather than silently degrading.
+  8. Emit the evidence bundle described below, then run the User
+     Verification Handoff phase (unless skipped per the rules above) and
+     finalize Overall once the user response is recorded.
 ```
 
-The skill does **not** invoke Playwright when no WebView/browser UI surface
-changed. This is a hard contract from SPEC-1935 FR-124.
+The skill does not invoke Playwright when no WebView / browser UI surface
+changed. This is a hard contract from SPEC-1935 FR-124. The same restraint
+applies to other UI runners (Cypress / Selenium / WinAppDriver / Unity Editor
+headed): they are only invoked when a UI surface is in scope.
 
 ## Evidence Bundle
 
@@ -61,24 +115,120 @@ Output to stdout in the following shape (Markdown):
 
 ```text
 ## Verification Report
+
 Mode: <quick|full|pre-pr>
 Baseline: merge-base HEAD..origin/develop (<N> commits, <M> files)
-Changed surfaces: <comma-separated list>
+Changed surfaces: <abstract surface list>
 
-Executed:
-- <command>: PASS|FAIL (<short detail, e.g., test count + duration>)
-
-Skipped / not-applicable:
+### Plan
+Detected runners: <e.g. Cargo, pnpm, Playwright | Unity Test Framework | dotnet test | pytest | go test>
+Selected commands per surface:
+- <surface>: <command> — <selection reason>
+Skipped (no matching surface or not applicable):
 - <command>: <reason>
+
+### Executed
+- <command>: PASS|FAIL (<short metric, e.g. test count + duration>)
+
+### Test Inventory
+<command>:
+- PASS  <suite> :: <test name / scenario>
+- FAIL  <suite> :: <test name>  -> <short failure>
+- SKIP  <suite> :: <test name>  -> <reason>
+(inventory unavailable: <reason>)  # when extraction failed for a runner
+
+### User Verification
+Status: required | recommended | skipped(<reason>)
+Surfaces requiring user check: <list>
+
+#### 導線 (How to access the changed behavior)
+1. build:     <project-specific build command>
+2. launch:    <how to start the app / open the editor / run the binary>
+3. navigate:  <how to reach the changed feature inside the running app>
+4. observe:   <what the user should look at / interact with>
+
+#### Check Items
+- [ ] <expected behavior — the representative happy path>
+- [ ] <edge case / failure handling — at least one>
+- [ ] <adjacent feature regression sanity — at least one>
+
+Expected: <one-line summary of the intended behavior>
+Observed: <user response slot>
+User Verification Result: pending | confirmed | rejected(<reason>) | n/a
 
 Headed verification: <yes|no>
 Tooling installed during run: <list, or "none">
+
 Overall: PASS|FAIL
 ```
 
-If any executed command fails, `Overall: FAIL` and the failing command's
-detail block is captured verbatim. `gwt-build-spec` treats `FAIL` and any
-`failed: tooling-missing` entry as a hard completion blocker.
+Rules:
+
+- `Overall: PASS` requires **both** every entry in `Executed` reporting `PASS`
+  **and** `User Verification Result ∈ {confirmed, n/a, skipped(<reason>)}`.
+  `pending` must never resolve to `PASS`.
+- If any executed command fails, `Overall: FAIL` and the failing command's
+  detail block is captured verbatim.
+- If the user rejects, `Overall: FAIL` and the reason is preserved.
+- `failed: tooling-missing` remains a hard completion blocker — callers
+  (`gwt-build-spec`, `gwt-manage-pr`) treat it as such.
+
+## Surface → User-Check Matrix (abstract)
+
+The matrix below is **abstract** so it applies to any project type. For
+project-specific specialization, see `references/surface-taxonomy.md`.
+
+| Abstract Surface | User Check | 導線 generation guidance |
+|---|---|---|
+| UI surface (visible markup / theme / layout / interactive controls) | **Required** | Launch the application using the project's normal launch path → present the entry point (URL / editor Play mode / GUI binary / TUI screen) → list the click / keystroke / navigation steps to reach the changed feature → describe what the user should look at. |
+| Interactive CLI / TUI surface | **Required** | Build the CLI → run a representative subcommand example → compare against expected output / screen state. |
+| Build / Release pipeline | **Required** | Generate the release artifact → manually unpack / install / launch it once → verify the artifact behaves as expected. |
+| Business logic (no observable surface) | **Recommended** | If there is any observable mouth (CLI, log, UI) where the change manifests, present that; otherwise mark as Optional. |
+| External binding / 3rd-party integration | **Recommended** | Show a representative outbound call and expected response shape. |
+| Skill asset / agent config | **Recommended** | Describe the trigger phrase or scenario that should activate the modified skill / agent, plus the expected effect. |
+| Docs / config-only (markdownlint clean) | **Skipped(docs-only)** | Automated checks are sufficient. |
+
+## User Verification Handoff (post-Executed)
+
+When `Overall` would otherwise be `PASS` (every `Executed` entry passed) and
+`--mode full` or `--mode pre-pr` is active and `--skip-user-check` was not
+supplied:
+
+1. Compute the `User Verification` block:
+   - `Status: required` if any changed surface is marked Required above.
+   - `Status: recommended` if only Recommended surfaces changed.
+   - `Status: skipped(<reason>)` for `--mode quick`, `Changed surfaces:
+     (none)`, docs-only changes, `--skip-user-check`, or any explicit
+     skip rule above. The reason must be human-readable and specific.
+2. Generate the 4-step 導線 ("How to access the changed behavior") using the
+   project's build / launch conventions. The structure is fixed across all
+   project types — **always exactly four labelled steps in this order**:
+   1. **build** — the project's build command for the smallest target that
+      exercises the change.
+   2. **launch** — how to start the running artifact (binary / server /
+      editor / interpreter / web page).
+   3. **navigate** — how to reach the changed feature from the entry point.
+   4. **observe** — what the user should look at, click, or interact with to
+      confirm the change.
+   See `references/user-verification-guide.md` for project-type-specific
+   launch patterns (Rust CLI / WebView / Unity Editor / .NET WPF / Python
+   service / generic TUI / long-running service).
+3. Produce a **Check Items** list with **three categories minimum**:
+   (1) expected happy-path behavior, (2) at least one edge case or failure
+   path, (3) at least one adjacent-feature regression sanity check.
+4. Ask the user via the platform's selection question tool
+   (`AskUserQuestionTool` for Claude Code, `request_user_input` for Codex,
+   the closest equivalent for other runtimes) to choose one of:
+   - `Confirmed` — observed behavior matches expectations; record
+     `User Verification Result: confirmed`.
+   - `Rejected(<reason>)` — observed behavior does not match; downgrade
+     `Overall: FAIL` and preserve the user's reason.
+   - `Skip with reason(<reason>)` — user defers verification with an
+     explicit justification; record `User Verification Result:
+     skipped(<reason>)`.
+
+If no selection UI exists in the current runtime, fall back to plain-text
+prompting but keep the same three-option discipline.
 
 ## Stop Conditions
 
@@ -88,12 +238,27 @@ Stop and surface a blocker to the caller when:
   cannot establish a baseline.
 - Tooling bootstrap exhausts auto-install options (see
   `references/tooling-bootstrap.md`) and emits `failed: tooling-missing`.
-- A required Playwright snapshot diff is non-zero in `--mode full` /
+- A required visual / UI snapshot diff is non-zero in `--mode full` /
   `--mode pre-pr` — agent must triage rather than silently regenerate
   snapshots.
-- The agent attempts to invoke Playwright for a surface not listed under the
-  "Browser (Playwright)" column of `references/test-matrix.md`. This is a
-  contract violation, not a runtime error.
+- The agent attempts to invoke Playwright (or any other browser UI runner)
+  for a surface not classified as a UI surface under
+  `references/surface-taxonomy.md`. This is a contract violation, not a
+  runtime error.
+- The User Verification phase is required but no platform question tool
+  and no plain-text channel are available to ask the user.
+
+## Project-local AGENTS.md takes precedence
+
+This skill is distributed into every gwt-managed worktree. The host project
+defines its own testing reality. When the project root holds an AGENTS.md /
+CLAUDE.md / README with a "ローカル検証" / "Testing" / "Verification" section,
+the agent must read those instructions and prefer them over the generic
+matrix in this skill. Use the generic matrix only to fill gaps.
+
+This mirrors the broader gwt rule: gwt's own AGENTS.md is project-local to
+the gwt repo, and any other project gwt opens has its own AGENTS.md as the
+authority.
 
 ## gwtd resolution
 
@@ -104,20 +269,33 @@ exists, stop with `gwtd not found`.
 
 ## References
 
-- `references/test-matrix.md` — canonical surface→execution-system table.
-- `references/playwright-runbook.md` — Chromium project selection, GUI
-  server bring-up, baseURL handoff, headed/headless toggling, snapshot
-  baseline policy.
-- `references/tooling-bootstrap.md` — pnpm / node_modules / Playwright
-  Chromium auto-install contract and `failed: tooling-missing` shape.
+- `references/surface-taxonomy.md` — abstract surface classification and
+  per-project path-pattern examples.
+- `references/runner-detection.md` — manifest → test-runner detection
+  table (Rust / Node / Python / Go / .NET / Unity / Ruby / Java / Make /
+  generic).
+- `references/user-verification-guide.md` — 4-step 導線 generation guide
+  with project-type-specific launch patterns and Check Items rules.
+- `references/test-matrix.md` — example matrix for the gwt repo itself,
+  referenced as a worked example of how to specialize the generic
+  contract.
+- `references/playwright-runbook.md` — operational details for browser /
+  WebView UI runners (Playwright is the canonical example; the same
+  pattern applies to Cypress / Selenium / WinAppDriver / Unity Editor
+  headed).
+- `references/tooling-bootstrap.md` — best-effort installer contract and
+  the `failed: tooling-missing` shape.
 
 ## Chain Suggestion
 
 On `Overall: PASS`, the caller proceeds:
 
-- `gwt-build-spec` Phase 3 → Phase 4 (PR Flow via `gwt-manage-pr`).
-- `gwt-manage-pr` → PR create/update.
-- Manual invocation → return evidence bundle to the user.
+- `gwt-build-spec` Phase 3 → Phase 4 (PR Flow via `gwt-manage-pr`), provided
+  `User Verification Result ∈ {confirmed, n/a, skipped(<reason>)}`.
+- `gwt-manage-pr` → PR create / update, provided the same User Verification
+  Result gate is satisfied.
+- Manual invocation → return the evidence bundle to the user.
 
-On `Overall: FAIL`, the caller stays in their current phase and routes the
-failure for repair (typically back into the TDD loop or `gwt-discussion`).
+On `Overall: FAIL` (including `User Verification Result: rejected(...)`),
+the caller stays in their current phase and routes the failure for repair
+(typically back into the TDD loop or `gwt-discussion`).

--- a/.codex/skills/gwt-verify/references/playwright-runbook.md
+++ b/.codex/skills/gwt-verify/references/playwright-runbook.md
@@ -1,32 +1,53 @@
-# Playwright Runbook
+# Browser / WebView UI Runner Runbook
 
-`gwt-verify` invokes Playwright **only** for WebView/browser UI surfaces (see
-`test-matrix.md`). This document covers the operational details required to
-run `pnpm test:visual` correctly in both headless (default) and headed
-(`--headed`) modes.
+`gwt-verify` invokes a browser-based UI runner **only** for WebView /
+browser UI surfaces (see `surface-taxonomy.md`). Playwright is the
+canonical example documented here; the same operational pattern applies
+to Cypress, Selenium WebDriver, WinAppDriver, and Unity Editor headed.
+For non-UI surfaces, this runbook does not apply — the runner is not
+invoked at all.
 
-## Project Layout
+The contract is the same regardless of the specific runner:
 
-The Playwright project lives under `crates/gwt/playwright/`:
+1. The application under test must be running and reachable before the
+   runner starts.
+2. The runner receives the application's base URL / executable path
+   through an environment variable agreed with the test harness.
+3. The runner runs **headless by default** (CI conditions). Headed mode
+   is opt-in via the `--headed` flag passed to `gwt-verify`.
+4. Snapshot or screenshot diffs are FAIL signals; the skill never
+   regenerates baselines silently.
 
-- `playwright.config.ts` — Chromium dark + Chromium light projects, snapshot
-  template `{snapshotDir}/{testFilePath}/{projectName}/{platform}/{arg}{ext}`.
-- `tests/*.spec.ts` — visual / interaction tests against the embedded gwt
-  frontend.
+## Project Layout (Playwright example, from the gwt repo)
+
+In the gwt repository, the Playwright project lives under
+`crates/gwt/playwright/`:
+
+- `playwright.config.ts` — Chromium dark + Chromium light projects,
+  snapshot template `{snapshotDir}/{testFilePath}/{projectName}/{platform}/{arg}{ext}`.
+- `tests/*.spec.ts` — visual / interaction tests against the embedded
+  gwt frontend.
 - `snapshots/` — committed baseline images.
-- `fixtures/` — WS server responses used by individual tests.
+- `fixtures/` — WebSocket server responses used by individual tests.
 
-## GUI Server Bring-up
+Other projects place their UI tests wherever their convention dictates
+(`tests/e2e/`, `cypress/e2e/`, `tests/playwright/`, `tests/integration/`,
+`Assets/Tests/PlayMode/` for Unity, `test/ui/` for .NET, etc.). The skill
+discovers the location through the project's runner-detection signals.
 
-`pnpm test:visual` expects a running gwt WebView server at the URL declared
-by `GWT_PLAYWRIGHT_BASE_URL`. The skill is responsible for getting that
-server ready before invoking Playwright.
+## Application Bring-up
+
+The runner expects the application under test to be reachable at the URL
+or path declared by its baseURL environment variable. The skill is
+responsible for bringing the application up before invoking the runner.
 
 ```bash
+# Playwright + WebView example (gwt repo):
+
 # 1. Build (debug mode is fine for verify runs)
 cargo build -p gwt --bin gwt
 
-# 2. Start the GUI server in the background
+# 2. Start the application server in the background
 ./target/debug/gwt &
 gui_pid=$!
 
@@ -37,58 +58,78 @@ gui_pid=$!
 # 6. Run Playwright
 pnpm test:visual
 
-# 7. Stop the GUI server
+# 7. Stop the application server
 kill "$gui_pid"
 ```
 
-If `GWT_PLAYWRIGHT_BASE_URL` is already set in the environment (e.g. by a
-preceding test harness) the skill must reuse it instead of spawning a new
-server, to avoid port collisions.
+If the baseURL environment variable is already set in the environment
+(e.g. by a preceding test harness) the skill must reuse it instead of
+spawning a new server, to avoid port collisions.
+
+For other UI runner pairings the same pattern applies:
+
+| Runner | Baseline env var | Application start pattern |
+|---|---|---|
+| Playwright (web / WebView) | `PLAYWRIGHT_BASE_URL` / project-specific (`GWT_PLAYWRIGHT_BASE_URL` in gwt repo) | Start the application server, wait for HTTP 200 |
+| Cypress | `CYPRESS_BASE_URL` | Same as Playwright |
+| Selenium WebDriver | `SELENIUM_BASE_URL` / per-test fixture | Same as Playwright; ensure driver process is running |
+| WinAppDriver (.NET / WPF / WinForms) | `WINAPPDRIVER_TARGET_APP` | Launch the app exe; WinAppDriver attaches by path |
+| Unity Editor headed (PlayMode) | `UNITY_PROJECT_PATH` | Unity Editor launched with `-projectPath` and `-runTests -testPlatform PlayMode` |
 
 ## Headless vs Headed
 
 | Invocation | Behavior |
 |---|---|
-| `pnpm test:visual` (default) | Headless Chromium dark + light projects. Same conditions as CI. |
-| `pnpm test:visual --headed` | Headed Chromium. Used only when the caller passed `--headed` to `gwt-verify`. The skill must surface the GUI URL to the user so they can also inspect the running app. |
-| `pnpm test:visual --update-snapshots` | Snapshot baseline update. **Not** part of `gwt-verify` — the caller must run it explicitly as a separate manual step. |
+| Default (no `--headed`) | Run headless. Same conditions as CI. |
+| `--headed` (passed to `gwt-verify`) | Run headed. The runner must surface the application URL / window so the user can also inspect the running app. Used only when the caller passed `--headed` to `gwt-verify`. |
+| Update-baseline invocation (e.g. `playwright test --update-snapshots`, `cypress test --update`) | **Not** part of `gwt-verify`. The caller must run baseline updates explicitly as a separate manual step, with intent, and commit the new baselines for PR review. |
 
-## Snapshot Diff Policy
+## Snapshot / Diff Policy
 
-- Visual regression failures are evidence-bundle FAIL, not snapshot
-  regeneration triggers.
-- The skill never passes `--update-snapshots` automatically. Baseline updates
-  must be performed by a human-driven step with intent, then committed
-  separately so the change shows up in the PR review.
-- `maxDiffPixelRatio: 0.005` in `playwright.config.ts` is the canonical
-  tolerance; the skill does not override it.
+- Visual / interaction regression failures are evidence-bundle FAIL, not
+  baseline regeneration triggers.
+- The skill never passes `--update-snapshots` (or any equivalent
+  baseline-rewrite flag) automatically. Baseline updates must be
+  performed by a human-driven step with intent, then committed
+  separately so the change appears in PR review.
+- Per-runner tolerance configuration (`maxDiffPixelRatio: 0.005` in
+  `playwright.config.ts`, `cypress-image-snapshot` `failureThreshold`,
+  etc.) is the canonical tolerance; the skill does not override it.
 
-## Project Selection
+## Project Selection (Playwright example)
 
-Both `chromium-dark` and `chromium-light` projects run by default. To narrow
-during quick iteration, the operator may run `pnpm test:visual --project
-chromium-dark` manually; the skill itself always runs both so coverage
-matches CI.
+Both `chromium-dark` and `chromium-light` projects run by default in the
+gwt repo. To narrow during quick iteration, the operator may run
+`pnpm test:visual --project chromium-dark` manually; the skill itself
+always runs both so coverage matches CI.
 
-## Common Failure Modes
+Other UI runners may expose similar narrowing flags (`cypress
+--browser`, `winappdriver` device-specific config). Default to the full
+matrix; narrow only when the operator asks explicitly.
+
+## Common Failure Modes (Playwright example, generalizes)
 
 | Symptom | Likely cause | Action |
 |---|---|---|
-| `Error: connect ECONNREFUSED 127.0.0.1:<port>` | GUI server not yet ready | Re-check the HTTP 200 wait step before invoking Playwright. |
+| `Error: connect ECONNREFUSED 127.0.0.1:<port>` | Application server not yet ready | Re-check the HTTP 200 wait step before invoking the runner. |
 | `Snapshot doesn't match` | Real UI regression OR legitimate redesign | Treat as FAIL; do not auto-regenerate snapshots. Triage in `gwt-discussion` or escalate to the user. |
 | Headed mode shows no window | Running inside a headless host (CI, container) | Detect missing display and downgrade to `Overall: FAIL` with `Headed verification: refused (no display)`. Do not silently fall back to headless. |
-| `browserType.launch: Executable doesn't exist` | Chromium not installed for current Playwright version | Trigger the tooling-bootstrap path (`pnpm exec playwright install --with-deps chromium`). |
+| `browserType.launch: Executable doesn't exist` | Browser not installed for current runner version | Trigger the tooling-bootstrap path (e.g. `pnpm exec playwright install --with-deps chromium`). |
+| WinAppDriver: `Cannot find a matching application` | The target binary is stale or in a different location | Rebuild and update `WINAPPDRIVER_TARGET_APP` before retrying. |
+| Unity PlayMode test: editor freezes | Scene or test code has a synchronous wait | Treat as FAIL; the operator must triage in the Editor, not the skill. |
 
-## Boundary
+## Boundary (do not invoke for non-UI surfaces)
 
-Playwright is for WebView/browser UI verification. Never invoke it for:
+UI runners are for browser / WebView / desktop GUI verification. Never
+invoke them for:
 
-- Pure Rust changes (`crates/*` outside `crates/gwt/web/**` and
-  `crates/gwt/playwright/**`).
-- gwtd CLI smoke (use `cargo run -p gwt --bin gwtd -- --version` instead).
-- Backend domain logic (use `cargo test -p <crate>`).
-- Release scripts (use `pnpm test:release-flow` / `test:release-assets`).
+- Pure backend / library / business-logic changes (use the project's
+  unit / integration test runners instead).
+- CLI smoke (use the project's CLI runner directly,
+  e.g. `cargo run --bin <bin> -- --version`).
+- Release scripts (use the project's release-flow / artifact tests).
 - Documentation-only changes (markdownlint only).
 
-This boundary is enforced by `gwt-verify` at command-selection time per the
-canonical surface table.
+This boundary is enforced by `gwt-verify` at command-selection time per
+`surface-taxonomy.md`. The same restraint applies to all UI runner
+families above, not just Playwright.

--- a/.codex/skills/gwt-verify/references/runner-detection.md
+++ b/.codex/skills/gwt-verify/references/runner-detection.md
@@ -1,0 +1,91 @@
+# Test-Runner Detection (project-agnostic)
+
+`gwt-verify` autodetects the host project's test runners from manifest
+signals before selecting any commands. A project may expose multiple
+runners (e.g. a Rust workspace that also contains a pnpm-driven web
+frontend); the agent picks one per surface based on which runner owns
+that surface's files.
+
+The host project's own AGENTS.md / CLAUDE.md / README always takes
+precedence. Use this table only when the project did not state a testing
+approach explicitly.
+
+## Manifest → Runner Table
+
+| Manifest / signal at project root | Primary runner family | Typical test invocation | Structured-output flag for inventory |
+|---|---|---|---|
+| `Cargo.toml` (workspace or single-crate) | Rust / `cargo test` (optionally `cargo nextest`) | `cargo test -p <crate>` for surface-narrow; `cargo test --workspace` for full | `--format=json` (unstable) or `cargo nextest run --message-format libtest-json` (preferred) |
+| `package.json` with `scripts.test` | Node — read scripts to identify Jest / Vitest / Mocha / Playwright / Cypress / Storybook test | `pnpm test` (or `npm test` / `yarn test`) for the script named in `scripts.test`; surface-specific scripts (`test:unit`, `test:integration`, `test:visual`, `test:e2e`) when present | Jest / Vitest: `--reporter=json`; Mocha: `--reporter=json`; Playwright: `--reporter=json,list`; Cypress: `--reporter=mocha-junit-reporter` |
+| `pyproject.toml` or `setup.cfg` / `setup.py` | Python — pytest / unittest / tox | `pytest -q` (surface-narrow with `-k <pattern>`); `tox -e <env>` when tox is present | `pytest --json-report` (via `pytest-json-report`) or `--junitxml=<file>` |
+| `go.mod` | Go — `go test` | `go test ./<pkg>/...` for surface-narrow; `go test ./...` for full | `go test -json` |
+| `*.sln` / `*.csproj` (and no Unity ProjectSettings) | .NET — `dotnet test` | `dotnet test <Project.csproj>` for surface-narrow; `dotnet test <Solution.sln>` for full | `--logger "trx;LogFileName=test_results.trx"` or `--logger "console;verbosity=detailed"` |
+| `ProjectSettings/ProjectVersion.txt` (presence) | Unity — Editor batch test runner | `Unity -batchmode -runTests -projectPath <path> -testPlatform <EditMode\|PlayMode> -testResults <result.xml> -quit` | NUnit XML at `-testResults` |
+| `Gemfile` | Ruby — RSpec / Minitest | `bundle exec rspec` or `bundle exec rake test` | `--format json` (RSpec) |
+| `pom.xml` | Java / Kotlin — Maven Surefire / Failsafe | `mvn test` (unit), `mvn verify` (integration) | Surefire writes `target/surefire-reports/*.xml` (JUnit XML) |
+| `build.gradle` / `build.gradle.kts` | Gradle — JUnit / Spek | `gradle test` or `gradle check` | `--scan` for build scans; per-task JUnit XML under `build/test-results/` |
+| `Makefile` exposing a `test` target | Project-defined wrapper | `make test` (also check for `make verify` / `make check`) | Depends on wrapped runner |
+| `pubspec.yaml` | Flutter / Dart | `flutter test` (unit) / `flutter test integration_test` | `--reporter json` |
+| `composer.json` | PHP — PHPUnit / Pest | `vendor/bin/phpunit` or `vendor/bin/pest` | `--log-junit` |
+| Standalone `tsconfig.json` without `package.json` (rare) | Likely embedded inside another project — defer to that project's runner | — | — |
+| No recognized manifest | Fallback: read the project's AGENTS.md / README for instructions; otherwise emit `failed: tooling-missing` with rationale | — | — |
+
+## Selection rules
+
+1. **Multi-runner projects.** A workspace may declare more than one
+   manifest (e.g. `Cargo.toml` + `package.json`). Detect all of them, then
+   assign each changed surface to the runner whose manifest owns the
+   surface's path. For example, in a Rust workspace with a pnpm-driven
+   `web/` subdirectory, web changes go to pnpm-driven runners and Rust
+   crate changes go to cargo.
+
+2. **Prefer scripts over inferred conventions.** If `package.json`
+   declares `scripts.test` and surface-specific scripts (`test:unit`,
+   `test:integration`, `test:visual`, `test:release-*`), use the script
+   names as they appear instead of guessing. Same for `Makefile` targets.
+
+3. **Visual / UI runners.** Playwright / Cypress / Selenium /
+   WinAppDriver / Unity Editor headed are only invoked when a UI surface
+   is in scope. Even if the manifest is present, do not invoke a UI
+   runner for non-UI changes.
+
+4. **Long-running runners and `--mode quick`.** Some runners (Unity Editor
+   batch, large `mvn verify`, full `dotnet test` solution) take many
+   minutes. In `--mode quick`, narrow the invocation to a single
+   project / module / `-k` filter relevant to the changed surface, or
+   skip the runner with a recorded `skipped(quick-mode-budget)` reason.
+
+5. **Plugin / module testing in Unity.** If the project ships under
+   `Packages/<id>` Unity package layout, prefer scoping the test runner
+   to that package's assemblies (`-testCategory` / `-testFilter`) instead
+   of running the entire Editor test suite.
+
+6. **Custom wrappers.** When the project defines a `make verify` /
+   `make check` / `scripts/verify.sh` / `bin/check` wrapper, that wrapper
+   is the canonical entry point. Use it instead of bypassing it; the
+   wrapper exists precisely so contributors do not have to remember the
+   runner-specific flags.
+
+7. **Generic fallback.** When no manifest is recognized, surface the
+   uncertainty: emit `failed: tooling-missing — no recognized test runner
+   manifest found at <project root>` and stop. Do not invent commands.
+
+## Inventory extraction hints
+
+The `Test Inventory` section of the evidence bundle lists the actual
+test names / scenarios / suite paths the runner executed. To populate it,
+prefer the runner's structured output flag (the rightmost column in the
+table above) and parse the following fields, in this order of preference:
+
+1. Test identifier — fully qualified name when available
+   (`module::path::test_name` for cargo; `describe > it` for Jest /
+   Vitest / Mocha / Playwright; `ClassName.MethodName` for JUnit /
+   NUnit / xUnit).
+2. Outcome (`PASS` / `FAIL` / `SKIP`).
+3. One-line failure summary (first line of the runner's error message
+   when `FAIL`).
+4. Skip reason when `SKIP`.
+
+When extraction is not feasible (no structured output, parsing failure,
+custom wrapper that swallows stdout), record
+`(inventory unavailable: <reason>)` for that command and continue. Do not
+silently degrade.

--- a/.codex/skills/gwt-verify/references/surface-taxonomy.md
+++ b/.codex/skills/gwt-verify/references/surface-taxonomy.md
@@ -1,0 +1,70 @@
+# Surface Taxonomy (project-agnostic)
+
+`gwt-verify` classifies every changed file into one of the abstract surfaces
+below. The surface determines (a) which test runners are relevant and (b)
+whether the User Verification Handoff is Required, Recommended, or Skipped.
+
+This taxonomy is intentionally project-agnostic. The patterns column shows
+**typical** signals for common project types; treat them as hints, not as
+exhaustive rules. If the host project's AGENTS.md / README defines a
+different classification, that wins.
+
+## Abstract Surfaces
+
+| Surface | Typical signals (any of) | User Check |
+|---|---|---|
+| **UI surface** — anything the end user sees rendered: markup, theme, layout, interactive controls, motion, accessibility affordances. | `*.html`, `*.css`, `*.scss`, `*.tsx` / `*.jsx` rendered components, `theme*.{js,ts}`, Unity `Assets/**/*.{prefab,uxml,uss,asset}` for UI, `.NET` XAML / WinForms designer files, Flutter `*.dart` widget files, Qt `*.ui` files, web assets under any `web/**`, `frontend/**`, `client/**`, `ui/**`, `static/**`. | **Required** |
+| **Interactive CLI / TUI surface** — a command-line or terminal UI a human invokes directly. | CLI entry points (`src/bin/*.rs`, `cmd/**/main.go`, `bin/*`, `scripts/cli.*`), ratatui / blessed / urwid / Bubble Tea TUI files, argparse / clap / cobra / commander definitions when the diff changes user-visible flags, help text, or output formatting. | **Required** |
+| **Business logic (no observable surface)** — pure functions, services, parsers, models, computation. | Source under `src/**` / `lib/**` / `internal/**` / `crates/**` excluding UI and CLI entry points; backend services without UI rendering. | **Recommended** |
+| **Build / Release pipeline** — code that produces or publishes the distributable. | `Dockerfile*`, `Containerfile`, GitHub Actions `release` workflows, `scripts/release-*.{sh,cjs,ps1}`, `goreleaser.yaml`, `Cargo.toml` `[package]` version bumps, `package.json` version bumps, installer specs (`*.iss`, `*.nsi`, `*.wxs`), Unity build scripts. | **Required** |
+| **External binding / 3rd-party integration** — code that crosses a network or process boundary to a service we don't own. | HTTP / gRPC client modules, SDK wrappers, message-broker producers / consumers, OAuth flows, webhook senders. | **Recommended** |
+| **Skill asset / agent config** — agent skills, prompts, hooks, slash-command files. | `.claude/skills/**`, `.codex/skills/**`, `.claude/commands/**`, `.gemini/**`, `.cursor/**`, `AGENTS.md` sections specifically describing agent behavior. | **Recommended** |
+| **Docs / config-only** — documentation, formatting, dependency bumps with no behavior change. | `*.md` outside skill assets, `*.txt`, `LICENSE*`, `CHANGELOG.md`, `.editorconfig`, lint config (`.eslintrc*`, `clippy.toml`), formatter config, no-op dependency bumps. | **Skipped(docs-only)** |
+
+## Selection Rules
+
+1. **A file may match multiple surfaces.** Pick the most user-visible
+   surface (UI > CLI > business logic > docs).
+2. **`ui` / `web` / `frontend` / `client` directories** default to UI surface
+   regardless of file extension when the diff touches files the user
+   ultimately renders. Pure build-config files inside those directories
+   (e.g. `webpack.config.js`) classify as Build / Release pipeline.
+3. **CLI entry-point logic changes** classify as Interactive CLI surface only
+   when the user-visible behavior (flags, output, error messages) changes.
+   Pure internal refactors of the CLI plumbing classify as Business logic.
+4. **Skill assets do not require Playwright** — they are agent-facing only.
+   Their User Check is Recommended (trigger sanity check), not Required.
+5. **Multiple surfaces → take the highest user-check tier across all
+   matched surfaces.** Required > Recommended > Skipped.
+6. **No changed files** → `Changed surfaces: (none)` and User Verification
+   is `skipped(no-change)`.
+
+## Per-project specialization hints
+
+Concrete projects may need finer-grained mappings. The host project's
+AGENTS.md may publish its own table; in that case, prefer the project table
+and use this taxonomy only as a fallback for files the project table does
+not mention. Example: the gwt repo's own example matrix lives in
+`test-matrix.md` alongside this file.
+
+For Unity projects, treat any change under `Assets/**` that is referenced by
+a `Scene` or a `Canvas` as UI surface even when the file is a `.cs` script;
+the rendered behavior is user-visible. Pure `Editor/**` scripts that only
+affect the Unity Editor classify as Build / Release pipeline.
+
+For .NET projects with WPF / WinForms, `*.xaml`, `*.Designer.cs`, and any
+code-behind files for windows / pages classify as UI surface. Backend
+service projects without windows classify as Business logic.
+
+For Web / SPA projects, route definitions, layout shells, and shared
+component libraries classify as UI surface. API route handlers without
+rendering classify as Business logic; if they expose schema visible to a
+human (OpenAPI specs, error responses), bump to External binding.
+
+## Non-Goals
+
+- This taxonomy does not pick the runner. That is `runner-detection.md`.
+- This taxonomy does not regenerate snapshots. Visual regression is FAIL,
+  not auto-update.
+- This taxonomy does not enumerate every file pattern; it gives enough
+  signal for the agent to classify confidently.

--- a/.codex/skills/gwt-verify/references/test-matrix.md
+++ b/.codex/skills/gwt-verify/references/test-matrix.md
@@ -1,54 +1,97 @@
-# Surface → Test Matrix (canonical)
+# Test Matrix (worked example for the gwt repo)
 
-This is the single source of truth for `gwt-verify` surface classification.
-The skill must not invoke Playwright for any row whose "Browser (Playwright)"
-column is empty — that contract comes from SPEC-1935 FR-124 and was reinforced
-by the user during the gwt-discussion that produced Phase 17.
+`gwt-verify` is project-agnostic. The canonical surface classification
+lives in `surface-taxonomy.md` and the manifest-to-runner mapping lives
+in `runner-detection.md`. This file documents the **gwt repository's
+own** specialization of that contract as a worked example. Other
+projects (Unity, .NET, Python, Go, Java, …) should document their own
+matrix in their project AGENTS.md / README and rely on the generic
+contract here as a fallback frame.
 
-## Matrix
+When agents run `gwt-verify` inside the gwt repository, this matrix is
+the project-specific recipe.
 
-| Surface (changed path pattern) | Non-browser execution | Browser (Playwright) |
-|---|---|---|
-| `crates/*/src/**`, `crates/*/tests/**` | `cargo test -p <crate>`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt -- --check` | — |
-| `crates/gwt/src/bin/gwtd*`, `crates/gwt/src/bin/gwt*` | cargo (as above) + bin smoke (`cargo run -p gwt --bin gwtd -- --version`) | — |
-| `crates/gwt/web/**/*.js` (logic only — no UI surface) | `pnpm test:frontend-bundle`, `pnpm test:frontend-unit`, `pnpm test:frontend-smoke` | — |
-| `crates/gwt/web/**` (UI / CSS / HTML / theme assets) | as above | `pnpm test:visual` |
-| `crates/gwt/playwright/**` | — | `pnpm test:visual` |
-| `scripts/check-release-flow.sh`, `scripts/test_release_assets.cjs`, release scripts | `pnpm test:release-flow`, `pnpm test:release-assets` | — |
-| `.claude/skills/**`, `.codex/skills/**`, `crates/gwt-skills/**` | `pnpm lint:skills`, `cargo test -p gwt-skills` | — |
-| `AGENTS.md`, `CLAUDE.md`, `README*.md`, `docs/**` | `markdownlint` (when available) | — |
+## Project: gwt repo (Rust workspace + pnpm-driven WebView frontend)
 
-## Selection Rules
+### Detected runners
 
-1. **Multiple surfaces match** — run the union of all matched commands. Skip
-   duplicates (e.g. only run `cargo clippy --all-targets` once per invocation).
-2. **Browser column is empty → do not invoke Playwright.** This is the user's
-   strong constraint: ブラウザ起動前提のシステムだけが Playwright 対象.
+- `Cargo.toml` workspace at the repo root → `cargo test`,
+  `cargo clippy --all-targets --all-features -- -D warnings`,
+  `cargo fmt -- --check`.
+- `package.json` at `crates/gwt/web/` (and root) → `pnpm` scripts
+  including `test:frontend-bundle`, `test:frontend-unit`,
+  `test:frontend-smoke`, `test:visual`, `test:release-flow`,
+  `test:release-assets`, `lint:skills`.
+- `crates/gwt/playwright/playwright.config.ts` → Playwright project
+  for WebView visual / interaction tests.
+
+### Surface → Command matrix (gwt repo specialization)
+
+| Surface (changed path pattern) | Non-browser execution | Browser (Playwright) | User Check |
+|---|---|---|---|
+| `crates/*/src/**`, `crates/*/tests/**` | `cargo test -p <crate>`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt -- --check` | — | Recommended (business logic) |
+| `crates/gwt/src/bin/gwtd*`, `crates/gwt/src/bin/gwt*` | cargo (as above) + bin smoke (`cargo run -p gwt --bin gwtd -- --version`) | — | Required (interactive CLI) |
+| `crates/gwt/web/**/*.js` (logic only — no UI surface) | `pnpm test:frontend-bundle`, `pnpm test:frontend-unit`, `pnpm test:frontend-smoke` | — | Recommended (business logic) |
+| `crates/gwt/web/**` (UI / CSS / HTML / theme assets) | as above | `pnpm test:visual` | **Required** (UI surface) |
+| `crates/gwt/playwright/**` | — | `pnpm test:visual` | **Required** (UI surface) |
+| `scripts/check-release-flow.sh`, `scripts/test_release_assets.cjs`, release scripts | `pnpm test:release-flow`, `pnpm test:release-assets` | — | **Required** (Build / Release pipeline) |
+| `.claude/skills/**`, `.codex/skills/**`, `crates/gwt-skills/**` | `pnpm lint:skills`, `cargo test -p gwt-skills` | — | Recommended (skill asset) |
+| `AGENTS.md`, `CLAUDE.md`, `README*.md`, `docs/**` | `markdownlint` (when available) | — | Skipped(docs-only) |
+
+### Selection Rules (gwt repo)
+
+1. **Multiple surfaces match** — run the union of all matched commands.
+   Skip duplicates (e.g. only run `cargo clippy --all-targets` once per
+   invocation).
+2. **Browser column is empty → do not invoke Playwright.** This is the
+   strong constraint inherited from SPEC-1935 FR-124: only WebView /
+   browser UI surfaces are eligible for Playwright. The same rule applies
+   to any other UI runner (Cypress / Selenium / WinAppDriver) in
+   future-arriving projects.
 3. **`crates/gwt/web/**` ambiguity** — if any of `*.html`, `*.css`,
-   `theme-*.js`, or visible UI assets changed, treat the surface as "UI / CSS
-   / HTML" and include `pnpm test:visual`. If only non-visual JS logic
-   changed, exclude `pnpm test:visual`.
-4. **`docs/**` only** — markdownlint is non-blocking when markdownlint is
-   absent on the system; the evidence bundle records this as `skipped:
-   markdownlint-not-installed`.
+   `theme-*.js`, or visible UI assets changed, treat the surface as
+   "UI / CSS / HTML" and include `pnpm test:visual`. If only non-visual
+   JS logic changed, exclude `pnpm test:visual`.
+4. **`docs/**` only** — markdownlint is non-blocking when markdownlint
+   is absent on the system; the evidence bundle records this as
+   `skipped: markdownlint-not-installed`.
 5. **No changed files** — evidence bundle is `Overall: PASS` with
-   `Changed surfaces: (none)` and no executed commands. The caller decides
-   whether that means "nothing to verify" or "baseline drift".
+   `Changed surfaces: (none)` and no executed commands. User
+   Verification is `skipped(no-change)`. The caller decides whether
+   that means "nothing to verify" or "baseline drift".
 
-## Mode → Subset
+### Mode → Subset (gwt repo)
 
 | Mode | Behavior |
 |---|---|
-| `quick` | Run the narrowest representative command per matched surface (e.g. `cargo test -p <single crate>`, `pnpm test:frontend-unit` only — skip bundle/smoke). Skip Playwright entirely unless the working tree explicitly carries a `.spec.ts` change under `crates/gwt/playwright/tests/**`. |
-| `full` | Run the full matched list per surface, including `pnpm test:visual` headless when the Browser column is non-empty. |
-| `pre-pr` | `full` plus release-flow tests whenever any release-system file is in the baseline diff. Visual regression is always included if any UI surface changed (no `quick` fallback). |
+| `quick` | Run the narrowest representative command per matched surface (e.g. `cargo test -p <single crate>`, `pnpm test:frontend-unit` only — skip bundle/smoke). Skip Playwright entirely unless the working tree explicitly carries a `.spec.ts` change under `crates/gwt/playwright/tests/**`. User Verification is `skipped(quick-mode)`. |
+| `full` | Run the full matched list per surface, including `pnpm test:visual` headless when the Browser column is non-empty. User Verification is required for Required surfaces. |
+| `pre-pr` | `full` plus release-flow tests whenever any release-system file is in the baseline diff. Visual regression is always included if any UI surface changed (no `quick` fallback). User Verification is required for Required surfaces. |
 | `--headed` | When a matched command would invoke Playwright, run it with `pnpm test:visual --headed` so Chromium starts headed. Default is headless to match CI. |
 
-## Non-Goals
+### Non-Goals (gwt repo)
 
 - `gwt-verify` does **not** mutate snapshots. Snapshot baseline updates
   remain a manual `pnpm test:visual --update-snapshots` step outside the
   skill (caller must run it explicitly with intent).
 - `gwt-verify` does **not** chase external CI. The skill answers "is the
-  local workspace in a verifiable state right now?" — CI verdicts are still
-  the responsibility of `gwt-manage-pr`.
+  local workspace in a verifiable state right now?" — CI verdicts are
+  still the responsibility of `gwt-manage-pr`.
+
+## Adapting this matrix for another project
+
+The matrix above is the gwt repo's specialization. To bring `gwt-verify`
+to a different project type, document a similar matrix in that project's
+AGENTS.md / README that:
+
+1. Lists the project's detected runners (per `runner-detection.md`).
+2. Maps each `surface-taxonomy.md` surface to the runner commands that
+   exercise it.
+3. Marks the User Check tier per surface (Required / Recommended /
+   Skipped).
+4. Describes mode-specific subsets if the project benefits from
+   `quick` vs `full` vs `pre-pr` narrowing.
+
+The skill follows the project's matrix when present; otherwise it
+relies on `surface-taxonomy.md` + `runner-detection.md` as the
+fallback frame.

--- a/.codex/skills/gwt-verify/references/tooling-bootstrap.md
+++ b/.codex/skills/gwt-verify/references/tooling-bootstrap.md
@@ -1,40 +1,64 @@
-# Tooling Bootstrap
+# Tooling Bootstrap (project-agnostic)
 
-`gwt-verify` checks for required tooling before running the selected
-commands. Missing tools follow a bounded auto-install path. When the
-auto-install path is exhausted, the skill records `failed: tooling-missing`
-in the evidence bundle and the caller (typically `gwt-build-spec` Phase 3)
-treats that as a hard completion blocker.
+`gwt-verify` checks that the test runners chosen via `runner-detection.md`
+are actually installed before invoking them. When a runner is missing, the
+skill follows a bounded best-effort auto-install path. If the auto-install
+path is exhausted, the skill records `failed: tooling-missing: <component>`
+in the evidence bundle. Callers (`gwt-build-spec` Phase 3,
+`gwt-manage-pr` Pre-PR) treat that as a hard completion blocker.
 
-## Auto-install Contract
+This contract is the same regardless of project language. The auto-install
+attempts and detection heuristics differ per runner but the *shape* of the
+contract (single attempt, no sudo, no OS package managers, deterministic
+failure mode) is identical.
 
-| Missing | Auto-install attempt | On failure |
-|---|---|---|
-| `pnpm` not on PATH | `corepack enable pnpm` | `failed: tooling-missing: pnpm` |
-| `node_modules` absent or stale | `pnpm install --frozen-lockfile` | `failed: tooling-missing: node_modules` |
-| Playwright Chromium browser absent | `pnpm exec playwright install --with-deps chromium` | `failed: tooling-missing: playwright-chromium` |
-| `cargo` not on PATH | — (pre-existing project requirement) | `failed: tooling-missing: cargo` |
-| `git` not on PATH or repo not initialized | — | `failed: tooling-missing: git` |
-| `markdownlint` not installed (for docs-only runs) | — | `skipped: markdownlint-not-installed` (non-blocking) |
+## Auto-install Contract (per runner family)
+
+The skill attempts the install paths in the rightmost column at most once
+per invocation. On failure, `failed: tooling-missing: <component>` is
+recorded. The component name should be the canonical runner identifier so
+callers can react.
+
+| Runner family | Missing tool detection | Best-effort install attempt | On failure |
+|---|---|---|---|
+| Node-based (npm / pnpm / yarn scripts) | `command -v <pm>` fails; or `node_modules` is absent | For pnpm: `corepack enable pnpm` then `pnpm install --frozen-lockfile`. For yarn: `corepack enable yarn` then `yarn install --frozen-lockfile`. For npm: `npm ci`. | `failed: tooling-missing: <pm>` or `<pm>-dependencies` |
+| Browser UI runner (Playwright / Cypress / WebDriver-based) | Runner CLI present but browsers / drivers absent | Playwright: `pnpm exec playwright install --with-deps <browser>`. Cypress: `pnpm exec cypress install`. WebDriver: rely on the project's own setup script if present. | `failed: tooling-missing: <runner>-browsers` |
+| Rust (`cargo`) | `command -v cargo` fails | — (not auto-installed; this is a developer environment requirement) | `failed: tooling-missing: cargo` |
+| Python (`pytest`, `tox`, runner declared in `pyproject.toml`) | `python -c "import <runner>"` fails | When a `requirements*.txt` / `pyproject.toml` declares dev dependencies, attempt `python -m pip install -r requirements-dev.txt` *only when running inside an active virtualenv*. Never install into a non-venv interpreter. | `failed: tooling-missing: <runner>` |
+| Go (`go test`) | `command -v go` fails | — | `failed: tooling-missing: go` |
+| .NET (`dotnet test`) | `command -v dotnet` fails, or `dotnet --list-sdks` is empty | — | `failed: tooling-missing: dotnet-sdk` |
+| Unity Editor batch runner | The detected Unity Editor executable is missing or version mismatch with `ProjectSettings/ProjectVersion.txt` | — (Unity Editor is provisioned out-of-band) | `failed: tooling-missing: unity-editor-<version>` |
+| Ruby (`bundle exec rspec`) | `command -v bundle` fails | — | `failed: tooling-missing: bundler` |
+| Java / Kotlin (`mvn` / `gradle`) | `command -v mvn` / `command -v gradle` fails | — | `failed: tooling-missing: maven` / `gradle` |
+| Lint / docs (`markdownlint`, etc.) | `command -v markdownlint` fails | — | `skipped: markdownlint-not-installed` (non-blocking) |
+| `git` | `git rev-parse --show-toplevel` fails | — | `failed: tooling-missing: git` |
 
 ## Guardrails
 
 - **No sudo.** The skill must not invoke `sudo` or any privilege escalation.
 - **No OS package managers.** Do not call `apt`, `brew`, `pacman`,
-  `dnf`, `pkg`, `pip`, `choco`, `winget`. The contract is limited to
-  `corepack`, `pnpm install`, and `pnpm exec playwright install`.
-- **No global mutations.** Installations target the worktree (`node_modules`,
-  Playwright cache under `~/.cache/ms-playwright` / `~/Library/Caches/ms-playwright`)
-  and must not modify other repositories.
-- **Cache reuse.** When the Playwright cache already contains the needed
-  Chromium build, the skill must reuse it instead of forcing a reinstall.
+  `dnf`, `pkg`, `pip` (outside an active virtualenv), `choco`, `winget`.
+- **No global mutations.** Installations target the worktree
+  (`node_modules`, `Pipfile.lock`-managed venvs, browser caches under
+  the standard per-user cache directories) and must not modify other
+  repositories.
+- **Cache reuse.** When the runner's browser / driver / package cache
+  already contains the needed version, the skill reuses it instead of
+  forcing a reinstall.
 - **No retries.** Each auto-install attempt runs at most once per
   `gwt-verify` invocation. Repeated transient failures escalate to
   `failed: tooling-missing`.
+- **Project wrapper precedence.** When the project ships its own setup
+  wrapper (`make setup`, `scripts/bootstrap.sh`, `bin/setup`,
+  `package.json` `scripts.bootstrap`), prefer it over invoking the
+  runner-specific install path.
 
 ## Evidence Bundle Shape on Failure
 
-When `failed: tooling-missing` is produced, the evidence bundle MUST include:
+When `failed: tooling-missing` is produced, the evidence bundle MUST
+include the per-attempt status so the caller can distinguish "the
+project's tests are broken" from "the local environment isn't ready to
+run any tests at all":
 
 ```text
 Tooling installed during run:
@@ -44,30 +68,33 @@ Overall: FAIL
 failed: tooling-missing: <component>
 ```
 
-So that the caller can distinguish "the project's tests are broken" from
-"the local environment isn't ready to run any tests at all".
-
-## Detection Heuristics
+## Detection Heuristics (recap)
 
 | Tool | Detection |
 |---|---|
-| `pnpm` | `command -v pnpm` succeeds and `pnpm --version` returns a string. |
-| `node_modules` | `package.json` exists AND `.pnpm-lock-hash` (if present) matches the lockfile, OR a marker file under `node_modules/.modules.yaml` matches the lockfile hash. Heuristic — when in doubt, run `pnpm install --frozen-lockfile` (idempotent when already satisfied). |
-| Playwright Chromium | `pnpm exec playwright --version` succeeds AND the Chromium revision listed in the Playwright version's bundled `browsers.json` is present under the OS-specific Playwright cache. Heuristic — when in doubt, run `pnpm exec playwright install --with-deps chromium --dry-run` and look for "browsers already installed". |
-| `cargo` | `command -v cargo` succeeds. |
+| `pnpm` / `npm` / `yarn` | `command -v <pm>` succeeds and `<pm> --version` returns a string. |
+| Node `node_modules` | `package.json` exists AND a marker file (`node_modules/.modules.yaml` for pnpm, `node_modules/.package-lock.json` for npm, `.yarn/install-state.gz` for yarn) matches the lockfile. When in doubt, run the project's frozen-lockfile install (idempotent). |
+| Playwright browsers | `pnpm exec playwright --version` succeeds AND the bundled `browsers.json` version matches the cache under `~/.cache/ms-playwright` / `~/Library/Caches/ms-playwright` / `%LOCALAPPDATA%\\ms-playwright`. When in doubt, dry-run `pnpm exec playwright install --with-deps <browser> --dry-run`. |
+| Cypress browsers | `pnpm exec cypress info` succeeds and lists at least one browser. |
+| `cargo` / `rustc` | `command -v cargo` succeeds. |
+| `python` runner libraries | `python -c "import <runner>"` succeeds inside the project's interpreter. |
+| `go` | `command -v go` and `go version` succeed. |
+| `dotnet` | `command -v dotnet` and `dotnet --list-sdks` returns ≥ 1 line. |
+| Unity Editor | The path resolved by the project's `ProjectSettings/ProjectVersion.txt` exists and reports the expected version when run with `-version`. |
 | `git` | `git rev-parse --show-toplevel` succeeds inside the worktree. |
 | `markdownlint` | `command -v markdownlint` (or `npx markdownlint --version`) succeeds. |
 
 ## Container / CI Notes
 
-In container environments where the Playwright Chromium cache may be
-pre-baked, the detection heuristic for "browsers already installed" is the
-primary path; the auto-install attempt should short-circuit immediately when
-the dry-run shows everything present.
+In container environments where caches may be pre-baked (Playwright
+browsers, `node_modules`, `~/.cargo`, Go module cache, Unity Editor
+install), the detection heuristics above are the primary path; the
+auto-install attempts should short-circuit immediately when the dry-run
+shows everything is present.
 
-If the environment is hermetic (no internet), the auto-install attempts will
-fail fast and the skill records `failed: tooling-missing` with the network
-error preserved verbatim in the evidence bundle. The caller may either:
+If the environment is hermetic (no internet), the auto-install attempts
+fail fast and the skill records `failed: tooling-missing` with the
+network error preserved verbatim. The caller may either:
 
 - Treat it as a hard block (default behavior in `gwt-build-spec` Phase 3).
 - Override with an explicit `gwtd build abort --reason ...` and have the

--- a/.codex/skills/gwt-verify/references/user-verification-guide.md
+++ b/.codex/skills/gwt-verify/references/user-verification-guide.md
@@ -1,0 +1,162 @@
+# User Verification Guide (4-step 導線 + Check Items)
+
+After automated tests pass, `gwt-verify` hands off to the user for manual
+confirmation when `--mode full` or `--mode pre-pr` is active and the
+changed surfaces include any `Required` or `Recommended` user-check
+entries (per `surface-taxonomy.md`).
+
+The handoff has two halves:
+
+1. **導線** — a fixed 4-step path that walks the user from a clean state
+   to the changed feature.
+2. **Check Items** — a checklist with three required categories of things
+   to verify.
+
+## The 4-step 導線
+
+The 4 steps are **always present and always in this order**, regardless of
+project type:
+
+| # | Label    | What it contains | Examples by project type |
+|---|----------|------------------|---|
+| 1 | **build**    | The project's smallest build command that exercises the change. Skip if the project does not require a build step. | Rust: `cargo build -p <crate>`. Node: `pnpm build` or `pnpm dev` if hot-reload covers the change. Unity: Unity Editor batch build, or "Open Unity Editor and load project" when no headless build exists. .NET: `dotnet build <Solution.sln>`. Python: skip when the script runs directly. Go: `go build ./...`. Mobile: `flutter build apk --debug` / `xcodebuild -scheme <app>`. |
+| 2 | **launch**   | How to start the running artifact. | Rust CLI: `./target/debug/<bin>`. Web/WebView: launch the application server and surface the URL line (e.g., `gwt browser URL: http://127.0.0.1:<port>/`); confirm HTTP 200 with `curl -fsS -I <URL>` before sharing. Unity: Press Play in the Editor on `<Scene>.unity`. .NET: `dotnet run --project <Project>` or launch the built exe. Python service: `python -m <module>` or `uvicorn app:main --reload`. Mobile: open simulator and install the build. Long-running daemon: `<bin> --serve` and tail its log. |
+| 3 | **navigate** | The user-visible steps from launch to the changed feature. | "Click Logs in the top bar → select Process chip → choose `gh`." "Run `<cli> issue spec list --spec 1935` and read the output." "In Unity Editor, open `Hierarchy → MainCanvas → ReleaseNotesWindow`." "In the running .NET app, open menu `Help → About` then close → reopen." |
+| 4 | **observe**  | Exactly what the user should look at, click, or interact with to confirm. | "Verify only `gh`-tagged log lines appear in the table." "Confirm `Closed:` field matches Issue state." "Verify the release-notes window snaps to the top-right and survives a `Ctrl+R` reload." "Confirm the About dialog's version string matches `package.json`." |
+
+Rules:
+
+- Use concrete commands, file paths, and UI affordance names that exist
+  in **this** project. Do not invent paths.
+- Always tell the user what HTTP / WS URL or local port to open when the
+  app is a server; confirm reachability (`curl -fsS -I`) before sharing.
+- Each step is one bullet or short sentence. If a step needs more than 2
+  sentences, the navigation step list is too long — split into
+  sub-bullets but keep the four parent labels.
+- When the project's AGENTS.md / README describes a project-specific
+  launch ritual (e.g., the gwt repo's `gwt browser URL` line at
+  `AGENTS.md` L187), reuse that ritual verbatim.
+
+## Check Items (three required categories)
+
+Every User Verification handoff must include **at least one** check item
+in each of these three categories:
+
+1. **Expected — the representative happy path.** What the change is
+   supposed to do, stated as the user would notice it.
+2. **Edge case / failure handling.** What the user should look at to
+   confirm a boundary, empty input, error response, or unusual size /
+   environment is handled correctly. Pick the most plausible failure
+   mode for this change.
+3. **Adjacent feature regression sanity.** A nearby feature the user
+   should briefly try to confirm nothing else broke. For UI changes,
+   this is usually a sibling screen or widget; for CLI, an adjacent
+   subcommand; for release pipeline, the previously-released artifact's
+   smoke test.
+
+Format each item as a Markdown checkbox so the user can tick it off:
+
+```markdown
+- [ ] Expected: <one-line description of expected behavior>
+- [ ] Edge: <one-line description of edge case to confirm>
+- [ ] Regression: <one-line description of adjacent feature sanity>
+```
+
+You may add more items beyond the three categories, but never fewer.
+
+## Selection question
+
+Ask the user via the platform's selection question tool
+(`AskUserQuestionTool` for Claude Code, `request_user_input` for Codex,
+the closest equivalent for other runtimes) with these three options:
+
+| Label | Effect on `User Verification Result` |
+|---|---|
+| `Confirmed` | `confirmed` — `Overall: PASS` (provided automated tests also passed) |
+| `Rejected(<reason>)` | `rejected(<reason>)` — `Overall: FAIL`; caller routes back to TDD loop or `gwt-discussion` |
+| `Skip with reason(<reason>)` | `skipped(<reason>)` — `Overall: PASS` is allowed but the skip reason is preserved in the evidence bundle for traceability |
+
+When no selection UI is available, ask the same three options in plain
+text and parse the user's free-form reply into one of the three states.
+
+## Rejection escalation
+
+When the user selects `Rejected`:
+
+1. Preserve the user's free-text reason in the evidence bundle's
+   `User Verification Result: rejected(<reason>)` line.
+2. The caller (`gwt-build-spec` Phase 3 / `gwt-manage-pr` Pre-PR) treats
+   this as `Overall: FAIL` and does not advance.
+3. If the rejection points at a spec / design gap rather than an
+   implementation bug, route to `gwt-discussion` to renegotiate scope.
+   Otherwise return to the TDD Red → Green → Refactor loop.
+
+## Skip rules
+
+The handoff is **automatically skipped** (no user prompt) when:
+
+- `--mode quick` is in effect (TDD mid-iteration).
+- `Changed surfaces: (none)` — nothing to verify.
+- All changed surfaces are `docs-only` per `surface-taxonomy.md`.
+- The caller passed `--skip-user-check` for an explicit non-interactive
+  run.
+
+In every skip case, the reason is recorded as
+`User Verification: skipped(<reason>)` so reviewers can audit why no user
+confirmation was requested.
+
+## Worked examples
+
+### Example A — gwt repo, Logs window filter changes
+
+```text
+User Verification: required
+Surfaces requiring user check: UI surface
+
+導線 (How to access):
+1. build:     cargo build -p gwt --bin gwt
+2. launch:    ./target/debug/gwt — note the published `gwt browser URL: http://127.0.0.1:<port>/` and confirm 200 with `curl -fsS -I <URL>`
+3. navigate:  Open the URL in a browser → click `Logs` in the top bar → choose `gh` from the Process chip filter
+4. observe:   Only `gh`-tagged lines should appear; non-`gh` processes are hidden
+
+Check Items:
+- [ ] Expected: `gh`-tagged lines are visible; other process lines are hidden
+- [ ] Edge: selecting "All" restores the unfiltered view without a reload
+- [ ] Regression: the adjacent "Severity" filter still filters as before
+```
+
+### Example B — Unity package, in-game settings menu
+
+```text
+User Verification: required
+Surfaces requiring user check: UI surface
+
+導線 (How to access):
+1. build:     Open Unity Editor on the project (no headless build required)
+2. launch:    Press Play on `Assets/Scenes/Main.unity`
+3. navigate:  In the running scene, open menu `Pause → Settings → Display`
+4. observe:   The new `Render Scale` slider appears under `Quality` and reflects the saved value
+
+Check Items:
+- [ ] Expected: slider moves smoothly and updates the runtime render scale
+- [ ] Edge: setting the slider to 0.5 and quitting Play mode persists the value across reloads
+- [ ] Regression: the existing `Master Volume` slider beside it still functions
+```
+
+### Example C — .NET WPF desktop application
+
+```text
+User Verification: required
+Surfaces requiring user check: UI surface
+
+導線 (How to access):
+1. build:     dotnet build src/App/App.csproj
+2. launch:    dotnet run --project src/App/App.csproj
+3. navigate:  In the running app, click `Help → About`
+4. observe:   The About dialog now lists the new `Build SHA` field below `Version`
+
+Check Items:
+- [ ] Expected: `Build SHA` shows the current commit short hash
+- [ ] Edge: closing and reopening the About dialog keeps the value (no flicker / blank state)
+- [ ] Regression: the existing `Check for updates` button still launches the update flow
+```

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -1882,4 +1882,198 @@ mod tests {
             "AGENTS.md must document the gwt-verify skill (SPEC-1935 Phase 17 FR-122)"
         );
     }
+
+    // SPEC-1935 Amendment (FR-129..FR-133): gwt-verify is a project-agnostic
+    // verification contract. The skill must document Test Inventory emission,
+    // a User Verification Handoff phase with a 4-step 導線 structure
+    // (build → launch → navigate → observe), and explicit Check Items.
+    // Callers (gwt-build-spec, gwt-manage-pr) must gate completion / push on
+    // the User Verification Result.
+
+    #[test]
+    fn gwt_verify_documents_test_inventory_section() {
+        let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+        for relative in [
+            ".claude/skills/gwt-verify/SKILL.md",
+            ".codex/skills/gwt-verify/SKILL.md",
+        ] {
+            let content = std::fs::read_to_string(workspace_root.join(relative))
+                .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+            assert!(
+                content.contains("Test Inventory"),
+                "{relative} must document the Test Inventory section (SPEC-1935 FR-130)"
+            );
+            assert!(
+                content.contains("inventory unavailable"),
+                "{relative} must specify the `inventory unavailable: <reason>` fallback for unparseable runner output"
+            );
+        }
+    }
+
+    #[test]
+    fn gwt_verify_documents_user_verification_phase() {
+        let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+        for relative in [
+            ".claude/skills/gwt-verify/SKILL.md",
+            ".codex/skills/gwt-verify/SKILL.md",
+        ] {
+            let content = std::fs::read_to_string(workspace_root.join(relative))
+                .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+            assert!(
+                content.contains("User Verification"),
+                "{relative} must document the User Verification Handoff phase (SPEC-1935 FR-131)"
+            );
+            assert!(
+                content.contains("User Verification Result"),
+                "{relative} must record User Verification Result in the evidence bundle"
+            );
+            assert!(
+                content.contains("confirmed")
+                    && content.contains("rejected")
+                    && content.contains("pending"),
+                "{relative} must enumerate User Verification Result states (pending/confirmed/rejected)"
+            );
+        }
+    }
+
+    #[test]
+    fn gwt_verify_documents_4_step_navigation_path() {
+        let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+        for relative in [
+            ".claude/skills/gwt-verify/SKILL.md",
+            ".codex/skills/gwt-verify/SKILL.md",
+        ] {
+            let content = std::fs::read_to_string(workspace_root.join(relative))
+                .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+            assert!(
+                content.contains("導線") || content.contains("How to access"),
+                "{relative} must include a 導線 / How-to-access section for user verification (SPEC-1935 FR-132)"
+            );
+            for step in ["build", "launch", "navigate", "observe"] {
+                assert!(
+                    content.contains(step),
+                    "{relative} must document the 4-step 導線 structure (missing step: {step})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn gwt_verify_documents_check_items_section() {
+        let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+        for relative in [
+            ".claude/skills/gwt-verify/SKILL.md",
+            ".codex/skills/gwt-verify/SKILL.md",
+        ] {
+            let content = std::fs::read_to_string(workspace_root.join(relative))
+                .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+            assert!(
+                content.contains("Check Items"),
+                "{relative} must document the Check Items section presented to the user"
+            );
+        }
+    }
+
+    #[test]
+    fn gwt_verify_is_project_agnostic() {
+        let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+        for relative in [
+            ".claude/skills/gwt-verify/SKILL.md",
+            ".codex/skills/gwt-verify/SKILL.md",
+        ] {
+            let content = std::fs::read_to_string(workspace_root.join(relative))
+                .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+            assert!(
+                content.contains("project-agnostic")
+                    || content.contains("Generic Verification Contract"),
+                "{relative} must declare itself as project-agnostic / generic verification contract (SPEC-1935 FR-129)"
+            );
+            // Runner manifests the skill should hint at for autodetection.
+            for manifest in [
+                "Cargo.toml",
+                "package.json",
+                "pyproject.toml",
+                "go.mod",
+                "ProjectSettings",
+            ] {
+                assert!(
+                    content.contains(manifest),
+                    "{relative} must mention runner-manifest signal `{manifest}` for autodetection"
+                );
+            }
+            // Project-local AGENTS.md must take precedence over the generic matrix.
+            assert!(
+                content.contains("AGENTS.md") && content.contains("project"),
+                "{relative} must require honoring the project's own AGENTS.md when present"
+            );
+        }
+    }
+
+    #[test]
+    fn gwt_verify_new_references_are_bundled() {
+        use crate::assets::CLAUDE_SKILLS;
+
+        let verify_dir = CLAUDE_SKILLS
+            .get_dir(".claude/skills/gwt-verify")
+            .or_else(|| CLAUDE_SKILLS.get_dir("gwt-verify"))
+            .expect("gwt-verify directory must be bundled in CLAUDE_SKILLS");
+
+        let references = verify_dir
+            .get_dir(
+                verify_dir
+                    .path()
+                    .join("references")
+                    .to_str()
+                    .expect("references path is utf8"),
+            )
+            .expect("gwt-verify must ship a references/ subdir");
+
+        let reference_files: Vec<&str> = references
+            .files()
+            .filter_map(|f| f.path().file_name().and_then(|n| n.to_str()))
+            .collect();
+
+        for required in [
+            "surface-taxonomy.md",
+            "runner-detection.md",
+            "user-verification-guide.md",
+        ] {
+            assert!(
+                reference_files.contains(&required),
+                "gwt-verify references/ must include {required} (SPEC-1935 Amendment FR-129..FR-132)"
+            );
+        }
+    }
+
+    #[test]
+    fn build_spec_phase_3_requires_user_verification_result() {
+        let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+        for relative in [
+            ".claude/skills/gwt-build-spec/SKILL.md",
+            ".codex/skills/gwt-build-spec/SKILL.md",
+        ] {
+            let content = std::fs::read_to_string(workspace_root.join(relative))
+                .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+            assert!(
+                content.contains("User Verification Result"),
+                "{relative} must gate Phase 3 completion on User Verification Result (SPEC-1935 FR-133)"
+            );
+        }
+    }
+
+    #[test]
+    fn manage_pr_pre_pr_requires_user_verification_result() {
+        let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+        for relative in [
+            ".claude/skills/gwt-manage-pr/SKILL.md",
+            ".codex/skills/gwt-manage-pr/SKILL.md",
+        ] {
+            let content = std::fs::read_to_string(workspace_root.join(relative))
+                .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+            assert!(
+                content.contains("User Verification Result"),
+                "{relative} must gate push / PR create / update on User Verification Result (SPEC-1935 FR-133)"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

外部プロセス (gh / git / docker / agent / Python runner) の stdout / stderr が事実上捨てられていた問題に対し、SPEC-1924 (通知・エラーバス) と SPEC-2019 (Logs ウィンドウ) の 2026-05-20 Amendment に沿って Process Console 基盤を導入する。

本 PR は Phase A 基盤 + Phase B (gh CLI 全 caller) を届け、Phase C (git 252 サイト) と Phase D (docker / agent / runner) は SPEC tasks で追跡しつつ follow-up PR で段階的に移行する。

## 主な変更

### crates/gwt-core/src/process_console/ (新規 module)
- `ProcessKind` enum (gh / git / docker / agent / runner)
- `ProcessLine` / `ProcessStream` + serde
- `ProcessConsoleHub` (kind ごと 5000 行 ring buffer + `tokio::sync::broadcast`)
- `set_global` / `global` でプロセス全域 hub をシングルトン化
- `spawn_logged` (async) / `spawn_logged_blocking` (sync) で `tokio::process::Command` + `read_to_end` をラップし stdout / stderr を redact + ring buffer + broadcast に流す
- secret redaction: `Authorization:` / `token=` / `gh_*` / `ghp_*` / `ghs_*` / `ghu_*` を `***redacted***` に置換
- 27 件の単体テスト

### gwt-core::logging 拡張
- `LoggingHandles.process_console_hub: Arc<ProcessConsoleHub>` 追加
- `logging::init` 内で `set_global` 実行
- `fmt_layer` に `target = "gwt.process.line"` 抑制 filter (FR-040 / SC-013)
- `crates/gwt-core/tests/process_console_filter.rs` regression test (canonical log に line-level event が漏れないことを固定)

### gh CLI 全 caller を `spawn_logged_blocking(ProcessKind::Gh, ...)` へ移行
- `crates/gwt/src/cli/pr/gh.rs` (PR fetch/create/edit/comment/reviews/threads/checks)
- `crates/gwt-git/src/pr_status.rs` (run_gh_command / fetch_pr_status / pr_check_report)
- `crates/gwt-git/src/issue.rs` (fetch_issues)
- `crates/gwt/src/cli/actions.rs` (gh run / gh api jobs)
- `crates/gwt/src/cli/issue.rs` (gh api graphql timelineItems)
- `crates/gwt/src/app_runtime/mod.rs` (gh search repos)
- `crates/gwt-github/src/client/http.rs` (gh auth token)

caller-facing `SpawnOutput.stdout` は raw 値、ring buffer / broadcast のみ redact するので `gh auth token` 等の token 取得は壊れない。

### SPEC 更新
- SPEC-2019: US-4 / FR-007..FR-009 / SC-005..SC-006 と 2026-05-20 Update セクション
- SPEC-1924: US-15 / FR-038..FR-041 / NFR-006 / SC-012..SC-013 と 2026-05-20 Update セクション
- plan / tasks を Phase G (SPEC-2019) と Phase D (SPEC-1924) として追加

## Test plan

- [x] `cargo test -p gwt-core --all-features` (310 + supporting passed)
- [x] `cargo test -p gwt-git` (126 + 8 + 16 passed)
- [x] `cargo test -p gwt-github` (87 across submodules)
- [x] `cargo test -p gwt --all-features` (1359 passed, 0 failed)
- [x] `cargo clippy -p gwt-core -p gwt-git -p gwt-github -p gwt --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `crates/gwt-core/tests/process_console_filter.rs` confirms `target = "gwt.process.line"` is excluded from canonical log file

## Follow-up

- SPEC-2019 Phase G: Logs ウィンドウに Process chip filter を追加する frontend 拡張
- SPEC-1924 Phase C / Phase D: 残り 252 件の git spawn サイトと docker / agent / runner caller の移行

🤖 Generated with [Claude Code](https://claude.com/claude-code)
