### PR TITLE
fix(gui): Claude Code 起動直後の terminal 表示崩れを修正 (#2832)

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -840,7 +840,7 @@ mod tests {
         // `isReady` flip while the window is still hidden, defeating the
         // deferredWrites buffer (CodeRabbit PR #2693 concern).
         let create_runtime_handshake = regex::Regex::new(
-            r#"(?s)isReady: false,\s*deferredWrites: \[\],\s*\};\s*terminalMap\.set\(windowId, runtime\);\s*decoderMap\.set\(windowId, new TextDecoder\(\)\);[\s\S]*?requestAnimationFrame\(\(\) => completeInitialFitHandshake\(windowId\)\);"#,
+            r#"(?s)isReady: false,\s*deferredWrites: \[\],[\s\S]*?handshakeAttempts: 0,\s*\};\s*terminalMap\.set\(windowId, runtime\);\s*decoderMap\.set\(windowId, new TextDecoder\(\)\);[\s\S]*?requestAnimationFrame\(\(\) => completeInitialFitHandshake\(windowId\)\);"#,
         )
         .expect("valid regex");
         // The helper itself must (a) bail when canRefreshTerminalViewport
@@ -896,6 +896,38 @@ mod tests {
         assert!(
             !legacy_sync_replay.is_match(html),
             "legacy synchronous snapshot replay before initial fit must be removed (FR-057 regression guard)",
+        );
+
+        // Issue #2832 — SPEC-2008 Phase 26.A regression fix: the
+        // visibility predicate (canRefreshTerminalViewport) only checks
+        // `.hidden` and `.minimized`. It does NOT catch the case where
+        // the element is structurally visible but layout has not yet
+        // propagated, leaving the parent container at 0×0 at the moment
+        // the initial-fit rAF fires. In that state fitAddon.fit() resolves
+        // against the 0-sized box and silently leaves xterm at the
+        // default 80×24 grid; flushing deferredWrites then renders the
+        // post-launch Claude Code output corrupted, with the
+        // resize-recovers-on-move signature documented in
+        // tasks/lessons.md 2026-05-13.
+        let layout_box_gate = regex::Regex::new(
+            r#"(?s)function completeInitialFitHandshake\(windowId\) \{[\s\S]*?if \(!canRefreshTerminalViewport\(windowId\)\) \{[\s\S]*?return;[\s\S]*?\}[\s\S]*?if \(!terminalContainerHasLayoutBox\(windowId\)\) \{\s*runtime\.handshakeAttempts = \(runtime\.handshakeAttempts \|\| 0\) \+ 1;[\s\S]*?if \(runtime\.handshakeAttempts <= HANDSHAKE_RETRY_LIMIT\) \{\s*requestAnimationFrame\(\(\) => completeInitialFitHandshake\(windowId\)\);\s*return;\s*\}"#,
+        )
+        .expect("valid regex");
+        assert!(
+            layout_box_gate.is_match(html),
+            "expected completeInitialFitHandshake to defer (and rAF-retry) while terminalContainerHasLayoutBox returns false so deferredWrites do not flush into xterm's default 80x24 grid before fit can resolve real cols/rows (Issue #2832)",
+        );
+        assert!(
+            html.contains("elementHasLayoutBox,"),
+            "expected app.js to import elementHasLayoutBox from terminal-viewport-reflow.js (Issue #2832)",
+        );
+        assert!(
+            html.contains("function terminalContainerHasLayoutBox(windowId)"),
+            "expected app.js to expose terminalContainerHasLayoutBox so the handshake can gate on layout (Issue #2832)",
+        );
+        assert!(
+            html.contains("const HANDSHAKE_RETRY_LIMIT ="),
+            "expected app.js to declare HANDSHAKE_RETRY_LIMIT so the retry loop has a ceiling (Issue #2832)",
         );
     }
 

--- a/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
@@ -18,6 +18,7 @@ import {
   applyVisibilityTransition,
   attachHostResizeReflow,
   classifyProjectWindowVisibility,
+  elementHasLayoutBox,
   runTerminalActivationSequence,
   viewportEligibleForRefresh,
 } from "../terminal-viewport-reflow.js";
@@ -293,6 +294,40 @@ test("attachHostResizeReflow throws when given a non-DOM window", () => {
   );
 });
 
+test("elementHasLayoutBox blocks 0-size containers (Issue #2832 / SPEC-2008 Phase 26.A regression)", () => {
+  // SPEC-2008 Phase 26.A only checked `.hidden` and `.minimized`, so a
+  // structurally-visible window whose flex/grid layout had not propagated
+  // could pass the visibility predicate while the parent container was
+  // still 0x0. fitAddon then resolved against the broken box, isReady
+  // flipped true, and the deferredWrites flushed into xterm's default
+  // 80x24 grid — the Claude Code post-launch corruption symptom.
+  assert.equal(elementHasLayoutBox({ clientWidth: 800, clientHeight: 480 }), true);
+  assert.equal(elementHasLayoutBox({ clientWidth: 0, clientHeight: 480 }), false);
+  assert.equal(elementHasLayoutBox({ clientWidth: 800, clientHeight: 0 }), false);
+  assert.equal(elementHasLayoutBox({ clientWidth: 0, clientHeight: 0 }), false);
+
+  // Falls back to getBoundingClientRect when client* are unavailable
+  // (e.g. linkedom fixtures used elsewhere in this suite).
+  assert.equal(
+    elementHasLayoutBox({
+      getBoundingClientRect: () => ({ width: 600, height: 320 }),
+    }),
+    true,
+  );
+  assert.equal(
+    elementHasLayoutBox({
+      getBoundingClientRect: () => ({ width: 0, height: 320 }),
+    }),
+    false,
+  );
+
+  // Defensive default: missing element falls through (don't pin the
+  // handshake retry loop on inputs the predicate can not measure).
+  assert.equal(elementHasLayoutBox(null), true);
+  assert.equal(elementHasLayoutBox(undefined), true);
+  assert.equal(elementHasLayoutBox({}), true);
+});
+
 test("app.js wires the reflow controller for resize, transition, and predicate", () => {
   // Source-string contract retained per the lesson — limited to wiring
   // detection so a future refactor that drops the import / call surfaces
@@ -336,5 +371,31 @@ test("app.js wires the reflow controller for resize, transition, and predicate",
     appSource,
     /scheduleTerminalFocusActivation\(topmostId,\s*\{\s*shouldPersistGeometry:\s*false,?\s*\}\)/,
     "topmost focus activation must not persist geometry on every workspace render",
+  );
+
+  // Issue #2832 — SPEC-2008 Phase 26.A regression fix: completeInitialFitHandshake
+  // must defer (and retry via rAF) while the container has no layout box,
+  // so deferredWrites do not flush into xterm's default 80x24 grid before
+  // fit can resolve real cols/rows. Wiring detection only — behavior
+  // coverage lives in the elementHasLayoutBox unit test above.
+  assert.match(
+    appSource,
+    /elementHasLayoutBox/,
+    "app.js must import elementHasLayoutBox so the initial-fit handshake can gate on container layout",
+  );
+  assert.match(
+    appSource,
+    /terminalContainerHasLayoutBox\(windowId\)/,
+    "completeInitialFitHandshake must consult terminalContainerHasLayoutBox",
+  );
+  assert.match(
+    appSource,
+    /handshakeAttempts/,
+    "completeInitialFitHandshake must bound its retry loop with a handshakeAttempts counter",
+  );
+  assert.match(
+    appSource,
+    /HANDSHAKE_RETRY_LIMIT/,
+    "handshake retry must be capped by HANDSHAKE_RETRY_LIMIT",
   );
 });

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -43,6 +43,7 @@
         applyVisibilityTransition,
         attachHostResizeReflow,
         classifyProjectWindowVisibility,
+        elementHasLayoutBox,
         runTerminalActivationSequence,
         viewportEligibleForRefresh,
       } from "/terminal-viewport-reflow.js";
