### PR TITLE
test(index): add E2E coverage for lessons scope (Closes #2815)

### DIFF
--- a/crates/gwt/playwright/tests/index-status.spec.ts
+++ b/crates/gwt/playwright/tests/index-status.spec.ts
@@ -315,6 +315,65 @@ test.describe("Project Index status surface", () => {
     expect(lastRebuild).not.toHaveProperty("worktree_hash");
   });
 
+  test("Settings.Index renders the lessons scope row and dispatches rebuild_index_cell (SPEC-2805)", async ({
+    page,
+  }) => {
+    await installEmbeddedRoutes(page);
+    await installIndexStatusBackend(page, {
+      state: "repair_required",
+      scopes: {
+        lessons: {
+          healthy: false,
+          repair_required: true,
+          document_count: 0,
+          reason: "manifest_missing",
+        },
+      },
+    });
+
+    await page.goto(APP_URL);
+    await expect(page.locator(".project-tab")).toBeVisible({ timeout: 10_000 });
+    await page.evaluate(() => {
+      document.dispatchEvent(
+        new CustomEvent("settings:open", { detail: { target: "index" }, bubbles: true }),
+      );
+    });
+
+    const lessonsRow = page
+      .locator("[data-settings-panel='index'] tr[data-scope='lessons']")
+      .first();
+    await expect(lessonsRow).toBeVisible({ timeout: 10_000 });
+    await expect(lessonsRow.locator(".settings-index-cell.unhealthy")).toContainText(
+      "manifest_missing",
+    );
+
+    const rebuildAll = lessonsRow.locator(".settings-index-rebuild-all[data-scope='lessons']");
+    await rebuildAll.click();
+
+    const lastRebuild = await page.evaluate(() => {
+      const sends = (window.__gwtFixtureWebSocket && window.__gwtFixtureWebSocket.recordedSends) || [];
+      return sends
+        .map((raw) => {
+          try {
+            return JSON.parse(raw);
+          } catch (e) {
+            return null;
+          }
+        })
+        .filter((m) => m && m.kind === "rebuild_index_cell")
+        .pop();
+    });
+
+    expect(lastRebuild).toMatchObject({
+      kind: "rebuild_index_cell",
+      project_root: "/fixture",
+      scope: "lessons",
+    });
+    // Lessons is repo-scoped just like issues/specs, so worktree_hash must
+    // not be included in the dispatched IPC payload.
+    expect(lastRebuild).not.toHaveProperty("worktree_hash");
+  });
+
   test("Settings.Index per-cell Rebuild dispatches rebuild_index_cell IPC (T-IDX-102/T-IDX-110)", async ({
     page,
   }) => {

--- a/crates/gwt/src/index_worker.rs
+++ b/crates/gwt/src/index_worker.rs
@@ -57,6 +57,7 @@ pub fn bootstrap_project_index_for_path(project_root: &Path) -> Result<(), Strin
 pub enum IndexRebuildScope {
     Issues,
     Specs,
+    Lessons,
     Files,
     #[serde(rename = "files-docs")]
     FilesDocs,
@@ -67,6 +68,7 @@ impl IndexRebuildScope {
         match self {
             Self::Issues => "issues",
             Self::Specs => "specs",
+            Self::Lessons => "lessons",
             Self::Files => "files",
             Self::FilesDocs => "files-docs",
         }
@@ -158,6 +160,8 @@ pub struct ProjectIndexScopes {
     pub issues: Option<ScopeHealthView>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub specs: Option<ScopeHealthView>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lessons: Option<ScopeHealthView>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     pub files: BTreeMap<String, ScopeHealthView>,
     #[serde(
@@ -172,6 +176,7 @@ impl ProjectIndexScopes {
     pub fn is_empty(&self) -> bool {
         self.issues.is_none()
             && self.specs.is_none()
+            && self.lessons.is_none()
             && self.files.is_empty()
             && self.files_docs.is_empty()
     }
@@ -790,6 +795,12 @@ pub fn default_rebuild_runner(
             scope: None,
             needs_worktree_hash: false,
         },
+        IndexRebuildScope::Lessons => RebuildAction {
+            label: "lessons",
+            action: "index-lessons",
+            scope: None,
+            needs_worktree_hash: false,
+        },
         IndexRebuildScope::Files => RebuildAction {
             label: "files",
             action: "index-files",
@@ -819,6 +830,9 @@ pub fn collect_unhealthy_rebuild_targets(scopes: &ProjectIndexScopes) -> Vec<Reb
     }
     if matches!(&scopes.specs, Some(view) if !view.healthy) {
         targets.push((IndexRebuildScope::Specs, None));
+    }
+    if matches!(&scopes.lessons, Some(view) if !view.healthy) {
+        targets.push((IndexRebuildScope::Lessons, None));
     }
     for (wt_hash, view) in &scopes.files {
         if !view.healthy {
@@ -860,6 +874,9 @@ fn collect_unhealthy_rebuild_targets_for_worktree_hash(
     }
     if matches!(&scopes.specs, Some(view) if !view.healthy) {
         targets.push((IndexRebuildScope::Specs, None));
+    }
+    if matches!(&scopes.lessons, Some(view) if !view.healthy) {
+        targets.push((IndexRebuildScope::Lessons, None));
     }
     if let Some(current_hash) = current_worktree_hash {
         if matches!(scopes.files.get(current_hash), Some(view) if !view.healthy) {

--- a/crates/gwt/tests/index_bootstrap_test.rs
+++ b/crates/gwt/tests/index_bootstrap_test.rs
@@ -129,6 +129,40 @@ fn bootstrap_helper_reconciles_index_layout_and_kicks_issue_refresh() {
     );
 }
 
+#[test]
+fn bootstrap_preserves_repo_scoped_lessons_index_directory() {
+    // SPEC-2805: lessons is repo-scoped at ~/.gwt/index/<repo>/lessons/. Bootstrap
+    // must not treat it as an orphan worktree dir or as legacy worktree-scoped
+    // state, regardless of whether a current worktree exists.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let repo = tmp.path().join("repo");
+    let wt = tmp.path().join("wt-feature");
+    init_git_repo(&repo);
+    add_origin(&repo, "https://github.com/example/project.git");
+    commit_file(&repo, "README.md", "# repo\n");
+    add_worktree(&repo, &wt);
+
+    let repo_hash = detect_repo_hash(&repo).expect("repo hash");
+    let index_root = tmp.path().join("index");
+    let lessons_dir = index_root.join(repo_hash.as_str()).join("lessons");
+    fs::create_dir_all(&lessons_dir).expect("create repo-scoped lessons dir");
+    fs::write(lessons_dir.join("chroma.sqlite3"), "fake-db").expect("write lessons db");
+    fs::write(lessons_dir.join("meta.json"), r#"{"schema_version":1}"#)
+        .expect("write lessons meta");
+
+    let spawner = RecordingSpawner::default();
+    bootstrap_project_index_for_path_with(&wt, &index_root, &spawner).expect("bootstrap index");
+
+    assert!(
+        lessons_dir.join("chroma.sqlite3").exists(),
+        "bootstrap must preserve the repo-scoped lessons chroma.sqlite3"
+    );
+    assert!(
+        lessons_dir.join("meta.json").exists(),
+        "bootstrap must preserve the repo-scoped lessons meta.json"
+    );
+}
+
 fn call_project_root_matches(call: &str, expected: &Path) -> bool {
     let Some(actual) = call.split('|').nth(1) else {
         return false;

--- a/crates/gwt/tests/index_rebuild_cell_protocol_test.rs
+++ b/crates/gwt/tests/index_rebuild_cell_protocol_test.rs
@@ -60,4 +60,36 @@ fn frontend_event_rebuild_index_cell_deserializes_with_all_scopes() {
         }
         other => panic!("unexpected event: {other:?}"),
     }
+
+    let lessons = serde_json::from_value::<FrontendEvent>(json!({
+        "kind": "rebuild_index_cell",
+        "project_root": "/abs/repo",
+        "scope": "lessons"
+    }))
+    .expect("rebuild_index_cell scope=lessons should deserialize (SPEC-2805)");
+    match lessons {
+        FrontendEvent::RebuildIndexCell {
+            project_root,
+            scope,
+            worktree_hash,
+        } => {
+            assert_eq!(project_root, "/abs/repo");
+            assert_eq!(scope, IndexRebuildScope::Lessons);
+            assert_eq!(
+                worktree_hash, None,
+                "lessons is repo-scoped, worktree_hash must not be required"
+            );
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
+}
+
+#[test]
+fn index_rebuild_scope_lessons_metadata_matches_repo_scoped_contract() {
+    let scope = IndexRebuildScope::Lessons;
+    assert_eq!(scope.label(), "lessons");
+    assert!(
+        !scope.requires_worktree_hash(),
+        "lessons is repo-scoped — rebuild cell must not require worktree_hash"
+    );
 }

--- a/crates/gwt/web/index-settings-panel.js
+++ b/crates/gwt/web/index-settings-panel.js
@@ -110,6 +110,7 @@ export function renderIndexSettingsPanel(options) {
     worktreeHashes.length === 0
     && !scopes.issues
     && !scopes.specs
+    && !scopes.lessons
     && (!scopes.files || Object.keys(scopes.files).length === 0)
     && (!scopes["files-docs"] || Object.keys(scopes["files-docs"]).length === 0)
   ) {


### PR DESCRIPTION
## Summary

- SPEC #2805 (Lessons Semantic Search, PR #2813) の **E2E 補完**として Rust integration + Playwright + GUI IPC のテストを追加。
- 補完作業で **GUI Settings.Index の lessons row 用 Rebuild ボタンが破綻**していた（`IndexRebuildScope` enum に Lessons variant が無く、`{scope: "lessons"}` の deserialize が失敗）実装ギャップを発見し、test-first で同 PR 内で修正。
- `tasks/lessons.md` の運用フロー / 検索結果は不変。GUI 経路の lessons 表示・操作が完全動作するようになる。

## Changes

### 実装ギャップの修正
- `crates/gwt/src/index_worker.rs`:
  - `IndexRebuildScope::Lessons` 追加 + `label() = "lessons"` + `requires_worktree_hash() = false`
  - `rebuild_index_cell` の RebuildAction mapping に Lessons => `action: "index-lessons" / scope: None / needs_worktree_hash: false` を追加
  - `ProjectIndexScopes.lessons: Option<ScopeHealthView>` 追加 + `is_empty()` 拡張
  - `collect_unhealthy_rebuild_targets` / `_for_worktree_hash` に lessons の unhealthy 検出を追加
- `crates/gwt/web/index-settings-panel.js`:
  - empty-state 判定に `!scopes.lessons` を追加（lessons-only payload で空表示になる regression を回避）

### 追加テスト
- `crates/gwt/tests/index_rebuild_cell_protocol_test.rs`:
  - `rebuild_index_cell scope=lessons` の serde deserialize ケース追加
  - `IndexRebuildScope::Lessons.label()` / `requires_worktree_hash()` 契約テスト
- `crates/gwt/tests/index_bootstrap_test.rs`:
  - `bootstrap_preserves_repo_scoped_lessons_index_directory`: repo-scoped lessons dir が bootstrap で orphan として削除されないことを assert
- `crates/gwt/playwright/tests/index-status.spec.ts`:
  - `Settings.Index renders the lessons scope row and dispatches rebuild_index_cell (SPEC-2805)`: lessons row 描画 + Rebuild all ボタンが worktree_hash なしの IPC を送出することを assert (chromium-light + chromium-dark)

## Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace --all-features`: 85 test groups, 0 failed
- [x] `cargo test -p gwt --test index_rebuild_cell_protocol_test`: 2 passed (+1 新規)
- [x] `cargo test -p gwt --test index_bootstrap_test`: 2 passed (+1 新規)
- [x] `pnpm test:frontend-unit`: 507 passed
- [x] `pnpm test:frontend-bundle`: PASS
- [x] `pnpm test:visual` (Playwright) index-status.spec.ts: **14 passed** (lessons 2 ケース新規 + 既存 12)

## Closing Issues

Closes #2815

## Related Issues

- 元 SPEC: #2805 (PR #2813 で develop merged)
- 元 Plan: `/Users/akiojin/.claude/plans/tasks-lessons-md-agents-md-gwt-lessons-wobbly-lollipop.md`

## Checklist

- [x] Conventional Commits (`test(index): ...`) — test type なので version bump なし
- [x] commitlint PASS
- [x] test-first（RED → 実装 → GREEN）
- [x] AGENTS.md L88 の 90% カバレッジ要件に対する gap をクローズ
- [x] GUI Settings.Index の lessons row が完全に動作する状態を担保
- [x] 既存テストへの破壊変更なし
