### PR TITLE
chore(installer): add Windows MSI diagnostics

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -55,6 +55,21 @@ curl -fsSL https://raw.githubusercontent.com/akiojin/gwt/main/installers/macos/i
 - GUI 向けの主配布物: `gwt-windows-x86_64.msi`
 - portable bundle: `gwt-windows-x86_64.zip`
 - public front door は `gwt.exe` で、`gwtd.exe` は内部 runtime 用の companion binary です
+- MSI をダブルクリックしても何も起きないように見える場合は、PowerShell から
+  診断スクリプトを実行し、生成された出力ディレクトリを Issue 報告に添付してください。
+
+```powershell
+$diag = "$env:TEMP\diagnose-windows-msi.ps1"
+Invoke-WebRequest `
+  https://raw.githubusercontent.com/akiojin/gwt/main/scripts/diagnose-windows-msi.ps1 `
+  -OutFile $diag
+powershell -ExecutionPolicy Bypass -File $diag `
+  -MsiPath "$env:USERPROFILE\Downloads\gwt-windows-x86_64.msi"
+```
+
+このスクリプトは MSI の SHA256、Authenticode 署名、Zone.Identifier
+download marker、Windows Installer の `msiexec` verbose log、インストール後の
+ファイル配置、基本的な `gwt.exe` 起動証跡を記録します。
 
 ### Linux
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ curl -fsSL https://raw.githubusercontent.com/akiojin/gwt/main/installers/macos/i
 - GUI-first installer: `gwt-windows-x86_64.msi`
 - Portable bundle: `gwt-windows-x86_64.zip`
 - The public front door is `gwt.exe`; `gwtd.exe` is bundled for internal runtime use
+- If double-clicking the MSI appears to do nothing, run the diagnostic script
+  from PowerShell and attach the output directory when reporting the issue:
+
+```powershell
+$diag = "$env:TEMP\diagnose-windows-msi.ps1"
+Invoke-WebRequest `
+  https://raw.githubusercontent.com/akiojin/gwt/main/scripts/diagnose-windows-msi.ps1 `
+  -OutFile $diag
+powershell -ExecutionPolicy Bypass -File $diag `
+  -MsiPath "$env:USERPROFILE\Downloads\gwt-windows-x86_64.msi"
+```
+
+The script records the MSI SHA256, Authenticode signature, Zone.Identifier
+download marker, Windows Installer `msiexec` verbose log, installed file layout,
+and basic `gwt.exe` launch evidence.
 
 ### Linux
 

