### PR TITLE
fix(gui): live headed E2E の update modal 4 failures を解消する

### DIFF
--- a/crates/gwt/web/__tests__/update-button.test.mjs
+++ b/crates/gwt/web/__tests__/update-button.test.mjs
@@ -337,6 +337,64 @@ test("phase19: update_ready transitions modal to ready state with [Later] [Resta
   assert.ok(modal.querySelector("[data-update-modal-later]"));
 });
 
+test("phase19: repeated update_ready for the same version is idempotent (Playwright update-modal.spec.ts harness)", () => {
+  // Live backend re-polls update_state / re-emits update_ready while the
+  // Playwright spec is driving the post-click flow. The old implementation
+  // recreated the entire modal panel on every call, detaching the
+  // [Later] / [Restart now] buttons mid-click and exhausting Playwright's
+  // detach-retry. Pinning idempotency here keeps that harness path green
+  // and protects the production runtime from button churn on transient
+  // duplicate emissions from the update poller.
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+
+  controller.handleUpdateReady({ version: "9.26.0", asset_path: "/x" });
+  const laterFirst = fixture.document.querySelector("[data-update-modal-later]");
+  assert.ok(laterFirst, "first ready render must produce a Later button");
+
+  controller.handleUpdateReady({ version: "9.26.0", asset_path: "/x" });
+  const laterSecond = fixture.document.querySelector("[data-update-modal-later]");
+  assert.strictEqual(
+    laterSecond,
+    laterFirst,
+    "duplicate update_ready with same version must reuse the existing Later button (no detach)",
+  );
+
+  // A new version, in contrast, MUST re-render the panel.
+  controller.handleUpdateReady({ version: "9.27.0", asset_path: "/x" });
+  const laterThird = fixture.document.querySelector("[data-update-modal-later]");
+  assert.notStrictEqual(
+    laterThird,
+    laterFirst,
+    "update_ready with new version must replace the Later button",
+  );
+});
+
+test("phase19: repeated downloading render for same version preserves [Cancel] button (Playwright update-modal.spec.ts harness)", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController(fixture.options);
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+
+  const cancelFirst = fixture.document.querySelector("[data-update-modal-cancel]");
+  assert.ok(cancelFirst, "downloading render must produce a Cancel button");
+
+  // Same-version progress events used to trigger re-render via
+  // updateProgressDisplay paths in older revisions. Calling showAvailable
+  // again (live backend often re-broadcasts on reconnect) used to clear
+  // the modal too. Pin idempotency at the renderModalDownloading layer.
+  controller.showAvailable("9.26.0");
+  fixture.document.getElementById("update-cta").click();
+  const cancelSecond = fixture.document.querySelector("[data-update-modal-cancel]");
+  assert.strictEqual(
+    cancelSecond,
+    cancelFirst,
+    "repeated downloading entry for same version must reuse the existing Cancel button",
+  );
+});
+
 test("SPEC-2780: ready modal exposes 'View release notes' when openReleaseNotes is wired", () => {
   const fixture = createFixture();
   const releaseNotesCalls = [];

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -797,6 +797,47 @@
         socketReceiveDispatcher.handle(event);
       }
 
+      // SPEC-2041 Phase 19 (Issue #2832 follow-up): synthetic event injection
+      // hook used by Playwright spec `update-modal.spec.ts` to drive the
+      // post-click update modal flow without a real GitHub release.
+      // Listeners forward `window.dispatchEvent(new CustomEvent("__gwt_test_inject", { detail: <payload> }))`
+      // straight into `receive(...)`, which is the same entrypoint that
+      // processed WebSocket frames use. The event name is double-underscored
+      // by convention (internal hook) and the payload must be the same
+      // discriminated union the backend emits (e.g. `{ kind: "update_state", ... }`).
+      // No-op without `event.detail.kind` so accidental dispatches do not
+      // misbehave.
+      //
+      // When the test injects an `update_*` event, set the test-mode flag so
+      // subsequent live backend `update_*` messages are dropped — the live
+      // gwt server emits its own real update_state / update_apply_error from
+      // the periodic update checker, which used to race against the
+      // synthetic flow and clobber the modal's reason / detach buttons
+      // mid-click. The flag is page-scoped (no global state outlives the
+      // Playwright page) so it never leaks into the production runtime.
+      let __testInjectModeActive = false;
+      window.addEventListener("__gwt_test_inject", (event) => {
+        const payload = event && event.detail;
+        if (!payload || typeof payload.kind !== "string") {
+          return;
+        }
+        if (payload.kind.startsWith("update_")) {
+          __testInjectModeActive = true;
+        }
+        payload.__injected = true;
+        try {
+          receive(payload);
+        } catch (err) {
+          console.warn("[gwt_test_inject] receive failed", err);
+        }
+      });
+      function shouldDropLiveEventForTestMode(event) {
+        if (!__testInjectModeActive) return false;
+        if (!event || typeof event.kind !== "string") return false;
+        if (event.__injected) return false;
+        return event.kind.startsWith("update_");
+      }
+
       function handleSocketClose() {
         socketReceiveDispatcherGeneration += 1;
         socketReceiveDispatcher = null;
@@ -10226,6 +10267,9 @@
       });
 
       function receive(event) {
+        if (shouldDropLiveEventForTestMode(event)) {
+          return;
+        }
         switch (event.kind) {
           case "workspace_state": {
             projectError = "";

--- a/crates/gwt/web/update-cta.js
+++ b/crates/gwt/web/update-cta.js
@@ -262,7 +262,18 @@ export function createUpdateCtaController({
 
   function renderModalDownloading(version) {
     const modal = ensureModal();
+    // SPEC-2041 Phase 19 (Playwright `update-modal.spec.ts` follow-up): keep
+    // renderModal* idempotent. Repeated identical events (live backend
+    // re-polling update state, retried `apply_update_start`, etc.) used to
+    // detach the action buttons mid-click while the test was driving the
+    // post-ready flow. Detect "no-op" calls by checking the state + the
+    // recorded version dataset, and skip the clearChildren/appendChild
+    // churn.
+    if (modal.dataset.state === "downloading" && modal.dataset.version === String(version || "")) {
+      return;
+    }
     modal.dataset.state = "downloading";
+    modal.dataset.version = String(version || "");
     clearChildren(modal);
 
     const fill = el("div", { className: "update-modal__progress-fill" });
@@ -317,7 +328,12 @@ export function createUpdateCtaController({
 
   function renderModalReady(version) {
     const modal = ensureModal();
+    // See renderModalDownloading: idempotency guard for repeated events.
+    if (modal.dataset.state === "ready" && modal.dataset.version === String(version || "")) {
+      return;
+    }
     modal.dataset.state = "ready";
+    modal.dataset.version = String(version || "");
     clearChildren(modal);
 
     const later = el("button", {
@@ -372,6 +388,7 @@ export function createUpdateCtaController({
   function renderModalFailed({ stage, reason, log_path, message }) {
     const modal = ensureModal();
     modal.dataset.state = "failed";
+    delete modal.dataset.version;
     clearChildren(modal);
 
     // Phase 19 promotes structured `reason`, but `message` is still on the


### PR DESCRIPTION
## Summary

- Live headed Playwright E2E で 7 件あった failures のうち、`update-modal.spec.ts` 4 件 + フロー側 race を根本対処する `__gwt_test_inject` ハンドラと idempotency を導入。
- `update-modal.spec.ts` は SPEC-2041 Phase 19 (PR a57c70b3a) で test scaffold だけ commit され、`__gwt_test_inject` の実装側が抜けていた。今回 app.js に WebSocket と同じ `receive(...)` 経路で event を流す内部 hook を追加。
- live gwt backend の周期的 `update_state` / `update_apply_error` が synthetic test inject を上書きして modal を re-render し、Playwright の `[Later]` click を retry 上限まで枯渇させていた race を、test-mode flag と `renderModal*` idempotency で除去。

## Changes

- `crates/gwt/web/app.js`
  - `__gwt_test_inject` CustomEvent listener を追加。`event.detail` を `payload.__injected = true` でマークし `receive(...)` に転送。`update_*` 系の inject は `__testInjectModeActive` flag を立てる。
  - `receive(event)` に `shouldDropLiveEventForTestMode(event)` ガードを追加。test-mode 中は live backend 由来の非-inject な `update_*` を drop する (production runtime には影響しない page-scoped flag)。
- `crates/gwt/web/update-cta.js`
  - `renderModalDownloading` / `renderModalReady` を idempotent 化 (`modal.dataset.state` + `modal.dataset.version` 一致で no-op)。重複 emission による button detach race を除去。
  - `renderModalFailed` は state 遷移を意図するため version dataset を clear してから再 render。
- `crates/gwt/web/__tests__/update-button.test.mjs`
  - 2 件の RED→GREEN 行動テストを追加 (同 version handleUpdateReady で Later ボタン同一性、同 version downloading entry で Cancel ボタン同一性)。

## Testing

| Surface | Command | Result |
|---------|---------|--------|
| update-cta unit | `node --test crates/gwt/web/__tests__/update-button.test.mjs` | 30 / 30 PASS (新規 2 件含む) |
| Frontend behaviour | `pnpm test:frontend-unit` | 528 / 528 PASS |
| Frontend syntax | `pnpm test:frontend-bundle` | PASS |
| Rust unit + integration | `cargo test -p gwt --all-features` | 全 PASS (embedded_web 91 件) |
| Rust core | `cargo test -p gwt-core --all-features` | 全 PASS |
| Lint | `cargo clippy --all-features --all-targets -- -D warnings` | PASS |
| Format | `cargo fmt --check` | PASS |
| Live headed Playwright (target) | `pnpm exec playwright test --headed crates/gwt/playwright/tests/update-modal.spec.ts` | 4 / 4 PASS (修正前 4 / 4 FAIL) |
| Live headed Playwright (siblings) | release-notes-live × 5 + console-window-live × 4 (small-file 単独) | 全 PASS |

### User Verification 導線

1. **Build**: `cargo build -p gwt --bin gwt`
2. **Launch**: `target/debug/gwt --headless`
3. **Run E2E**: `GWT_PLAYWRIGHT_BASE_URL=http://127.0.0.1:<port>/ pnpm exec playwright test --config crates/gwt/playwright/playwright.config.ts --headed crates/gwt/playwright/tests/update-modal.spec.ts`
4. **Observe**: 4 / 4 PASS。

## Closing Issues

None

## Related Issues

- Refs SPEC-2041 Phase 19 / T-121 (PR a57c70b3a で test scaffold)
- Refs Issue #2832 (Phase 26 regression、本 follow-up はそこから連続する live E2E healing)
- Coordination: Codex @ develop session `4ec36fe1-0347-4e64-b473-ed2e11d1157d` の "live headed E2E failure 原因特定と修正" claim (2026-05-20)

## Known Out-of-Scope (本 PR では扱わない)

- 全 spec parallel 実行時に flaky になる 2-3 件 (`release-notes-live.spec.ts:65` と `chrome.spec.ts:33`): prior `console-window-live` が canvas に Console pane を蓄積し、後続 test の click が intercept される workspace cross-test state pollution。harness lifecycle 側の責務で、Codex @ develop が claim 済み。

## Checklist

- [x] frontend / Rust の自動テスト追加 + GREEN
- [x] `cargo clippy` / `cargo fmt` clean
- [x] Conventional Commits + commitlint pass (footer leading-blank warning は許容範囲)
- [x] 手動 live E2E で対象 spec 4 / 4 PASS 確認済み
- [ ] Codex @ develop による harness flaky 対応との衝突確認 (Board で coordination 済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed update modal from re-rendering unnecessarily when receiving duplicate version events, eliminating UI churn during reconnects and live re-polls.

* **Tests**
  * Added modal idempotency test cases to verify consistent update modal behavior across repeated backend events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2836?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->