### PR TITLE
feat(gui): show branch cleanup progress and add force delete

### DIFF
--- a/crates/gwt-git/src/worktree.rs
+++ b/crates/gwt-git/src/worktree.rs
@@ -392,6 +392,33 @@ impl WorktreeManager {
         Ok(())
     }
 
+    /// Force-remove the worktree at `path`, including locked worktrees.
+    ///
+    /// Git requires `--force` twice for locked worktrees. Keep this behind
+    /// the explicit cleanup force mode so normal cleanup still respects that
+    /// extra guardrail.
+    pub fn remove_force_twice(&self, path: &Path) -> Result<()> {
+        let path_arg = path_arg_for_git(path);
+        let output = gwt_core::process::hidden_command("git")
+            .args([
+                "worktree",
+                "remove",
+                "--force",
+                "--force",
+                path_arg.as_str(),
+            ])
+            .current_dir(&self.repo_path)
+            .output()
+            .map_err(|e| GwtError::Git(format!("worktree remove --force --force: {e}")))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            return Err(GwtError::Git(stderr));
+        }
+
+        Ok(())
+    }
+
     /// Run `git worktree prune --expire now` to clear orphaned worktree
     /// metadata immediately. Plain `git worktree prune` honors the
     /// `gc.worktreePruneExpire` grace period (default `3.months.ago`), so a