--- a/scripts/diagnose-windows-msi.ps1
+++ b/scripts/diagnose-windows-msi.ps1
@@ -1,0 +1,226 @@
+[CmdletBinding()]
+param(
+  [string]$MsiPath = (Join-Path $env:USERPROFILE "Downloads\gwt-windows-x86_64.msi"),
+  [string]$ExpectedSha256 = "",
+  [string]$OutputDir = "",
+  [switch]$SkipInstall,
+  [switch]$CheckHeadless
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function New-DefaultOutputDir {
+  $stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+  return Join-Path $env:TEMP "gwt-msi-diagnostics-$stamp"
+}
+
+if ([string]::IsNullOrWhiteSpace($OutputDir)) {
+  $OutputDir = New-DefaultOutputDir
+}
+
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+$SummaryPath = Join-Path $OutputDir "summary.txt"
+$TranscriptPath = Join-Path $OutputDir "transcript.txt"
+$InstallerLogPath = Join-Path $OutputDir "msiexec-install.log"
+$InstallerMatchesPath = Join-Path $OutputDir "msiexec-interesting-lines.txt"
+
+Set-Content -Path $SummaryPath -Value "GWT Windows MSI diagnostics" -Encoding UTF8
+
+function Add-Summary {
+  param([string]$Message)
+
+  $Message | Tee-Object -FilePath $SummaryPath -Append
+}
+
+function Add-Section {
+  param([string]$Title)
+
+  Add-Summary ""
+  Add-Summary "== $Title =="
+}
+
+function Save-Object {
+  param(
+    [Parameter(Mandatory = $true)]$InputObject,
+    [Parameter(Mandatory = $true)][string]$Path
+  )
+
+  $InputObject | Format-List * | Out-File -FilePath $Path -Encoding UTF8
+}
+
+function Capture-InstalledLayout {
+  param([string]$InstallRoot)
+
+  Add-Section "Installed layout"
+  Add-Summary "InstallRoot=$InstallRoot"
+
+  if (-not (Test-Path -LiteralPath $InstallRoot)) {
+    Add-Summary "Install root not found."
+    return
+  }
+
+  $layoutPath = Join-Path $OutputDir "installed-layout.txt"
+  Get-ChildItem -LiteralPath $InstallRoot -Force |
+    Select-Object Mode, LastWriteTime, Length, Name |
+    Format-Table -AutoSize |
+    Out-String |
+    Tee-Object -FilePath $layoutPath |
+    Write-Host
+
+  Add-Summary "Installed layout written to $layoutPath"
+}
+
+function Capture-GwtVersion {
+  param([string]$GwtExe)
+
+  Add-Section "gwt.exe version"
+  Add-Summary "GwtExe=$GwtExe"
+
+  if (-not (Test-Path -LiteralPath $GwtExe)) {
+    Add-Summary "gwt.exe not found."
+    return
+  }
+
+  $versionPath = Join-Path $OutputDir "gwt-version.txt"
+  try {
+    & $GwtExe --version 2>&1 |
+      Tee-Object -FilePath $versionPath |
+      Write-Host
+    Add-Summary "gwt.exe --version output written to $versionPath"
+  } catch {
+    Add-Summary "gwt.exe --version failed: $($_.Exception.Message)"
+  }
+}
+
+function Capture-HeadlessLaunch {
+  param([string]$GwtExe)
+
+  if (-not $CheckHeadless) {
+    return
+  }
+
+  Add-Section "gwt serve headless smoke"
+  Add-Summary "GwtExe=$GwtExe"
+
+  if (-not (Test-Path -LiteralPath $GwtExe)) {
+    Add-Summary "gwt.exe not found; skipping headless smoke."
+    return
+  }
+
+  $stdoutPath = Join-Path $OutputDir "gwt-serve-stdout.txt"
+  $stderrPath = Join-Path $OutputDir "gwt-serve-stderr.txt"
+  $args = "serve --no-open --port 0"
+  Add-Summary "Starting: $GwtExe $args"
+
+  $process = Start-Process -FilePath $GwtExe `
+    -ArgumentList $args `
+    -RedirectStandardOutput $stdoutPath `
+    -RedirectStandardError $stderrPath `
+    -PassThru
+
+  Start-Sleep -Seconds 5
+
+  if ($process.HasExited) {
+    Add-Summary "gwt serve exited early with code $($process.ExitCode)."
+  } else {
+    Add-Summary "gwt serve stayed alive for 5 seconds; stopping diagnostic process."
+    Stop-Process -Id $process.Id -Force
+  }
+
+  Add-Summary "stdout=$stdoutPath"
+  Add-Summary "stderr=$stderrPath"
+}
+
+Start-Transcript -Path $TranscriptPath -Force | Out-Null
+
+try {
+  Add-Section "Environment"
+  Add-Summary "OutputDir=$OutputDir"
+  Add-Summary "ComputerName=$env:COMPUTERNAME"
+  Add-Summary "UserName=$env:USERNAME"
+  Add-Summary "OS=$([System.Environment]::OSVersion.VersionString)"
+  Add-Summary "PowerShell=$($PSVersionTable.PSVersion)"
+
+  Add-Section "MSI file"
+  $resolvedMsi = Resolve-Path -LiteralPath $MsiPath
+  $msiFullPath = $resolvedMsi.Path
+  $msiItem = Get-Item -LiteralPath $msiFullPath
+  Add-Summary "MsiPath=$msiFullPath"
+  Add-Summary "Length=$($msiItem.Length)"
+  Add-Summary "LastWriteTime=$($msiItem.LastWriteTime.ToString('o'))"
+
+  $hash = Get-FileHash -LiteralPath $msiFullPath -Algorithm SHA256
+  Save-Object -InputObject $hash -Path (Join-Path $OutputDir "msi-sha256.txt")
+  Add-Summary "SHA256=$($hash.Hash.ToLowerInvariant())"
+  if (-not [string]::IsNullOrWhiteSpace($ExpectedSha256)) {
+    $expected = $ExpectedSha256.ToLowerInvariant()
+    if ($hash.Hash.ToLowerInvariant() -eq $expected) {
+      Add-Summary "ExpectedSha256=match"
+    } else {
+      Add-Summary "ExpectedSha256=mismatch expected=$expected"
+    }
+  }
+
+  Add-Section "Authenticode signature"
+  $signature = Get-AuthenticodeSignature -LiteralPath $msiFullPath
+  Save-Object -InputObject $signature -Path (Join-Path $OutputDir "authenticode-signature.txt")
+  Add-Summary "SignatureStatus=$($signature.Status)"
+  Add-Summary "SignatureStatusMessage=$($signature.StatusMessage)"
+  if ($null -ne $signature.SignerCertificate) {
+    Add-Summary "SignerSubject=$($signature.SignerCertificate.Subject)"
+    Add-Summary "SignerThumbprint=$($signature.SignerCertificate.Thumbprint)"
+  } else {
+    Add-Summary "SignerCertificate=<none>"
+  }
+
+  Add-Section "Zone.Identifier"
+  $zonePath = Join-Path $OutputDir "zone-identifier.txt"
+  try {
+    Get-Content -LiteralPath $msiFullPath -Stream Zone.Identifier -ErrorAction Stop |
+      Tee-Object -FilePath $zonePath |
+      Write-Host
+    Add-Summary "Zone.Identifier written to $zonePath"
+  } catch {
+    Add-Summary "Zone.Identifier not found or unreadable: $($_.Exception.Message)"
+  }
+
+  Add-Section "Windows Installer"
+  if ($SkipInstall) {
+    Add-Summary "SkipInstall=true; msiexec was not run."
+  } else {
+    $msiexecArgs = "/i `"$msiFullPath`" /L*V `"$InstallerLogPath`""
+    Add-Summary "Starting: msiexec.exe $msiexecArgs"
+    $installer = Start-Process -FilePath "msiexec.exe" `
+      -ArgumentList $msiexecArgs `
+      -Wait `
+      -PassThru
+    Add-Summary "msiexec exit code=$($installer.ExitCode)"
+    Add-Summary "msiexec log=$InstallerLogPath"
+
+    if (Test-Path -LiteralPath $InstallerLogPath) {
+      Select-String -Path $InstallerLogPath `
+        -Pattern "Return value 3", "Error ", "LaunchCondition", "GWT_LEGACY", "MainEngineThread", "Product: GWT" `
+        -Context 2, 2 |
+        Out-File -FilePath $InstallerMatchesPath -Encoding UTF8
+      Add-Summary "Interesting msiexec lines=$InstallerMatchesPath"
+    } else {
+      Add-Summary "msiexec log was not created."
+    }
+  }
+
+  $installRoot = Join-Path $env:LOCALAPPDATA "Programs\GWT"
+  $gwtExe = Join-Path $installRoot "gwt.exe"
+  Capture-InstalledLayout -InstallRoot $installRoot
+  Capture-GwtVersion -GwtExe $gwtExe
+  Capture-HeadlessLaunch -GwtExe $gwtExe
+
+  Add-Section "Result"
+  Add-Summary "Diagnostics complete."
+  Add-Summary "Attach this directory when reporting the issue: $OutputDir"
+} finally {
+  Stop-Transcript | Out-Null
+  Write-Host ""
+  Write-Host "Diagnostics written to $OutputDir"
+}

--- a/scripts/test_release_assets.cjs
+++ b/scripts/test_release_assets.cjs
@@ -236,6 +236,42 @@ run("README install guidance points to GUI-first release assets", () => {
   }
 });
 
+run("windows MSI diagnostics are documented for launch failures", () => {
+  const readme = fs.readFileSync(path.join(__dirname, "..", "README.md"), "utf8");
+  const readmeJa = fs.readFileSync(path.join(__dirname, "..", "README.ja.md"), "utf8");
+
+  for (const doc of [readme, readmeJa]) {
+    assert.match(doc, /diagnose-windows-msi\.ps1/);
+    assert.match(doc, /msiexec|Windows Installer/);
+  }
+});
+
+run("windows MSI diagnostic script captures installer evidence", () => {
+  const diagnosticScript = fs.readFileSync(
+    path.join(__dirname, "diagnose-windows-msi.ps1"),
+    "utf8"
+  );
+
+  for (const required of [
+    "Get-FileHash",
+    "Get-AuthenticodeSignature",
+    "Zone.Identifier",
+    "Start-Transcript",
+    "msiexec.exe",
+    "/L*V",
+    "Get-ChildItem",
+    "gwt.exe",
+    "--version",
+    "serve",
+    "--no-open",
+  ]) {
+    assert.ok(
+      diagnosticScript.includes(required),
+      `diagnose-windows-msi.ps1 must include "${required}"`
+    );
+  }
+});
+
 run("portable tarball extraction installs the unix bundle", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "gwt-release-test-"));
   const sourceDir = path.join(root, "source");


### PR DESCRIPTION
## Summary

- Add a Windows PowerShell diagnostic script for MSI double-click launch failures so users can capture installer evidence before we guess at a root cause.
- Document the Windows diagnostic path in both README files and keep it covered by the release asset contract test.

## Changes

- `scripts/diagnose-windows-msi.ps1`: captures MSI metadata, SHA256, Authenticode signature, Zone.Identifier, `msiexec /L*V` verbose logs, installed layout, `gwt.exe --version`, and optional `gwt serve --no-open` smoke evidence.
- `README.md` / `README.ja.md`: add Windows MSI troubleshooting commands that download and run the diagnostic script from the raw GitHub URL.
- `scripts/test_release_assets.cjs`: require the diagnostic script and README guidance as part of release-flow checks.

## Testing

- [x] `node scripts/test_release_assets.cjs` — release asset contract and new Windows MSI diagnostic checks pass.
- [x] `npm run --silent test:release-flow` — release flow checks pass.
- [x] `bunx markdownlint-cli README.md README.ja.md` — README markdown lint passes.
- [x] `git diff --check` — whitespace check passes.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — commit message lint passes.

## Closing Issues

- Closes #2820

## Related Issues / Links

- #2775
- #2776
- SPEC-1932
- SPEC-2041

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`bunx markdownlint-cli README.md README.ja.md`)
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (not applicable: no schema/data change)
- [x] CHANGELOG impact considered (chore-only diagnostic tooling, no release note required)

## Context

- v9.40.0 Windows MSI was reported as doing nothing when double-clicked. The MSI asset exists and its build job succeeded, but this environment cannot reproduce Windows Explorer, SmartScreen, or Windows Installer behavior directly.
- This PR adds a diagnostic collection path instead of guessing at a fix without root-cause evidence.

## Risk / Impact

- **Affected areas**: README install guidance and release diagnostic scripts only.
- **Rollback plan**: Revert this PR; no runtime behavior or release artifact generation changes are made.
