### PR TITLE
feat(index): add Lessons semantic search scope (SPEC #2805)

### DIFF
--- a/.claude/commands/gwt-lessons-search.md
+++ b/.claude/commands/gwt-lessons-search.md
@@ -1,0 +1,39 @@
+---
+description: Semantic search over the project's `tasks/lessons.md` post-mortem entries
+author: akiojin
+allowed-tools: Read, Glob, Grep, Bash
+---
+
+# Lessons Search Command
+
+Run a vector-embedded semantic search over the post-mortem lessons recorded
+at `tasks/lessons.md`. Use before starting work that resembles a past
+failure, when you want to reuse a previously-verified prevention strategy,
+or when you suspect the current bug has already been documented.
+
+## Usage
+
+```text
+/gwt:gwt-lessons-search [query]
+```
+
+## Steps
+
+1. Load `.claude/skills/gwt-lessons-search/SKILL.md` and follow the workflow.
+2. Execute the search query against the lessons index.
+3. Return ranked results with `date`, `title`, `heading`, `chunk_idx`, and
+   `distance`. Lower distance values are more relevant.
+
+## Examples
+
+```text
+/gwt:gwt-lessons-search "watcher debounce silent failure"
+```
+
+```text
+/gwt:gwt-lessons-search "spec section マーカー"
+```
+
+For a unified search that also includes SPECs, Issues, and project files,
+use `/gwt:gwt-search "query"` (default merge) or `/gwt:gwt-search --lessons
+"query"` to keep only lesson results.

--- a/.claude/skills/gwt-issue-search/SKILL.md
+++ b/.claude/skills/gwt-issue-search/SKILL.md
@@ -5,7 +5,7 @@ description: "Semantic search over all GitHub Issues using vector embeddings. Us
 
 # Issue Search
 
-gwt maintains a vector search index of GitHub Issues using ChromaDB embeddings (model: `intfloat/multilingual-e5-base`). The index is stored at `~/.gwt/index/<repo-hash>/issues/` and is Worktree-independent. The gwt TUI refreshes it asynchronously at startup with a 15-minute TTL; non-TUI sessions get an auto-build on the first search.
+gwt maintains a vector search index of GitHub Issues using ChromaDB embeddings (model: `intfloat/multilingual-e5-base`). The index is stored at `~/.gwt/index/<repo-hash>/issues/` and is Worktree-independent. The gwt GUI app (WebView built with `wry + tao + axum WebSocket` and `xterm.js`) refreshes it asynchronously at startup with a 15-minute TTL; external runner invocations get an auto-build on the first search.
 
 ## gwtd resolution
 
@@ -42,7 +42,7 @@ Suggested query patterns:
 
 ## Environment
 
-When the gwt TUI launches an agent pane, the following env vars are exported automatically:
+When the gwt GUI app launches an agent pane, the following env vars are exported automatically:
 
 - `GWT_PROJECT_ROOT` — absolute path of the active worktree
 - `GWT_REPO_HASH` — SHA256[:16] of the normalized origin URL
@@ -70,7 +70,7 @@ To force a refresh ignoring TTL:
   --project-root "$GWT_PROJECT_ROOT"
 ```
 
-Add `--respect-ttl` to skip when the previous refresh is younger than 15 minutes (used by the TUI startup background task).
+Add `--respect-ttl` to skip when the previous refresh is younger than 15 minutes (used by the gwt GUI startup background task).
 
 ## Issues search output format
 
@@ -89,7 +89,7 @@ Add `--respect-ttl` to skip when the previous refresh is younger than 15 minutes
 
 ## Notes
 
-- The TUI refreshes the Issue index automatically at startup (TTL 15 min). Non-TUI sessions trigger an inline build on the first search.
+- The gwt GUI app refreshes the Issue index automatically at startup (TTL 15 min). External runner invocations trigger an inline build on the first search.
 - Uses semantic similarity (not just keyword matching)
 - Lower distance values indicate higher relevance
 - For SPEC search, use `gwt-spec-search` instead (SPECs are GitHub Issues cached at `~/.gwt/cache/issues/`)

--- a/.claude/skills/gwt-lessons-search/SKILL.md
+++ b/.claude/skills/gwt-lessons-search/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: gwt-lessons-search
+description: "Semantic search over the project's lessons log at `tasks/lessons.md` using vector embeddings. Use when looking for past post-mortem fixes, prior re-occurrence prevention notes, or before starting work that resembles an earlier failure. Use when user says 'search lessons', 'find related lesson', 'check past failures', 'has this been hit before', '過去 lesson を引いて', '同じ失敗があるか確認して'."
+---
+
+# Lessons Search
+
+gwt maintains a vector search index over post-mortem lesson entries kept in
+`tasks/lessons.md` using ChromaDB embeddings (model:
+`intfloat/multilingual-e5-base`). Each H2 section (`## YYYY-MM-DD — title` plus
+the canonical `### 事象 / 原因 / 再発防止策` subsections) is chunked and
+embedded. The index is repo-scoped and stored at
+`~/.gwt/index/<repo-hash>/lessons/`, shared across worktrees. Lessons are the
+only canonical record of post-mortem learning for this project — write to
+`tasks/lessons.md` directly; this skill never edits content.
+
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
+## Lessons search first when work resembles past failures
+
+When the user asks any of the following, use lessons search **before** writing
+new code or spec text:
+
+- "過去 lesson を引いて"
+- "同じ失敗があるか確認して"
+- "before fixing X, check whether we have learned this before"
+- "Has this regression been recorded?"
+
+Minimum workflow:
+
+1. Run `search-lessons` with 2-3 semantic queries derived from the request.
+2. Pick the most relevant past lesson if one exists.
+3. Read the matching section in `tasks/lessons.md` before deciding the
+   approach. Reuse the existing prevention strategy when applicable.
+
+## Environment
+
+When the gwt GUI app (WebView built with `wry + tao + axum WebSocket` and
+`xterm.js`) launches an agent pane, the following env vars are exported
+automatically:
+
+- `GWT_PROJECT_ROOT` — absolute path of the active worktree
+- `GWT_REPO_HASH` — SHA256[:16] of the normalized origin URL
+- `GWT_WORKTREE_HASH` — SHA256[:16] of the canonicalized worktree absolute path
+
+If you invoke the runner outside the gwt app, recompute them as shown in
+`gwt-search` (the runner accepts the same flags for all scopes).
+
+## Lessons search command
+
+```bash
+~/.gwt/runtime/chroma-venv/bin/python3 ~/.gwt/runtime/chroma_index_runner.py \
+  --action search-lessons \
+  --repo-hash "$GWT_REPO_HASH" \
+  --project-root "$GWT_PROJECT_ROOT" \
+  --query "your search query" \
+  --n-results 10
+```
+
+If the lessons index does not yet exist, the runner builds it inline (full
+mode) from `<project_root>/tasks/lessons.md` and emits NDJSON progress on
+stderr before returning the search result.
+
+To force a full re-index (normally handled by the project watcher or the
+search auto-build fallback):
+
+```bash
+~/.gwt/runtime/chroma-venv/bin/python3 ~/.gwt/runtime/chroma_index_runner.py \
+  --action index-lessons \
+  --repo-hash "$GWT_REPO_HASH" \
+  --project-root "$GWT_PROJECT_ROOT" \
+  --mode full
+```
+
+`--worktree-hash` is accepted for symmetry with the other scopes but is
+ignored — lessons is repo-scoped and serves every worktree from a single
+index.
+
+## Lessons search output format
+
+```json
+{"ok": true, "lessonResults": [
+  {"date": "2026-05-20", "title": "gwtd issue spec create -f は section マーカーを付けない", "heading": "## 2026-05-20 — gwtd issue spec create -f は section マーカーを付けない", "chunk_idx": 0, "distance": 0.12}
+]}
+```
+
+When a lesson spans multiple chunks (long body or paragraph-split), only the
+best-scoring chunk per `(date, title)` pair is surfaced. Use the `heading`
+field to locate the exact section in `tasks/lessons.md`.
+
+## When to use
+
+- Pre-work duplication check: before fixing a bug or adding a feature, confirm
+  whether a related lesson already captures the prevention strategy.
+- Architecture discussions: surface relevant past learnings during
+  `gwt-discussion` or `gwt-arch-review`.
+- Code review: cite the original lesson that motivates a defensive change.
+- Onboarding: discover recurring failure modes documented in the project.
+
+## Write path is unchanged
+
+This skill does **not** write to `tasks/lessons.md`. New lessons must be added
+by editing the file directly with the canonical structure (`## YYYY-MM-DD —
+title` + `### 事象 / ### 原因 / ### 再発防止策`). The watcher and the
+auto-build fallback pick up the change automatically.
+
+## Notes
+
+- The runner auto-builds the lessons index when missing (use
+  `--no-auto-build` to suppress).
+- Uses semantic similarity (not just keyword matching). Lower distance values
+  indicate higher relevance.
+- For SPEC search, use `gwt-spec-search`. For GitHub Issue search, use
+  `gwt-issue-search`. For implementation file search, use
+  `gwt-project-search`. For a unified result across all four, use
+  `gwt-search` and add `--lessons` (or omit filters to merge every scope).

--- a/.claude/skills/gwt-project-search/SKILL.md
+++ b/.claude/skills/gwt-project-search/SKILL.md
@@ -5,11 +5,11 @@ description: "Semantic search over project source files using vector embeddings.
 
 # Project Search
 
-gwt maintains a vector search index of project implementation files using ChromaDB embeddings (model: `intfloat/multilingual-e5-base`). The index is stored at `~/.gwt/index/<repo-hash>/worktrees/<worktree-hash>/files/` (with a sibling `files-docs/` collection for documentation). The gwt TUI keeps a per-Worktree filesystem watcher running so changes flow into the index automatically. When invoked outside the TUI, the runner auto-builds the index on the first call.
+gwt maintains a vector search index of project implementation files using ChromaDB embeddings (model: `intfloat/multilingual-e5-base`). The index is stored at `~/.gwt/index/<repo-hash>/worktrees/<worktree-hash>/files/` (with a sibling `files-docs/` collection for documentation). The gwt GUI app (WebView built with `wry + tao + axum WebSocket` and `xterm.js`) keeps a per-Worktree filesystem watcher running so changes flow into the index automatically. When invoked outside the gwt app, the runner auto-builds the index on the first call.
 
 ## Environment
 
-When the gwt TUI launches an agent pane, the following env vars are exported automatically:
+When the gwt GUI app launches an agent pane, the following env vars are exported automatically:
 
 - `GWT_PROJECT_ROOT` — absolute path of the active worktree
 - `GWT_REPO_HASH` — SHA256[:16] of the normalized origin URL
@@ -59,7 +59,7 @@ On Windows, use `~/.gwt/runtime/chroma-venv/Scripts/python.exe` as the Python ex
 
 ## Notes
 
-- The TUI watcher (2 s debounce, 100-file batch) keeps the index live; non-TUI sessions get an mtime+size diff per call
+- The gwt GUI watcher (2 s debounce, 100-file batch) keeps the index live; external runner invocations get an mtime+size diff per call
 - The runner auto-builds the index when missing (use `--no-auto-build` to suppress)
 - `search-files` is implementation-focused and excludes embedded skill assets, local/archived SPEC trees, local task logs, and snapshot files
 - Project docs are indexed separately and can be searched with `search-files-docs`

