### PR TITLE
fix(gui): redact action log urls

### DIFF
--- a/.claude/skills/headless-browser-check/SKILL.md
+++ b/.claude/skills/headless-browser-check/SKILL.md
@@ -51,8 +51,8 @@ not use it for CI-only Playwright runs or generic web app servers.
 7. Monitor until the user is done:
    - Keep the exec session running.
    - Poll output about every 30 seconds.
-   - Also tail recently modified structured logs:
-     `find ~/.gwt/projects -path "*/logs/gwt.log.$(date -u +%F)" -mmin -30`.
+   - Also locate and tail recently modified structured logs:
+     `find ~/.gwt/projects -path "*/logs/gwt.log.$(date -u +%F)" -mmin -30 -print | while IFS= read -r log; do tail -n 200 "$log"; done`.
    - Watch for `panic`, `ERROR`, `WARN`, `failed`, `refused`, `500`, WebSocket
      failures, asset load failures, and unexpected process exit.
    - Do not promise that every window open or click will be logged. Normal UI

--- a/.codex/skills/headless-browser-check/SKILL.md
+++ b/.codex/skills/headless-browser-check/SKILL.md
@@ -51,8 +51,8 @@ not use it for CI-only Playwright runs or generic web app servers.
 7. Monitor until the user is done:
    - Keep the exec session running.
    - Poll output about every 30 seconds.
-   - Also tail recently modified structured logs:
-     `find ~/.gwt/projects -path "*/logs/gwt.log.$(date -u +%F)" -mmin -30`.
+   - Also locate and tail recently modified structured logs:
+     `find ~/.gwt/projects -path "*/logs/gwt.log.$(date -u +%F)" -mmin -30 -print | while IFS= read -r log; do tail -n 200 "$log"; done`.
    - Watch for `panic`, `ERROR`, `WARN`, `failed`, `refused`, `500`, WebSocket
      failures, asset load failures, and unexpected process exit.
    - Do not promise that every window open or click will be logged. Normal UI

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -252,6 +252,25 @@ fn sanitize_ui_action_field(value: &str) -> String {
         .collect()
 }
 
+fn sanitize_ui_action_url(value: &str) -> String {
+    let sanitized = sanitize_ui_action_field(value);
+    let Some((scheme, rest)) = sanitized.split_once("://") else {
+        return sanitized;
+    };
+    let authority = rest
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or_default()
+        .rsplit('@')
+        .next()
+        .unwrap_or_default();
+    if authority.is_empty() {
+        sanitized
+    } else {
+        format!("{scheme}://{authority}")
+    }
+}
+
 fn summarize_ui_action_values<'a>(values: impl IntoIterator<Item = &'a str>) -> String {
     let mut items: Vec<String> = values
         .into_iter()
@@ -271,38 +290,6 @@ fn summarize_ui_action_values<'a>(values: impl IntoIterator<Item = &'a str>) -> 
         }
     }
     summary