@@ -421,6 +448,21 @@ impl WorktreeManager {
     /// branches, and orphaned worktree metadata: a `git worktree prune`
     /// fallback handles entries whose on-disk path has already vanished.
     pub fn cleanup_branch(&self, branch: &str) -> Result<()> {
+        self.cleanup_branch_with_force_filesystem_delete(branch, false)
+    }
+
+    /// Remove the worktree and local branch for `branch`.
+    ///
+    /// When `force_filesystem_delete` is true, cleanup may use Git's double
+    /// force for locked worktrees and may remove leftover filesystem residue
+    /// from the Git-registered worktree path if Git reports a non-empty
+    /// directory class failure. Callers must still apply branch-level safety
+    /// checks before enabling this mode.
+    pub fn cleanup_branch_with_force_filesystem_delete(
+        &self,
+        branch: &str,
+        force_filesystem_delete: bool,
+    ) -> Result<()> {
         let worktree_path = self
             .list()?
             .into_iter()
@@ -428,10 +470,19 @@ impl WorktreeManager {
             .map(|wt| wt.path);
 
         if let Some(path) = worktree_path {
-            match self.remove_force(&path) {
+            let remove_result = if force_filesystem_delete {
+                self.remove_force_twice(&path)
+            } else {
+                self.remove_force(&path)
+            };
+            match remove_result {
                 Ok(()) => {}
                 Err(err) if is_missing_worktree_error(&err) => {
                     // Worktree metadata is stale; prune and continue.
+                    self.prune()?;
+                }
+                Err(err) if force_filesystem_delete && is_filesystem_residue_error(&err) => {
+                    remove_worktree_filesystem_residue(&path)?;
                     self.prune()?;
                 }
                 Err(err) => return Err(err),
@@ -452,6 +503,24 @@ fn is_missing_worktree_error(err: &GwtError) -> bool {
         || message.contains("not a work tree")
         || message.contains("no such file or directory")
         || message.contains("does not exist")
+}
+
+fn is_filesystem_residue_error(err: &GwtError) -> bool {
+    let message = err.to_string().to_lowercase();
+    message.contains("directory not empty")
+        || message.contains("failed to delete")
+        || message.contains("failed to remove")
+}
+
+fn remove_worktree_filesystem_residue(path: &Path) -> Result<()> {
+    match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_dir() => std::fs::remove_dir_all(path)
+            .map_err(|e| GwtError::Git(format!("remove worktree residue: {e}"))),
+        Ok(_) => std::fs::remove_file(path)
+            .map_err(|e| GwtError::Git(format!("remove worktree residue: {e}"))),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(GwtError::Git(format!("inspect worktree residue: {err}"))),
+    }
 }
 
 fn run_command_with_timeout(
@@ -1136,6 +1205,73 @@ prunable gitdir file points to non-existent location
         assert!(manager.remove(&worktree_path).is_err());
         manager.remove_force(&worktree_path).unwrap();
         assert!(!worktree_path.exists());
+    }
+
+    #[test]
+    fn cleanup_branch_force_filesystem_mode_removes_locked_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo_path).unwrap();
+        init_git_repo(&repo_path);
+        git_commit_allow_empty(&repo_path, "initial commit");
+
+        let manager = WorktreeManager::new(&repo_path);
+        let worktree_path = sibling_worktree_path(&repo_path, "work/locked");
+        manager
+            .create_from_base("main", "work/locked", &worktree_path)
+            .or_else(|_| manager.create_from_base("master", "work/locked", &worktree_path))
+            .unwrap();
+
+        let lock = gwt_core::process::hidden_command("git")
+            .args(["worktree", "lock", worktree_path.to_str().unwrap()])
+            .current_dir(&repo_path)
+            .output()
+            .expect("git worktree lock");
+        assert!(
+            lock.status.success(),
+            "git worktree lock failed: {}",
+            String::from_utf8_lossy(&lock.stderr)
+        );
+
+        assert!(
+            manager.cleanup_branch("work/locked").is_err(),
+            "single-force cleanup should not remove a locked worktree"
+        );
+        manager
+            .cleanup_branch_with_force_filesystem_delete("work/locked", true)
+            .unwrap();
+
+        assert!(!worktree_path.exists());
+        let branches = crate::branch::list_branches(&repo_path).unwrap();
+        assert!(!branches
+            .iter()
+            .any(|b| b.is_local && b.name == "work/locked"));
+    }
+
+    #[test]
+    fn filesystem_residue_helper_removes_non_empty_worktree_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let residue_path = tmp.path().join("work").join("residue");
+        std::fs::create_dir_all(residue_path.join("nested")).unwrap();
+        std::fs::write(
+            residue_path.join("nested").join("leftover.txt"),
+            "leftover\n",
+        )
+        .unwrap();
+
+        remove_worktree_filesystem_residue(&residue_path).unwrap();
+
+        assert!(!residue_path.exists());
+    }
+
+    #[test]
+    fn filesystem_residue_error_matches_git_directory_not_empty_failures() {
+        assert!(is_filesystem_residue_error(&GwtError::Git(
+            "error: failed to delete '/repo/work/old': Directory not empty".to_string(),
+        )));
+        assert!(!is_filesystem_residue_error(&GwtError::Git(
+            "fatal: invalid reference: work/old".to_string(),
+        )));
     }
 
     #[test]

--- a/crates/gwt/playwright/tests/branch-cleanup.spec.ts
+++ b/crates/gwt/playwright/tests/branch-cleanup.spec.ts
@@ -1,0 +1,299 @@
+/* SPEC-2009 Phase 3 - Branch Cleanup E2E coverage.
+ *
+ * Exercises the embedded Branches window with a deterministic WebSocket
+ * backend so the cleanup confirmation, force-delete option, progress stream,
+ * and result modal are verified without touching a real Git repository.
+ */
+import { expect, test } from "@playwright/test";
+import { APP_URL, installEmbeddedRoutes } from "./_helpers/embedded-frontend";
+
+test.describe("Branch Cleanup E2E", () => {
+  test.use({
+    deviceScaleFactor: 1,
+    viewport: { width: 1440, height: 900 },
+  });
+
+  test("shows cleanup progress and sends force filesystem delete", async ({
+    page,
+  }) => {
+    await installEmbeddedRoutes(page);
+    await installBranchCleanupBackend(page);
+
+    await page.goto(APP_URL);
+
+    const branchesWindow = page.locator(".workspace-window.surface-branches");
+    await expect(branchesWindow).toBeVisible({ timeout: 10_000 });
+
+    const firstBranch = branchesWindow.locator(
+      ".branch-row[data-branch-name='work/cleanup-one']",
+    );
+    const secondBranch = branchesWindow.locator(
+      ".branch-row[data-branch-name='work/cleanup-two']",
+    );
+    await expect(firstBranch).toContainText("safe");
+    await expect(secondBranch).toContainText("risky");
+
+    await firstBranch.locator(".branch-cleanup-toggle").click();
+    await secondBranch.locator(".branch-cleanup-toggle").click();
+
+    const cleanupTrigger = branchesWindow.getByRole("button", {
+      name: "Clean Up (2)",
+    });
+    await expect(cleanupTrigger).toBeEnabled();
+    await cleanupTrigger.click();
+
+    const modal = page.locator("#branch-cleanup-modal");
+    await expect(modal).toHaveClass(/open/);
+    await expect(modal.getByRole("dialog", { name: "Branch cleanup" }))
+      .toContainText("Delete 2 selected branches.");
+    await expect(modal).toContainText("work/cleanup-one");
+    await expect(modal).toContainText("work/cleanup-two");
+
+    const forceToggle = modal.getByLabel("Force remove remaining worktree files");
+    await expect(forceToggle).not.toBeChecked();
+    await forceToggle.check();
+    await expect(forceToggle).toBeChecked();
+
+    await modal.getByRole("button", { name: "Run cleanup" }).click();
+    await page.waitForFunction(() =>
+      window.__branchCleanupCalls?.some(
+        (call) => call.kind === "run_branch_cleanup",
+      ),
+    );
+
+    const cleanupCall = await page.evaluate(() =>
+      window.__branchCleanupCalls.find(
+        (call) => call.kind === "run_branch_cleanup",
+      ),
+    );
+    expect(cleanupCall).toMatchObject({
+      kind: "run_branch_cleanup",
+      id: "branches-1",
+      branches: ["work/cleanup-one", "work/cleanup-two"],
+      delete_remote: false,
+      force_filesystem_delete: true,
+    });
+
+    await page.evaluate(() => {
+      window.__branchCleanupFixture.emit({
+        kind: "branch_cleanup_progress",
+        id: "branches-1",
+        branch: "work/cleanup-one",
+        execution_branch: "work/cleanup-one",
+        index: 1,
+        total: 2,
+        phase: "running",
+        message: "Removing worktree for work/cleanup-one",
+      });
+    });
+    await expect(modal).toContainText("Cleaning 1 of 2: work/cleanup-one");
+    await expect(modal.locator(".branch-cleanup-progress-item.running"))
+      .toContainText("work/cleanup-one");
+    await expect(modal).toContainText("Removing worktree for work/cleanup-one");
+
+    await page.evaluate(() => {
+      window.__branchCleanupFixture.emit({
+        kind: "branch_cleanup_progress",
+        id: "branches-1",
+        branch: "work/cleanup-one",
+        execution_branch: "work/cleanup-one",
+        index: 1,
+        total: 2,
+        phase: "done",
+        message: "Deleted local branch",
+      });
+      window.__branchCleanupFixture.emit({
+        kind: "branch_cleanup_progress",
+        id: "branches-1",
+        branch: "work/cleanup-two",
+        execution_branch: "work/cleanup-two",
+        index: 2,
+        total: 2,
+        phase: "running",
+        message: "Removing worktree for work/cleanup-two",
+      });
+    });
+    await expect(modal).toContainText("Cleaning 2 of 2: work/cleanup-two");
+    await expect(modal.locator(".branch-cleanup-progress-item.done"))
+      .toContainText("work/cleanup-one");
+
+    await page.evaluate(() => {
+      window.__branchCleanupFixture.emit({
+        kind: "branch_cleanup_result",
+        id: "branches-1",
+        results: [
+          {
+            branch: "work/cleanup-one",
+            execution_branch: "work/cleanup-one",
+            status: "success",
+            message: "Deleted local branch and worktree",
+          },
+          {
+            branch: "work/cleanup-two",
+            execution_branch: "work/cleanup-two",
+            status: "success",
+            message: "Deleted local branch and worktree",
+          },
+        ],
+      });
+    });
+    await expect(modal).toContainText("Cleanup result");
+    await expect(modal).toContainText("success 2 · partial 0 · failed 0");
+    await expect(modal.getByRole("button", { name: "Close" })).toBeVisible();
+  });
+});
+
+async function installBranchCleanupBackend(page) {
+  await page.addInitScript(() => {
+    const branchEntries = [
+      cleanupBranch({
+        name: "work/cleanup-one",
+        availability: "safe",
+        mergeTarget: { kind: "develop", reference: "origin/develop" },
+        risks: [],
+      }),
+      cleanupBranch({
+        name: "work/cleanup-two",
+        availability: "risky",
+        mergeTarget: { kind: "develop", reference: "origin/develop" },
+        risks: ["unmerged"],
+      }),
+      cleanupBranch({
+        name: "develop",
+        availability: "blocked",
+        isHead: true,
+        mergeTarget: null,
+        blockedReason: "current_head",
+        risks: [],
+      }),
+    ];
+
+    const workspaceState = {
+      kind: "workspace_state",
+      workspace: {
+        app_version: "playwright",
+        tabs: [
+          {
+            id: "tab-1",
+            title: "Fixture",
+            project_root: "/fixture",
+            kind: "git",
+            workspace: {
+              viewport: { x: 0, y: 0, zoom: 1 },
+              windows: [
+                {
+                  id: "branches-1",
+                  title: "Branches",
+                  preset: "branches",
+                  geometry: { x: 96, y: 96, width: 760, height: 620 },
+                  z_index: 1,
+                  status: "running",
+                  minimized: false,
+                  maximized: false,
+                  pre_maximize_geometry: null,
+                  persist: true,
+                  purpose_title: null,
+                  dynamic_title: null,
+                  dynamic_title_detail: null,
+                  agent_id: null,
+                  agent_color: null,
+                  tab_group_id: null,
+                  tab_group_active: false,
+                },
+              ],
+            },
+          },
+        ],
+        active_tab_id: "tab-1",
+        recent_projects: [],
+      },
+    };
+
+    const recordedCalls = [];
+    window.__branchCleanupCalls = recordedCalls;
+
+    class FixtureWebSocket extends EventTarget {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+
+      constructor(url) {
+        super();
+        this.url = url;
+        this.readyState = FixtureWebSocket.CONNECTING;
+        window.__branchCleanupFixture = this;
+        setTimeout(() => {
+          this.readyState = FixtureWebSocket.OPEN;
+          this.dispatchEvent(new Event("open"));
+        }, 0);
+      }
+
+      send(raw) {
+        const message = JSON.parse(raw);
+        recordedCalls.push(message);
+        switch (message.kind) {
+          case "frontend_ready":
+            this.emit(workspaceState);
+            break;
+          case "load_branches":
+            this.emit({
+              kind: "branch_entries",
+              id: message.id,
+              phase: "hydrated",
+              entries: branchEntries,
+            });
+            break;
+          default:
+            break;
+        }
+      }
+
+      close() {
+        this.readyState = FixtureWebSocket.CLOSED;
+        this.dispatchEvent(new CloseEvent("close"));
+      }
+
+      emit(payload) {
+        setTimeout(() => {
+          this.dispatchEvent(
+            new MessageEvent("message", { data: JSON.stringify(payload) }),
+          );
+        }, 0);
+      }
+    }
+
+    function cleanupBranch({
+      name,
+      availability,
+      isHead = false,
+      mergeTarget,
+      blockedReason = null,
+      risks,
+    }) {
+      return {
+        name,
+        scope: "local",
+        is_head: isHead,
+        upstream: null,
+        ahead: 0,
+        behind: 0,
+        last_commit_date: "2026-05-20",
+        cleanup_ready: true,
+        cleanup: {
+          availability,
+          execution_branch: name,
+          merge_target: mergeTarget,
+          upstream: null,
+          blocked_reason: blockedReason,
+          risks,
+        },
+      };
+    }
+
+    Object.defineProperty(window, "WebSocket", {
+      configurable: true,
+      value: FixtureWebSocket,
+    });
+  });
+}

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -2237,11 +2237,24 @@ impl AppRuntime {
                 id,
                 branches,
                 delete_remote,
-            } => self.run_branch_cleanup_events(&client_id, &id, &branches, delete_remote),
+                force_filesystem_delete,
+            } => self.run_branch_cleanup_events(
+                &client_id,
+                &id,
+                &branches,
+                delete_remote,
+                force_filesystem_delete,
+            ),
             FrontendEvent::RunWorkspaceCleanup {
                 branch,
                 delete_remote,
-            } => self.run_workspace_cleanup_events(&client_id, &branch, delete_remote),
+                force_filesystem_delete,
+            } => self.run_workspace_cleanup_events(
+                &client_id,
+                &branch,
+                delete_remote,
+                force_filesystem_delete,
+            ),
             FrontendEvent::RebuildIndexCell {
                 project_root,
                 scope,
@@ -4615,6 +4628,7 @@ impl AppRuntime {
         id: &str,
         branches: &[String],
         delete_remote: bool,
+        force_filesystem_delete: bool,
     ) -> Vec<OutboundEvent> {
         let Some(address) = self.window_lookup.get(id) else {
             return vec![OutboundEvent::reply(
@@ -4661,7 +4675,10 @@ impl AppRuntime {
             tab.project_root.clone(),
             self.active_session_branches_for_tab(&address.tab_id),
             branches.to_vec(),
-            delete_remote,
+            BranchCleanupOptions {
+                delete_remote,
+                force_filesystem_delete,
+            },
         );
         Vec::new()
     }
@@ -4671,6 +4688,7 @@ impl AppRuntime {
         client_id: &str,
         branch: &str,
         delete_remote: bool,
+        force_filesystem_delete: bool,
     ) -> Vec<OutboundEvent> {
         let Some(tab_id) = self.active_tab_id.as_deref() else {
             return vec![OutboundEvent::reply(
@@ -4706,7 +4724,10 @@ impl AppRuntime {
             tab.project_root.clone(),
             self.active_session_branches_for_tab(tab_id),
             branch.to_string(),
-            delete_remote,
+            BranchCleanupOptions {
+                delete_remote,
+                force_filesystem_delete,
+            },
         );
         Vec::new()
     }
@@ -4783,18 +4804,35 @@ fn spawn_branch_cleanup_async(
     project_root: PathBuf,
     active_session_branches: std::collections::HashSet<String>,
     branches: Vec<String>,
-    delete_remote: bool,
+    options: BranchCleanupOptions,
 ) {
     thread::spawn(move || {
         let events =
             match list_branch_entries_with_active_sessions(&project_root, &active_session_branches)
             {
                 Ok(entries) => {
-                    let results = cleanup_selected_branches(
+                    let progress_proxy = proxy.clone();
+                    let progress_client_id = client_id.clone();
+                    let progress_window_id = window_id.clone();
+                    let results = cleanup_selected_branches_with_progress(
                         &project_root,
                         &entries,
                         &branches,
-                        delete_remote,
+                        options,
+                        move |progress| {
+                            progress_proxy.send(UserEvent::Dispatch(vec![OutboundEvent::reply(
+                                progress_client_id.clone(),
+                                BackendEvent::BranchCleanupProgress {
+                                    id: progress_window_id.clone(),
+                                    branch: progress.branch,
+                                    execution_branch: progress.execution_branch,
+                                    index: progress.index,
+                                    total: progress.total,
+                                    phase: progress.phase,
+                                    message: progress.message,
+                                },
+                            )]));
+                        },
                     );
                     let mut events = vec![OutboundEvent::reply(
                         client_id.clone(),
@@ -4843,18 +4881,34 @@ fn spawn_workspace_cleanup_async(
     project_root: PathBuf,
     active_session_branches: std::collections::HashSet<String>,
     branch: String,
-    delete_remote: bool,
+    options: BranchCleanupOptions,
 ) {
     thread::spawn(move || {
         let events =
             match list_branch_entries_with_active_sessions(&project_root, &active_session_branches)
             {
                 Ok(entries) => {
-                    let results = cleanup_selected_branches(
+                    let progress_proxy = proxy.clone();
+                    let progress_client_id = client_id.clone();
+                    let results = cleanup_selected_branches_with_progress(
                         &project_root,
                         &entries,
                         std::slice::from_ref(&branch),
-                        delete_remote,
+                        options,
+                        move |progress| {
+                            progress_proxy.send(UserEvent::Dispatch(vec![OutboundEvent::reply(
+                                progress_client_id.clone(),
+                                BackendEvent::BranchCleanupProgress {
+                                    id: WORKSPACE_CLEANUP_EVENT_ID.to_string(),
+                                    branch: progress.branch,
+                                    execution_branch: progress.execution_branch,
+                                    index: progress.index,
+                                    total: progress.total,
+                                    phase: progress.phase,
+                                    message: progress.message,
+                                },
+                            )]));
+                        },
                     );
                     let mut events = vec![OutboundEvent::reply(
                         client_id.clone(),

--- a/crates/gwt/src/branch_cleanup.rs
+++ b/crates/gwt/src/branch_cleanup.rs
@@ -20,11 +20,62 @@ pub struct BranchCleanupResultEntry {
     pub message: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct BranchCleanupOptions {
+    pub delete_remote: bool,
+    pub force_filesystem_delete: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BranchCleanupProgressPhase {
+    Running,
+    Done,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BranchCleanupProgressEntry {
+    pub branch: String,
+    pub execution_branch: Option<String>,
+    pub index: usize,
+    pub total: usize,
+    pub phase: BranchCleanupProgressPhase,
+    pub message: String,
+}
+
 pub fn cleanup_selected_branches(
     repo_path: &Path,
     entries: &[BranchListEntry],
     selected_branches: &[String],
     delete_remote: bool,
+) -> Vec<BranchCleanupResultEntry> {
+    cleanup_selected_branches_with_options(
+        repo_path,
+        entries,
+        selected_branches,
+        BranchCleanupOptions {
+            delete_remote,
+            force_filesystem_delete: false,
+        },
+    )
+}
+
+pub fn cleanup_selected_branches_with_options(
+    repo_path: &Path,
+    entries: &[BranchListEntry],
+    selected_branches: &[String],
+    options: BranchCleanupOptions,
+) -> Vec<BranchCleanupResultEntry> {
+    cleanup_selected_branches_with_progress(repo_path, entries, selected_branches, options, |_| {})
+}
+
+pub fn cleanup_selected_branches_with_progress(
+    repo_path: &Path,
+    entries: &[BranchListEntry],
+    selected_branches: &[String],
+    options: BranchCleanupOptions,
+    mut progress: impl FnMut(BranchCleanupProgressEntry),
 ) -> Vec<BranchCleanupResultEntry> {
     let git_root = git_command_root(repo_path);
     let manager = gwt_git::WorktreeManager::new(&git_root);
@@ -32,21 +83,34 @@ pub fn cleanup_selected_branches(
         .iter()
         .map(|entry| (entry.name.as_str(), entry))
         .collect();
+    let total = selected_branches.len();
 
     selected_branches
         .iter()
-        .map(|branch_name| {
+        .enumerate()
+        .map(|(offset, branch_name)| {
+            let index = offset + 1;
             let Some(entry) = lookup.get(branch_name.as_str()).copied() else {
-                return BranchCleanupResultEntry {
+                let result = BranchCleanupResultEntry {
                     branch: branch_name.clone(),
                     execution_branch: None,
                     status: BranchCleanupResultStatus::Failed,
                     message: "Branch not found".to_string(),
                 };
+                emit_result_progress(&mut progress, &result, index, total);
+                return result;
             };
             let execution_branch = entry.cleanup.execution_branch.clone();
+            progress(BranchCleanupProgressEntry {
+                branch: entry.name.clone(),
+                execution_branch: execution_branch.clone(),
+                index,
+                total,
+                phase: BranchCleanupProgressPhase::Running,
+                message: format!("Cleaning {}", entry.name),
+            });
             let Some(target_branch) = execution_branch.clone() else {
-                return BranchCleanupResultEntry {
+                let result = BranchCleanupResultEntry {
                     branch: entry.name.clone(),
                     execution_branch,
                     status: BranchCleanupResultStatus::Failed,
@@ -57,9 +121,11 @@ pub fn cleanup_selected_branches(
                             .unwrap_or(BranchCleanupBlockedReason::Unknown),
                     ),
                 };
+                emit_result_progress(&mut progress, &result, index, total);
+                return result;
             };
             if entry.cleanup.availability == BranchCleanupAvailability::Blocked {
-                return BranchCleanupResultEntry {
+                let result = BranchCleanupResultEntry {
                     branch: entry.name.clone(),
                     execution_branch: Some(target_branch),
                     status: BranchCleanupResultStatus::Failed,
@@ -70,19 +136,28 @@ pub fn cleanup_selected_branches(
                             .unwrap_or(BranchCleanupBlockedReason::Unknown),
                     ),
                 };
+                emit_result_progress(&mut progress, &result, index, total);
+                return result;
             }
             if !is_gwt_workspace_branch(&target_branch) {
-                return BranchCleanupResultEntry {
+                let result = BranchCleanupResultEntry {
                     branch: entry.name.clone(),
                     execution_branch: Some(target_branch),
                     status: BranchCleanupResultStatus::Failed,
                     message: blocked_reason_message(BranchCleanupBlockedReason::NonWorkspaceBranch),
                 };
+                emit_result_progress(&mut progress, &result, index, total);
+                return result;
             }
 
-            match manager.cleanup_branch(&target_branch) {
+            let cleanup_result = if options.force_filesystem_delete {
+                manager.cleanup_branch_with_force_filesystem_delete(&target_branch, true)
+            } else {
+                manager.cleanup_branch(&target_branch)
+            };
+            let result = match cleanup_result {
                 Ok(()) => {
-                    if delete_remote && entry.cleanup.upstream.is_some() {
+                    if options.delete_remote && entry.cleanup.upstream.is_some() {
                         match manager
                             .delete_remote_branch(&target_branch, entry.cleanup.upstream.as_deref())
                         {
@@ -126,9 +201,33 @@ pub fn cleanup_selected_branches(
                     status: BranchCleanupResultStatus::Failed,
                     message: format!("Cleanup failed: {error}"),
                 },
-            }
+            };
+            emit_result_progress(&mut progress, &result, index, total);
+            result
         })
         .collect()
+}
+
+fn emit_result_progress(
+    progress: &mut impl FnMut(BranchCleanupProgressEntry),
+    result: &BranchCleanupResultEntry,
+    index: usize,
+    total: usize,
+) {
+    let phase = match result.status {
+        BranchCleanupResultStatus::Success | BranchCleanupResultStatus::Partial => {
+            BranchCleanupProgressPhase::Done
+        }
+        BranchCleanupResultStatus::Failed => BranchCleanupProgressPhase::Failed,
+    };
+    progress(BranchCleanupProgressEntry {
+        branch: result.branch.clone(),
+        execution_branch: result.execution_branch.clone(),
+        index,
+        total,
+        phase,
+        message: result.message.clone(),
+    });
 }
 
 fn is_gwt_workspace_branch(branch_name: &str) -> bool {

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -43,7 +43,9 @@ pub(crate) fn env_test_lock() -> &'static std::sync::Mutex<()> {
 }
 
 pub use branch_cleanup::{
-    cleanup_selected_branches, BranchCleanupResultEntry, BranchCleanupResultStatus,
+    cleanup_selected_branches, cleanup_selected_branches_with_options,
+    cleanup_selected_branches_with_progress, BranchCleanupOptions, BranchCleanupProgressEntry,
+    BranchCleanupProgressPhase, BranchCleanupResultEntry, BranchCleanupResultStatus,
 };
 pub use branch_list::{
     hydrate_branch_entries_with_active_sessions, list_branch_entries_with_active_sessions,

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -14,14 +14,14 @@ use crate::repo_browser::{preferred_issue_launch_branch, spawn_branch_load_async
 use base64::Engine;
 use gwt::protocol::{FileContentErrorKind, FileContentMode};
 use gwt::{
-    cleanup_selected_branches, detect_shell_program, list_branch_entries_with_active_sessions,
-    list_directory_entries, load_knowledge_bridge, load_restored_workspace_state,
-    load_session_state, migrate_legacy_workspace_state, read_binary_chunk, read_text_file,
-    refresh_managed_gwt_assets_for_agent, resolve_launch_spec, workspace_state_path, BackendEvent,
-    BranchEntriesPhase, BranchListEntry, ContentLimits, DockerWizardContext, FileContentError,
-    FrontendEvent, HookForwardTarget, KnowledgeKind, LaunchWizardState, LiveSessionEntry,
-    ShellLaunchConfig, UiTracePayload, WindowGeometry, WindowPreset, WindowProcessStatus,
-    WorkspaceState, APP_NAME,
+    cleanup_selected_branches_with_progress, detect_shell_program,
+    list_branch_entries_with_active_sessions, list_directory_entries, load_knowledge_bridge,
+    load_restored_workspace_state, load_session_state, migrate_legacy_workspace_state,
+    read_binary_chunk, read_text_file, refresh_managed_gwt_assets_for_agent, resolve_launch_spec,
+    workspace_state_path, BackendEvent, BranchCleanupOptions, BranchEntriesPhase, BranchListEntry,
+    ContentLimits, DockerWizardContext, FileContentError, FrontendEvent, HookForwardTarget,
+    KnowledgeKind, LaunchWizardState, LiveSessionEntry, ShellLaunchConfig, UiTracePayload,
+    WindowGeometry, WindowPreset, WindowProcessStatus, WorkspaceState, APP_NAME,
 };
 use gwt_terminal::{Pane, PaneStatus, PtyHandle};
 use tao::{
@@ -2897,7 +2897,8 @@ mod tests {
                 if message == "Window is not a knowledge bridge"
         ));
 
-        let cleanup_missing = runtime.run_branch_cleanup_events("client-1", "missing", &[], false);
+        let cleanup_missing =
+            runtime.run_branch_cleanup_events("client-1", "missing", &[], false, false);
         assert_eq!(cleanup_missing.len(), 1);
         assert!(matches!(
             cleanup_missing[0].event,
@@ -2905,7 +2906,7 @@ mod tests {
         ));
 
         let cleanup_wrong =
-            runtime.run_branch_cleanup_events("client-1", &file_tree_id, &[], false);
+            runtime.run_branch_cleanup_events("client-1", &file_tree_id, &[], false, false);
         assert_eq!(cleanup_wrong.len(), 1);
         assert!(matches!(
             cleanup_wrong[0].event,
@@ -3228,8 +3229,21 @@ mod tests {
             &branches_id,
             &[String::from("feature/prune-me")],
             false,
+            false,
         );
         assert!(cleanup_events.is_empty());
+        wait_for_recorded_event("branch cleanup progress dispatch", &events, |events| {
+            events.iter().any(|event| {
+                matches!(
+                    event,
+                    UserEvent::Dispatch(dispatched)
+                        if dispatched.iter().any(|outbound| matches!(
+                            outbound.event,
+                            BackendEvent::BranchCleanupProgress { .. }
+                        ))
+                )
+            })
+        });
         wait_for_recorded_event("branch cleanup dispatch", &events, |events| {
             events.iter().any(|event| {
                 matches!(
@@ -3529,6 +3543,7 @@ mod tests {
                 id: branches_id.clone(),
                 branches: vec!["feature/missing".to_string()],
                 delete_remote: false,
+                force_filesystem_delete: false,
             },
         );
         assert!(cleanup_events.is_empty());

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -6,7 +6,7 @@ use gwt_core::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    branch_cleanup::BranchCleanupResultEntry,
+    branch_cleanup::{BranchCleanupProgressPhase, BranchCleanupResultEntry},
     branch_list::BranchListEntry,
     daemon_runtime::RuntimeHookEvent,
     file_content::{Encoding, Newline},
@@ -280,10 +280,14 @@ pub enum FrontendEvent {
         id: String,
         branches: Vec<String>,
         delete_remote: bool,
+        #[serde(default)]
+        force_filesystem_delete: bool,
     },
     RunWorkspaceCleanup {
         branch: String,
         delete_remote: bool,
+        #[serde(default)]
+        force_filesystem_delete: bool,
     },
     /// SPEC-1939 US-5: trigger a per-cell index rebuild for
     /// `(project_root, scope, worktree_hash?)`. The backend funnels this
@@ -1021,6 +1025,15 @@ pub enum BackendEvent {
         id: String,
         results: Vec<BranchCleanupResultEntry>,
     },
+    BranchCleanupProgress {
+        id: String,
+        branch: String,
+        execution_branch: Option<String>,
+        index: usize,
+        total: usize,
+        phase: BranchCleanupProgressPhase,
+        message: String,
+    },
     BranchError {
         id: String,
         message: String,
@@ -1482,6 +1495,11 @@ pub const BACKEND_EVENT_POLICIES: &[BackendEventPolicy] = &[
         BackendEventBackpressurePolicy::BestEffort,
     ),
     BackendEventPolicy::new(
+        "branch_cleanup_progress",
+        BackendEventDeliveryClass::Streamed,
+        BackendEventBackpressurePolicy::PreserveOrder,
+    ),
+    BackendEventPolicy::new(
         "branch_error",
         BackendEventDeliveryClass::Error,
         BackendEventBackpressurePolicy::FailOpenError,
@@ -1758,6 +1776,7 @@ impl BackendEvent {
             BackendEvent::KnowledgeDetail { .. } => "knowledge_detail",
             BackendEvent::KnowledgeBridgePhaseUpdated { .. } => "knowledge_bridge_phase_updated",
             BackendEvent::BranchCleanupResult { .. } => "branch_cleanup_result",
+            BackendEvent::BranchCleanupProgress { .. } => "branch_cleanup_progress",
             BackendEvent::BranchError { .. } => "branch_error",
             BackendEvent::BoardError { .. } => "board_error",
             BackendEvent::ProfileError { .. } => "profile_error",

--- a/crates/gwt/tests/branch_cleanup_protocol_test.rs
+++ b/crates/gwt/tests/branch_cleanup_protocol_test.rs
@@ -1,0 +1,75 @@
+use gwt::{BackendEvent, BranchCleanupProgressPhase, FrontendEvent};
+use serde_json::json;
+
+#[test]
+fn run_branch_cleanup_defaults_force_filesystem_delete_to_false() {
+    let event = serde_json::from_value::<FrontendEvent>(json!({
+        "kind": "run_branch_cleanup",
+        "id": "branches-1",
+        "branches": ["work/old"],
+        "delete_remote": false
+    }))
+    .expect("run_branch_cleanup should deserialize");
+
+    match event {
+        FrontendEvent::RunBranchCleanup {
+            id,
+            branches,
+            delete_remote,
+            force_filesystem_delete,
+        } => {
+            assert_eq!(id, "branches-1");
+            assert_eq!(branches, vec!["work/old"]);
+            assert!(!delete_remote);
+            assert!(!force_filesystem_delete);
+        }
+        other => panic!("expected RunBranchCleanup, got {other:?}"),
+    }
+}
+
+#[test]
+fn run_workspace_cleanup_defaults_force_filesystem_delete_to_false() {
+    let event = serde_json::from_value::<FrontendEvent>(json!({
+        "kind": "run_workspace_cleanup",
+        "branch": "work/old",
+        "delete_remote": true
+    }))
+    .expect("run_workspace_cleanup should deserialize");
+
+    match event {
+        FrontendEvent::RunWorkspaceCleanup {
+            branch,
+            delete_remote,
+            force_filesystem_delete,
+        } => {
+            assert_eq!(branch, "work/old");
+            assert!(delete_remote);
+            assert!(!force_filesystem_delete);
+        }
+        other => panic!("expected RunWorkspaceCleanup, got {other:?}"),
+    }
+}
+
+#[test]
+fn branch_cleanup_progress_serializes_as_backend_event() {
+    let event = BackendEvent::BranchCleanupProgress {
+        id: "branches-1".to_string(),
+        branch: "work/old".to_string(),
+        execution_branch: Some("work/old".to_string()),
+        index: 2,
+        total: 5,
+        phase: BranchCleanupProgressPhase::Running,
+        message: "Removing work/old".to_string(),
+    };
+
+    let value = serde_json::to_value(&event).expect("serialize progress event");
+
+    assert_eq!(value["kind"], "branch_cleanup_progress");
+    assert_eq!(value["id"], "branches-1");
+    assert_eq!(value["branch"], "work/old");
+    assert_eq!(value["execution_branch"], "work/old");
+    assert_eq!(value["index"], 2);
+    assert_eq!(value["total"], 5);
+    assert_eq!(value["phase"], "running");
+    assert_eq!(value["message"], "Removing work/old");
+}

--- a/crates/gwt/tests/branch_cleanup_test.rs
+++ b/crates/gwt/tests/branch_cleanup_test.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
 
 use gwt::{
-    cleanup_selected_branches, list_branch_entries_with_active_sessions, BranchCleanupResultStatus,
+    cleanup_selected_branches, cleanup_selected_branches_with_options,
+    list_branch_entries_with_active_sessions, BranchCleanupOptions, BranchCleanupResultStatus,
 };
 use tempfile::tempdir;
 
@@ -167,6 +168,46 @@ fn cleanup_selected_branches_rejects_blocked_branch() {
     assert!(
         branch_exists(repo.path(), "refs/heads/main"),
         "protected branch should remain"
+    );
+}
+
+#[test]
+fn cleanup_selected_branches_force_mode_does_not_bypass_non_workspace_branch_guard() {
+    let temp = tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+
+    run_git(
+        temp.path(),
+        &["init", "-q", repo.to_str().expect("repo path")],
+    );
+    init_repo(&repo);
+    run_git(&repo, &["checkout", "-qb", "feature/manual"]);
+    std::fs::write(repo.join("manual.txt"), "manual\n").expect("write manual");
+    run_git(&repo, &["add", "manual.txt"]);
+    run_git(&repo, &["commit", "-qm", "manual"]);
+    run_git(&repo, &["checkout", "main"]);
+
+    let entries =
+        list_branch_entries_with_active_sessions(&repo, &HashSet::new()).expect("entries");
+    let results = cleanup_selected_branches_with_options(
+        &repo,
+        &entries,
+        &[String::from("feature/manual")],
+        BranchCleanupOptions {
+            delete_remote: false,
+            force_filesystem_delete: true,
+        },
+    );
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].status, BranchCleanupResultStatus::Failed);
+    assert_eq!(
+        results[0].message,
+        "Only gwt-managed workspaces can be cleaned up"
+    );
+    assert!(
+        branch_exists(&repo, "refs/heads/feature/manual"),
+        "force filesystem cleanup must not delete non-workspace branches"
     );
 }
 

--- a/crates/gwt/web/__tests__/branch-cleanup.smoke.test.mjs
+++ b/crates/gwt/web/__tests__/branch-cleanup.smoke.test.mjs
@@ -66,6 +66,8 @@ function makeState(overrides = {}) {
       open: true,
       stage: "confirm",
       deleteRemote: false,
+      forceFilesystemDelete: false,
+      progress: null,
       results: [],
       timeoutId: null,
       ...overrides.cleanupModal,
@@ -208,9 +210,65 @@ test("confirm stage: deleteRemote toggle appears when any entry has upstream", (
   assert.equal(toggledTo, true);
 });
 
+test("confirm stage: force filesystem delete toggle is explicit opt-in", () => {
+  const { dialogEl, modalEl, createNode } = mount();
+  const state = makeState();
+  let toggledTo = null;
+
+  renderBranchCleanupModal({
+    modalEl,
+    dialogEl,
+    windowId: "win-1",
+    state,
+    selectedEntries: [makeEntry("work/old")],
+    createNode,
+    resultSummary,
+    mergeTargetText,
+    riskLabels,
+    onCancel: () => {},
+    onSubmit: () => {},
+    onDeleteRemoteToggle: () => {},
+    onForceFilesystemDeleteToggle: (checked) => {
+      toggledTo = checked;
+    },
+  });
+
+  const labels = Array.from(dialogEl.querySelectorAll(".branch-cleanup-toggle-row"));
+  const forceRow = labels.find((row) =>
+    row.textContent.includes("Force remove remaining worktree files"),
+  );
+  assert.ok(forceRow, "expected force filesystem cleanup checkbox");
+  const checkbox = forceRow.querySelector("input[type='checkbox']");
+  assert.ok(checkbox);
+  assert.equal(checkbox.checked, false);
+
+  checkbox.checked = true;
+  checkbox.dispatchEvent(new dialogEl.ownerDocument.defaultView.Event("change"));
+
+  assert.equal(toggledTo, true);
+});
+
 test("running stage: renders running heading and copy", () => {
   const { modalEl, dialogEl, createNode } = mount();
-  const state = makeState({ cleanupModal: { open: true, stage: "running" } });
+  const state = makeState({
+    cleanupModal: {
+      open: true,
+      stage: "running",
+      progress: {
+        current: {
+          branch: "work/b",
+          index: 2,
+          total: 3,
+          message: "Removing work/b",
+        },
+        items: [
+          { branch: "work/a", status: "done", message: "Deleted local branch" },
+          { branch: "work/b", status: "running", message: "Removing work/b" },
+          { branch: "work/c", status: "pending", message: "" },
+        ],
+      },
+    },
+  });
 
   renderBranchCleanupModal({
     modalEl,
@@ -231,7 +289,11 @@ test("running stage: renders running heading and copy", () => {
   assert.equal(heading.textContent, "Cleaning up branches");
   const running = dialogEl.querySelector(".branch-cleanup-running");
   assert.ok(running);
-  assert.match(running.textContent, /Running cleanup for 2 branches\./);
+  assert.match(running.textContent, /Cleaning 2 of 3: work\/b/);
+  const rows = dialogEl.querySelectorAll(".branch-cleanup-progress-item");
+  assert.equal(rows.length, 3);
+  assert.match(rows[1].textContent, /work\/b/);
+  assert.match(rows[1].textContent, /running/);
 });
 
 test("result stage: renders summary, per-result rows and Close button", () => {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1746,6 +1746,8 @@
           // Workspace cleanup is local-only by default even when
           // cleanup_candidate.default_delete_remote is present on the wire.
           deleteRemote: false,
+          forceFilesystemDelete: false,
+          progress: null,
           results: [],
         };
         branchCleanupWindowId = WORKSPACE_CLEANUP_WINDOW_ID;
@@ -4531,6 +4533,8 @@
               open: false,
               stage: "confirm",
               deleteRemote: false,
+              forceFilesystemDelete: false,
+              progress: null,
               results: [],
             },
           });
@@ -8048,6 +8052,44 @@
         }));
       }
 
+      function initialBranchCleanupProgress(branches) {
+        return {
+          current: null,
+          items: branches.map((branch) => ({
+            branch,
+            status: "pending",
+            message: "",
+          })),
+        };
+      }
+
+      function updateBranchCleanupProgress(windowId, event) {
+        const state = ensureBranchListState(windowId);
+        const branches = Array.from(state.cleanupSelected);
+        if (!state.cleanupModal.progress) {
+          state.cleanupModal.progress = initialBranchCleanupProgress(
+            branches.length > 0 ? branches : [event.branch],
+          );
+        }
+        const progress = state.cleanupModal.progress;
+        progress.current = {
+          branch: event.branch,
+          executionBranch: event.execution_branch || null,
+          index: event.index,
+          total: event.total,
+          phase: event.phase,
+          message: event.message || "",
+        };
+        let item = progress.items.find((candidate) => candidate.branch === event.branch);
+        if (!item) {
+          item = { branch: event.branch, status: "pending", message: "" };
+          progress.items.push(item);
+        }
+        item.executionBranch = event.execution_branch || null;
+        item.status = event.phase || "running";
+        item.message = event.message || "";
+      }
+
       function failRunningBranchCleanup(windowId, message) {
         const state = ensureBranchListState(windowId);
         if (state.cleanupModal.stage !== "running") {
@@ -8208,6 +8250,8 @@
         state.cleanupModal.open = true;
         state.cleanupModal.stage = "confirm";
         state.cleanupModal.deleteRemote = false;
+        state.cleanupModal.forceFilesystemDelete = false;
+        state.cleanupModal.progress = null;
         state.cleanupModal.results = [];
         branchCleanupWindowId = windowId;
         renderBranches(windowId);
@@ -8226,6 +8270,8 @@
         state.cleanupModal.open = false;
         state.cleanupModal.stage = "confirm";
         state.cleanupModal.deleteRemote = false;
+        state.cleanupModal.forceFilesystemDelete = false;
+        state.cleanupModal.progress = null;
         state.cleanupModal.results = [];
         if (branchCleanupWindowId === windowId) {
           branchCleanupWindowId = null;
@@ -8243,6 +8289,7 @@
         }
         state.notice = "";
         state.cleanupModal.stage = "running";
+        state.cleanupModal.progress = initialBranchCleanupProgress(branches);
         state.cleanupModal.results = [];
         renderBranchCleanupModal();
         if (windowId === WORKSPACE_CLEANUP_WINDOW_ID) {
@@ -8250,6 +8297,7 @@
             kind: "run_workspace_cleanup",
             branch: branches[0],
             delete_remote: state.cleanupModal.deleteRemote,
+            force_filesystem_delete: state.cleanupModal.forceFilesystemDelete,
           });
           return;
         }
@@ -8258,6 +8306,7 @@
           id: windowId,
           branches,
           delete_remote: state.cleanupModal.deleteRemote,
+          force_filesystem_delete: state.cleanupModal.forceFilesystemDelete,
         });
       }
 
@@ -8290,6 +8339,11 @@
           onDeleteRemoteToggle: (checked) => {
             if (state) {
               state.cleanupModal.deleteRemote = checked;
+            }
+          },
+          onForceFilesystemDeleteToggle: (checked) => {
+            if (state) {
+              state.cleanupModal.forceFilesystemDelete = checked;
             }
           },
         });
@@ -10049,6 +10103,7 @@
         openBranchCleanupModal,
         closeBranchCleanupModal,
         renderBranchCleanupModal,
+        updateBranchCleanupProgress,
         // SPEC-2009 amendment: Worktree picker + file content viewer.
         openWorktreePicker,
         closeWorktreePicker,
@@ -10735,6 +10790,19 @@
             if (event.id === WORKSPACE_CLEANUP_WINDOW_ID) {
               frontendUnits.branchesFileTreeSurface.renderBranchCleanupModal();
               workspaceKanbanSurface.renderWindows();
+              break;
+            }
+            frontendUnits.branchesFileTreeSurface.renderBranches(event.id);
+            break;
+          }
+          case "branch_cleanup_progress": {
+            frontendUnits.branchesFileTreeSurface.updateBranchCleanupProgress(
+              event.id,
+              event,
+            );
+            branchCleanupWindowId = event.id;
+            if (event.id === WORKSPACE_CLEANUP_WINDOW_ID) {
+              frontendUnits.branchesFileTreeSurface.renderBranchCleanupModal();
               break;
             }
             frontendUnits.branchesFileTreeSurface.renderBranches(event.id);

--- a/crates/gwt/web/branch-cleanup-modal.js
+++ b/crates/gwt/web/branch-cleanup-modal.js
@@ -28,6 +28,7 @@ export function renderBranchCleanupModal({
   onCancel,
   onSubmit,
   onDeleteRemoteToggle,
+  onForceFilesystemDeleteToggle,
 }) {
   if (!windowId || !state || !state.cleanupModal.open) {
     const wasOpenBeforeClose = modalEl.classList.contains("open");
@@ -93,13 +94,49 @@ export function renderBranchCleanupModal({
   if (state.cleanupModal.stage === "running") {
     dialogEl.appendChild(createNode("h2", "", "Cleaning up branches"));
     const count = Math.max(selectedEntries.length, 1);
+    const progress = state.cleanupModal.progress || null;
+    const current = progress?.current || null;
+    const runningCopy = current
+      ? `Cleaning ${current.index} of ${current.total}: ${current.branch}`
+      : `Running cleanup for ${count} branch${count === 1 ? "" : "es"}.`;
     dialogEl.appendChild(
       createNode(
         "div",
         "branch-cleanup-running",
-        `Running cleanup for ${count} branch${count === 1 ? "" : "es"}.`,
+        runningCopy,
       ),
     );
+    if (current?.message) {
+      dialogEl.appendChild(
+        createNode("div", "branch-cleanup-item-copy", current.message),
+      );
+    }
+    if (Array.isArray(progress?.items) && progress.items.length > 0) {
+      const progressList = createNode("div", "branch-cleanup-progress-list");
+      for (const item of progress.items) {
+        const row = createNode(
+          "div",
+          `branch-cleanup-progress-item ${item.status || "pending"}`,
+        );
+        row.appendChild(
+          createNode("span", "branch-cleanup-progress-branch", item.branch),
+        );
+        row.appendChild(
+          createNode(
+            "span",
+            "branch-cleanup-progress-status",
+            item.status || "pending",
+          ),
+        );
+        if (item.message) {
+          row.appendChild(
+            createNode("span", "branch-cleanup-progress-message", item.message),
+          );
+        }
+        progressList.appendChild(row);
+      }
+      dialogEl.appendChild(progressList);
+    }
     return;
   }
 
@@ -218,6 +255,20 @@ export function renderBranchCleanupModal({
     );
     dialogEl.appendChild(toggleRow);
   }
+  const forceToggleRow = createNode("label", "branch-cleanup-toggle-row");
+  const forceCheckbox = createNode("input", "");
+  forceCheckbox.type = "checkbox";
+  forceCheckbox.checked = Boolean(state.cleanupModal.forceFilesystemDelete);
+  forceCheckbox.addEventListener("change", () => {
+    if (typeof onForceFilesystemDeleteToggle === "function") {
+      onForceFilesystemDeleteToggle(forceCheckbox.checked);
+    }
+  });
+  forceToggleRow.appendChild(forceCheckbox);
+  forceToggleRow.appendChild(
+    createNode("span", "", "Force remove remaining worktree files"),
+  );
+  dialogEl.appendChild(forceToggleRow);
   const footer = createNode("div", "modal-footer");
   const cancel = createNode("button", "wizard-button", "Cancel");
   cancel.type = "button";

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -2531,6 +2531,43 @@ body {
   color: var(--color-text-muted);
 }
 
+.branch-cleanup-progress-list {
+  display: grid;
+  gap: 6px;
+  margin-top: 12px;
+}
+
+.branch-cleanup-progress-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  align-items: center;
+  padding: 8px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-elevated);
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+}
+
+.branch-cleanup-progress-branch {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.branch-cleanup-progress-status {
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+}
+
+.branch-cleanup-progress-message {
+  grid-column: 1 / -1;
+  color: var(--color-text-muted);
+}
+
 .branch-cleanup-results-summary {
   margin-top: 12px;
   font-family: var(--font-mono);


### PR DESCRIPTION
## Summary

- Branch Cleanup の実行中に、現在処理している branch と進捗件数を GUI に表示します。
- directory-not-empty など通常削除で失敗する worktree cleanup に対して、ユーザーが明示的に force delete を選べるようにします。
- backend protocol、git worktree cleanup、GUI smoke / Playwright E2E を更新し、cleanup の通常経路と force 経路を回帰確認できるようにします。

## Changes

- `crates/gwt/src/branch_cleanup.rs`: cleanup job に progress event と force delete option を追加し、削除対象 branch / worktree の状態を返すようにしました。
- `crates/gwt-git/src/worktree.rs`: 通常削除と force delete を分離し、directory-not-empty 失敗時の retry path を扱えるようにしました。
- `crates/gwt/src/protocol.rs` / `crates/gwt/src/app_runtime/mod.rs` / `crates/gwt/src/main.rs`: GUI runtime に cleanup progress / force option の protocol wiring を追加しました。
- `crates/gwt/web/app.js` / `crates/gwt/web/branch-cleanup-modal.js` / `crates/gwt/web/styles/app.css`: cleanup modal に progress 表示と force delete checkbox を追加しました。
- `crates/gwt/tests/*` / `crates/gwt/web/__tests__/*` / `crates/gwt/playwright/tests/branch-cleanup.spec.ts`: backend protocol、Rust cleanup、frontend smoke、Playwright E2E の coverage を追加・更新しました。

## Testing

- [x] `cargo fmt -- --check` - formatting check passed.
- [x] `pnpm run --silent test:frontend-bundle` - frontend bundle check passed.
- [x] `pnpm run --silent test:frontend-smoke` - 25 frontend smoke tests passed.
- [x] `cargo test -p gwt --test branch_cleanup_protocol_test --test branch_cleanup_test -- --nocapture` - 8 branch cleanup focused tests passed.
- [x] `cargo test -p gwt-git` - gwt-git unit / integration / doc tests passed.
- [x] `pnpm run --silent test:visual -- --project=chromium-dark crates/gwt/playwright/tests/branch-cleanup.spec.ts` - branch cleanup Playwright scenarios passed.
- [x] `pnpm run --silent test:visual` - full visual suite passed with 38 passed / 38 skipped.
- [x] `cargo test -p gwt-core -p gwt --all-features` - all selected Cargo tests passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - clippy passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` - debug binaries built successfully.
- [x] `bunx commitlint --from origin/develop --to HEAD` - commit messages passed.

## Closing Issues

None

## Related Issues / Links

- #2009

## Checklist

- [x] Tests added/updated.
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`).
- [x] Documentation updated: N/A, this change is covered by in-app UI labels and tests.
- [x] Migration/backfill plan included: N/A, no schema or data migration.
- [x] CHANGELOG impact considered: feature change represented by the `feat(gui)` commit.

## Context

- Branch Cleanup previously surfaced only a generic cleanup failure, so users could not tell which branch was being removed or recover from a non-empty worktree directory without leaving the GUI.
- The update keeps normal cleanup as the default path and requires an explicit force delete checkbox before destructive retry behavior is enabled.

## Risk / Impact

- **Affected areas**: Branch Cleanup modal, GUI protocol events, git worktree cleanup helpers, and cleanup tests.
- **Rollback plan**: Revert this PR to return cleanup behavior to the previous non-progress, non-force path.

## Screenshots

- Not attached; the changed modal states are covered by the branch cleanup Playwright scenarios in dark and light Chromium projects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Force remove remaining worktree files" checkbox option to the branch cleanup modal for more aggressive cleanup handling.
  * Real-time progress updates during cleanup operations now display per-branch status and current cleanup details.
  * Improved cleanup robustness with automatic recovery from filesystem residue issues.

* **Tests**
  * Added end-to-end test coverage for branch cleanup UI workflows.
  * Extended unit test coverage for force cleanup and progress reporting scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2828?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->