--- a/.claude/skills/gwt-search/SKILL.md
+++ b/.claude/skills/gwt-search/SKILL.md
@@ -1,21 +1,29 @@
 ---
 name: gwt-search
-description: "Mandatory preflight before gwt-discussion, gwt-register-issue, and gwt-fix-issue. Use proactively before creating any SPEC or Issue owner or before reusing an existing one. Searches SPEC Issues, GitHub Issues, and project files via ChromaDB. Triggers: 'search', 'find related', 'check duplicates'."
+description: "Mandatory preflight before gwt-discussion, gwt-register-issue, and gwt-fix-issue. Use proactively before creating any SPEC or Issue owner or before reusing an existing one. Searches SPEC Issues, GitHub Issues, project files, and post-mortem lessons via ChromaDB. Triggers: 'search', 'find related', 'check duplicates', '過去 lesson を引いて'."
 ---
 
 # Unified Search
 
-gwt maintains ChromaDB vector search indexes for three scopes (Phase 8 layout):
+gwt maintains ChromaDB vector search indexes for four scopes (Phase 8 layout
+plus SPEC-2805 Lessons):
 
 | Scope | Content | Lifecycle |
 |-------|---------|-----------|
-| SPECs | GitHub Issue cache (`~/.gwt/cache/issues/`) | Populated by `gwtd issue spec pull` or TUI startup sync |
-| Issues | GitHub Issues (all states) | TUI startup async refresh (TTL 15 min) + runner auto-build on first search |
-| Files | Project implementation files (excludes skill assets, SPEC trees, snapshots) | Watcher (TUI) + runner auto-build on first search |
+| SPECs | GitHub Issue cache (`~/.gwt/cache/issues/`) | Populated by `gwtd issue spec pull` or gwt GUI startup sync |
+| Issues | GitHub Issues (all states) | gwt GUI startup async refresh (TTL 15 min) + runner auto-build on first search |
+| Files | Project implementation files (excludes skill assets, SPEC trees, snapshots) | Per-worktree watcher (gwt GUI) + runner auto-build on first search |
+| Lessons | Post-mortem entries in `tasks/lessons.md` | Pinpoint allowlist watcher on `tasks/lessons.md` + runner auto-build on first search |
 
-All vector data is stored under `~/.gwt/index/<repo-hash>/...`. Issues are repo-scoped and shared across worktrees; SPECs and Files are worktree-scoped under `worktrees/<worktree-hash>/`. The legacy `$WORKTREE/.gwt/index/` location is no longer used and is deleted automatically by the TUI on startup.
+All vector data is stored under `~/.gwt/index/<repo-hash>/...`. Issues,
+SPECs, and Lessons are repo-scoped and shared across worktrees; Files (code
++ docs) is worktree-scoped under `worktrees/<worktree-hash>/`. The legacy
+`$WORKTREE/.gwt/index/` location is no longer used and is deleted
+automatically by the gwt GUI on startup.
 
-When invoked outside the gwt TUI, the runner falls back to a synchronous mtime+size diff per call: results are always correct, just slower than the TUI watcher path.
+When invoked outside the gwt GUI app, the runner falls back to a
+synchronous mtime+size diff per call: results are always correct, just
+slower than the GUI watcher path.
 
 ## gwtd resolution
 
@@ -28,30 +36,34 @@ command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
 ## Quick reference
 
 ```text
-gwt-search "query"              # search all three scopes
+gwt-search "query"              # search all four scopes (default merge)
 gwt-search --specs "query"      # SPECs only
 gwt-search --issues "query"     # GitHub Issues only
 gwt-search --files "query"      # implementation files only
+gwt-search --lessons "query"    # post-mortem lessons only
 ```
 
 ## Filter options
 
 | Flag | Scope | Action flag |
 |------|-------|------------|
-| (none) | All three | Run all three searches |
+| (none) | All four | Run all four searches |
 | `--specs` | SPECs only | `search-specs` |
 | `--issues` | Issues only | `search-issues` |
 | `--files` | Files only | `search-files` |
+| `--lessons` | Lessons only | `search-lessons` |
 
 ## Environment
 
-When the gwt TUI launches an agent pane, the following env vars are exported automatically:
+When the gwt GUI app (WebView built with `wry + tao + axum WebSocket` and
+`xterm.js`) launches an agent pane, the following env vars are exported
+automatically:
 
 - `GWT_PROJECT_ROOT` — absolute path of the active worktree
 - `GWT_REPO_HASH` — SHA256[:16] of the normalized origin URL
 - `GWT_WORKTREE_HASH` — SHA256[:16] of the canonicalized worktree absolute path
 
-If you launch outside the TUI, recompute them:
+If you launch outside the gwt app, recompute them:
 
 ```bash
 GWT_PROJECT_ROOT="$(pwd)"
@@ -119,9 +131,25 @@ $PYTHON $RUNNER \
   --n-results 10
 ```
 
+### Search Lessons
+
+```bash
+$PYTHON $RUNNER \
+  --action search-lessons \
+  --repo-hash "$GWT_REPO_HASH" \
+  --project-root "$GWT_PROJECT_ROOT" \
+  --query "your search query" \
+  --n-results 10
+```
+
+`search-lessons` reads from the repo-scoped lessons index built from
+`<project_root>/tasks/lessons.md`. `--worktree-hash` is accepted but ignored
+for this scope.
+
 ### Search all scopes (default)
 
-Run all four search commands above and merge results by scope.
+Run all five search commands above (SPECs, Issues, Files-code, Files-docs,
+Lessons) and merge results by scope.
 
 ## Auto-build fallback
 
@@ -140,7 +168,8 @@ Pass `--no-auto-build` to disable this behavior; in that case the runner returns
 
 ## Index update commands
 
