### PR TITLE
feat(git): migrate high-visibility git callers to run_git_logged (SPEC-1924 Phase C-visible-1)

### DIFF
--- a/crates/gwt-core/src/process.rs
+++ b/crates/gwt-core/src/process.rs
@@ -43,6 +43,130 @@ pub fn run_command_with_env(cmd: &str, args: &[&str], env: &[(String, String)]) 
     capture_output(cmd, output)
 }
 
+// =====================================================================
+// SPEC-1924 Phase C-git — synchronous git wrapper that emits
+// `gwt.process.summary` start/end tracing and pushes captured stdout /
+// stderr lines into the `ProcessConsoleHub`. Drop-in replacement for the
+// common `hidden_command("git").args(...).current_dir(...).output()`
+// idiom; preserves the std::process::Output return so callers do not
+// need to change their downstream logic.
+// =====================================================================
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static GIT_SPAWN_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+fn next_git_spawn_id() -> u64 {
+    GIT_SPAWN_COUNTER.fetch_add(1, Ordering::Relaxed)
+}
+
+/// Spawn `git` with `args` in `current_dir`, capture stdout / stderr,
+/// emit Process facet summary tracing, and forward redacted lines to
+/// the hub (kind = `Git`).
+///
+/// Returns the same `std::process::Output` as `Command::output()` so the
+/// caller's existing `status.success()` / `stdout` / `stderr` handling
+/// keeps working unchanged.
+pub fn run_git_logged(
+    args: &[&str],
+    current_dir: Option<&std::path::Path>,
+) -> std::io::Result<std::process::Output> {
+    let spawn_id = next_git_spawn_id();
+    let label = format!("git {}", args.join(" "));
+    let started_at = std::time::Instant::now();
+
+    tracing::info!(
+        target: "gwt.process.summary",
+        kind = "git",
+        spawn_id = spawn_id,
+        label = %label,
+        phase = "start",
+        "process start",
+    );
+
+    let mut command = hidden_command("git");
+    command.args(args);
+    if let Some(dir) = current_dir {
+        command.current_dir(dir);
+    }
+    let result = command.output();
+
+    let (exit_code, success, stdout_lines, stderr_lines) = match &result {
+        Ok(output) => {
+            forward_git_lines(spawn_id, &output.stdout, &output.stderr);
+            let stdout_lines = String::from_utf8_lossy(&output.stdout).lines().count() as u64;
+            let stderr_lines = String::from_utf8_lossy(&output.stderr).lines().count() as u64;
+            (
+                output.status.code(),
+                output.status.success(),
+                stdout_lines,
+                stderr_lines,
+            )
+        }
+        Err(_) => (None, false, 0, 0),
+    };
+
+    tracing::info!(
+        target: "gwt.process.summary",
+        kind = "git",
+        spawn_id = spawn_id,
+        label = %label,
+        phase = "end",
+        exit_code = exit_code.map(|c| c as i64),
+        duration_ms = started_at.elapsed().as_millis() as u64,
+        stdout_lines = stdout_lines,
+        stderr_lines = stderr_lines,
+        success = success,
+        "process end",
+    );
+
+    result
+}
+
+fn forward_git_lines(spawn_id: u64, stdout: &[u8], stderr: &[u8]) {
+    let hub = crate::process_console::global();
+    forward_bytes_to_hub(
+        &hub,
+        spawn_id,
+        crate::process_console::ProcessStream::Stdout,
+        stdout,
+    );
+    forward_bytes_to_hub(
+        &hub,
+        spawn_id,
+        crate::process_console::ProcessStream::Stderr,
+        stderr,
+    );
+}
+
+fn forward_bytes_to_hub(
+    hub: &crate::process_console::ProcessConsoleHub,
+    spawn_id: u64,
+    stream: crate::process_console::ProcessStream,
+    bytes: &[u8],
+) {
+    if bytes.is_empty() {
+        return;
+    }
+    let text = String::from_utf8_lossy(bytes);
+    for piece in text.split(['\n', '\r']) {
+        if piece.is_empty() {
+            continue;
+        }
+        // Match the redact + ANSI strip discipline of the async
+        // `spawn_logged` path so the hub never sees raw secrets or
+        // ANSI sequences.
+        let sanitized =
+            crate::process_console::redact_line(&crate::process_console::strip_ansi(piece));
+        hub.push(crate::process_console::ProcessLine::new(
+            crate::process_console::ProcessKind::Git,
+            spawn_id,
+            stream,
+            sanitized,
+        ));
+    }
+}
+
 /// Check whether a command exists on `$PATH`.
 pub fn command_exists(cmd: &str) -> bool {
     which::which(cmd).is_ok()

--- a/crates/gwt-git/src/branch.rs
+++ b/crates/gwt-git/src/branch.rs
@@ -76,10 +76,7 @@ pub fn is_branch_merged_into(repo_path: &Path, branch: &str, base: &str) -> Resu
         return Ok(false);
     }
 
