### PR TITLE
fix(launch): use work branches for Issue launch

### DIFF
--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -41,7 +41,10 @@ pub enum LaunchWizardMode {
 }
 
 pub fn knowledge_launch_target_branch_name(kind: LinkedIssueKind, number: u64) -> String {
-    format!("feature/{}-{number}", kind.branch_kind_segment())
+    match kind {
+        LinkedIssueKind::Issue => format!("work/issue-{number}"),
+        LinkedIssueKind::Spec => format!("feature/spec-{number}"),
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -5242,14 +5245,14 @@ mod tests {
         assert_eq!(state.step, LaunchWizardStep::LaunchTarget);
         assert_eq!(view.title, "Launch Agent");
         assert_eq!(view.mode, LaunchWizardMode::Knowledge);
-        assert_eq!(view.branch_name, "feature/issue-7");
+        assert_eq!(view.branch_name, "work/issue-7");
         assert_eq!(view.branch_mode, "create_new");
         assert!(!view.show_branch_controls);
         assert!(state.is_new_branch);
         assert_eq!(state.base_branch_name.as_deref(), Some("develop"));
 
         let config = state.build_launch_config().expect("launch config");
-        assert_eq!(config.branch.as_deref(), Some("feature/issue-7"));
+        assert_eq!(config.branch.as_deref(), Some("work/issue-7"));
         assert_eq!(config.base_branch.as_deref(), Some("develop"));
         assert!(config.working_dir.is_none());
         assert_eq!(config.linked_issue_number, Some(7));

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -3686,14 +3686,14 @@ mod tests {
         assert!(!issue_session.wizard.is_hydrating);
         let issue_view = issue_session.wizard.view();
         assert_eq!(issue_view.mode, gwt::LaunchWizardMode::Knowledge);
-        assert_eq!(issue_view.branch_name, "feature/issue-7");
+        assert_eq!(issue_view.branch_name, "work/issue-7");
         assert_eq!(issue_view.branch_mode, "create_new");
         assert!(!issue_view.show_branch_controls);
         let issue_config = issue_session
             .wizard
             .build_launch_config()
             .expect("issue launch config");
-        assert_eq!(issue_config.branch.as_deref(), Some("feature/issue-7"));
+        assert_eq!(issue_config.branch.as_deref(), Some("work/issue-7"));
         assert_eq!(issue_config.base_branch.as_deref(), Some("feature/demo"));
         assert!(issue_config.working_dir.is_none());
         assert_eq!(
@@ -5068,7 +5068,7 @@ mod tests {
         let mut base_branch = Some("develop".to_string());
         super::resolve_launch_worktree_request(
             &repo,
-            Some("feature/issue-7"),
+            Some("work/issue-7"),
             &mut base_branch,
             &mut knowledge_dir,
             &mut knowledge_env,
@@ -5093,7 +5093,7 @@ mod tests {
         );
         assert_eq!(
             String::from_utf8_lossy(&output.stdout).trim(),
-            "feature/issue-7"
+            "work/issue-7"
         );
 
         let preset = temp.path().join("preset");


### PR DESCRIPTION
## Summary

- Change Issue Knowledge Launch target branches from `feature/issue-N` to `work/issue-N`.
- Keep SPEC Knowledge Launch target branches as `feature/spec-N`.
- Update Launch Wizard, AppRuntime, and worktree-resolution regression coverage for the new Issue branch namespace.

## Verification

- `cargo test -p gwt --lib knowledge_launch_mode -- --nocapture`
- `cargo test -p gwt --bin gwt wizard_handler_helpers_cover_preparation_focus_and_error_paths -- --nocapture`
- `cargo test -p gwt --bin gwt resolve_launch_worktree_helpers_cover_short_circuits_existing_and_remote_creation -- --nocapture`
- `cargo fmt -- --check`
- `git diff --check`
- `cargo test -p gwt-core -p gwt --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build -p gwt --bin gwt --bin gwtd`
- `bunx commitlint --from HEAD~1 --to HEAD`
- `git push` pre-push CI-equivalent checks and coverage passed; filtered line coverage: 90.34%.

## Related

- Follow-up to #2816
- SPEC #2014