-These are run automatically by the TUI watcher (or by the runner's auto-build fallback). Run manually only when forcing a full rebuild.
+These are run automatically by the gwt GUI watcher (or by the runner's
+auto-build fallback). Run manually only when forcing a full rebuild.
 
 ### Update SPEC index (force full)
 
@@ -178,6 +207,18 @@ $PYTHON $RUNNER \
 
 For the docs collection, repeat with `--scope files-docs`.
 
+### Update lessons index (force full)
+
+```bash
+$PYTHON $RUNNER \
+  --action index-lessons \
+  --repo-hash "$GWT_REPO_HASH" \
+  --project-root "$GWT_PROJECT_ROOT" \
+  --mode full
+```
+
+Lessons is repo-scoped; `--worktree-hash` is accepted but ignored.
+
 ## Output formats
 
 ### SPEC results
@@ -201,6 +242,14 @@ For the docs collection, repeat with `--scope files-docs`.
 ```json
 {"ok": true, "results": [
   {"path": "src/git/issue.rs", "description": "GitHub Issue commands", "distance": 0.12}
+]}
+```
+
+### Lessons results
+
+```json
+{"ok": true, "lessonResults": [
+  {"date": "2026-05-20", "title": "gwtd issue spec create -f は section マーカーを付けない", "heading": "## 2026-05-20 — gwtd issue spec create -f は section マーカーを付けない", "chunk_idx": 0, "distance": 0.12}
 ]}
 ```
 
@@ -228,23 +277,27 @@ Run at least 2-3 semantic queries derived from the request before creating any n
 
 - **Spec integration**: find the canonical spec before creating or updating
 - **Issue lookup**: find existing GitHub Issues before creating new ones
-- **Task start**: search for specs, issues, and files related to the assigned feature
-- **Bug investigation**: find issues and files that might relate to the bug
-- **Duplicate check**: verify no existing spec or issue covers the same scope
-- **Architecture understanding**: discover how features are specified and implemented
-- **Feature addition**: locate existing similar implementations across all scopes
+- **Lessons lookup**: before fixing a bug, check whether a prior `tasks/lessons.md` entry already records the prevention strategy
+- **Task start**: search for specs, issues, files, and lessons related to the assigned feature
+- **Bug investigation**: find issues, files, and lessons that might relate to the bug
+- **Duplicate check**: verify no existing spec, issue, or lesson covers the same scope
+- **Architecture understanding**: discover how features are specified, implemented, and previously failed
+- **Feature addition**: locate existing similar implementations and recurring failure modes across all scopes
 
 ### Trigger phrases
 
-- "search specs / issues / files"
-- "find related specs / issues / files"
+- "search specs / issues / files / lessons"
+- "find related specs / issues / files / lessons"
 - "check for duplicates"
 - "which spec / issue handles X"
+- "has this regression been recorded?"
 - "既存仕様を探して"
 - "関連 Issue を探して"
 - "どの SPEC に統合するべきか"
 - "重複する SPEC はないか確認して"
 - "この機能の仕様は？"
+- "過去 lesson を引いて"
+- "同じ失敗があるか確認して"
 
 ## Suggested query patterns
 
@@ -253,12 +306,13 @@ Use 2-3 queries with different angles for thorough coverage:
 - **Subsystem + purpose**: `project index issue search spec`
 - **User-facing problem + architecture term**: `chroma persisted db recovery project index`
 - **Workflow + discoverability**: `LLM should use search before spec creation`
-- **Japanese keywords**: `TUI ナビゲーション キーバインド`
+- **Japanese keywords**: `ターミナル ナビゲーション キーバインド`
 - **Domain concept**: `worktree management branch isolation`
+- **Past failure**: `watcher debounce silent failure`, `spec section マーカー罠`
 
 ## Minimum search workflow
 
 1. Run searches with 2-3 semantic queries derived from the request
 2. The runner auto-builds any missing index on the first call
-3. Pick the canonical existing spec or issue if found
+3. Pick the canonical existing spec, issue, or lesson if found
 4. Only fall back to creating a new spec or issue when no suitable canonical match exists

--- a/.claude/skills/gwt-spec-search/SKILL.md
+++ b/.claude/skills/gwt-spec-search/SKILL.md
@@ -33,7 +33,7 @@ Minimum workflow:
 
 ## Environment
 
-When the gwt TUI launches an agent pane, the following env vars are exported automatically:
+When the gwt GUI app (WebView built with `wry + tao + axum WebSocket` and `xterm.js`) launches an agent pane, the following env vars are exported automatically:
 
 - `GWT_PROJECT_ROOT` — absolute path of the active worktree
 - `GWT_REPO_HASH` — SHA256[:16] of the normalized origin URL
@@ -81,7 +81,7 @@ To force a full re-index (normally handled by the watcher / auto-build):
 
 ## Notes
 
-- `search-specs` refreshes the worktree-scoped SPEC index from the repo-scoped Issue cache before non-TUI searches
+- `search-specs` refreshes the worktree-scoped SPEC index from the repo-scoped Issue cache before external (non-GUI) runner invocations
 - The runner auto-builds the index when missing (use `--no-auto-build` to suppress)
 - Uses semantic similarity (not just keyword matching)
 - Lower distance values indicate higher relevance

--- a/.codex/skills/gwt-issue-search/SKILL.md
+++ b/.codex/skills/gwt-issue-search/SKILL.md
@@ -5,7 +5,7 @@ description: "Semantic search over all GitHub Issues using vector embeddings. Us
 
 # Issue Search
 
-gwt maintains a vector search index of GitHub Issues using ChromaDB embeddings (model: `intfloat/multilingual-e5-base`). The index is stored at `~/.gwt/index/<repo-hash>/issues/` and is Worktree-independent. The gwt TUI refreshes it asynchronously at startup with a 15-minute TTL; non-TUI sessions get an auto-build on the first search.
+gwt maintains a vector search index of GitHub Issues using ChromaDB embeddings (model: `intfloat/multilingual-e5-base`). The index is stored at `~/.gwt/index/<repo-hash>/issues/` and is Worktree-independent. The gwt GUI app (WebView built with `wry + tao + axum WebSocket` and `xterm.js`) refreshes it asynchronously at startup with a 15-minute TTL; external runner invocations get an auto-build on the first search.
 
 ## gwtd resolution
 
@@ -42,7 +42,7 @@ Suggested query patterns:
 
 ## Environment
 
-When the gwt TUI launches an agent pane, the following env vars are exported automatically:
+When the gwt GUI app launches an agent pane, the following env vars are exported automatically:
 
 - `GWT_PROJECT_ROOT` — absolute path of the active worktree
 - `GWT_REPO_HASH` — SHA256[:16] of the normalized origin URL
@@ -70,7 +70,7 @@ To force a refresh ignoring TTL:
   --project-root "$GWT_PROJECT_ROOT"
 ```
 
-Add `--respect-ttl` to skip when the previous refresh is younger than 15 minutes (used by the TUI startup background task).
+Add `--respect-ttl` to skip when the previous refresh is younger than 15 minutes (used by the gwt GUI startup background task).
 
 ## Issues search output format
 
@@ -89,7 +89,7 @@ Add `--respect-ttl` to skip when the previous refresh is younger than 15 minutes
 
 ## Notes
 
-- The TUI refreshes the Issue index automatically at startup (TTL 15 min). Non-TUI sessions trigger an inline build on the first search.
+- The gwt GUI app refreshes the Issue index automatically at startup (TTL 15 min). External runner invocations trigger an inline build on the first search.
 - Uses semantic similarity (not just keyword matching)
 - Lower distance values indicate higher relevance
 - For SPEC search, use `gwt-spec-search` instead (SPECs are GitHub Issues cached at `~/.gwt/cache/issues/`)

--- a/.codex/skills/gwt-lessons-search/SKILL.md
+++ b/.codex/skills/gwt-lessons-search/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: gwt-lessons-search
+description: "Semantic search over the project's lessons log at `tasks/lessons.md` using vector embeddings. Use when looking for past post-mortem fixes, prior re-occurrence prevention notes, or before starting work that resembles an earlier failure. Use when user says 'search lessons', 'find related lesson', 'check past failures', 'has this been hit before', '過去 lesson を引いて', '同じ失敗があるか確認して'."
+---
+
+# Lessons Search
+
+gwt maintains a vector search index over post-mortem lesson entries kept in
+`tasks/lessons.md` using ChromaDB embeddings (model:
+`intfloat/multilingual-e5-base`). Each H2 section (`## YYYY-MM-DD — title` plus
+the canonical `### 事象 / 原因 / 再発防止策` subsections) is chunked and
+embedded. The index is repo-scoped and stored at
+`~/.gwt/index/<repo-hash>/lessons/`, shared across worktrees. Lessons are the
+only canonical record of post-mortem learning for this project — write to
+`tasks/lessons.md` directly; this skill never edits content.
+
+## gwtd resolution
+
+Before executing any `gwtd ...` command from this skill or its references,
+resolve `GWT_BIN` first: executable `GWT_BIN_PATH`, then `command -v gwtd`,
+then `$GWT_PROJECT_ROOT/target/debug/gwtd` or `./target/debug/gwtd`. Run the
+command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
+`gwtd not found` error.
+
+## Lessons search first when work resembles past failures
+
+When the user asks any of the following, use lessons search **before** writing
+new code or spec text:
+
+- "過去 lesson を引いて"
+- "同じ失敗があるか確認して"
+- "before fixing X, check whether we have learned this before"
+- "Has this regression been recorded?"
+
+Minimum workflow:
+
+1. Run `search-lessons` with 2-3 semantic queries derived from the request.
+2. Pick the most relevant past lesson if one exists.
+3. Read the matching section in `tasks/lessons.md` before deciding the
+   approach. Reuse the existing prevention strategy when applicable.
+
+## Environment
+
+When the gwt GUI app (WebView built with `wry + tao + axum WebSocket` and
+`xterm.js`) launches an agent pane, the following env vars are exported
+automatically:
+
+- `GWT_PROJECT_ROOT` — absolute path of the active worktree
+- `GWT_REPO_HASH` — SHA256[:16] of the normalized origin URL
+- `GWT_WORKTREE_HASH` — SHA256[:16] of the canonicalized worktree absolute path
+
+If you invoke the runner outside the gwt app, recompute them as shown in
+`gwt-search` (the runner accepts the same flags for all scopes).
+
+## Lessons search command
+
+```bash
+~/.gwt/runtime/chroma-venv/bin/python3 ~/.gwt/runtime/chroma_index_runner.py \
+  --action search-lessons \
+  --repo-hash "$GWT_REPO_HASH" \
+  --project-root "$GWT_PROJECT_ROOT" \
+  --query "your search query" \
+  --n-results 10
+```
+
+If the lessons index does not yet exist, the runner builds it inline (full
+mode) from `<project_root>/tasks/lessons.md` and emits NDJSON progress on
+stderr before returning the search result.
+
+To force a full re-index (normally handled by the project watcher or the
+search auto-build fallback):
+
+```bash
+~/.gwt/runtime/chroma-venv/bin/python3 ~/.gwt/runtime/chroma_index_runner.py \
+  --action index-lessons \
+  --repo-hash "$GWT_REPO_HASH" \
+  --project-root "$GWT_PROJECT_ROOT" \
+  --mode full
+```
+
+`--worktree-hash` is accepted for symmetry with the other scopes but is
+ignored — lessons is repo-scoped and serves every worktree from a single
+index.
+
+## Lessons search output format
+
+```json
+{"ok": true, "lessonResults": [
+  {"date": "2026-05-20", "title": "gwtd issue spec create -f は section マーカーを付けない", "heading": "## 2026-05-20 — gwtd issue spec create -f は section マーカーを付けない", "chunk_idx": 0, "distance": 0.12}
+]}
+```
+
+When a lesson spans multiple chunks (long body or paragraph-split), only the
+best-scoring chunk per `(date, title)` pair is surfaced. Use the `heading`
+field to locate the exact section in `tasks/lessons.md`.
+
+## When to use
+
+- Pre-work duplication check: before fixing a bug or adding a feature, confirm
+  whether a related lesson already captures the prevention strategy.
+- Architecture discussions: surface relevant past learnings during
+  `gwt-discussion` or `gwt-arch-review`.
+- Code review: cite the original lesson that motivates a defensive change.
+- Onboarding: discover recurring failure modes documented in the project.
+
+## Write path is unchanged
+
+This skill does **not** write to `tasks/lessons.md`. New lessons must be added
+by editing the file directly with the canonical structure (`## YYYY-MM-DD —
+title` + `### 事象 / ### 原因 / ### 再発防止策`). The watcher and the
+auto-build fallback pick up the change automatically.
+
+## Notes
+
+- The runner auto-builds the lessons index when missing (use
+  `--no-auto-build` to suppress).
+- Uses semantic similarity (not just keyword matching). Lower distance values
+  indicate higher relevance.
+- For SPEC search, use `gwt-spec-search`. For GitHub Issue search, use
+  `gwt-issue-search`. For implementation file search, use
+  `gwt-project-search`. For a unified result across all four, use
+  `gwt-search` and add `--lessons` (or omit filters to merge every scope).

--- a/.codex/skills/gwt-project-search/SKILL.md
+++ b/.codex/skills/gwt-project-search/SKILL.md
@@ -5,26 +5,43 @@ description: "Semantic search over project source files using vector embeddings.
 
 # Project Search
 
-gwt maintains a vector search index of project implementation files using ChromaDB embeddings.
-The index is automatically updated when source files change (via file system watcher).
+gwt maintains a vector search index of project implementation files using ChromaDB embeddings (model: `intfloat/multilingual-e5-base`). The index is stored at `~/.gwt/index/<repo-hash>/worktrees/<worktree-hash>/files/` (with a sibling `files-docs/` collection for documentation). The gwt GUI app (WebView built with `wry + tao + axum WebSocket` and `xterm.js`) keeps a per-Worktree filesystem watcher running so changes flow into the index automatically. When invoked outside the gwt app, the runner auto-builds the index on the first call.
 
-## File search command
+## Environment
 
-Run in terminal to find files related to a feature or concept:
+When the gwt GUI app launches an agent pane, the following env vars are exported automatically:
+
+- `GWT_PROJECT_ROOT` — absolute path of the active worktree
+- `GWT_REPO_HASH` — SHA256[:16] of the normalized origin URL
+- `GWT_WORKTREE_HASH` — SHA256[:16] of the canonicalized worktree absolute path
+
+## File search command (code)
 
 ```bash
 ~/.gwt/runtime/chroma-venv/bin/python3 ~/.gwt/runtime/chroma_index_runner.py \
   --action search-files \
-  --db-path "$GWT_PROJECT_ROOT/.gwt/index" \
+  --repo-hash "$GWT_REPO_HASH" \
+  --worktree-hash "$GWT_WORKTREE_HASH" \
+  --project-root "$GWT_PROJECT_ROOT" \
   --query "your search query" \
   --n-results 10
 ```
 
 On Windows, use `~/.gwt/runtime/chroma-venv/Scripts/python.exe` as the Python executable.
 
-## File search output format
+## Project docs search
 
