### PR TITLE
fix(gui): harden branch cleanup safety

### DIFF
--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -1407,8 +1407,8 @@ fn workspace_projection_is_eligible_for_auto_done(projection: &WorkspaceProjecti
 /// WorkItem currently associated with `branch`. The function loads the current
 /// projection at `current_path` and emits Done iff
 /// `projection.git_details.branch` matches `branch`. Used by user-confirmed
-/// cleanup to mark the matching Workspace as completed before worktree/branch
-/// deletion. Idempotent per `work_item_id` via
+/// cleanup to mark the matching Workspace as completed after worktree/branch
+/// deletion succeeds. Idempotent per `work_item_id` via
 /// [`emit_workspace_done_event_if_absent_paths`].
 pub fn emit_workspace_done_event_for_branch_paths(
     current_path: &Path,

--- a/crates/gwt-git/src/worktree.rs
+++ b/crates/gwt-git/src/worktree.rs
@@ -482,6 +482,7 @@ impl WorktreeManager {
                     self.prune()?;
                 }
                 Err(err) if force_filesystem_delete && is_filesystem_residue_error(&err) => {
+                    validate_force_filesystem_residue_path(&self.repo_path, branch, &path)?;
                     remove_worktree_filesystem_residue(&path)?;
                     self.prune()?;
                 }
@@ -521,6 +522,37 @@ fn remove_worktree_filesystem_residue(path: &Path) -> Result<()> {
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(err) => Err(GwtError::Git(format!("inspect worktree residue: {err}"))),
     }
+}
+
+fn validate_force_filesystem_residue_path(
+    repo_path: &Path,
+    branch: &str,
+    path: &Path,
+) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let expected_path = sibling_worktree_path(repo_path, branch);
+    let actual = std::fs::canonicalize(path)
+        .map_err(|e| GwtError::Git(format!("inspect worktree residue path: {e}")))?;
+    let expected = std::fs::canonicalize(&expected_path).map_err(|_| {
+        GwtError::Git(format!(
+            "refusing to force-delete worktree residue outside managed workspace: {} (expected {})",
+            path.display(),
+            expected_path.display()
+        ))
+    })?;
+
+    if actual != expected {
+        return Err(GwtError::Git(format!(
+            "refusing to force-delete worktree residue outside managed workspace: {} (expected {})",
+            path.display(),
+            expected_path.display()
+        )));
+    }
+
+    Ok(())
 }
 
 fn run_command_with_timeout(
@@ -1262,6 +1294,39 @@ prunable gitdir file points to non-existent location
         remove_worktree_filesystem_residue(&residue_path).unwrap();
 
         assert!(!residue_path.exists());
+    }
+
+    #[test]
+    fn force_filesystem_residue_path_validation_rejects_path_outside_expected_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = tmp.path().join("repo");
+        let unrelated_path = tmp.path().join("unrelated").join("work").join("residue");
+        std::fs::create_dir_all(&repo_path).unwrap();
+        std::fs::create_dir_all(&unrelated_path).unwrap();
+
+        let err =
+            validate_force_filesystem_residue_path(&repo_path, "work/residue", &unrelated_path)
+                .expect_err("force residue cleanup must reject unrelated paths");
+
+        assert!(err
+            .to_string()
+            .contains("refusing to force-delete worktree residue outside managed workspace"));
+        assert!(
+            unrelated_path.exists(),
+            "validation must not remove unrelated paths"
+        );
+    }
+
+    #[test]
+    fn force_filesystem_residue_path_validation_accepts_expected_worktree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = tmp.path().join("repo");
+        let expected_path = sibling_worktree_path(&repo_path, "work/residue");
+        std::fs::create_dir_all(&repo_path).unwrap();
+        std::fs::create_dir_all(&expected_path).unwrap();
+
+        validate_force_filesystem_residue_path(&repo_path, "work/residue", &expected_path)
+            .expect("expected sibling worktree path should be force-deletable");
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -4709,15 +4709,6 @@ impl AppRuntime {
             )];
         };
 
