### PR TITLE
feat: migrate docker/agent/runner callers to spawn_logged surface (SPEC-1924 Phase D)

### DIFF
--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -760,9 +760,26 @@ fn probe_host_package_runner(
     remove_env: &[String],
     cwd: Option<PathBuf>,
 ) -> bool {
+    // SPEC-1924 FR-039 / SPEC-2809 Phase D-agent — emit
+    // `gwt.process.summary` start / end events so agent-bootstrap
+    // probes appear in the Logs Process facet and the Console window
+    // counts them under the `agent` tab. stdio stays redirected to
+    // /dev/null because the probe only consumes the exit status.
+    let spawn_id = next_agent_spawn_id();
+    let label = format!("{} {}", command, args.join(" "));
+    tracing::info!(
+        target: "gwt.process.summary",
+        kind = "agent",
+        spawn_id = spawn_id,
+        label = %label,
+        phase = "start",
+        "process start",
+    );
+    let started_at = std::time::Instant::now();
+
     let mut process = gwt_core::process::hidden_command(command);
     process
-        .args(args)
+        .args(&args)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
@@ -773,7 +790,30 @@ fn probe_host_package_runner(
     if let Some(cwd) = cwd {
         process.current_dir(cwd);
     }
-    process.status().is_ok_and(|status| status.success())
+    let status = process.status();
+    let ok = status.as_ref().is_ok_and(|status| status.success());
+
+    let duration_ms = started_at.elapsed().as_millis() as u64;
+    let exit_code = status.ok().and_then(|s| s.code()).map(|c| c as i64);
+    tracing::info!(
+        target: "gwt.process.summary",
+        kind = "agent",
+        spawn_id = spawn_id,
+        label = %label,
+        phase = "end",
+        exit_code = exit_code,
+        duration_ms = duration_ms,
+        success = ok,
+        "process end",
+    );
+
+    ok
+}
+
+static AGENT_SPAWN_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+fn next_agent_spawn_id() -> u64 {
+    AGENT_SPAWN_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
 }
 
 fn command_matches_runner(command: &str, runner: &str) -> bool {

--- a/crates/gwt-core/src/index/runtime.rs
+++ b/crates/gwt-core/src/index/runtime.rs
@@ -239,6 +239,29 @@ impl RunnerSpawner for PythonRunnerSpawner {
         project_root: &Path,
         respect_ttl: bool,
     ) -> std::io::Result<()> {
+        // SPEC-1924 FR-039 / SPEC-2809 Phase D-runner — emit a
+        // `gwt.process.summary` start event so the Console window's
+        // runner tab and the Logs Process facet observe the Python
+        // chroma index runner spawn. The process is fire-and-forget
+        // (caller does not wait), so the `end` event is best-effort
+        // and intentionally omitted; the canonical log retains the
+        // start sentinel which is enough for incident triage.
+        let spawn_id = RUNNER_SPAWN_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let label = format!(
+            "{} {} --action index-issues",
+            self.python_executable.display(),
+            self.runner_script.display(),
+        );
+        tracing::info!(
+            target: "gwt.process.summary",
+            kind = "runner",
+            spawn_id = spawn_id,
+            label = %label,
+            phase = "start",
+            respect_ttl = respect_ttl,
+            "process start",
+        );
+
         let mut cmd = crate::process::hidden_command(&self.python_executable);
         cmd.arg(&self.runner_script)
             .arg("--action")
@@ -255,6 +278,8 @@ impl RunnerSpawner for PythonRunnerSpawner {
         cmd.spawn().map(|_| ())
     }
 }
+
+static RUNNER_SPAWN_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
 
 // gwt_index_worktree_dir is re-exported from `crate::index::paths`; keep this
 // path in scope so tests can verify the layout matches.

--- a/crates/gwt-docker/src/container.rs
+++ b/crates/gwt-docker/src/container.rs
@@ -80,6 +80,71 @@ fn docker_binary() -> OsString {
     std::env::var_os("GWT_DOCKER_BIN").unwrap_or_else(|| OsString::from("docker"))
 }
 
+// SPEC-2809 / SPEC-1924 Phase D-docker — per-spawn correlation id so the
+// Console window can render an invocation header between distinct docker
+// commands. Atomic so multiple compose calls from parallel handlers do not
+// collide.
+static DOCKER_SPAWN_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+fn next_docker_spawn_id() -> u64 {
+    DOCKER_SPAWN_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+}
+
+fn emit_docker_start(spawn_id: u64, action: &str, args: &[&str]) {
+    tracing::info!(
+        target: "gwt.process.summary",
+        kind = "docker",
+        spawn_id = spawn_id,
+        label = %format!("docker {}", args.join(" ")),
+        action = action,
+        phase = "start",
+        "process start",
+    );
+}
+
+fn emit_docker_end(spawn_id: u64, action: &str, exit_code: Option<i32>, duration_ms: u64) {
+    tracing::info!(
+        target: "gwt.process.summary",
+        kind = "docker",
+        spawn_id = spawn_id,
+        action = action,
+        phase = "end",
+        exit_code = exit_code.map(|c| c as i64),
+        duration_ms = duration_ms,
+        "process end",
+    );
+}
+
+fn wrap_on_line_with_hub<F>(
+    mut original: F,
+    hub: gwt_core::process_console::ProcessConsoleHub,
+    spawn_id: u64,
+) -> impl FnMut(CommandOutputStream, &str)
+where
+    F: FnMut(CommandOutputStream, &str),
+{
+    move |stream, line| {
+        // Push the line through the existing callback first so callers
+        // still see their on_line emissions in their original ordering.
+        original(stream, line);
+        let process_stream = match stream {
+            CommandOutputStream::Stdout => gwt_core::process_console::ProcessStream::Stdout,
+            CommandOutputStream::Stderr => gwt_core::process_console::ProcessStream::Stderr,
+        };
+        // Apply the same `redact_line` + `strip_ansi` discipline the
+        // async `spawn_logged` path uses so secrets and ANSI escapes
+        // never reach the hub-facing buffer.
+        let sanitized =
+            gwt_core::process_console::redact_line(&gwt_core::process_console::strip_ansi(line));
+        hub.push(gwt_core::process_console::ProcessLine::new(
+            gwt_core::process_console::ProcessKind::Docker,
+            spawn_id,
+            process_stream,
+            sanitized,
+        ));
+    }
+}
+
 fn docker_timeout() -> Duration {
     const DEFAULT_TIMEOUT_MS: u64 = 5_000;
     std::env::var("GWT_DOCKER_TIMEOUT_MS")
@@ -196,11 +261,22 @@ fn run_docker_with_output_streaming_in_dir_and_timeout<F>(
     action: &str,
     current_dir: Option<&std::path::Path>,
     timeout: Duration,
-    mut on_line: F,
+    on_line: F,
 ) -> Result<Output>
 where
     F: FnMut(CommandOutputStream, &str),
 {
+    // SPEC-2809 / SPEC-1924 Phase D-docker — chain the existing callback
+    // with a `ProcessConsoleHub` push so the docker tab of the Console
+    // window and the Logs Process facet observe every line. The timeout
+    // / streaming loop below is unchanged because rewriting it as async
+    // would risk regressing compose timeout semantics.
+    let hub = gwt_core::process_console::global();
+    let spawn_id = next_docker_spawn_id();
+    emit_docker_start(spawn_id, action, args);
+    let started_at = Instant::now();
+    let mut on_line = wrap_on_line_with_hub(on_line, hub.clone(), spawn_id);
+
     let mut command = Command::new(docker_binary());
     command
         .args(args)
@@ -292,6 +368,13 @@ where
         &mut collected_stdout,
         &mut collected_stderr,
         &mut on_line,
+    );
+
+    emit_docker_end(
+        spawn_id,
+        action,
+        status.code(),
+        started_at.elapsed().as_millis() as u64,
     );
 
     Ok(Output {

--- a/crates/gwt-docker/src/detect.rs
+++ b/crates/gwt-docker/src/detect.rs
@@ -30,12 +30,25 @@ impl DockerFiles {
 
 /// Run a docker sub-command and return whether it succeeded.
 fn docker_probe(args: &[&str], label: &str) -> bool {
+    // SPEC-2809 / SPEC-1924 Phase D-docker — route docker probes through
+    // `spawn_logged_blocking` so the docker tab of the Console window /
+    // Logs Process facet sees them. The `binary` may be a `GWT_DOCKER_BIN`
+    // override; pass it as the program directly.
     let binary = docker_binary();
     let attempted_binary = binary.to_string_lossy().into_owned();
-    let result = std::process::Command::new(&binary).args(args).output();
+    let hub = gwt_core::process_console::global();
+    let options =
+        gwt_core::process_console::SpawnOptions::new(format!("docker {}", args.join(" ")));
+    let result = gwt_core::process_console::spawn_logged_blocking(
+        &hub,
+        gwt_core::process_console::ProcessKind::Docker,
+        &binary,
+        args,
+        options,
+    );
     match result {
         Ok(output) => {
-            let ok = output.status.success();
+            let ok = output.success();
             info!(
                 target: "gwt::launch::probe",
                 category = "docker",
@@ -45,8 +58,7 @@ fn docker_probe(args: &[&str], label: &str) -> bool {
                 "docker probe"
             );
             if !ok {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                let stderr = stderr.trim();
+                let stderr = output.stderr.trim();
                 if !stderr.is_empty() {
                     debug!(
                         target: "gwt::launch::probe",

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -485,9 +485,26 @@ pub fn probe_host_package_runner_with_timeout(
     timeout: Duration,
     poll_interval: Duration,
 ) -> bool {
+    // SPEC-1924 FR-039 / SPEC-2809 Phase D-agent — emit summary tracing
+    // around the bounded-poll spawn so the Logs Process facet (kind =
+    // agent) and the Console window see the launch attempt. stdio is
+    // intentionally null because the caller only consumes the timeout +
+    // exit status; nothing to forward to the hub.
+    let agent_spawn_id =
+        AGENT_LAUNCH_SPAWN_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let agent_label = format!("{} {}", command, args.join(" "));
+    tracing::info!(
+        target: "gwt.process.summary",
+        kind = "agent",
+        spawn_id = agent_spawn_id,
+        label = %agent_label,
+        phase = "start",
+        "process start",
+    );
+
     let mut process = gwt_core::process::hidden_command(command);
     process
-        .args(args)
+        .args(&args)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
@@ -499,16 +516,46 @@ pub fn probe_host_package_runner_with_timeout(
         process.current_dir(cwd);
     }
     let Ok(mut child) = process.spawn() else {
+        tracing::info!(
+            target: "gwt.process.summary",
+            kind = "agent",
+            spawn_id = agent_spawn_id,
+            label = %agent_label,
+            phase = "end",
+            exit_code = None::<i64>,
+            success = false,
+            error = "spawn failed",
+            "process end",
+        );
         return false;
     };
     let start = Instant::now();
+    let emit_end = |exit_code: Option<i32>, success: bool, note: Option<&str>| {
+        tracing::info!(
+            target: "gwt.process.summary",
+            kind = "agent",
+            spawn_id = agent_spawn_id,
+            label = %agent_label,
+            phase = "end",
+            exit_code = exit_code.map(|c| c as i64),
+            duration_ms = start.elapsed().as_millis() as u64,
+            success = success,
+            note = note,
+            "process end",
+        );
+    };
     loop {
         match child.try_wait() {
-            Ok(Some(status)) => return status.success(),
+            Ok(Some(status)) => {
+                let success = status.success();
+                emit_end(status.code(), success, None);
+                return success;
+            }
             Ok(None) => {
                 if start.elapsed() >= timeout {
                     let _ = child.kill();
                     let _ = child.wait();
+                    emit_end(None, false, Some("timeout"));
                     return false;
                 }
                 thread::sleep(poll_interval);
@@ -516,11 +563,15 @@ pub fn probe_host_package_runner_with_timeout(
             Err(_) => {
                 let _ = child.kill();
                 let _ = child.wait();
+                emit_end(None, false, Some("wait error"));
                 return false;
             }
         }
     }
 }
+
+static AGENT_LAUNCH_SPAWN_COUNTER: std::sync::atomic::AtomicU64 =
+    std::sync::atomic::AtomicU64::new(1);
 
 pub fn command_matches_runner(command: &str, runner: &str) -> bool {
     let path = Path::new(command);


### PR DESCRIPTION
## Summary

PR #2792 で gh CLI 全 caller、PR #2810 で Console window、PR #2818 で Logs Process facet が揃った後の **SPEC-1924 Phase D** 移行。docker / agent bootstrap / Python index runner の caller を Process facet + Console window に乗せる。これにより Process facet 5 kind のうち git 以外の 4 kind が live forward / summary tracing 経路に乗る。

git caller (252 spawn site) の段階移行は Phase C-git-visible で別 PR にする。

## 主な変更

### docker (crates/gwt-docker)

- `detect.rs::docker_probe` — `Command::new` → `spawn_logged_blocking(ProcessKind::Docker)`. stdout/stderr は output 経由 (line forward は Console window へ自動)
- `container.rs::run_docker_with_output_streaming_in_dir_and_timeout` — 既存の thread-spawned reader + timeout poll loop を保持しつつ、`on_line` callback を `wrap_on_line_with_hub` で chain して line を `ProcessConsoleHub` に push。`redact_line` + `strip_ansi` を同じ layer で適用するので Console window/Logs facet の plain-text 契約は維持。spawn 前後で `emit_docker_start` / `emit_docker_end` が `gwt.process.summary` を発行

### agent bootstrap

- `crates/gwt-agent/src/prepare.rs::probe_host_package_runner` — 既存の null-stdio probe を保持しつつ前後で summary tracing (`kind=agent`, spawn_id, exit_code, duration_ms) を emit。Process facet で agent 起動探索が可視化される
- `crates/gwt/src/launch_runtime.rs::probe_host_package_runner_with_timeout` — 同上。spawn 失敗 / timeout / wait error の各 return point で end summary を emit して欠落を防ぐ

### Python index runner

- `crates/gwt-core/src/index/runtime.rs::PythonRunnerSpawner::spawn_index_issues` — Python chroma index runner spawn 前に `kind=runner` の start summary を emit。fire-and-forget 設計なので end は best-effort 省略 (start sentinel で incident triage に十分)

## Test plan

- [x] `cargo test -p gwt-core -p gwt-docker -p gwt-agent -p gwt --all-features` (2178 件 PASS)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual verification (user): Console window で `docker` / `agent` / `runner` タブを開く → 該当操作 (Docker container start / agent launch / index refresh) を行う → 各タブに live tail (docker) または summary (agent/runner) が表示される。Logs window Process kind chip を docker/agent/runner に切替で AND 結合フィルタが効くことを確認。

## Follow-up

- Phase C-git-visible: 252 git spawn site の段階移行 (gwt-git/{branch,commit,diff,refs,worktree,repository,migration,pr_status,issue}.rs 等)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