-JSON object with ranked results:
+```bash
+~/.gwt/runtime/chroma-venv/bin/python3 ~/.gwt/runtime/chroma_index_runner.py \
+  --action search-files-docs \
+  --repo-hash "$GWT_REPO_HASH" \
+  --worktree-hash "$GWT_WORKTREE_HASH" \
+  --project-root "$GWT_PROJECT_ROOT" \
+  --query "your search query" \
+  --n-results 10
+```
+
+## File search output format
 
 ```json
 {"ok": true, "results": [
@@ -40,13 +57,10 @@ JSON object with ranked results:
 - Feature addition: locate existing similar implementations in the project
 - Architecture understanding: discover how project components are organized
 
-## Environment
-
-- `GWT_PROJECT_ROOT`: absolute path to the project root (set by gwt at pane launch)
-
 ## Notes
 
-- Project file index is automatically maintained by the file system watcher (changes trigger re-indexing)
+- The gwt GUI watcher (2 s debounce, 100-file batch) keeps the index live; external runner invocations get an mtime+size diff per call
+- The runner auto-builds the index when missing (use `--no-auto-build` to suppress)
 - `search-files` is implementation-focused and excludes embedded skill assets, local/archived SPEC trees, local task logs, and snapshot files
 - Project docs are indexed separately and can be searched with `search-files-docs`
 - Uses semantic similarity (not just keyword matching)

--- a/.codex/skills/gwt-search/SKILL.md
+++ b/.codex/skills/gwt-search/SKILL.md
@@ -1,21 +1,29 @@
 ---
 name: gwt-search
-description: "Mandatory preflight before gwt-discussion, gwt-register-issue, and gwt-fix-issue. Use proactively before creating any SPEC or Issue owner or before reusing an existing one. Searches SPEC Issues, GitHub Issues, and project files via ChromaDB. Triggers: 'search', 'find related', 'check duplicates'."
+description: "Mandatory preflight before gwt-discussion, gwt-register-issue, and gwt-fix-issue. Use proactively before creating any SPEC or Issue owner or before reusing an existing one. Searches SPEC Issues, GitHub Issues, project files, and post-mortem lessons via ChromaDB. Triggers: 'search', 'find related', 'check duplicates', '過去 lesson を引いて'."
 ---
 
 # Unified Search
 
-gwt maintains ChromaDB vector search indexes for three scopes (Phase 8 layout):
+gwt maintains ChromaDB vector search indexes for four scopes (Phase 8 layout
+plus SPEC-2805 Lessons):
 
 | Scope | Content | Lifecycle |
 |-------|---------|-----------|
-| SPECs | GitHub Issue cache (`~/.gwt/cache/issues/`) | Populated by `gwtd issue spec pull` or TUI startup sync |
-| Issues | GitHub Issues (all states) | TUI startup async refresh (TTL 15 min) + runner auto-build on first search |
-| Files | Project implementation files (excludes skill assets, SPEC trees, snapshots) | Watcher (TUI) + runner auto-build on first search |
+| SPECs | GitHub Issue cache (`~/.gwt/cache/issues/`) | Populated by `gwtd issue spec pull` or gwt GUI startup sync |
+| Issues | GitHub Issues (all states) | gwt GUI startup async refresh (TTL 15 min) + runner auto-build on first search |
+| Files | Project implementation files (excludes skill assets, SPEC trees, snapshots) | Per-worktree watcher (gwt GUI) + runner auto-build on first search |
+| Lessons | Post-mortem entries in `tasks/lessons.md` | Pinpoint allowlist watcher on `tasks/lessons.md` + runner auto-build on first search |
 
-All vector data is stored under `~/.gwt/index/<repo-hash>/...`. Issues are repo-scoped and shared across worktrees; SPECs and Files are worktree-scoped under `worktrees/<worktree-hash>/`. The legacy `$WORKTREE/.gwt/index/` location is no longer used and is deleted automatically by the TUI on startup.
+All vector data is stored under `~/.gwt/index/<repo-hash>/...`. Issues,
+SPECs, and Lessons are repo-scoped and shared across worktrees; Files (code
++ docs) is worktree-scoped under `worktrees/<worktree-hash>/`. The legacy
+`$WORKTREE/.gwt/index/` location is no longer used and is deleted
+automatically by the gwt GUI on startup.
 
-When invoked outside the gwt TUI, the runner falls back to a synchronous mtime+size diff per call: results are always correct, just slower than the TUI watcher path.
+When invoked outside the gwt GUI app, the runner falls back to a
+synchronous mtime+size diff per call: results are always correct, just
+slower than the GUI watcher path.
 
 ## gwtd resolution
 
@@ -28,30 +36,34 @@ command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
 ## Quick reference
 
 ```text
-gwt-search "query"              # search all three scopes
+gwt-search "query"              # search all four scopes (default merge)
 gwt-search --specs "query"      # SPECs only
 gwt-search --issues "query"     # GitHub Issues only
 gwt-search --files "query"      # implementation files only
+gwt-search --lessons "query"    # post-mortem lessons only
 ```
 
 ## Filter options
 
 | Flag | Scope | Action flag |
 |------|-------|------------|
-| (none) | All three | Run all three searches |
+| (none) | All four | Run all four searches |
 | `--specs` | SPECs only | `search-specs` |
 | `--issues` | Issues only | `search-issues` |
 | `--files` | Files only | `search-files` |
+| `--lessons` | Lessons only | `search-lessons` |
 
 ## Environment
 
-When the gwt TUI launches an agent pane, the following env vars are exported automatically:
+When the gwt GUI app (WebView built with `wry + tao + axum WebSocket` and
+`xterm.js`) launches an agent pane, the following env vars are exported
+automatically:
 
 - `GWT_PROJECT_ROOT` — absolute path of the active worktree
 - `GWT_REPO_HASH` — SHA256[:16] of the normalized origin URL
 - `GWT_WORKTREE_HASH` — SHA256[:16] of the canonicalized worktree absolute path
 
-If you launch outside the TUI, recompute them:
+If you launch outside the gwt app, recompute them:
 
 ```bash
 GWT_PROJECT_ROOT="$(pwd)"
