### PR TITLE
fix(agent): use official Gemini CLI package

### DIFF
--- a/crates/gwt-agent/src/custom.rs
+++ b/crates/gwt-agent/src/custom.rs
@@ -228,6 +228,24 @@ mod tests {
     }
 
     #[test]
+    fn validate_external_only_rejects_gemini_package_impersonation() {
+        for command in ["@google/gemini-cli", "@google/gemini-cli@latest"] {
+            let mut a = sample_agent();
+            a.command = command.to_string();
+            let err = a.validate_external_only().unwrap_err();
+            match err {
+                ExternalAgentValidationError::BuiltInImpersonation {
+                    builtin_display_name,
+                    ..
+                } => {
+                    assert_eq!(builtin_display_name, "Gemini CLI");
+                }
+                other => panic!("unexpected variant: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
     fn validate_external_only_translates_basic_field_failures() {
         let mut a = sample_agent();
         a.id = String::new();

--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -1427,12 +1427,12 @@ mod tests {
     #[test]
     fn build_gemini_with_model() {
         let config = AgentLaunchBuilder::new(AgentId::Gemini)
-            .model("gemini-2.5-pro")
+            .model("gemini-3-flash-preview")
             .build();
 
         assert_eq!(config.command, "gemini");
         assert!(config.args.contains(&"--model".to_string()));
-        assert!(config.args.contains(&"gemini-2.5-pro".to_string()));
+        assert!(config.args.contains(&"gemini-3-flash-preview".to_string()));
     }
 
     #[test]
@@ -1504,6 +1504,17 @@ mod tests {
         assert!(spec_arg
             .unwrap()
             .contains("@anthropic-ai/claude-code@latest"));
+    }
+
+    #[test]
+    fn resolve_runner_latest_uses_official_gemini_package() {
+        let runner = resolve_runner(&AgentId::Gemini, "latest");
+        assert!(!runner.executable.is_empty());
+        let spec_arg = runner.base_args.iter().find(|a| a.contains('@'));
+        assert_eq!(
+            spec_arg.map(String::as_str),
+            Some("@google/gemini-cli@latest")
+        );
     }
 
     #[test]

--- a/crates/gwt-agent/src/session.rs
+++ b/crates/gwt-agent/src/session.rs
@@ -546,7 +546,7 @@ display_name = "Claude Code"
     fn save_and_load_roundtrip() {
         let dir = tempfile::tempdir().unwrap();
         let mut session = Session::new("/tmp/wt", "feature/x", AgentId::Gemini);
-        session.model = Some("gemini-2.5-pro".into());
+        session.model = Some("gemini-3-flash-preview".into());
         session.tool_version = Some("0.1.0".into());
         session.agent_session_id = Some("agent-abc".into());
         session.reasoning_level = Some("high".into());
@@ -573,7 +573,7 @@ display_name = "Claude Code"
         assert_eq!(loaded.id, session.id);
         assert_eq!(loaded.branch, "feature/x");
         assert_eq!(loaded.agent_id, AgentId::Gemini);
-        assert_eq!(loaded.model, Some("gemini-2.5-pro".into()));
+        assert_eq!(loaded.model, Some("gemini-3-flash-preview".into()));
         assert_eq!(loaded.tool_version, Some("0.1.0".into()));
         assert_eq!(loaded.agent_session_id, Some("agent-abc".into()));
         assert_eq!(loaded.reasoning_level, Some("high".into()));

--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -118,7 +118,7 @@ const BUILTIN_AGENT_DESCRIPTORS: &[BuiltinAgentDescriptor] = &[
         id: AgentId::Gemini,
         command: "gemini",
         display_name: "Gemini CLI",
-        package_name: Some("@anthropic-ai/gemini-cli"),
+        package_name: Some("@google/gemini-cli"),
         color: AgentColor::Magenta,
         aliases: &["gemini", "gemini cli", "gemini-cli"],
         cache_key: "gemini",
@@ -345,6 +345,7 @@ mod tests {
             AgentId::ClaudeCode.package_name(),
             Some("@anthropic-ai/claude-code")
         );
+        assert_eq!(AgentId::Gemini.package_name(), Some("@google/gemini-cli"));
         assert_eq!(AgentId::OpenCode.package_name(), None);
         assert_eq!(AgentId::OpenClaw.package_name(), None);
         assert_eq!(AgentId::Hermes.package_name(), None);

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -3021,30 +3021,34 @@ const CODEX_MODEL_OPTIONS: [ModelDisplayOption; 7] = [
     },
 ];
 
-const GEMINI_MODEL_OPTIONS: [ModelDisplayOption; 6] = [
+const GEMINI_MODEL_OPTIONS: [ModelDisplayOption; 7] = [
     ModelDisplayOption {
         label: "Default (Auto)",
         description: "Use Gemini default model",
-    },
-    ModelDisplayOption {
-        label: "gemini-3-pro-preview",
-        description: "Preview pro model",
     },
     ModelDisplayOption {
         label: "gemini-3-flash-preview",
         description: "Preview flash model",
     },
     ModelDisplayOption {
-        label: "gemini-2.5-pro",
-        description: "Stable pro model",
+        label: "gemini-3.1-flash-lite-preview",
+        description: "Preview flash-lite model",
     },
     ModelDisplayOption {
         label: "gemini-2.5-flash",
-        description: "Balanced speed and reasoning",
+        description: "Stable flash model",
     },
     ModelDisplayOption {
         label: "gemini-2.5-flash-lite",
-        description: "Fastest Gemini option",
+        description: "Stable flash-lite model",
+    },
+    ModelDisplayOption {
+        label: "gemma-4-31b-it",
+        description: "Gemma 4 31B instruction model",
+    },
+    ModelDisplayOption {
+        label: "gemma-4-26b-a4b-it",
+        description: "Gemma 4 26B A4B instruction model",
     },
 ];
 
@@ -6410,7 +6414,18 @@ mod tests {
                 "gpt-5.2",
             ]
         );
-        assert!(current_model_options("gemini").contains(&"gemini-2.5-pro"));
+        assert_eq!(
+            current_model_options("gemini"),
+            vec![
+                "Default (Auto)",
+                "gemini-3-flash-preview",
+                "gemini-3.1-flash-lite-preview",
+                "gemini-2.5-flash",
+                "gemini-2.5-flash-lite",
+                "gemma-4-31b-it",
+                "gemma-4-26b-a4b-it",
+            ]
+        );
         assert!(current_model_options("custom").is_empty());
         assert!(model_display_options("custom").is_empty());
         assert!(!model_display_options("codex").is_empty());


### PR DESCRIPTION
## Summary

- Fixes Gemini CLI startup by switching the built-in package reference to the official `@google/gemini-cli` package.
- Updates the Launch Wizard Gemini model list to the current snapshot while preserving `Default (Auto)`.
- Adds regression coverage for package resolution, custom-agent impersonation protection, and the Gemini model catalog.

## Changes

- `crates/gwt-agent/src/types.rs`: changes the Gemini built-in descriptor package from `@anthropic-ai/gemini-cli` to `@google/gemini-cli`.
- `crates/gwt-agent/src/launch.rs`: verifies `latest` version resolution uses `@google/gemini-cli@latest` and updates the Gemini model launch fixture.
- `crates/gwt-agent/src/custom.rs`: verifies custom external agents cannot impersonate the official Gemini package.
- `crates/gwt-agent/src/session.rs`: updates the Gemini session round-trip fixture to the new default model snapshot.
- `crates/gwt/src/launch_wizard.rs`: refreshes the Gemini model options shown in the Launch Wizard.

## Testing

- [x] `cargo fmt -- --check` — passed.
- [x] `cargo test -p gwt-agent -p gwt --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `bunx @google/gemini-cli@latest --version` — returned `0.42.0`.
- [x] Manual browser verification — launched gwt locally, opened the browser URL, and user confirmed the Launch Wizard check was OK.
- [x] `bunx commitlint --from origin/develop --to HEAD` — passed.

## Closing Issues

- None

## Related Issues / Links

- #1921

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (not applicable: no README/user-guide changes needed)
- [x] Migration/backfill plan included (not applicable: no schema/data change)
- [x] CHANGELOG impact considered (patch-level `fix:` commit)

## Context

- The previous Gemini built-in descriptor pointed at `@anthropic-ai/gemini-cli`, which causes npm E404 when GWT launches Gemini via a package runner.

## Risk / Impact

- **Affected areas**: Gemini CLI launch path, Gemini Launch Wizard model selection, custom-agent validation.
- **Rollback plan**: revert this PR to restore the previous package/model snapshot.