-    let output = gwt_core::process::hidden_command("git")
-        .args(["cherry", base, branch])
-        .current_dir(repo_path)
-        .output()
+    let output = gwt_core::process::run_git_logged(&["cherry", base, branch], Some(repo_path))
         .map_err(|e| GwtError::Git(format!("cherry: {e}")))?;
 
     if !output.status.success() {
@@ -176,15 +173,15 @@ fn detect_cleanable_target_for_remote(
 /// `[gone]` (FR-018a). Used to flag branches whose remote was deleted but
 /// which still exist locally.
 pub fn list_gone_branches(repo_path: &Path) -> Result<HashSet<String>> {
-    let output = gwt_core::process::hidden_command("git")
-        .args([
+    let output = gwt_core::process::run_git_logged(
+        &[
             "for-each-ref",
             "--format=%(refname:short)\t%(upstream:track)",
             "refs/heads/",
-        ])
-        .current_dir(repo_path)
-        .output()
-        .map_err(|e| GwtError::Git(format!("for-each-ref gone: {e}")))?;
+        ],
+        Some(repo_path),
+    )
+    .map_err(|e| GwtError::Git(format!("for-each-ref gone: {e}")))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
@@ -218,10 +215,7 @@ pub fn delete_local_branch(repo_path: &Path, name: &str, force: bool) -> Result<
     }
 
     let flag = if force { "-D" } else { "-d" };
-    let output = gwt_core::process::hidden_command("git")
-        .args(["branch", flag, name])
-        .current_dir(repo_path)
-        .output()
+    let output = gwt_core::process::run_git_logged(&["branch", flag, name], Some(repo_path))
         .map_err(|e| GwtError::Git(format!("branch {flag}: {e}")))?;
 
     if !output.status.success() {
@@ -233,11 +227,11 @@ pub fn delete_local_branch(repo_path: &Path, name: &str, force: bool) -> Result<
 
 /// Returns true when `git rev-parse --verify <ref>` succeeds.
 fn ref_exists(repo_path: &Path, refname: &str) -> Result<bool> {
-    let output = gwt_core::process::hidden_command("git")
-        .args(["rev-parse", "--verify", "--quiet", refname])
-        .current_dir(repo_path)
-        .output()
-        .map_err(|e| GwtError::Git(format!("rev-parse: {e}")))?;
+    let output = gwt_core::process::run_git_logged(
+        &["rev-parse", "--verify", "--quiet", refname],
+        Some(repo_path),
+    )
+    .map_err(|e| GwtError::Git(format!("rev-parse: {e}")))?;
     Ok(output.status.success())
 }
 
@@ -268,17 +262,23 @@ pub struct DivergenceInfo {
 /// Returns `DivergenceInfo { ahead, behind }`. If either ref is missing the
 /// command will fail and an error is returned.
 pub fn git_divergence(repo_path: &Path, branch: &str, upstream: &str) -> Result<DivergenceInfo> {
-    let output = gwt_core::process::hidden_command("git")
-        .args([
+    // `-C <path>` is on the argv so callers can run from any CWD; we
+    // still pass `current_dir=None` because the `-C` flag is canonical
+    // and run_git_logged should not silently re-anchor the directory.
+    let repo_str = repo_path.to_string_lossy();
+    let range = format!("{branch}...{upstream}");
+    let output = gwt_core::process::run_git_logged(
+        &[
             "-C",
-            &repo_path.to_string_lossy(),
+            repo_str.as_ref(),
             "rev-list",
             "--count",
             "--left-right",
-            &format!("{branch}...{upstream}"),
-        ])
-        .output()
-        .map_err(|e| GwtError::Git(format!("rev-list --left-right: {e}")))?;
+            &range,
+        ],
+        None,
+    )
+    .map_err(|e| GwtError::Git(format!("rev-list --left-right: {e}")))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
@@ -340,11 +340,12 @@ pub struct Branch {
 pub fn list_branches(repo_path: &Path) -> Result<Vec<Branch>> {
     let format =
         "%(refname:short)\t%(HEAD)\t%(upstream:short)\t%(upstream:track)\t%(creatordate:iso8601)";
-    let output = gwt_core::process::hidden_command("git")
-        .args(["for-each-ref", &format!("--format={format}"), "refs/heads/"])
-        .current_dir(repo_path)
-        .output()
-        .map_err(|e| GwtError::Git(format!("for-each-ref: {e}")))?;
+    let format_arg = format!("--format={format}");
+    let output = gwt_core::process::run_git_logged(
+        &["for-each-ref", &format_arg, "refs/heads/"],
+        Some(repo_path),
+    )
+    .map_err(|e| GwtError::Git(format!("for-each-ref: {e}")))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
@@ -361,15 +362,15 @@ pub fn list_branches(repo_path: &Path) -> Result<Vec<Branch>> {
     let remote_names = list_remote_names(repo_path).unwrap_or_default();
 
     // Also list remote branches
-    let remote_output = gwt_core::process::hidden_command("git")
-        .args([
+    let remote_output = gwt_core::process::run_git_logged(
+        &[
             "for-each-ref",
             "--format=%(refname:short)\t%(creatordate:iso8601)",
             "refs/remotes/",
-        ])
-        .current_dir(repo_path)
-        .output()
-        .map_err(|e| GwtError::Git(format!("for-each-ref remotes: {e}")))?;
+        ],
+        Some(repo_path),
+    )
+    .map_err(|e| GwtError::Git(format!("for-each-ref remotes: {e}")))?;
 
     if remote_output.status.success() {
         for line in String::from_utf8_lossy(&remote_output.stdout).lines() {
@@ -403,10 +404,7 @@ pub fn list_branches(repo_path: &Path) -> Result<Vec<Branch>> {
 }
 
 pub fn list_remote_names(repo_path: &Path) -> Result<Vec<String>> {
-    let output = gwt_core::process::hidden_command("git")
-        .arg("remote")
-        .current_dir(repo_path)
-        .output()
+    let output = gwt_core::process::run_git_logged(&["remote"], Some(repo_path))
         .map_err(|e| GwtError::Git(format!("remote: {e}")))?;
 
     if !output.status.success() {

--- a/crates/gwt-git/src/commit.rs
+++ b/crates/gwt-git/src/commit.rs
@@ -23,15 +23,11 @@ pub struct CommitEntry {
 /// Returns up to `count` commits from HEAD.
 pub fn recent_commits(repo_path: &Path, count: usize) -> Result<Vec<CommitEntry>> {
     let format = "%h\t%s\t%an\t%aI";
-    let output = gwt_core::process::hidden_command("git")
-        .args([
-            "log",
-            &format!("--max-count={count}"),
-            &format!("--format={format}"),
-        ])
-        .current_dir(repo_path)
-        .output()
-        .map_err(|e| GwtError::Git(format!("log: {e}")))?;
+    let max_count = format!("--max-count={count}");
+    let format_arg = format!("--format={format}");
+    let output =
+        gwt_core::process::run_git_logged(&["log", &max_count, &format_arg], Some(repo_path))
+            .map_err(|e| GwtError::Git(format!("log: {e}")))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();

--- a/crates/gwt-git/src/diff.rs
+++ b/crates/gwt-git/src/diff.rs
@@ -40,19 +40,19 @@ impl FileEntry {
     pub fn diff_content(&self, repo_path: &Path) -> Result<String> {
         match self.status {
             FileStatus::Staged => {
-                let output = gwt_core::process::hidden_command("git")
-                    .args(["diff", "--cached", "--", self.path.to_str().unwrap_or("")])
-                    .current_dir(repo_path)
-                    .output()
-                    .map_err(|e| GwtError::Git(format!("diff --cached: {e}")))?;
+                let path_str = self.path.to_str().unwrap_or("");
+                let output = gwt_core::process::run_git_logged(
+                    &["diff", "--cached", "--", path_str],
+                    Some(repo_path),
+                )
+                .map_err(|e| GwtError::Git(format!("diff --cached: {e}")))?;
                 Ok(String::from_utf8_lossy(&output.stdout).to_string())
             }
             FileStatus::Unstaged => {
-                let output = gwt_core::process::hidden_command("git")
-                    .args(["diff", "--", self.path.to_str().unwrap_or("")])
-                    .current_dir(repo_path)
-                    .output()
-                    .map_err(|e| GwtError::Git(format!("diff: {e}")))?;
+                let path_str = self.path.to_str().unwrap_or("");
+                let output =
+                    gwt_core::process::run_git_logged(&["diff", "--", path_str], Some(repo_path))
+                        .map_err(|e| GwtError::Git(format!("diff: {e}")))?;
                 Ok(String::from_utf8_lossy(&output.stdout).to_string())
             }
             FileStatus::Untracked => {
@@ -65,10 +65,7 @@ impl FileEntry {
 
 /// Get the working tree status as a list of `FileEntry`.
 pub fn get_status(repo_path: &Path) -> Result<Vec<FileEntry>> {
-    let output = gwt_core::process::hidden_command("git")
-        .args(["status", "--porcelain=v1"])
-        .current_dir(repo_path)
-        .output()
+    let output = gwt_core::process::run_git_logged(&["status", "--porcelain=v1"], Some(repo_path))
         .map_err(|e| GwtError::Git(format!("status: {e}")))?;
 
     if !output.status.success() {

--- a/crates/gwt-git/src/refs.rs
+++ b/crates/gwt-git/src/refs.rs
@@ -33,14 +33,9 @@ pub fn list_existing_refs(repo_path: &Path, candidates: &[&str]) -> Result<HashS
         return Ok(HashSet::new());
     }
 
-    let mut command = gwt_core::process::hidden_command("git");
-    command
-        .arg("for-each-ref")
-        .arg("--format=%(refname)")
-        .args(&trimmed)
-        .current_dir(repo_path);
-    let output = command
-        .output()
+    let mut args: Vec<&str> = vec!["for-each-ref", "--format=%(refname)"];
+    args.extend(trimmed.iter().copied());
+    let output = gwt_core::process::run_git_logged(&args, Some(repo_path))
         .map_err(|error| GwtError::Git(format!("for-each-ref: {error}")))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();


### PR DESCRIPTION
## Summary

PR #2792 (gh) / PR #2810 (Console window) / PR #2818 (Logs facet) / PR #2821 (docker/agent/runner) の後の **SPEC-1924 Phase C-visible-1**。git CLI caller 252 spawn site の段階移行を user-visible 経路から開始する。

本 PR は `gwt-git/{refs, branch, commit, diff}.rs` の主要 caller を `run_git_logged` 経由に切り替える。残り (worktree, repository, migration, pr_status の git 部分) は Phase C-visible-2 / 3 で続ける。

## 新規 helper

`gwt_core::process::run_git_logged(args, current_dir) -> std::io::Result<Output>`:

- `hidden_command("git").args(...).current_dir(...).output()` の 1:1 drop-in 置き換え
- 前後で `gwt.process.summary` start/end (kind=git, spawn_id, label, exit_code, duration_ms, stdout_lines, stderr_lines) を emit
- 完了後に stdout/stderr の各行を `ProcessConsoleHub` に push (`redact_line` + `strip_ansi` 経由なので Console window/Logs facet は plain text + secret-safe)
- 返り値は `std::process::Output` のまま (callers の `status.success()` / `stdout` / `stderr` 解析は変更不要)

## 移行 caller

- `crates/gwt-git/src/refs.rs::list_existing_refs` (Launch Wizard hot path、SPEC-2014 FR-PERF-001)
- `crates/gwt-git/src/branch.rs`:
  - `cherry` / `list_gone_branches` / `delete_local_branch` / `ref_exists` / `git_divergence` / `list_branches` / `list_remote_names`
- `crates/gwt-git/src/commit.rs::recent_commits`
- `crates/gwt-git/src/diff.rs`:
  - `FileEntry::diff_content` (Staged/Unstaged) / `get_status`

## Test plan

- [x] `cargo test -p gwt-core -p gwt-git -p gwt --all-features` (1973 件 PASS)
- [x] `cargo clippy -p gwt-core -p gwt-git -p gwt --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual verification (user): Console window の git タブが Branches window を開いたタイミング (list_branches) や PR diff loading (diff_content) で line を受信。Logs window Process chip = git に切り替えると git kind の summary 行のみが表示される。

## Follow-up (Phase C-visible-2 / 3)

- `crates/gwt-git/src/worktree.rs` (36 sites、Stdio::null + spawn 等が mixed)
- `crates/gwt-git/src/repository.rs` (29 sites)
- `crates/gwt-git/src/migration.rs` / `pr_status.rs` の git 部分
- `crates/gwt-core` 内部 (`repo_hash` / `paths` / `coordination` の setup-only git)
- `crates/gwt-ai/src/branch_suggest.rs` (test-only Command::new、低優先)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