-        // SPEC-2359 US-37 / FR-118: emit Done for the Workspace WorkItem whose
-        // git_details.branch matches the cleanup target before delegating to
-        // worktree/branch deletion. Idempotent per work_item_id.
-        let _ = gwt_core::workspace_projection::emit_workspace_done_event_for_branch(
-            &tab.project_root,
-            branch,
-            chrono::Utc::now(),
-        );
-
         spawn_workspace_cleanup_async(
             self.proxy.clone(),
             client_id.to_string(),
@@ -4925,6 +4916,14 @@ fn spawn_workspace_cleanup_async(
                                     | gwt::BranchCleanupResultStatus::Partial
                             )
                     }) {
+                        // SPEC-2359 US-37 / FR-118: emit Done only after the
+                        // matching workspace cleanup actually succeeded.
+                        let _ =
+                            gwt_core::workspace_projection::emit_workspace_done_event_for_branch(
+                                &project_root,
+                                &branch,
+                                chrono::Utc::now(),
+                            );
                         if let Some(event) =
                             clear_workspace_cleanup_git_details_event(&project_root)
                         {
@@ -10342,6 +10341,79 @@ exit 1
         assert!(
             invocations.trim().is_empty(),
             "active-work projection must not spawn git on the GUI hot path; invocations:\n{invocations}"
+        );
+    }
+
+    #[test]
+    fn workspace_cleanup_failure_does_not_emit_done_work_item() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let branch = "work/missing";
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+        projection.git_details = Some(gwt_core::workspace_projection::GitDetails {
+            branch: Some(branch.to_string()),
+            worktree_path: Some(repo.join("work/missing")),
+            base_branch: Some("origin/develop".to_string()),
+            pr_number: Some(2828),
+            pr_state: Some("MERGED".to_string()),
+            pr_url: Some("https://github.com/akiojin/gwt/pull/2828".to_string()),
+            pr_created_at: None,
+            created_by_start_work: true,
+            created_at: chrono::Utc::now(),
+        });
+        let work_item_id = projection.id.clone();
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+        let start = gwt_core::workspace_projection::WorkspaceWorkEvent::new(
+            gwt_core::workspace_projection::WorkspaceWorkEventKind::Start,
+            &work_item_id,
+            chrono::Utc::now(),
+        );
+        gwt_core::workspace_projection::record_workspace_work_event(&repo, start)
+            .expect("record start");
+        let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+        let (runtime, events) = sample_runtime_with_events(temp.path(), vec![tab], Some("tab-1"));
+
+        let immediate_events =
+            runtime.run_workspace_cleanup_events("client-1", branch, false, false);
+
+        assert!(immediate_events.is_empty());
+        wait_for_recorded_event("workspace cleanup failure", &events, |events| {
+            events.iter().any(|event| {
+                matches!(
+                    event,
+                    UserEvent::Dispatch(outbound_events)
+                        if outbound_events.iter().any(|outbound| matches!(
+                            outbound.event,
+                            BackendEvent::BranchCleanupResult { .. }
+                                | BackendEvent::BranchError { .. }
+                        ))
+                )
+            })
+        });
+        let work_items = gwt_core::workspace_projection::load_workspace_work_items(&repo)
+            .expect("load work items")
+            .expect("work items");
+        let item = work_items
+            .work_items
+            .iter()
+            .find(|item| item.id == work_item_id)
+            .expect("work item");
+
+        assert!(
+            !item
+                .events
+                .iter()
+                .any(|event| event.kind
+                    == gwt_core::workspace_projection::WorkspaceWorkEventKind::Done),
+            "failed cleanup must not mark the Workspace work item done"
         );
     }
 


### PR DESCRIPTION
## Summary

- Harden branch cleanup force mode so filesystem residue deletion is limited to the expected gwt-managed worktree path.
- Emit Workspace Done only after workspace cleanup reports success or partial success.
- Add regression coverage for the post-merge review findings from #2828.

## Changes

- `crates/gwt-git/src/worktree.rs`: validate the canonical residue path against `sibling_worktree_path` before any force filesystem deletion.
- `crates/gwt/src/app_runtime/mod.rs`: move Workspace Done emission into the successful workspace cleanup path and cover failed cleanup with a regression test.
- `crates/gwt-core/src/workspace_projection.rs`: update the cleanup timing comment to match the new Done emission behavior.

## Testing

- [x] `cargo fmt -- --check` - passed.
- [x] `cargo test -p gwt-git force_filesystem_residue_path_validation` - passed.
- [x] `cargo test -p gwt workspace_cleanup_failure_does_not_emit_done_work_item` - passed.
- [x] `cargo test -p gwt-git` - passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` - passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` - passed.
- [x] `bunx commitlint --from origin/develop --to HEAD` - passed.
- [x] `git push` pre-push hook - passed with filtered line coverage 90.47% and skill frontmatter validation.

## Closing Issues

- None

## Related Issues / Links

- #2828

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (if user-facing change; not applicable because behavior is internal cleanup safety)
- [x] Migration/backfill plan included (if schema/data change; not applicable)
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- PR #2828 was merged before automated review feedback completed. This follow-up addresses the merged review feedback without reopening the already-merged feature PR.

## Risk / Impact

- **Affected areas**: branch cleanup force mode and workspace cleanup completion bookkeeping.
- **Rollback plan**: revert this PR; no schema or migration changes are involved.
