### PR TITLE
fix(launch): isolate knowledge launch worktrees

### DIFF
--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -20,9 +20,9 @@ use std::{
 
 use chrono::Utc;
 use gwt::{
-    KnowledgeKind, LaunchWizardCompletion, LaunchWizardContext, LaunchWizardHydration,
-    LaunchWizardLaunchPath, LaunchWizardLaunchRequest, LaunchWizardState, LaunchWizardView,
-    LinkedIssueKind, WindowGeometry,
+    knowledge_launch_target_branch_name, KnowledgeKind, LaunchWizardCompletion,
+    LaunchWizardContext, LaunchWizardHydration, LaunchWizardLaunchPath, LaunchWizardLaunchRequest,
+    LaunchWizardState, LaunchWizardView, LinkedIssueKind, WindowGeometry,
 };
 use uuid::Uuid;
 
@@ -209,6 +209,53 @@ impl AppRuntime {
             wizard_id,
             wizard,
             workspace_resume_context,
+        });
+
+        Ok(())
+    }
+
+    pub(crate) fn open_knowledge_launch_wizard_for_base_branch(
+        &mut self,
+        tab_id: &str,
+        project_root: &Path,
+        base_branch_name: &str,
+        issue_number: u64,
+        linked_issue_kind: LinkedIssueKind,
+    ) -> Result<(), String> {
+        let base_branch_name = normalize_branch_name(base_branch_name);
+        let target_branch_name =
+            knowledge_launch_target_branch_name(linked_issue_kind, issue_number);
+        let live_sessions = self.live_sessions_for_branch(tab_id, &target_branch_name);
+        let quick_start_root = project_root.to_path_buf();
+        let quick_start_entries = Vec::new();
+        let previous_profiles = self.launch_wizard_cache.agent_preferences();
+        let agent_options = self.launch_wizard_cache.agent_options();
+        let docker_context = None;
+        let docker_service_status = gwt_docker::ComposeServiceStatus::NotFound;
+        let wizard_id = Uuid::new_v4().to_string();
+        let mut wizard = LaunchWizardState::open_knowledge_launch_with_previous_profiles(
+            LaunchWizardContext {
+                selected_branch: synthetic_branch_entry(&base_branch_name),
+                normalized_branch_name: target_branch_name,
+                worktree_path: None,
+                quick_start_root,
+                live_sessions,
+                docker_context,
+                docker_service_status,
+                linked_issue_number: Some(issue_number),
+                linked_issue_kind: Some(linked_issue_kind),
+            },
+            base_branch_name,
+            agent_options,
+            quick_start_entries,
+            previous_profiles,
+        );
+        wizard.mark_runtime_context_unresolved();
+        self.launch_wizard = Some(LaunchWizardSession {
+            tab_id: tab_id.to_string(),
+            wizard_id,
+            wizard,
+            workspace_resume_context: None,
         });
 
         Ok(())
@@ -810,19 +857,34 @@ impl AppRuntime {
         }
 
         match result {
-            Ok(branch_name) => match self.open_launch_wizard_for_branch(
-                &tab_id,
-                &project_root,
-                &branch_name,
-                Some(issue_number),
-                linked_issue_kind_from_knowledge(knowledge_kind),
-            ) {
-                Ok(()) => vec![self.launch_wizard_state_outbound()],
-                Err(error) => vec![OutboundEvent::reply(
-                    &client_id,
-                    knowledge_error_event(id, knowledge_kind, error, None, None),
-                )],
-            },
+            Ok(base_branch_name) => {
+                let Some(linked_issue_kind) = linked_issue_kind_from_knowledge(knowledge_kind)
+                else {
+                    return vec![OutboundEvent::reply(
+                        &client_id,
+                        knowledge_error_event(
+                            id,
+                            knowledge_kind,
+                            "Launch Agent is not available for this knowledge bridge",
+                            None,
+                            None,
+                        ),
+                    )];
+                };
+                match self.open_knowledge_launch_wizard_for_base_branch(
+                    &tab_id,
+                    &project_root,
+                    &base_branch_name,
+                    issue_number,
+                    linked_issue_kind,
+                ) {
+                    Ok(()) => vec![self.launch_wizard_state_outbound()],
+                    Err(error) => vec![OutboundEvent::reply(
+                        &client_id,
+                        knowledge_error_event(id, knowledge_kind, error, None, None),
+                    )],
+                }
+            }
             Err(error) => vec![OutboundEvent::reply(
                 &client_id,
                 knowledge_error_event(id, knowledge_kind, error, None, None),

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -37,6 +37,11 @@ impl LinkedIssueKind {
 pub enum LaunchWizardMode {
     Branch,
     StartWork,
+    Knowledge,
+}
+
+pub fn knowledge_launch_target_branch_name(kind: LinkedIssueKind, number: u64) -> String {
+    format!("feature/{}-{number}", kind.branch_kind_segment())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -904,6 +909,30 @@ impl LaunchWizardState {
             quick_start_entries,
             LaunchWizardPreviousProfiles::from_profile(previous_profile),
         )
+    }
+
+    pub fn open_knowledge_launch_with_previous_profiles(
+        context: LaunchWizardContext,
+        base_branch_name: String,
+        agent_options: Vec<AgentOption>,
+        quick_start_entries: Vec<QuickStartEntry>,
+        previous_profiles: LaunchWizardPreviousProfiles,
+    ) -> Self {
+        let mut state = Self::new_with(
+            context,
+            agent_options,
+            quick_start_entries,
+            previous_profiles,
+            false,
+        );
+        state.wizard_mode = LaunchWizardMode::Knowledge;
+        state.step = LaunchWizardStep::LaunchTarget;
+        state.launch_path = LaunchWizardLaunchPath::ManualSetup;
+        state.selected = step_default_selection(state.step, &state);
+        state.is_new_branch = true;
+        state.base_branch_name = Some(base_branch_name);
+        state.branch_name = state.context.normalized_branch_name.clone();
+        state
     }
 
     pub fn open_loading(context: LaunchWizardContext, agent_options: Vec<AgentOption>) -> Self {
@@ -5195,6 +5224,66 @@ mod tests {
             config.working_dir.is_none(),
             "Start Work must defer worktree materialization until launch confirmation"
         );
+    }
+
+    #[test]
+    fn knowledge_launch_mode_uses_issue_target_branch_and_hides_branch_controls() {
+        let target_branch = knowledge_launch_target_branch_name(LinkedIssueKind::Issue, 7);
+        let state = LaunchWizardState::open_knowledge_launch_with_previous_profiles(
+            context_with_linked_issue(branch("develop"), &target_branch, LinkedIssueKind::Issue, 7),
+            "develop".to_string(),
+            sample_agent_options(),
+            Vec::new(),
+            LaunchWizardPreviousProfiles::default(),
+        );
+
+        let view = state.view();
+
+        assert_eq!(state.step, LaunchWizardStep::LaunchTarget);
+        assert_eq!(view.title, "Launch Agent");
+        assert_eq!(view.mode, LaunchWizardMode::Knowledge);
+        assert_eq!(view.branch_name, "feature/issue-7");
+        assert_eq!(view.branch_mode, "create_new");
+        assert!(!view.show_branch_controls);
+        assert!(state.is_new_branch);
+        assert_eq!(state.base_branch_name.as_deref(), Some("develop"));
+
+        let config = state.build_launch_config().expect("launch config");
+        assert_eq!(config.branch.as_deref(), Some("feature/issue-7"));
+        assert_eq!(config.base_branch.as_deref(), Some("develop"));
+        assert!(config.working_dir.is_none());
+        assert_eq!(config.linked_issue_number, Some(7));
+    }
+
+    #[test]
+    fn knowledge_launch_mode_uses_spec_target_branch_and_hides_linked_issue_section() {
+        let target_branch = knowledge_launch_target_branch_name(LinkedIssueKind::Spec, 2014);
+        let state = LaunchWizardState::open_knowledge_launch_with_previous_profiles(
+            context_with_linked_issue(
+                branch("develop"),
+                &target_branch,
+                LinkedIssueKind::Spec,
+                2014,
+            ),
+            "develop".to_string(),
+            sample_agent_options(),
+            Vec::new(),
+            LaunchWizardPreviousProfiles::default(),
+        );
+
+        let view = state.view();
+
+        assert_eq!(view.mode, LaunchWizardMode::Knowledge);
+        assert_eq!(view.branch_name, "feature/spec-2014");
+        assert_eq!(view.branch_mode, "create_new");
+        assert!(!view.show_branch_controls);
+        assert!(!view.show_linked_issue);
+
+        let config = state.build_launch_config().expect("launch config");
+        assert_eq!(config.branch.as_deref(), Some("feature/spec-2014"));
+        assert_eq!(config.base_branch.as_deref(), Some("develop"));
+        assert!(config.working_dir.is_none());
+        assert_eq!(config.linked_issue_number, Some(2014));
     }
 
     #[test]

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -79,13 +79,14 @@ pub use knowledge_bridge::{
 };
 pub use launch_wizard::{
     build_agent_options, build_builtin_agent_options, default_wizard_version_cache_path,
-    load_agent_options, AgentOption, DockerWizardContext, LaunchTargetKind, LaunchWizardAction,
-    LaunchWizardCompletion, LaunchWizardContext, LaunchWizardHydration, LaunchWizardLaunchPath,
-    LaunchWizardLaunchRequest, LaunchWizardLiveSessionView, LaunchWizardMode,
-    LaunchWizardOptionView, LaunchWizardPreviousProfile, LaunchWizardPreviousProfiles,
-    LaunchWizardProgressStepView, LaunchWizardQuickStartView, LaunchWizardState, LaunchWizardStep,
-    LaunchWizardSummaryView, LaunchWizardView, LinkedIssueKind, LiveSessionEntry, QuickStartEntry,
-    QuickStartLaunchMode, ResumableAgentResumeKind, ResumableAgentView, ShellLaunchConfig,
+    knowledge_launch_target_branch_name, load_agent_options, AgentOption, DockerWizardContext,
+    LaunchTargetKind, LaunchWizardAction, LaunchWizardCompletion, LaunchWizardContext,
+    LaunchWizardHydration, LaunchWizardLaunchPath, LaunchWizardLaunchRequest,
+    LaunchWizardLiveSessionView, LaunchWizardMode, LaunchWizardOptionView,
+    LaunchWizardPreviousProfile, LaunchWizardPreviousProfiles, LaunchWizardProgressStepView,
+    LaunchWizardQuickStartView, LaunchWizardState, LaunchWizardStep, LaunchWizardSummaryView,
+    LaunchWizardView, LinkedIssueKind, LiveSessionEntry, QuickStartEntry, QuickStartLaunchMode,
+    ResumableAgentResumeKind, ResumableAgentView, ShellLaunchConfig,
 };
 pub use managed_assets::{
     refresh_existing_managed_gwt_assets_for_worktree, refresh_managed_gwt_assets_for_agent,

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -3684,6 +3684,18 @@ mod tests {
         ));
         let issue_session = runtime.launch_wizard.as_ref().expect("launch wizard");
         assert!(!issue_session.wizard.is_hydrating);
+        let issue_view = issue_session.wizard.view();
+        assert_eq!(issue_view.mode, gwt::LaunchWizardMode::Knowledge);
+        assert_eq!(issue_view.branch_name, "feature/issue-7");
+        assert_eq!(issue_view.branch_mode, "create_new");
+        assert!(!issue_view.show_branch_controls);
+        let issue_config = issue_session
+            .wizard
+            .build_launch_config()
+            .expect("issue launch config");
+        assert_eq!(issue_config.branch.as_deref(), Some("feature/issue-7"));
+        assert_eq!(issue_config.base_branch.as_deref(), Some("feature/demo"));
+        assert!(issue_config.working_dir.is_none());
         assert_eq!(
             issue_session.wizard.context.linked_issue_kind,
             Some(gwt::LinkedIssueKind::Issue)
@@ -3703,6 +3715,18 @@ mod tests {
             });
         assert_eq!(prepared_spec.len(), 1);
         let spec_session = runtime.launch_wizard.as_ref().expect("launch wizard");
+        let spec_view = spec_session.wizard.view();
+        assert_eq!(spec_view.mode, gwt::LaunchWizardMode::Knowledge);
+        assert_eq!(spec_view.branch_name, "feature/spec-2014");
+        assert_eq!(spec_view.branch_mode, "create_new");
+        assert!(!spec_view.show_branch_controls);
+        let spec_config = spec_session
+            .wizard
+            .build_launch_config()
+            .expect("spec launch config");
+        assert_eq!(spec_config.branch.as_deref(), Some("feature/spec-2014"));
+        assert_eq!(spec_config.base_branch.as_deref(), Some("feature/demo"));
+        assert!(spec_config.working_dir.is_none());
         assert_eq!(
             spec_session.wizard.context.linked_issue_kind,
             Some(gwt::LinkedIssueKind::Spec)
@@ -5038,6 +5062,39 @@ mod tests {
         assert!(current_env
             .get("GWT_PROJECT_ROOT")
             .is_some_and(|value| super::same_worktree_path(Path::new(value), &repo)));
+
+        let mut knowledge_dir = None;
+        let mut knowledge_env = HashMap::new();
+        let mut base_branch = Some("develop".to_string());
+        super::resolve_launch_worktree_request(
+            &repo,
+            Some("feature/issue-7"),
+            &mut base_branch,
+            &mut knowledge_dir,
+            &mut knowledge_env,
+        )
+        .expect("knowledge launch worktree");
+        let knowledge_dir = knowledge_dir.expect("knowledge launch worktree dir");
+        assert!(
+            !super::same_worktree_path(&knowledge_dir, &repo),
+            "Knowledge Launch must not reuse the current develop project root"
+        );
+        assert!(knowledge_env
+            .get("GWT_PROJECT_ROOT")
+            .is_some_and(|value| { super::same_worktree_path(Path::new(value), &knowledge_dir) }));
+        let output = gwt_core::process::hidden_command("git")
+            .args(["branch", "--show-current"])
+            .current_dir(&knowledge_dir)
+            .output()
+            .expect("current branch in knowledge worktree");
+        assert!(
+            output.status.success(),
+            "git branch --show-current failed for knowledge worktree"
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&output.stdout).trim(),
+            "feature/issue-7"
+        );
 
         let preset = temp.path().join("preset");
         let mut preset_dir = Some(preset.clone());


### PR DESCRIPTION
## Summary

- Ensure Knowledge Bridge Launch Agent opens a dedicated branch worktree instead of reusing the current project root when the selected base branch is `develop`.
- Route Issue launches to `feature/issue-N` and SPEC launches to `feature/spec-N` while preserving the selected preferred branch as `base_branch`.

## Changes

- `crates/gwt/src/launch_wizard.rs`: Add Knowledge launch mode, deterministic Knowledge target branch naming, and tests for Issue/SPEC launch configs.
- `crates/gwt/src/app_runtime/wizard.rs`: Open Knowledge launches with separate base and target branches instead of forwarding the preferred branch as the launch target.
- `crates/gwt/src/main.rs`: Cover Issue/SPEC preparation and runtime worktree materialization so `develop` project roots are not reused for Knowledge launches.
- `crates/gwt/src/lib.rs`: Export the shared Knowledge launch target branch helper.

## Testing

- [x] `cargo test -p gwt --bin gwt wizard_handler_helpers_cover_preparation_focus_and_error_paths -- --nocapture` — failed before implementation because Knowledge mode did not exist; passed after implementation.
- [x] `cargo test -p gwt --lib knowledge_launch_mode -- --nocapture` — passed.
- [x] `cargo test -p gwt --bin gwt resolve_launch_worktree_helpers_cover_short_circuits_existing_and_remote_creation -- --nocapture` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `pnpm test:visual` — passed: 34 passed, 28 skipped.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed.

## Closing Issues

None

## Related Issues / Links

- #2014
- #2359

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC #2014 sections updated)
- [x] Migration/backfill plan included (not applicable; no schema/data change)
- [x] CHANGELOG impact considered (patch fix)

## Context

- Launch Agent from an Issue/SPEC Knowledge Bridge previously selected `develop` as the launch target and then runtime short-circuited to the existing project root, so no dedicated worktree was created.

## Risk / Impact

- **Affected areas**: Launch Wizard, Knowledge Bridge Issue/SPEC launch preparation, launch worktree resolution tests.
- **Rollback plan**: Revert this PR if Knowledge launches regress; no data migration is involved.