@@ -2021,6 +2022,23 @@
         });
       }
 
+      // SPEC-2008 Phase 26.A regression fix (Issue #2832): completeInitialFitHandshake
+      // must verify the container has a real layout box before flipping
+      // `isReady` true, otherwise fit resolves against a 0-sized parent
+      // and the deferredWrites flush into xterm's default 80×24 grid.
+      // 60 frames at the default 60Hz cap retries to ~1 s, after which we
+      // fall through so a permanently 0-size window can not pin Claude
+      // Code output forever.
+      const HANDSHAKE_RETRY_LIMIT = 60;
+
+      function terminalContainerHasLayoutBox(windowId) {
+        const element = windowMap.get(windowId);
+        // Fall through to true when the element is not registered yet — the
+        // initial-fit handshake is gated by canRefreshTerminalViewport which
+        // already short-circuits the no-element case.
+        return elementHasLayoutBox(element);
+      }
+
       function fitTerminal(windowId, persist = false) {
         return traceMeasure(
           UI_TRACE_EVENT.fitTerminal,
@@ -3370,6 +3388,8 @@
           // producing the post-launch corruption symptom.
           isReady: false,
           deferredWrites: [],
+          // Issue #2832: see completeInitialFitHandshake.
+          handshakeAttempts: 0,
         };
         terminalMap.set(windowId, runtime);
         decoderMap.set(windowId, new TextDecoder());
@@ -3403,6 +3423,31 @@
           // will call back into this helper.
           return;
         }