-}
-
-fn launch_wizard_action_name(action: &LaunchWizardAction) -> &'static str {
-    match action {
-        LaunchWizardAction::Select { .. } => "select",
-        LaunchWizardAction::Back => "back",
-        LaunchWizardAction::Cancel => "cancel",
-        LaunchWizardAction::SubmitText { .. } => "submit_text",
-        LaunchWizardAction::ApplyQuickStart { .. } => "apply_quick_start",
-        LaunchWizardAction::SetLaunchPath { .. } => "set_launch_path",
-        LaunchWizardAction::SelectQuickStart { .. } => "select_quick_start",
-        LaunchWizardAction::SelectLiveSession { .. } => "select_live_session",
-        LaunchWizardAction::FocusExistingSession { .. } => "focus_existing_session",
-        LaunchWizardAction::SetBranchMode { .. } => "set_branch_mode",
-        LaunchWizardAction::SetBranchType { .. } => "set_branch_type",
-        LaunchWizardAction::SetBranchName { .. } => "set_branch_name",
-        LaunchWizardAction::SetLaunchTarget { .. } => "set_launch_target",
-        LaunchWizardAction::SetAgent { .. } => "set_agent",
-        LaunchWizardAction::SetModel { .. } => "set_model",
-        LaunchWizardAction::SetReasoning { .. } => "set_reasoning",
-        LaunchWizardAction::SetRuntimeTarget { .. } => "set_runtime_target",
-        LaunchWizardAction::SetWindowsShell { .. } => "set_windows_shell",
-        LaunchWizardAction::SetDockerService { .. } => "set_docker_service",
-        LaunchWizardAction::SetDockerLifecycle { .. } => "set_docker_lifecycle",
-        LaunchWizardAction::SetVersion { .. } => "set_version",
-        LaunchWizardAction::SetExecutionMode { .. } => "set_execution_mode",
-        LaunchWizardAction::SetLinkedIssue { .. } => "set_linked_issue",
-        LaunchWizardAction::ClearLinkedIssue => "clear_linked_issue",
-        LaunchWizardAction::SetSkipPermissions { .. } => "set_skip_permissions",
-        LaunchWizardAction::SetCodexFastMode { .. } => "set_codex_fast_mode",
-        LaunchWizardAction::Submit => "submit",
-    }
 }
 
 fn frontend_user_action_log(event: &FrontendEvent) -> Option<FrontendUserActionLog> {
@@ -569,7 +556,7 @@ fn frontend_user_action_log(event: &FrontendEvent) -> Option<FrontendUserActionL
             .count(linked_issue_number.unwrap_or_default() as usize),
         FrontendEvent::LaunchWizardAction { action, .. } => {
             let mut log = FrontendUserActionLog::new("launch_wizard_action", "launch")
-                .mode(launch_wizard_action_name(action));
+                .mode(AppRuntime::launch_wizard_action_label(action));
             match action {
                 LaunchWizardAction::SetAgent { agent_id } => {
                     log = log.agent(agent_id);
@@ -638,7 +625,8 @@ fn frontend_user_action_log(event: &FrontendEvent) -> Option<FrontendUserActionL
             FrontendUserActionLog::new("delete_custom_agent", "custom_agents").agent(agent_id)
         }
         FrontendEvent::TestBackendConnection { base_url, .. } => {
-            FrontendUserActionLog::new("test_backend_connection", "custom_agents").target(base_url)
+            FrontendUserActionLog::new("test_backend_connection", "custom_agents")
+                .target(sanitize_ui_action_url(base_url))
         }
         FrontendEvent::ListAgentBackends { agent } => {
             FrontendUserActionLog::new("list_agent_backends", "agent_backends")
@@ -663,7 +651,7 @@ fn frontend_user_action_log(event: &FrontendEvent) -> Option<FrontendUserActionL
             agent, base_url, ..
         } => FrontendUserActionLog::new("test_agent_backend_connection", "agent_backends")
             .agent(agent.as_str())
-            .target(base_url),
+            .target(sanitize_ui_action_url(base_url)),
         FrontendEvent::StartMigration { tab_id } => {
             FrontendUserActionLog::new("start_migration", "migration").target(tab_id)
         }
@@ -12861,6 +12849,38 @@ exit 1
                 .values()
                 .any(|value| value.contains("must-not-leak")),
             "env values must not be written to the user action log: {action:?}"
+        );
+    }
+
+    #[test]
+    fn frontend_user_action_redacts_backend_test_url_secrets() {
+        let custom_agent_log =
+            super::frontend_user_action_log(&FrontendEvent::TestBackendConnection {
+                base_url: "https://user:pass@example.com/v1?token=secret#frag".to_string(),
+                api_key: "api-key-must-not-leak".to_string(),
+            })
+            .expect("custom agent backend test action log");
+        assert_eq!(custom_agent_log.ui_target, "https://example.com");
+
+        let builtin_agent_log =
+            super::frontend_user_action_log(&FrontendEvent::TestAgentBackendConnection {
+                agent: gwt_agent::BuiltinAgentId::Codex,
+                base_url: "http://token@example.net:11434/openai?signed=secret".to_string(),
+                api_key: "agent-key-must-not-leak".to_string(),
+            })
+            .expect("builtin agent backend test action log");
+        assert_eq!(builtin_agent_log.ui_target, "http://example.net:11434");
+
+        let logged_values = [
+            custom_agent_log.ui_target.as_str(),
+            builtin_agent_log.ui_target.as_str(),
+        ];
+        assert!(
+            !logged_values.iter().any(|value| value.contains("user")
+                || value.contains("pass")
+                || value.contains("token")
+                || value.contains("secret")),
+            "backend test URLs must not leak credentials or query strings: {logged_values:?}"
         );
     }
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -5830,3 +5830,25 @@ Agent window 内の TTY 表示が白一色になった。
 2. `NO_COLOR` を profile env で明示した場合は尊重し、親 process 由来の値だけを剥がす。
 3. WebView の色回帰を調査するときは、xterm.css の読み込み、WebSocket payload の SGR、
    frontend DOM の computed color、launch env の順に切り分ける。
+
+## URL をユーザー操作ログに出すときは authority までに正規化する
+
+### 事象
+
+`gwt_ui_action` の backend connection test ログで `api_key` は出力していなかったが、`base_url` を
+そのまま `ui_target` に入れていたため、userinfo や signed query を含む URL がログに残る可能性があった。
+
+### 原因
+
+既存の `sanitize_ui_action_field()` は改行や制御文字をログ向けに整形するだけで、URL の
+credential / path / query / fragment を機密情報として扱っていなかった。レビューでは
+`https://user:pass@example.com/v1?token=...` のような入力がそのまま残る点を指摘された。
+
+### 再発防止策
+
+1. ユーザー操作ログに外部 URL を入れるときは、既定で `scheme://authority` までに正規化し、
+   userinfo / path / query / fragment を落とす。
+2. `api_key` の非出力だけで安全と判断せず、URL 自体に credential や token が含まれるケースを
+   regression test に入れる。
+3. ログ sanitization の helper 名は「format sanitization」と「secret redaction」を区別し、
+   期待する保護範囲をテスト名で明示する。


### PR DESCRIPTION
## Summary

- Redacts backend test URLs in `gwt_ui_action` logs so credentials, paths, query strings, and fragments are not persisted.
- Follows up on the CodeRabbit review from PR #2837 while keeping the original frontend action logging behavior intact.

## Changes

- `crates/gwt/src/app_runtime/mod.rs`: logs backend test URL targets as `scheme://authority` and adds a regression test for credential/query redaction.
- `crates/gwt/src/app_runtime/mod.rs`: reuses `AppRuntime::launch_wizard_action_label()` instead of maintaining a duplicate launch wizard action mapping.
- `.codex/skills/headless-browser-check/SKILL.md` and `.claude/skills/headless-browser-check/SKILL.md`: update the monitoring instruction so agents actually tail recently modified structured logs.
- `tasks/lessons.md`: records the URL logging redaction lesson from this review.

## Testing

- [x] `cargo test -p gwt frontend_user_action_redacts_backend_test_url_secrets --all-features` — PASS.
- [x] `cargo test -p gwt app_runtime_logs_profile_save_user_action_without_env_values --all-features` — PASS.
- [x] `cargo test -p gwt-core -p gwt --all-features` — PASS.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — PASS.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — PASS.
- [x] `cargo fmt -- --check` — PASS.
- [x] `git diff --check` — PASS.
- [x] `bun run lint:skills` — PASS.
- [x] `bunx markdownlint-cli2 tasks/lessons.md` — PASS.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — PASS.
- [x] `git push -u origin work/20260520-0925` pre-push checks — PASS, including 90.49% filtered line coverage.

## Closing Issues

None

## Related Issues / Links

- #2837

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (skill instructions and lesson note)
- [ ] Migration/backfill plan included — Not applicable; no schema or data migration.
- [x] CHANGELOG impact considered (patch-level fix, no breaking change)

## Context

- PR #2837 added structured frontend action logging and was merged, but CodeRabbit correctly identified that backend connection test URLs could include credentials or signed query parameters.

## Risk / Impact

- **Affected areas**: structured `gwt_ui_action` logging for backend connection test actions and generated headless browser check skill instructions.
- **Rollback plan**: revert this commit; logging will return to the previous unsanitized URL target behavior.
