### PR TITLE
fix(gui): recover Branches loading after reconnect

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -607,6 +607,29 @@ test("Branches remains a branch browser, not a planning workspace", () => {
   );
 });
 
+test("Branches loading state becomes recoverable when the WebSocket disconnects", () => {
+  assert.match(
+    appSource,
+    /function\s+failLoadingBranchesOnConnectionLoss\(windowId,\s*state\)/,
+    "expected a dedicated Branches loading connection-loss helper",
+  );
+  assert.match(
+    appSource,
+    /failLoadingBranchesOnConnectionLoss[\s\S]+state\.loading\s*=\s*false[\s\S]+state\.receivedFreshEntries\s*=\s*false/,
+    "expected connection loss to clear stale Branches loading flags",
+  );
+  assert.match(
+    appSource,
+    /Connection lost while loading branches/,
+    "expected initial branch inventory loss to surface a retryable error",
+  );
+  assert.match(
+    appSource,
+    /function\s+setConnectionState\(connected\)[\s\S]+failLoadingBranchesOnConnectionLoss\(windowId,\s*state\)[\s\S]+renderBranches\(windowId\)/,
+    "expected socket disconnect to re-render Branches after clearing stale loading",
+  );
+});
+
 test("hotkey overlay lists ⌘P/⌘B/⌘G/⌘L/⌘?/Esc (sidebar toggle hotkey is removed in Phase 9)", () => {
   const overlay = document.getElementById("op-hotkey-overlay");
   assert.ok(overlay, "hotkey overlay missing");

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -747,13 +747,20 @@
           strip.classList.toggle("op-status-strip--offline", !connected);
         }
         if (!connected) {
-          for (const [windowId] of branchListStateMap.entries()) {
+          for (const [windowId, state] of branchListStateMap.entries()) {
+            let shouldRenderBranches = false;
             if (
               failRunningBranchCleanup(
                 windowId,
                 "Connection lost while cleaning up branches",
               )
             ) {
+              shouldRenderBranches = true;
+            }
+            if (failLoadingBranchesOnConnectionLoss(windowId, state)) {
+              shouldRenderBranches = true;
+            }
+            if (shouldRenderBranches) {
               renderBranches(windowId);
             }
           }
@@ -8290,6 +8297,23 @@
           return "";
         }
         return state.entries.length === 0 ? "" : "Loading branch details";
+      }
+
+      function failLoadingBranchesOnConnectionLoss(windowId, state) {
+        if (!state || !state.loading) {
+          return false;
+        }
+        state.loading = false;
+        state.receivedFreshEntries = false;
+        if (state.entries.length === 0) {
+          state.error = "Connection lost while loading branches";
+          state.notice = "";
+        } else {
+          state.error = "";
+          state.notice = "Connection lost while loading branch details";
+        }
+        syncBranchSelectionState(state);
+        return true;
       }
 
       function branchCleanupPendingText(state) {


### PR DESCRIPTION
## Summary

- Recover the Branches window when a WebSocket reconnect interrupts branch loading.
- Clear stale loading state on connection loss so Refresh can retry instead of leaving `Loading branches` stuck.
- Cover the recovery path with a frontend structure regression test.

## Changes

- `crates/gwt/web/app.js`: add a connection-loss helper that clears Branches loading state, surfaces a retryable initial-load error, and preserves partial branch rows with a notice during detail hydration.
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: add a regression test for WebSocket disconnect recovery while Branches is loading.

## Testing

- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — PASS, including the new Branches disconnect recovery contract.
- [x] `node --check crates/gwt/web/app.js` — PASS.
- [x] `pnpm test:frontend-bundle` — PASS.
- [x] `pnpm test:frontend-unit` — PASS, 531 tests.
- [x] `cargo test -p gwt embedded_web_branches_surface --all-features` — PASS.
- [x] `cargo fmt -- --check` — PASS.
- [x] `cargo test -p gwt-core -p gwt --all-features -- --test-threads=1` — PASS.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — PASS.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — PASS.
- [x] `pnpm run --silent test:visual -- --project=chromium-dark crates/gwt/playwright/tests/branch-cleanup.spec.ts` — PASS, 2 tests.
- [x] Manual check via `target/debug/gwt serve` — confirmed Branches window no longer stays stuck on `Loading branches`.

## Closing Issues

None

## Related Issues / Links

- #2009

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (not required: no README or user-guide behavior changed)
- [ ] Migration/backfill plan included (not required: no schema or data migration)
- [x] CHANGELOG impact considered (patch fix via `fix:` commit)

## Context

- SPEC-2009 owns the Branches window. The failure mode was that branch load replies are scoped to the WebSocket client id; if reconnect happens mid-load, the old reply can be dropped and frontend `state.loading` remains true.

## Risk / Impact

- **Affected areas**: Branches window connection-loss recovery and loading notices.
- **Rollback plan**: Revert this PR to restore the previous Branches loading behavior.

## Screenshots

Manual verification was performed in `gwt serve`; no visual layout change is introduced by this recovery-state fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of WebSocket connection loss during branch loading. The UI now properly clears loading states and displays relevant messages, preventing stuck loading indicators. Branch data automatically refreshes once the connection is restored.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2840?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->