@@ -119,9 +131,25 @@ $PYTHON $RUNNER \
   --n-results 10
 ```
 
+### Search Lessons
+
+```bash
+$PYTHON $RUNNER \
+  --action search-lessons \
+  --repo-hash "$GWT_REPO_HASH" \
+  --project-root "$GWT_PROJECT_ROOT" \
+  --query "your search query" \
+  --n-results 10
+```
+
+`search-lessons` reads from the repo-scoped lessons index built from
+`<project_root>/tasks/lessons.md`. `--worktree-hash` is accepted but ignored
+for this scope.
+
 ### Search all scopes (default)
 
-Run all four search commands above and merge results by scope.
+Run all five search commands above (SPECs, Issues, Files-code, Files-docs,
+Lessons) and merge results by scope.
 
 ## Auto-build fallback
 
@@ -140,7 +168,8 @@ Pass `--no-auto-build` to disable this behavior; in that case the runner returns
 
 ## Index update commands
 
-These are run automatically by the TUI watcher (or by the runner's auto-build fallback). Run manually only when forcing a full rebuild.
+These are run automatically by the gwt GUI watcher (or by the runner's
+auto-build fallback). Run manually only when forcing a full rebuild.
 
 ### Update SPEC index (force full)
 
@@ -178,6 +207,18 @@ $PYTHON $RUNNER \
 
 For the docs collection, repeat with `--scope files-docs`.
 
+### Update lessons index (force full)
+
+```bash
+$PYTHON $RUNNER \
+  --action index-lessons \
+  --repo-hash "$GWT_REPO_HASH" \
+  --project-root "$GWT_PROJECT_ROOT" \
+  --mode full
+```
+
+Lessons is repo-scoped; `--worktree-hash` is accepted but ignored.
+
 ## Output formats
 
 ### SPEC results
@@ -201,6 +242,14 @@ For the docs collection, repeat with `--scope files-docs`.
 ```json
 {"ok": true, "results": [
   {"path": "src/git/issue.rs", "description": "GitHub Issue commands", "distance": 0.12}
+]}
+```
+
+### Lessons results
+
+```json
+{"ok": true, "lessonResults": [
+  {"date": "2026-05-20", "title": "gwtd issue spec create -f は section マーカーを付けない", "heading": "## 2026-05-20 — gwtd issue spec create -f は section マーカーを付けない", "chunk_idx": 0, "distance": 0.12}
 ]}
 ```
 
@@ -228,23 +277,27 @@ Run at least 2-3 semantic queries derived from the request before creating any n
 
 - **Spec integration**: find the canonical spec before creating or updating
 - **Issue lookup**: find existing GitHub Issues before creating new ones
-- **Task start**: search for specs, issues, and files related to the assigned feature
-- **Bug investigation**: find issues and files that might relate to the bug
-- **Duplicate check**: verify no existing spec or issue covers the same scope
-- **Architecture understanding**: discover how features are specified and implemented
-- **Feature addition**: locate existing similar implementations across all scopes
+- **Lessons lookup**: before fixing a bug, check whether a prior `tasks/lessons.md` entry already records the prevention strategy
+- **Task start**: search for specs, issues, files, and lessons related to the assigned feature
+- **Bug investigation**: find issues, files, and lessons that might relate to the bug
+- **Duplicate check**: verify no existing spec, issue, or lesson covers the same scope
+- **Architecture understanding**: discover how features are specified, implemented, and previously failed
+- **Feature addition**: locate existing similar implementations and recurring failure modes across all scopes
 
 ### Trigger phrases
 
-- "search specs / issues / files"
-- "find related specs / issues / files"
+- "search specs / issues / files / lessons"
+- "find related specs / issues / files / lessons"
 - "check for duplicates"
 - "which spec / issue handles X"
+- "has this regression been recorded?"
 - "既存仕様を探して"
 - "関連 Issue を探して"
 - "どの SPEC に統合するべきか"
 - "重複する SPEC はないか確認して"
 - "この機能の仕様は？"
+- "過去 lesson を引いて"
+- "同じ失敗があるか確認して"
 
 ## Suggested query patterns
 
@@ -253,12 +306,13 @@ Use 2-3 queries with different angles for thorough coverage:
 - **Subsystem + purpose**: `project index issue search spec`
 - **User-facing problem + architecture term**: `chroma persisted db recovery project index`
 - **Workflow + discoverability**: `LLM should use search before spec creation`
-- **Japanese keywords**: `TUI ナビゲーション キーバインド`
+- **Japanese keywords**: `ターミナル ナビゲーション キーバインド`
 - **Domain concept**: `worktree management branch isolation`
+- **Past failure**: `watcher debounce silent failure`, `spec section マーカー罠`
 
 ## Minimum search workflow
 
 1. Run searches with 2-3 semantic queries derived from the request
 2. The runner auto-builds any missing index on the first call
-3. Pick the canonical existing spec or issue if found
+3. Pick the canonical existing spec, issue, or lesson if found
 4. Only fall back to creating a new spec or issue when no suitable canonical match exists

--- a/.codex/skills/gwt-spec-search/SKILL.md
+++ b/.codex/skills/gwt-spec-search/SKILL.md
@@ -33,7 +33,7 @@ Minimum workflow:
 
 ## Environment
 
-When the gwt TUI launches an agent pane, the following env vars are exported automatically:
+When the gwt GUI app (WebView built with `wry + tao + axum WebSocket` and `xterm.js`) launches an agent pane, the following env vars are exported automatically:
 
 - `GWT_PROJECT_ROOT` — absolute path of the active worktree
 - `GWT_REPO_HASH` — SHA256[:16] of the normalized origin URL
@@ -81,7 +81,7 @@ To force a full re-index (normally handled by the watcher / auto-build):
 
 ## Notes
 
-- `search-specs` refreshes the worktree-scoped SPEC index from the repo-scoped Issue cache before non-TUI searches
+- `search-specs` refreshes the worktree-scoped SPEC index from the repo-scoped Issue cache before external (non-GUI) runner invocations
 - The runner auto-builds the index when missing (use `--no-auto-build` to suppress)
 - Uses semantic similarity (not just keyword matching)
 - Lower distance values indicate higher relevance

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,7 @@
 - 中規模以上の作業では `tasks/todo.md` をローカル作業ログとして使用する。存在しない場合は作成し、Plan と進捗チェックボックスを管理する。
 - `tasks/todo.md` には「背景」「実装ステップ」「検証結果」を残し、作業に合わせて更新する。ただし `tasks/todo.md` は version 管理しない。恒久的に残すべき内容は GitHub Issue / PR / README 等へ転記する。
 - 再発防止に値する失敗やレビュー指摘は `tasks/lessons.md` に「事象 / 原因 / 再発防止策」の形式で記録する。
-- 同種の作業を始める前に `tasks/lessons.md` を確認し、既知の失敗を繰り返さない。
+- 同種の作業を始める前に `tasks/lessons.md` を確認し、既知の失敗を繰り返さない。発見導線として `gwt-search --lessons "<query>"` または `/gwt:gwt-lessons-search "<query>"` を使い、関連 lesson が見つかった場合はその再発防止策を再利用する（SPEC #2805）。
 
 ### サブエージェント活用（並列化）
 

--- a/crates/gwt-core/runtime/chroma_index_runner.py
+++ b/crates/gwt-core/runtime/chroma_index_runner.py
@@ -972,13 +972,14 @@ MANIFEST_FILENAME = "manifest.json"
 LOCK_FILENAME = ".lock"
 META_FILENAME = "meta.json"
 
-V2_SCOPES = ("issues", "specs", "files", "files-docs")
+V2_SCOPES = ("issues", "specs", "lessons", "files", "files-docs")
 WORKTREE_SCOPED = {"files", "files-docs"}
 
 V2_FILES_CODE_COLLECTION = "files_code"
 V2_FILES_DOCS_COLLECTION = "files_docs"
 V2_SPECS_COLLECTION = "specs"
 V2_ISSUES_COLLECTION = "issues"
+V2_LESSONS_COLLECTION = "lessons"
 
 
 def gwt_index_root() -> Path:
@@ -1002,7 +1003,7 @@ def resolve_db_path(
     root = (db_root or gwt_index_root()).resolve()
     repo_dir = root / repo_hash
 
-    if scope in {"issues", "specs"}:
+    if scope in {"issues", "specs", "lessons"}:
         return repo_dir / scope
 
     return repo_dir / "worktrees" / worktree_hash / scope
@@ -1254,7 +1255,7 @@ def _manifest_path(worktree_dir: Path, scope: str) -> Path:
     (`.../worktrees/<wt>/files/`); both are normalized to the worktree
     level so writers and readers always agree on the location.
     """
-    if worktree_dir.name in ("specs", "files", "files-docs", "issues"):
+    if worktree_dir.name in ("specs", "files", "files-docs", "issues", "lessons"):
         return worktree_dir.parent / f"manifest-{scope}.json"
     return worktree_dir / f"manifest-{scope}.json"
 
@@ -1880,6 +1881,261 @@ def _load_cached_spec_documents(
     return specs, manifest_entries
 
 
+_LESSON_DATE_HEADING_RE = re.compile(
+    r"^##\s+(?P<date>\d{4}-\d{2}-\d{2})\s+(?:—|--|-)\s+(?P<title>.+?)\s*$"
+)
+_LESSON_BARE_HEADING_RE = re.compile(r"^##\s+(?P<title>.+?)\s*$")
+_LESSON_HEADING_CHUNK_SUFFIX_RE = re.compile(r"\s+\[\d+\]\s*$")
+
+
+def _parse_lesson_heading(heading: str) -> tuple[str, str]:
+    """Extract (date, title) from an H2 heading.
+
+    Handles three shapes:
+    - ``## 2026-05-20 — title`` → ("2026-05-20", "title")
+    - ``## title without date`` → ("", "title without date")
+    - ``## 2026-05-20 — title [2]`` (paragraph-split suffix) → strip suffix
+    """
+    cleaned = _LESSON_HEADING_CHUNK_SUFFIX_RE.sub("", heading)
+    dated = _LESSON_DATE_HEADING_RE.match(cleaned)
+    if dated:
+        return dated.group("date"), dated.group("title").strip()
+    bare = _LESSON_BARE_HEADING_RE.match(cleaned)
+    if bare:
+        return "", bare.group("title").strip()
+    return "", heading.strip()
+
+
+def _load_lessons_documents(
+    project_root: str,
+) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Load ``<project_root>/tasks/lessons.md`` and chunk it into lesson units.
+
+    Returns a tuple ``(lessons, manifest_entries)`` where ``manifest_entries``
+    contains at most one entry describing the source file's mtime/size.
+    Missing file → both empty. Empty file → empty lessons but a manifest
+    entry so that the runner can still detect future content additions.
+    """
+    root = Path(project_root)
+    source_path = root / "tasks" / "lessons.md"
+    if not source_path.is_file():
+        return [], []
+
+    try:
+        content = source_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return [], []
+
+    try:
+        stat = source_path.stat()
+    except OSError:
+        return [], []
+    manifest_entries = [
+        {
+            "path": "tasks/lessons.md",
+            "mtime": int(stat.st_mtime),
+            "size": int(stat.st_size),
+        }
+    ]
+
+    chunks = _chunk_spec_content(content)
+    if not chunks:
+        return [], manifest_entries
+
+    lessons: List[Dict[str, Any]] = []
+    grouped: Dict[tuple[str, str], int] = {}
+    for chunk in chunks:
+        heading = chunk["heading"]
+        body = chunk["body"]
+        # `_chunk_spec_content` emits a synthetic "(intro)" chunk for any
+        # leading content before the first H2 (e.g. the `# Lessons Learned`
+        # title line). That preamble is not a real lesson — skip it.
+        if not heading.startswith("## "):
+            continue
+        date, title = _parse_lesson_heading(heading)
+        key = (date, title)
+        chunk_idx = grouped.get(key, 0)
+        grouped[key] = chunk_idx + 1
+        digest_input = f"{heading}\n{body}".encode("utf-8")
+        lesson_id = hashlib.sha1(digest_input).hexdigest()[:12]
+        lessons.append(
+            {
+                "lesson_id": lesson_id,
+                "date": date,
+                "title": title,
+                "heading": heading,
+                "body": body,
+                "chunk_idx": chunk_idx,
+                # total_chunks is filled in once the whole file is scanned
+                "total_chunks": 0,
+            }
+        )
+
+    for lesson in lessons:
+        key = (lesson["date"], lesson["title"])
+        lesson["total_chunks"] = grouped[key]
+
+    return lessons, manifest_entries
+
+
+def _build_lesson_records(
+    lessons: Sequence[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Materialize Chroma upsert records for the lessons scope."""
+    records: List[Dict[str, Any]] = []
+    for lesson in lessons:
+        title = lesson.get("title", "")
+        heading = lesson.get("heading", "")
+        body = lesson.get("body", "")
+        document = f"{title}\n{heading}\n{body}".strip()
+        records.append(
+            {
+                "id": f"lesson-{lesson.get('lesson_id', '')}",
+                "document": document,
+                "metadata": {
+                    "lesson_id": lesson.get("lesson_id", ""),
+                    "date": lesson.get("date", ""),
+                    "title": title,
+                    "heading": heading,
+                    "chunk_idx": int(lesson.get("chunk_idx", 0)),
+                    "total_chunks": int(lesson.get("total_chunks", 1)),
+                },
+            }
+        )
+    return records
+
+
+def action_index_lessons_v2(
+    project_root: str,
+    repo_hash: str,
+    worktree_hash: Optional[str],
+    mode: str = "full",
+    db_root: Optional[Path] = None,
+) -> dict:
+    """Index ``tasks/lessons.md`` into the repo-scoped lessons Chroma store.
+
+    `worktree_hash` is accepted for symmetry with the other v2 actions but is
+    ignored — lessons is repo-scoped. Manifest diff degenerates to a single
+    entry; when the file changes (mtime or size), all chunks are re-upserted
+    after deleting prior records for the file.
+    """
+    del worktree_hash  # repo-scoped scope does not consume the worktree hash
+    db_path = resolve_db_path(repo_hash, None, "lessons", db_root=db_root)
+    lessons, new_entries = _load_lessons_documents(project_root)
+
+    emit_progress(
+        {
+            "phase": "indexing",
+            "scope": "lessons",
+            "mode": mode,
+            "done": 0,
+            "total": len(lessons),
+        }
+    )
+
+    indexed = 0
+    with acquire_lock(db_path, exclusive=True):
+        if mode != "incremental":
+            _reset_chroma_store(db_path)
+        make_collection = (
+            _make_chroma_collection
+            if mode == "incremental"
+            else _make_chroma_collection_repairing
+        )
+        client, collection = make_collection(db_path, V2_LESSONS_COLLECTION)
+        try:
+            old_entries = read_manifest(db_path, scope="lessons")
+            diff = compute_manifest_diff(old_entries, new_entries)
+            file_changed = bool(diff["added"] or diff["changed"] or diff["removed"])
+
+            if mode != "incremental" or file_changed:
+                try:
+                    existing = collection.get()
+                    if existing.get("ids"):
+                        collection.delete(ids=existing["ids"])
+                except Exception:
+                    pass
+                lesson_records = _build_lesson_records(lessons)
+            else:
+                lesson_records = []
+
+            emit_progress(
+                {
+                    "phase": "diff",
+                    "scope": "lessons",
+                    "added": len(diff["added"]),
+                    "changed": len(diff["changed"]),
+                    "removed": len(diff["removed"]),
+                }
+            )
+
+            if lesson_records:
+                ids = [r["id"] for r in lesson_records]
+                documents = [r["document"] for r in lesson_records]
+                metadatas = [r["metadata"] for r in lesson_records]
+                batch = 100
+                for i in range(0, len(ids), batch):
+                    collection.upsert(
+                        ids=ids[i : i + batch],
+                        documents=documents[i : i + batch],
+                        metadatas=metadatas[i : i + batch],
+                    )
+                indexed = len(lesson_records)
+
+            write_manifest(db_path, scope="lessons", entries=new_entries)
+            _write_scope_meta(
+                repo_hash=repo_hash,
+                worktree_hash=None,
+                scope="lessons",
+                db_root=db_root,
+                updates={
+                    "last_repair_at": _now_utc().isoformat(),
+                    "document_count": indexed,
+                },
+            )
+        finally:
+            _close_chroma_client(client)
+
+    emit_progress(
+        {
+            "phase": "complete",
+            "scope": "lessons",
+            "mode": mode,
+            "indexed": indexed,
+            "total": indexed,
+        }
+    )
+    return {"ok": True, "scope": "lessons", "indexed": indexed}
+
+
+def _format_lessons_results(
+    items: List[Dict[str, Any]], n_results: int = 10
+) -> List[Dict[str, Any]]:
+    """Collapse chunked lesson results so each (date, title) appears once."""
+    formatted: List[Dict[str, Any]] = []
+    seen: set = set()
+    for it in items:
+        meta = it.get("metadata") or {}
+        date = meta.get("date", "")
+        title = meta.get("title", "")
+        key = (date, title)
+        if key in seen:
+            continue
+        seen.add(key)
+        formatted.append(
+            {
+                "date": date,
+                "title": title,
+                "heading": meta.get("heading", ""),
+                "chunk_idx": int(meta.get("chunk_idx", 0)),
+                "distance": it.get("distance"),
+            }
+        )
+        if len(formatted) >= n_results:
+            break
+    return formatted
+
+
 def _build_spec_records(specs: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
     records: List[Dict[str, Any]] = []
     for spec in specs:
@@ -1949,6 +2205,8 @@ def _scope_meta_path(
 ) -> Path:
     if scope == "specs":
         return resolve_db_path(repo_hash, None, "specs", db_root=db_root) / META_FILENAME
+    if scope == "lessons":
+        return resolve_db_path(repo_hash, None, "lessons", db_root=db_root) / META_FILENAME
     if scope in WORKTREE_SCOPED:
         worktree_dir = resolve_db_path(repo_hash, worktree_hash, scope, db_root=db_root).parent
         return worktree_dir / META_FILENAME
@@ -2018,6 +2276,7 @@ def _scope_collection_name(scope: str) -> str:
         "files-docs": V2_FILES_DOCS_COLLECTION,
         "specs": V2_SPECS_COLLECTION,
         "issues": V2_ISSUES_COLLECTION,
+        "lessons": V2_LESSONS_COLLECTION,
     }[scope]
 
 
@@ -2089,11 +2348,11 @@ def _scope_status_v2(
         reason = "empty_collection"
         healthy = False
         repair_required = True
-    elif scope == "specs" and document_count < manifest_count:
+    elif scope in ("specs", "lessons") and document_count < manifest_count:
         reason = "count_mismatch"
         healthy = False
         repair_required = True
-    elif scope != "specs" and document_count != manifest_count:
+    elif scope not in ("specs", "lessons") and document_count != manifest_count:
         reason = "empty_collection" if document_count == 0 and manifest_count > 0 else "count_mismatch"
         healthy = False
         repair_required = True
@@ -2366,6 +2625,7 @@ def action_search_v2(
         "search-files-docs": "files-docs",
         "search-specs": "specs",
         "search-issues": "issues",
+        "search-lessons": "lessons",
     }
     if action not in scope_for_action:
         return {"ok": False, "error_code": "BAD_ARGS", "error": f"unknown action {action}"}
@@ -2415,6 +2675,14 @@ def action_search_v2(
                 mode="full" if needs_build else "incremental",
                 db_root=db_root,
             )
+        elif scope == "lessons":
+            build = action_index_lessons_v2(
+                project_root=project_root,
+                repo_hash=repo_hash,
+                worktree_hash=None,
+                mode="full",
+                db_root=db_root,
+            )
         else:
             build = action_index_files_v2(
                 project_root=project_root,
@@ -2431,9 +2699,9 @@ def action_search_v2(
     with acquire_lock(db_path, exclusive=False):
         client, collection = _open_chroma_collection(db_path, _scope_collection_name(scope))
         try:
-            # SPECs are chunked, so a single SPEC can span many Chroma records.
-            # Over-fetch by 5x then collapse by spec_id in the formatter.
-            fetch_n = n_results * 5 if scope == "specs" else n_results
+            # SPECs / Lessons are chunked, so a single owner can span many
+            # Chroma records. Over-fetch by 5x then collapse in the formatter.
+            fetch_n = n_results * 5 if scope in ("specs", "lessons") else n_results
             items = _search_collection_v2(collection, query, fetch_n)
         finally:
             _close_chroma_client(client)
@@ -2442,6 +2710,8 @@ def action_search_v2(
         return {"ok": True, "results": _format_file_results(items)}
     if scope == "specs":
         return {"ok": True, "specResults": _format_spec_results(items)[:n_results]}
+    if scope == "lessons":
+        return {"ok": True, "lessonResults": _format_lessons_results(items, n_results)}
     return {"ok": True, "issueResults": _format_issue_results(items)}
 
 
@@ -2472,6 +2742,7 @@ def action_status_v2(
     out: Dict[str, Any] = {
         "issues": _issue_status_v2(repo_hash, db_root=db_root),
         "specs": _scope_status_v2(repo_hash, None, "specs", db_root=db_root),
+        "lessons": _scope_status_v2(repo_hash, None, "lessons", db_root=db_root),
     }
     if worktree_hash:
         for scope in ("files", "files-docs"):
@@ -2502,6 +2773,8 @@ def parse_args() -> argparse.Namespace:
             "search-issues",
             "index-specs",
             "search-specs",
+            "index-lessons",
+            "search-lessons",
         ],
     )
     parser.add_argument("--project-root", default="")
@@ -2514,7 +2787,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--scope",
         default="",
-        choices=["", "issues", "specs", "files", "files-docs"],
+        choices=["", "issues", "specs", "files", "files-docs", "lessons"],
     )
     parser.add_argument("--mode", default="full", choices=["full", "incremental"])
     parser.add_argument("--no-auto-build", dest="no_auto_build", action="store_true")
@@ -2575,7 +2848,27 @@ def _dispatch_v2(action: str, args: argparse.Namespace) -> int:
             )
             return 0
 
-        if action in ("search-files", "search-files-docs", "search-specs", "search-issues"):
+        if action == "index-lessons":
+            if not args.project_root:
+                emit({"ok": False, "error_code": "BAD_ARGS", "error": "--project-root is required"})
+                return 2
+            emit(
+                action_index_lessons_v2(
+                    project_root=args.project_root,
+                    repo_hash=repo_hash,
+                    worktree_hash=None,
+                    mode=args.mode,
+                )
+            )
+            return 0
+
+        if action in (
+            "search-files",
+            "search-files-docs",
+            "search-specs",
+            "search-issues",
+            "search-lessons",
+        ):
             if not args.query:
                 emit({"ok": False, "error_code": "BAD_ARGS", "error": "--query is required"})
                 return 2

--- a/crates/gwt-core/runtime/tests/test_auto_build_fallback.py
+++ b/crates/gwt-core/runtime/tests/test_auto_build_fallback.py
@@ -186,6 +186,61 @@ class AutoBuildFallbackTests(unittest.TestCase):
             db = db_root / "abc1234567890def" / "specs"
             self.assertTrue(db.exists(), f"index dir was not created: {db}")
 
+    def test_search_lessons_auto_builds_when_index_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            (root / "tasks").mkdir(parents=True)
+            (root / "tasks" / "lessons.md").write_text(
+                "# Lessons Learned\n\n"
+                "## 2026-05-20 — watcher debounce regression\n\n"
+                "### 事象\n watcher fired too often.\n\n"
+                "### 原因\n debounce too low.\n\n"
+                "### 再発防止策\n raise debounce.\n",
+                encoding="utf-8",
+            )
+
+            db_root = Path(tmp) / "index_root"
+            result = runner.action_search_v2(
+                action="search-lessons",
+                repo_hash="abc1234567890def",
+                worktree_hash=None,
+                project_root=str(root),
+                query="watcher debounce",
+                n_results=5,
+                no_auto_build=False,
+                db_root=db_root,
+            )
+
+            self.assertTrue(result["ok"], result)
+            self.assertIn("lessonResults", result)
+            self.assertGreaterEqual(len(result["lessonResults"]), 1, result["lessonResults"])
+            top = result["lessonResults"][0]
+            self.assertEqual(top["date"], "2026-05-20")
+            self.assertIn("watcher debounce", top["title"])
+            db = db_root / "abc1234567890def" / "lessons"
+            self.assertTrue(db.exists(), f"lessons index dir was not created: {db}")
+
+    def test_search_lessons_returns_index_missing_when_no_auto_build(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            (root / "tasks").mkdir(parents=True)
+            (root / "tasks" / "lessons.md").write_text("# empty\n", encoding="utf-8")
+            db_root = Path(tmp) / "index_root"
+
+            result = runner.action_search_v2(
+                action="search-lessons",
+                repo_hash="abc1234567890def",
+                worktree_hash=None,
+                project_root=str(root),
+                query="anything",
+                n_results=5,
+                no_auto_build=True,
+                db_root=db_root,
+            )
+
+            self.assertFalse(result["ok"], result)
+            self.assertEqual(result["error_code"], "INDEX_MISSING")
+
     def test_search_specs_refreshes_existing_index_from_issue_cache(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "repo"

--- a/crates/gwt-core/runtime/tests/test_lessons_indexer.py
+++ b/crates/gwt-core/runtime/tests/test_lessons_indexer.py
@@ -1,0 +1,222 @@
+"""Tests for the lessons (post-mortem) scope indexer.
+
+Lessons live in `tasks/lessons.md` as H2 sections with the canonical shape:
+
+    ## YYYY-MM-DD — title
+    ### 事象
+    ...
+    ### 原因
+    ...
+    ### 再発防止策
+    ...
+
+A small minority of sections at the tail of the file lack the date prefix.
+The chunker must handle both shapes without raising.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import chroma_index_runner as runner
+
+
+SAMPLE_LESSONS = """# Lessons Learned
+
+## 2026-05-20 — alpha section title
+
+### 事象
+alpha symptom.
+
+### 原因
+alpha cause.
+
+### 再発防止策
+1. alpha prevention.
+
+## 2026-05-19 — beta section title
+
+### 事象
+beta symptom.
+
+### 原因
+beta cause.
+
+## undated tail section about manual reflection
+
+This section omits the date prefix and uses a single paragraph format.
+"""
+
+
+class LoadLessonsDocumentsTests(unittest.TestCase):
+    def _write_lessons_file(self, contents: str) -> Path:
+        tmp = tempfile.mkdtemp()
+        root = Path(tmp)
+        tasks = root / "tasks"
+        tasks.mkdir(parents=True, exist_ok=True)
+        (tasks / "lessons.md").write_text(contents, encoding="utf-8")
+        return root
+
+    def test_returns_chunks_for_each_h2_section(self):
+        root = self._write_lessons_file(SAMPLE_LESSONS)
+        lessons, manifest = runner._load_lessons_documents(str(root))
+        # 3 H2 sections in SAMPLE_LESSONS
+        self.assertEqual(len(lessons), 3)
+        # manifest has exactly one entry (the single source file)
+        self.assertEqual(len(manifest), 1)
+        self.assertEqual(manifest[0]["path"], "tasks/lessons.md")
+
+    def test_extracts_date_from_dated_sections(self):
+        root = self._write_lessons_file(SAMPLE_LESSONS)
+        lessons, _manifest = runner._load_lessons_documents(str(root))
+        dates = [lesson["date"] for lesson in lessons]
+        self.assertIn("2026-05-20", dates)
+        self.assertIn("2026-05-19", dates)
+
+    def test_date_less_section_uses_empty_string(self):
+        root = self._write_lessons_file(SAMPLE_LESSONS)
+        lessons, _manifest = runner._load_lessons_documents(str(root))
+        undated = [lesson for lesson in lessons if lesson["date"] == ""]
+        self.assertEqual(len(undated), 1)
+        self.assertIn("undated tail section", undated[0]["title"])
+
+    def test_lesson_id_is_stable_for_same_content(self):
+        root = self._write_lessons_file(SAMPLE_LESSONS)
+        first, _ = runner._load_lessons_documents(str(root))
+        second, _ = runner._load_lessons_documents(str(root))
+        self.assertEqual([l["lesson_id"] for l in first], [l["lesson_id"] for l in second])
+
+    def test_missing_lessons_file_returns_empty(self):
+        tmp = Path(tempfile.mkdtemp())
+        lessons, manifest = runner._load_lessons_documents(str(tmp))
+        self.assertEqual(lessons, [])
+        self.assertEqual(manifest, [])
+
+    def test_empty_lessons_file_returns_empty(self):
+        root = self._write_lessons_file("")
+        lessons, manifest = runner._load_lessons_documents(str(root))
+        self.assertEqual(lessons, [])
+        # manifest still records the file presence so unhealthy detection can work
+        # (single-file scope behaviour)
+        self.assertEqual(len(manifest), 1)
+
+
+class BuildLessonRecordsTests(unittest.TestCase):
+    def test_returns_chroma_records_with_metadata(self):
+        lessons = [
+            {
+                "lesson_id": "abc123def456",
+                "date": "2026-05-20",
+                "title": "alpha",
+                "heading": "## 2026-05-20 — alpha",
+                "body": "### 事象\nalpha symptom.",
+                "chunk_idx": 0,
+                "total_chunks": 1,
+            }
+        ]
+        records = runner._build_lesson_records(lessons)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["id"], "lesson-abc123def456")
+        self.assertIn("alpha", records[0]["document"])
+        meta = records[0]["metadata"]
+        self.assertEqual(meta["date"], "2026-05-20")
+        self.assertEqual(meta["title"], "alpha")
+        self.assertEqual(meta["chunk_idx"], 0)
+
+
+class ActionIndexLessonsTests(unittest.TestCase):
+    def test_full_mode_writes_manifest_and_chunks(self):
+        with tempfile.TemporaryDirectory() as wt, tempfile.TemporaryDirectory() as db_root_dir:
+            root = Path(wt)
+            tasks = root / "tasks"
+            tasks.mkdir(parents=True, exist_ok=True)
+            (tasks / "lessons.md").write_text(SAMPLE_LESSONS, encoding="utf-8")
+
+            result = runner.action_index_lessons_v2(
+                project_root=str(root),
+                repo_hash="abc1234567890def",
+                worktree_hash=None,
+                mode="full",
+                db_root=Path(db_root_dir),
+            )
+            self.assertTrue(result.get("ok"), result)
+            self.assertEqual(result["scope"], "lessons")
+            self.assertGreaterEqual(result["indexed"], 3)
+
+            db_path = runner.resolve_db_path(
+                "abc1234567890def", None, "lessons", db_root=Path(db_root_dir)
+            )
+            manifest_file = runner._manifest_path(db_path, "lessons")
+            self.assertTrue(manifest_file.is_file(), f"missing manifest at {manifest_file}")
+            manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+            entries = manifest.get("entries") if isinstance(manifest, dict) else manifest
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0]["path"], "tasks/lessons.md")
+
+    def test_missing_lessons_file_returns_indexed_zero(self):
+        with tempfile.TemporaryDirectory() as wt, tempfile.TemporaryDirectory() as db_root_dir:
+            result = runner.action_index_lessons_v2(
+                project_root=wt,
+                repo_hash="abc1234567890def",
+                worktree_hash=None,
+                mode="full",
+                db_root=Path(db_root_dir),
+            )
+            self.assertTrue(result.get("ok"), result)
+            self.assertEqual(result["indexed"], 0)
+
+
+class FormatLessonsResultsTests(unittest.TestCase):
+    def test_collapses_chunks_by_date_title_and_limits_to_n(self):
+        items = [
+            {
+                "id": "lesson-aaa",
+                "distance": 0.12,
+                "metadata": {
+                    "lesson_id": "aaa",
+                    "date": "2026-05-20",
+                    "title": "alpha",
+                    "heading": "## 2026-05-20 — alpha",
+                    "chunk_idx": 0,
+                    "total_chunks": 2,
+                },
+            },
+            {
+                "id": "lesson-aaa-2",
+                "distance": 0.15,
+                "metadata": {
+                    "lesson_id": "aaa-2",
+                    "date": "2026-05-20",
+                    "title": "alpha",
+                    "heading": "## 2026-05-20 — alpha [2]",
+                    "chunk_idx": 1,
+                    "total_chunks": 2,
+                },
+            },
+            {
+                "id": "lesson-bbb",
+                "distance": 0.20,
+                "metadata": {
+                    "lesson_id": "bbb",
+                    "date": "2026-05-19",
+                    "title": "beta",
+                    "heading": "## 2026-05-19 — beta",
+                    "chunk_idx": 0,
+                    "total_chunks": 1,
+                },
+            },
+        ]
+        out = runner._format_lessons_results(items, n_results=10)
+        # 2 unique (date, title) groups
+        self.assertEqual(len(out), 2)
+        # best-scoring chunk wins for each group
+        first = out[0]
+        self.assertEqual(first["date"], "2026-05-20")
+        self.assertEqual(first["title"], "alpha")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/crates/gwt-core/runtime/tests/test_repo_layout.py
+++ b/crates/gwt-core/runtime/tests/test_repo_layout.py
@@ -69,6 +69,29 @@ class ResolveDbPathTests(unittest.TestCase):
         )
         self.assertEqual(path.parts[-len(expected) :], expected)
 