+        // SPEC-2008 Phase 26.A / FR-057 (regression fix, Issue #2832): the
+        // visibility predicate above only checks `.hidden` / `.minimized`.
+        // It does not catch the case where the element is structurally
+        // visible but the parent has not yet been laid out (e.g. a freshly
+        // appended workspace window whose CSS width/height has not
+        // propagated by the time `requestAnimationFrame` fires). In that
+        // state `fitAddon.fit()` resolves cell-grid dimensions against a
+        // 0-sized container and silently leaves the terminal at the xterm
+        // default 80×24 grid. The previous code then flipped
+        // `isReady = true` and flushed `deferredWrites` into that broken
+        // grid, producing the post-launch corruption that resize/move
+        // recovered from. Re-schedule via rAF until the container has a
+        // non-zero box, with an attempt ceiling so a perma-hidden window
+        // can not pin the loop.
+        if (!terminalContainerHasLayoutBox(windowId)) {
+          runtime.handshakeAttempts = (runtime.handshakeAttempts || 0) + 1;
+          if (runtime.handshakeAttempts <= HANDSHAKE_RETRY_LIMIT) {
+            requestAnimationFrame(() => completeInitialFitHandshake(windowId));
+            return;
+          }
+          console.warn(
+            `[gwt] terminal ${windowId} initial-fit handshake gave up after ${HANDSHAKE_RETRY_LIMIT} attempts; container stayed 0-size. Falling back to immediate activation.`,
+          );
+        }
+
         runTerminalActivationSequence({
           runtime,
           windowId,

--- a/crates/gwt/web/terminal-viewport-reflow.js
+++ b/crates/gwt/web/terminal-viewport-reflow.js
@@ -112,6 +112,36 @@ export function viewportEligibleForRefresh({ element, workspaceWindow }) {
 }
 
 /**
+ * SPEC-2008 Phase 26.A regression fix (Issue #2832): a window can be
+ * structurally visible (`.hidden = false`, not minimized) yet still have
+ * no layout box at the moment the initial-fit `requestAnimationFrame`
+ * fires — flex/grid layout has not propagated to the descendants, custom
+ * fonts have not loaded, or the workspace is mid-render. In that state
+ * `fitAddon.fit()` resolves against a 0-sized parent and silently leaves
+ * xterm at its default 80×24 grid; flipping `isReady = true` then flushes
+ * `deferredWrites` into that broken grid, producing the Claude-Code
+ * startup corruption that ships until the next resize/move.
+ *
+ * The handshake should defer until the container has a real layout box.
+ * `clientWidth` / `clientHeight` is preferred over `getBoundingClientRect`
+ * because it ignores transforms and is cheap to read in a rAF callback.
+ * `null` / missing elements fall through to `true` so non-DOM callers
+ * (e.g. test fixtures without a workspace window registered) do not
+ * regress.
+ */
+export function elementHasLayoutBox(element) {
+  if (!element) return true;
+  if (typeof element.clientWidth === "number" && typeof element.clientHeight === "number") {
+    return element.clientWidth > 0 && element.clientHeight > 0;
+  }
+  if (typeof element.getBoundingClientRect === "function") {
+    const rect = element.getBoundingClientRect();
+    return !!rect && rect.width > 0 && rect.height > 0;
+  }
+  return true;
+}
+
+/**
  * SPEC-2008 Phase 26.B / FR-056 — terminal activation must render BEFORE
  * fit. Phase 24 activation called fitAddon.fit() first, then scheduled a
  * later viewport refresh. But fitAddon.proposeDimensions() returns

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,32 @@
 # Lessons Learned
 
+## 2026-05-20 — Phase 26 の visibility 述語だけでは silent no-op を防げない: layout box が立つまで `isReady` を flip しない (Issue #2832 / SPEC-2008 Phase 26.A regression)
+
+### 事象
+
+SPEC-2008 Phase 26 で導入した `runTerminalActivationSequence` (refresh→layout flush→fit) と `createTerminalRuntime` の `isReady` / `deferredWrites` handshake は intact だったにも関わらず、Claude Code を gwt agent pane で起動した直後にテキストをペーストすると terminal 表示全体が崩れる症状がユーザー報告 (`work/20260520-1050`) で再発した。resize / window move で復活する。スクリーンショット `.gwt/paste-images/1779274308833-11-image.png` で確認済み。
+
+### 原因
+
+`completeInitialFitHandshake` は `canRefreshTerminalViewport(windowId)` が true を返した時点で `runTerminalActivationSequence` を呼び、結果に関係なく `runtime.isReady = true` を立てて deferredWrites を flush していた。`viewportEligibleForRefresh` は `element.hidden` と `workspaceWindow.minimized` のみ確認するため、**構造的には visible だが parent の flex/grid layout が rAF 時点で propagate していない (clientWidth/clientHeight=0)** 状態を素通りする。この状態で `fitAddon.fit()` を呼ぶと `_renderService.dimensions.css.cell.width` 自体は font metrics 経由で populate されても、`proposeDimensions` が `getComputedStyle(parent).width / cell.width` を計算する段で 0÷n=0 cols になり、fit が silent no-op するか xterm default 80×24 にロックされる。直後の `isReady = true` で deferredWrites が誤グリッドへ flush され、ユーザーには Claude Code splash と paste 直後の表示が崩れて見える。OS resize で fan-out が走るとそこで初めて正しい cols/rows に fit されるため、resize で復活する signature になる。
+
+Phase 26.A の `isReady` handshake は「writes を fit 完了まで buffer する」ことは保証していたが、「fit が valid cols/rows を返した」ことを保証しておらず、layout が settle するまでの race window がそのまま残っていた。
+
+### 再発防止策
+
+1. **handshake は `isReady=true` を flip する前に container の layout box (`clientWidth/clientHeight > 0`) を確認する。** `terminal-viewport-reflow.js::elementHasLayoutBox` で predicate を export し、`completeInitialFitHandshake` から `terminalContainerHasLayoutBox(windowId)` 経由で gate する (Issue #2832 fix)。
+2. **layout box が無い場合は rAF retry を上限付き (`HANDSHAKE_RETRY_LIMIT = 60` ≒ 1 秒 @ 60Hz) でループさせる。** 上限超過時は `console.warn` で観測可能にしつつ fall-through して activation を強制する (perma-hidden window が deferred writes を永久に pin しない保険)。
+3. **Rust source-string contract で wiring を pin する。** `crates/gwt/src/embedded_web.rs` の `embedded_web_terminal_runtime_buffers_writes_until_initial_fit_handshake` に `terminalContainerHasLayoutBox` / `handshakeAttempts` / `HANDSHAKE_RETRY_LIMIT` regex を追加し、将来 helper を drop する refactor が CI で即座に炎上するようにする。
+4. **frontend behaviour test に 0-size container の判定を pin する。** `__tests__/terminal-viewport-reflow.test.mjs` の `elementHasLayoutBox blocks 0-size containers` で clientWidth/clientHeight = 0、getBoundingClientRect fallback、null defensive の各分岐を直接 assert する。
+
+`viewportEligibleForRefresh` 自体を破壊的に書き換えると、host resize fan-out / project tab switch / dock target 等の既存 caller が hidden short-circuit に依存している側面を壊しうるため、predicate を増やす形で blast radius を最小化した (Phase 26 が Phase 24 を上書きせずに helper を増やしたのと同じ方針)。
+
+### 関連 PR / Issue
+
+- Issue #2832 (本件 bug Issue)
+- SPEC-2008 Phase 26 / FR-056 / FR-057 / FR-059 (lineage)
+- 過去の closed regressions: #2096 / #2091 / #2668 / #2513
+
 ## 2026-05-20 — develop merge ≠ 既存 session で動く: hook 経路 binary は `installed gwtd` で固定される (Phase U-9 self-bench で発見)
 
 ### 事象


### PR DESCRIPTION
## Summary

- `completeInitialFitHandshake` の visibility predicate (`.hidden` / `.minimized` のみ) を通過した時点で `runtime.isReady = true` を立てていた race を修正。`elementHasLayoutBox` predicate を追加し、container の `clientWidth/clientHeight` が立つまで rAF retry で待機する。
- これにより Claude Code 起動直後の paste で terminal 表示全体が崩れる Phase 26.A regression (Issue #2832) を解消する。`resize` / window move 不要で初回描画から正しく描かれる。
- `HANDSHAKE_RETRY_LIMIT = 60` (≒ 1 秒 @ 60Hz) で perma-hidden window が deferredWrites を永久に pin することを防ぎ、上限超過時は `console.warn` で観測可能化。

## Changes

- `crates/gwt/web/terminal-viewport-reflow.js` — `elementHasLayoutBox(element)` export を追加 (`clientWidth/clientHeight` 優先、`getBoundingClientRect` fallback、null defensive default)。
- `crates/gwt/web/app.js`
  - `elementHasLayoutBox` を import。
  - `HANDSHAKE_RETRY_LIMIT` 定数と `terminalContainerHasLayoutBox(windowId)` helper を新設。
  - `createTerminalRuntime` の runtime state に `handshakeAttempts: 0` を追加。
  - `completeInitialFitHandshake` に layout-box gate と rAF retry / fallback warn を追加。
- `crates/gwt/src/embedded_web.rs` — `embedded_web_terminal_runtime_buffers_writes_until_initial_fit_handshake` の regex / import / helper / 上限 const を pin する Rust source-string contract を追加。
- `crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs` — `elementHasLayoutBox` の 0-size / fallback / null defensive 分岐を pin する behaviour test を追加。
- `tasks/lessons.md` — 「Phase 26 の visibility 述語だけでは silent no-op を防げない」事象 / 原因 / 再発防止策を追記。

## Testing

| Surface | Command | Result |
|---------|---------|--------|
| Frontend syntax | `pnpm test:frontend-bundle` | PASS |
| Frontend behaviour | `pnpm test:frontend-unit` | 524 / 524 PASS |
| Targeted reflow | `node --test crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs` | 10 / 10 PASS (新規 1 件含む) |
| Rust source-string contract | `cargo test -p gwt --all-features embedded_web_terminal_runtime_buffers_writes_until_initial_fit_handshake` | PASS |
| Rust unit + integration | `cargo test -p gwt --all-features` | 全 PASS (`embedded_web` 91 件) |
| Rust core | `cargo test -p gwt-core --all-features` | 全 PASS |
| Lint | `cargo clippy --all-targets --all-features -- -D warnings` | PASS |
| Format | `cargo fmt --check` | PASS |

### User Verification 導線

回帰の root cause が race window のため、自動テストでは race を再現しきれない。以下手順で手動確認をお願いします:

1. **Build**: `cargo build -p gwt --bin gwt`
2. **Launch**: `target/debug/gwt --headless` (既存 GUI が立っていれば共存 OK)
3. **Navigate**: ターミナルに出る `gwt browser URL: http://127.0.0.1:<port>/` を browser で開く
4. **Observe**: 任意 project tab で Claude Code agent pane を新規 launch し、splash 表示中に任意のテキスト / 画像を paste。`resize` / window move を **行わない** 状態で表示が崩れないこと、DevTools console に `gwt initial-fit handshake gave up` の warn が出ないことを確認。

Check items:

- [ ] Claude Code splash + paste 直後に表示崩れなし
- [ ] window resize / move なしで読み取り可能
- [ ] DevTools に handshake gave up warn が出ない (出る場合は perma-hidden window や font load 遅延が長期化している兆候)

## Closing Issues

Closes #2832

## Related Issues

- Refs SPEC-2008 Phase 26.A / FR-056 / FR-057 / FR-059 (lineage)
- Refs `tasks/lessons.md` 2026-05-13 lesson (`xterm fitAddon.fit() は cell.width=0 で silent no-op になる`)
- Lineage of closed Phase 24/26 regressions: #2096 / #2091 / #2668 / #2513
- PR #2693 (Phase 26 一括導入)

## Checklist

- [x] frontend / Rust の自動テスト追加 + GREEN
- [x] `cargo clippy` / `cargo fmt` clean
- [x] `tasks/lessons.md` に再発防止策追記
- [x] Conventional Commits + commitlint OK
- [ ] 手動確認 (User Verification 導線参照)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Issue `#2832`: Fixed terminal initialization regression where visually hidden containers could cause rendering corruption by implementing layout readiness validation before terminal activation.

* **Tests**
  * Enhanced test coverage for terminal initialization behavior, including validation of container layout detection and handshake retry logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2835?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->