### PR TITLE
fix(gui): populate lessons scope in aggregated project_index_status

### DIFF
--- a/crates/gwt/src/index_worker.rs
+++ b/crates/gwt/src/index_worker.rs
@@ -339,6 +339,11 @@ pub fn build_aggregated_status_view(
                 scopes.specs = Some(view);
             }
         }
+        if scopes.lessons.is_none() {
+            if let Some(view) = status_obj.get("lessons").and_then(parse_scope_health) {
+                scopes.lessons = Some(view);
+            }
+        }
         if let Some(view) = status_obj.get("files").and_then(parse_scope_health) {
             scopes.files.insert(probe.input.worktree_hash.clone(), view);
         }
@@ -385,6 +390,9 @@ fn count_unhealthy_scopes(scopes: &ProjectIndexScopes) -> usize {
         count += 1;
     }
     if matches!(&scopes.specs, Some(view) if !view.healthy) {
+        count += 1;
+    }
+    if matches!(&scopes.lessons, Some(view) if !view.healthy) {
         count += 1;
     }
     count += scopes.files.values().filter(|view| !view.healthy).count();
@@ -1505,6 +1513,7 @@ detached
                 "status": {
                     "issues": {"healthy": true, "document_count": 100, "reason": "ready"},
                     "specs": {"healthy": true, "document_count": 50, "reason": "ready"},
+                    "lessons": {"healthy": true, "document_count": 243, "reason": "ready"},
                     "files": {"healthy": true, "document_count": 310, "reason": "ready"},
                     "files-docs": {"healthy": true, "document_count": 16, "reason": "ready"}
                 }
@@ -1517,9 +1526,46 @@ detached
         assert!(view.detail.contains("asset-hash-12"));
         assert!(view.scopes.issues.is_some());
         assert!(view.scopes.specs.is_some());
+        assert!(
+            view.scopes.lessons.is_some(),
+            "lessons scope must be present in aggregated view (SPEC-2805)"
+        );
+        assert_eq!(
+            view.scopes.lessons.as_ref().map(|view| view.document_count),
+            Some(243),
+        );
         assert_eq!(view.scopes.files.len(), 1);
         assert_eq!(view.scopes.files_docs.len(), 1);
         assert_eq!(view.worktrees.len(), 1);
+    }
+
+    #[test]
+    fn build_aggregated_status_view_counts_lessons_in_unhealthy_summary() {
+        let probes = vec![WorktreeProbeOutcome {
+            input: WorktreeProbeInput {
+                worktree_hash: "wtAhash".to_string(),
+                branch: "develop".to_string(),
+                path: PathBuf::from("/abs/wtA"),
+            },
+            status_payload: Ok(serde_json::json!({
+                "status": {
+                    "issues": {"healthy": true, "document_count": 100, "reason": "ready"},
+                    "specs": {"healthy": true, "document_count": 50, "reason": "ready"},
+                    "lessons": {"healthy": false, "repair_required": true, "reason": "manifest_missing", "document_count": 0},
+                    "files": {"healthy": true, "document_count": 310, "reason": "ready"},
+                    "files-docs": {"healthy": true, "document_count": 16, "reason": "ready"}
+                }
+            })),
+        }];
+
+        let view = build_aggregated_status_view("asset-hash-12", &probes);
+
+        assert_eq!(view.state, ProjectIndexStatusState::RepairRequired);
+        assert!(
+            view.detail.contains("1 index scope(s)"),
+            "unhealthy lessons must be counted (SPEC-2805); detail: {}",
+            view.detail
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- SPEC #2805 (`Scope::Lessons` 追加) の最終層が漏れていた。`build_aggregated_status_view` が runner status payload の `lessons` フィールドを読まないため、GUI Settings.Index タブで lessons row が render されてもセルが **`—` (empty placeholder)** のままだった。
- ユーザーから GUI スクリーンショットで報告された問題を test-first で修正。
- 同セッションで他レビュアー（ALEF autonomous agent）から「chunk accumulation drift」の指摘があり、実装は事前 `collection.delete(ids=existing["ids"])` で sweep するため accumulation しない実証を返信。observability ギャップは別 Issue #2825 として登録（本 PR の scope 外）。

## Changes

- `crates/gwt/src/index_worker.rs`:
  - `build_aggregated_status_view`: `status_obj.get("lessons").and_then(parse_scope_health)` を追加し、probe payload から lessons scope を抽出して `scopes.lessons` に格納（issues / specs と同じ repo-shared 扱い）
  - `count_unhealthy_scopes`: lessons が unhealthy のとき repair_required summary に含めるよう拡張

## Testing

- [x] `cargo test -p gwt --lib -- build_aggregated_status_view`: 4 passed（既存 2 件拡張 + 新規 2 件）
  - `build_aggregated_status_view_reports_ready_when_all_scopes_healthy`: probe に lessons scope を含めて `scopes.lessons.document_count == 243` を assert
  - `build_aggregated_status_view_counts_lessons_in_unhealthy_summary` (新): unhealthy lessons が detail summary の `1 index scope(s) require repair` に反映されることを assert
- [x] `cargo test --workspace --all-features`: 56 test groups, 0 failed
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] **実機 GUI 確認**: `./target/debug/gwt serve --no-open` で起動した GUI (http://127.0.0.1:58985/) の Settings.Index タブで lessons row が **`ready / 243 docs / last 2026-05-20T07:59:09Z`** で表示されることを目視確認

## Closing Issues

なし（本 PR は SPEC #2805 の追加 implementation gap fix で、Closes 対象 issue は無し。#2825 は別 PR で扱う observability hardening）

## Related Issues

- SPEC #2805 (PR #2813 initial / PR #2817 IPC + UI)
- 関連 review thread: https://github.com/akiojin/gwt/issues/2805#issuecomment-4496603227 (ALEF agent observability comment)
- Follow-up: #2825 (lessons index health check chunk_count_drift detection)

## Checklist

- [x] Conventional Commits (`fix(gui): ...`) — patch bump 妥当
- [x] commitlint PASS
- [x] test-first（RED → 実装 → GREEN）
- [x] 既存テスト破壊なし
- [x] 実機 GUI で修正後の挙動を目視確認 + ユーザー承認済み