+    def test_lessons_scope_is_repo_scoped(self):
+        path = runner.resolve_db_path(
+            repo_hash="abc1234567890def",
+            worktree_hash=None,
+            scope="lessons",
+        )
+        expected = (".gwt", "index", "abc1234567890def", "lessons")
+        self.assertEqual(path.parts[-len(expected) :], expected)
+
+    def test_lessons_scope_ignores_worktree_hash(self):
+        with_wt = runner.resolve_db_path(
+            repo_hash="abc1234567890def",
+            worktree_hash="111122223333ffff",
+            scope="lessons",
+        )
+        without_wt = runner.resolve_db_path(
+            repo_hash="abc1234567890def",
+            worktree_hash=None,
+            scope="lessons",
+        )
+        self.assertEqual(with_wt, without_wt)
+        self.assertNotIn("worktrees", with_wt.parts)
+
     def test_files_scope_without_worktree_hash_raises(self):
         with self.assertRaises(ValueError):
             runner.resolve_db_path(

--- a/crates/gwt-core/src/index/paths.rs
+++ b/crates/gwt-core/src/index/paths.rs
@@ -13,6 +13,10 @@
 //!   specs/
 //!     chroma.sqlite3
 //!     .lock
+//!   lessons/
+//!     chroma.sqlite3
+//!     .lock
+//!     manifest.json
 //!   worktrees/
 //!     <wt-hash>/
 //!       meta.json
@@ -38,6 +42,8 @@ pub enum Scope {
     Issues,
     /// Repo-scoped: cached SPEC Issue search index.
     Specs,
+    /// Repo-scoped: post-mortem fix knowledge sourced from `tasks/lessons.md`.
+    Lessons,
     /// Worktree-scoped: project source code files.
     FilesCode,
     /// Worktree-scoped: project documentation files.
@@ -54,6 +60,7 @@ impl Scope {
         match self {
             Scope::Issues => "issues",
             Scope::Specs => "specs",
+            Scope::Lessons => "lessons",
             Scope::FilesCode => "files",
             Scope::FilesDocs => "files-docs",
         }
@@ -87,7 +94,7 @@ pub fn gwt_index_db_path(
     worktree: Option<&WorktreeHash>,
     scope: Scope,
 ) -> Result<PathBuf> {
-    if matches!(scope, Scope::Issues | Scope::Specs) {
+    if matches!(scope, Scope::Issues | Scope::Specs | Scope::Lessons) {
         return Ok(gwt_index_repo_dir(repo).join(scope.subdir()));
     }
     let wt = worktree.ok_or_else(|| {
@@ -133,5 +140,35 @@ mod tests {
                 .and_then(|name| name.to_str()),
             Some(wt.as_str())
         );
+    }
+
+    #[test]
+    fn lessons_scope_resolution() {
+        let repo = compute_repo_hash("https://github.com/akiojin/gwt.git");
+        let path = gwt_index_db_path(&repo, None, Scope::Lessons).unwrap();
+        assert!(path.ends_with(format!("{}/lessons", repo.as_str())));
+    }
+
+    #[test]
+    fn lessons_requires_worktree_false() {
+        assert!(!Scope::Lessons.requires_worktree());
+    }
+
+    #[test]
+    fn lessons_subdir_is_lessons() {
+        assert_eq!(Scope::Lessons.subdir(), "lessons");
+    }
+
+    #[test]
+    fn lessons_scope_ignores_worktree_hash() {
+        let repo = compute_repo_hash("https://github.com/akiojin/gwt.git");
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = compute_worktree_hash(tmp.path()).unwrap();
+        let with_wt = gwt_index_db_path(&repo, Some(&wt), Scope::Lessons).unwrap();
+        let without_wt = gwt_index_db_path(&repo, None, Scope::Lessons).unwrap();
+        assert_eq!(with_wt, without_wt);
+        assert!(!with_wt
+            .components()
+            .any(|component| component.as_os_str() == "worktrees"));
     }
 }

--- a/crates/gwt-core/src/index/watcher.rs
+++ b/crates/gwt-core/src/index/watcher.rs
@@ -196,7 +196,23 @@ fn is_builtin_skip(worktree: &Path, path: &Path) -> bool {
     }
 }
 
+/// Worktree-relative paths that override the builtin skip list. These files
+/// participate in the watcher even when their parent directory would normally
+/// be skipped. Keep the list intentionally small — every entry weakens the
+/// builtin skip guarantee.
+const WATCHER_BUILTIN_ALLOWLIST: &[&str] = &["tasks/lessons.md"];
+
+fn is_allowlisted(worktree: &Path, path: &Path) -> bool {
+    let rel = path.strip_prefix(worktree).unwrap_or(path);
+    WATCHER_BUILTIN_ALLOWLIST
+        .iter()
+        .any(|allowed| rel == Path::new(allowed))
+}
+
 fn is_ignored(gi: &Gitignore, worktree: &Path, path: &Path) -> bool {
+    if is_allowlisted(worktree, path) {
+        return false;
+    }
     if is_builtin_skip(worktree, path) {
         return true;
     }
@@ -233,5 +249,32 @@ mod tests {
         let path = root.join("specs-archive/SPEC-10/spec.md");
 
         assert!(!is_builtin_skip(root, &path));
+    }
+
+    #[test]
+    fn tasks_lessons_md_is_watched_despite_tasks_skip() {
+        let root = Path::new("/repo");
+        let path = root.join("tasks/lessons.md");
+
+        let gi = build_gitignore(root);
+        assert!(!is_ignored(&gi, root, &path));
+    }
+
+    #[test]
+    fn tasks_todo_md_remains_skipped() {
+        let root = Path::new("/repo");
+        let path = root.join("tasks/todo.md");
+
+        let gi = build_gitignore(root);
+        assert!(is_ignored(&gi, root, &path));
+    }
+
+    #[test]
+    fn tasks_spec_archive_dir_remains_skipped() {
+        let root = Path::new("/repo");
+        let path = root.join("tasks/spec-1939/notes.md");
+
+        let gi = build_gitignore(root);
+        assert!(is_ignored(&gi, root, &path));
     }
 }

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -380,8 +380,7 @@ pub type BuildCommand = SkillStateAction;
 
 /// SPEC-2784 family enum for `gwtd register ...`. Same skill-state lifecycle.
 pub type RegisterCommand = SkillStateAction;
-/// SPEC-1935 / Issue #2529: canonical CLI surface for `gwt-agent` pane
-/// inspection and lifecycle operations.
+/// SPEC-1935 / Issue #2529: canonical CLI surface for `gwt-agent` pane inspection and lifecycle.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PaneCommand {
     /// `gwtd pane list`.
@@ -397,6 +396,7 @@ pub enum IndexScope {
     All,
     Issues,
     Specs,
+    Lessons,
     Files,
     FilesDocs,
 }

--- a/crates/gwt/src/cli/index/audit.rs
+++ b/crates/gwt/src/cli/index/audit.rs
@@ -77,7 +77,7 @@ fn audit_health(payload: &Value) -> AuditHealth {
     };
 
     let mut unhealthy_scopes = Vec::new();
-    for scope in ["issues", "specs", "files", "files-docs"] {
+    for scope in ["issues", "specs", "lessons", "files", "files-docs"] {
         let Some(scope_status) = status.get(scope) else {
             continue;
         };

--- a/crates/gwt/src/cli/index/mod.rs
+++ b/crates/gwt/src/cli/index/mod.rs
@@ -52,6 +52,7 @@ fn parse_rebuild_scope(args: &[String]) -> Result<IndexScope, CliParseError> {
         "all" => Ok(IndexScope::All),
         "issues" => Ok(IndexScope::Issues),
         "specs" => Ok(IndexScope::Specs),
+        "lessons" => Ok(IndexScope::Lessons),
         "files" => Ok(IndexScope::Files),
         "files-docs" => Ok(IndexScope::FilesDocs),
         other => Err(CliParseError::UnknownSubcommand(other.to_string())),
@@ -162,6 +163,16 @@ mod tests {
     }
 
     #[test]
+    fn parses_index_rebuild_lessons_scope() {
+        assert_eq!(
+            parse(&s(&["rebuild", "--scope", "lessons"])).unwrap(),
+            IndexCommand::Rebuild {
+                scope: IndexScope::Lessons
+            }
+        );
+    }
+
+    #[test]
     fn audit_log_dir_uses_project_scoped_gwt_log_directory() {
         let dir = tempfile::tempdir().unwrap();
         let project_root = dir.path().join("repo");
@@ -216,6 +227,38 @@ mod tests {
         assert!(out.contains("runtime: ready asset=cccccccccccccccc smoke=passed"));
         assert!(out
             .contains("files: unhealthy reason=manifest_missing documents=3 repair_required=true"));
+    }
+
+    #[test]
+    fn renders_lessons_scope_health() {
+        let report = gwt_core::runtime::ProjectIndexRuntimeReport {
+            runner_hash: "aaaaaaaaaaaaaaaa".to_string(),
+            requirements_hash: "bbbbbbbbbbbbbbbb".to_string(),
+            runner_smoke_tested: true,
+            ..Default::default()
+        };
+        let payload = serde_json::json!({
+            "runtime": {
+                "healthy": true,
+                "reason": "ready",
+                "asset_hash": "cccccccccccccccc",
+                "smoke_test": "passed"
+            },
+            "status": {
+                "lessons": {
+                    "healthy": true,
+                    "repair_required": false,
+                    "reason": "ready",
+                    "document_count": 234
+                }
+            }
+        });
+        let mut out = String::new();
+        render_index_status(&mut out, &report, &payload);
+        assert!(
+            out.contains("lessons: ready reason=ready documents=234 repair_required=false"),
+            "render output missing lessons line:\n{out}"
+        );
     }
 
     #[test]

--- a/crates/gwt/src/cli/index/runtime.rs
+++ b/crates/gwt/src/cli/index/runtime.rs
@@ -92,6 +92,12 @@ pub(crate) fn rebuild_actions(scope: IndexScope) -> Vec<RebuildAction> {
             needs_worktree_hash: false,
         },
         RebuildAction {
+            label: "lessons",
+            action: "index-lessons",
+            scope: None,
+            needs_worktree_hash: false,
+        },
+        RebuildAction {
             label: "files",
             action: "index-files",
             scope: Some("files"),
@@ -108,6 +114,7 @@ pub(crate) fn rebuild_actions(scope: IndexScope) -> Vec<RebuildAction> {
         IndexScope::All => all,
         IndexScope::Issues => all.into_iter().filter(|a| a.label == "issues").collect(),
         IndexScope::Specs => all.into_iter().filter(|a| a.label == "specs").collect(),
+        IndexScope::Lessons => all.into_iter().filter(|a| a.label == "lessons").collect(),
         IndexScope::Files => all.into_iter().filter(|a| a.label == "files").collect(),
         IndexScope::FilesDocs => all
             .into_iter()
@@ -183,7 +190,7 @@ pub fn render_index_status(
         report.dependencies_installed
     ));
     if let Some(status) = payload.get("status").and_then(Value::as_object) {
-        for scope in ["issues", "specs", "files", "files-docs"] {
+        for scope in ["issues", "specs", "lessons", "files", "files-docs"] {
             if let Some(scope_status) = status.get(scope) {
                 let healthy = scope_status
                     .get("healthy")

--- a/crates/gwt/web/__tests__/index-settings-panel.test.mjs
+++ b/crates/gwt/web/__tests__/index-settings-panel.test.mjs
@@ -82,7 +82,7 @@ test("renderIndexSettingsPanel renders one row per scope and one column per work
 
   const scopeRows = Array.from(table.querySelectorAll("tbody tr"));
   const scopes = scopeRows.map((tr) => tr.dataset.scope);
-  assert.deepEqual(scopes, ["issues", "specs", "files", "files-docs"]);
+  assert.deepEqual(scopes, ["issues", "specs", "lessons", "files", "files-docs"]);
 
   // Repo-shared issues row spans all worktree columns and reports ready.
   const issuesCell = scopeRows[0].querySelector(".settings-index-cell");
@@ -94,15 +94,19 @@ test("renderIndexSettingsPanel renders one row per scope and one column per work
   assert.match(specsCell.textContent, /count_mismatch/);
   assert.ok(specsCell.classList.contains("unhealthy"));
 
+  // lessons row is repo-shared and renders a single column-spanning cell.
+  const lessonsCell = scopeRows[2].querySelector(".settings-index-cell");
+  assert.equal(lessonsCell.colSpan, 2);
+
   // files row has one cell per worktree, in worktree-hash sort order.
-  const filesCells = scopeRows[2].querySelectorAll(".settings-index-cell");
+  const filesCells = scopeRows[3].querySelectorAll(".settings-index-cell");
   assert.equal(filesCells.length, 2);
   assert.equal(filesCells[0].dataset.worktreeHash, "wtAhash");
   assert.equal(filesCells[1].dataset.worktreeHash, "wtBhash");
   assert.ok(filesCells[1].classList.contains("unhealthy"));
 
   // files-docs only seeded wtAhash — wtB renders an empty placeholder.
-  const docsCells = scopeRows[3].querySelectorAll(".settings-index-cell");
+  const docsCells = scopeRows[4].querySelectorAll(".settings-index-cell");
   assert.equal(docsCells.length, 2);
   assert.ok(docsCells[1].classList.contains("settings-index-cell-empty"));
 });

--- a/crates/gwt/web/index-settings-panel.js
+++ b/crates/gwt/web/index-settings-panel.js
@@ -6,7 +6,7 @@
 // and a per-cell Rebuild button that emits `rebuild_index_cell` with
 // `(project_root, scope, worktree_hash?)`.
 
-const REPO_SHARED_SCOPES = ["issues", "specs"];
+const REPO_SHARED_SCOPES = ["issues", "specs", "lessons"];
 const PER_WORKTREE_SCOPES = ["files", "files-docs"];
 const ALL_SCOPES = [...REPO_SHARED_SCOPES, ...PER_WORKTREE_SCOPES];
 


### PR DESCRIPTION
## Summary

- `tasks/lessons.md` (5661 行 / 234 H2 sections) を 5 番目の ChromaDB スコープ `Scope::Lessons` として **repo-scoped** に index 化。`gwt-search --lessons` / default merge / 新規 `gwt-lessons-search` skill から発見可能に。
- Watcher は `tasks/lessons.md` のみ **ピンポイント allowlist** で live update をサポート。`tasks/todo.md` / `tasks/spec-*/` は引き続き skip。
- 同 SPEC で 4 既存 search skill (gwt-search / gwt-issue-search / gwt-project-search / gwt-spec-search) の **TUI 表記を WebView GUI 実態** (`wry + tao + axum WebSocket + xterm.js`) に統一し、新規 `gwt-lessons-search` への伝播を防止。
- 書き込み経路 (lessons.md への manual edit) は不変。`gwtd lesson add` のような helper は未導入。

## Changes

- `Scope::Lessons` + repo-scoped path layout (`crates/gwt-core/src/index/paths.rs`)
- pinpoint allowlist (`crates/gwt-core/src/index/watcher.rs`: `WATCHER_BUILTIN_ALLOWLIST = ["tasks/lessons.md"]`)
- Runner (`crates/gwt-core/runtime/chroma_index_runner.py`): `V2_LESSONS_COLLECTION` + `action_index_lessons_v2` + `_load_lessons_documents` + `_build_lesson_records` + `_format_lessons_results` + `search-lessons` action + scope status / collection name dispatch 拡張 + argparse choices
- gwtd CLI (`crates/gwt/src/cli/index/`): `IndexScope::Lessons` + rebuild action / render / audit scope iteration
- GUI: `crates/gwt/web/index-settings-panel.js` の `REPO_SHARED_SCOPES` に `lessons` 追加 + 対応する `__tests__/index-settings-panel.test.mjs` の scope 配列を 5 要素化
- 新 skill: `.claude/skills/gwt-lessons-search/SKILL.md` + `.codex/skills/gwt-lessons-search/SKILL.md` + `.claude/commands/gwt-lessons-search.md`
- `.claude/skills/gwt-search/SKILL.md` 更新: `--lessons` / `search-lessons` / `index-lessons` 追記、default merge を 4 scopes に、Lessons 出力形式追加、TUI 表記 6 件を `gwt GUI` に統一 (`.codex` mirror も同様)
- 隣接 3 skill (`.claude/skills/gwt-{issue,project,spec}-search/SKILL.md` + `.codex` mirror) の TUI 表記を `gwt GUI` / WebView 実態に統一
- `AGENTS.md` L146-147 直後に `gwt-search --lessons` 発見導線を 1 文追記

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features` (688 + 398 + ... groups, 0 failed; cli_file_size_test 999<1000 OK)
- [x] `python -m pytest crates/gwt-core/runtime/tests/` (73 passed, **+14 new** lessons cases)
- [x] `pnpm test:frontend-unit` (507 passed)
- [x] `pnpm test:frontend-bundle` (PASS)
- [x] `pnpm lint:skills` (33 SKILL.md validated)
- [x] `grep -rn "TUI" .claude/skills/gwt-{search,lessons-search,issue-search,project-search,spec-search}/SKILL.md .codex/skills/gwt-{search,lessons-search,issue-search,project-search,spec-search}/SKILL.md` → 0 件
- [x] Live verification: `search-lessons "spec section マーカー"` が `tasks/lessons.md` から 243 chunks を index し、2026-05-20 entry (`gwtd issue spec create -f` marker trap lesson) を distance 0.1553 で top hit として返す（Acceptance Scenario 1）
- [x] pre-push CI-equivalent hook (`bash scripts/test-all.sh` 相当) PASS

## Closing Issues

Closes #2805

## Related Issues

- Foundations: SPEC #1939 (semantic search platform), SPEC #12 (GitHub Issue SOT), SPEC #2784 (gwt-register-spec)
- gwt-discussion artifact: Proposal A [chosen], Q1 Repo-scoped / Q2 Pinpoint allowlist / Q3 Full parity / Q4 隣接スキル一括修正
- Plan: `/Users/akiojin/.claude/plans/tasks-lessons-md-agents-md-gwt-lessons-wobbly-lollipop.md`

## Checklist

- [x] Conventional Commits 形式の commit message (`feat(index): ...`)
- [x] commitlint check PASS (subject ≤ 100 chars, footer line ≤ 100 chars)
- [x] テスト追加 (cargo 7 件 + pytest 14 件)
- [x] TDD (Red → Green → Refactor) を全タスクで実施
- [x] AGENTS.md L102-103 の SPEC 登録ルール遵守 (`gwt-register-spec` 経由で #2805 作成)
- [x] 既存運用 (lessons.md への manual edit) を破壊しない
- [x] 隣接 3 skill の TUI 表記統一で新 skill 雛型コピーから legacy が伝播しない
