### PR TITLE
fix(gui): stabilize terminal initial fit

### DIFF
--- a/.claude/skills/headless-browser-check/SKILL.md
+++ b/.claude/skills/headless-browser-check/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: headless-browser-check
-description: Use when a user needs a manual browser check of this gwt project, asks to launch gwt in headless or serve mode, or wants the agent to monitor logs while they inspect the UI.
+description: Use when a user needs a manual browser check of this gwt project, asks to launch gwt in headless or serve mode, or needs a served browser URL for UI inspection.
 ---
 
 # Headless Browser Check
 
 Run the gwt GUI as a headless browser-served app, hand the browser URL to the
-user, and stay on log watch while the user checks the UI.
+user, and wait for the user's visual confirmation.
 
 ## Scope
 
@@ -44,29 +44,19 @@ not use it for CI-only Playwright runs or generic web app servers.
    - The URL.
    - The log file path.
    - That the startup/stdout log may stay quiet during normal UI actions.
-   - That the agent is also watching recent project structured logs under
-     `~/.gwt/projects/*/logs/gwt.log.<date>` for backend events, access logs,
-     warnings, and errors.
    - Ask them to report what they see, or say when they are done.
-7. Monitor until the user is done:
+7. Wait until the user is done:
    - Keep the exec session running.
-   - Poll output about every 30 seconds.
-   - Also locate and tail recently modified structured logs:
-     `find ~/.gwt/projects -path "*/logs/gwt.log.$(date -u +%F)" -mmin -30 -print | while IFS= read -r log; do tail -n 200 "$log"; done`.
-   - Watch for `panic`, `ERROR`, `WARN`, `failed`, `refused`, `500`, WebSocket
-     failures, asset load failures, and unexpected process exit.
-   - Do not promise that every window open or click will be logged. Normal UI
-     actions may show only HTTP/WebSocket/access activity, not semantic window
-     names.
-   - Summarize only meaningful new log events. If nothing changed, say so
-     briefly.
-   - If the user reports a UI problem, immediately inspect recent server output
-     and the log file before proposing fixes.
+   - Do not poll or tail logs on a timer while the user inspects the UI.
+   - Do not run periodic structured-log checks under
+     `~/.gwt/projects/*/logs/gwt.log.<date>`.
+   - If the user reports a UI problem, inspect recent server output, the
+     startup/stdout log file, and then relevant structured logs before
+     proposing fixes.
 8. Shutdown:
    - When the user says the check is finished, send Ctrl-C to the headless
      process and wait for it to exit.
-   - Report any observed log issues, the tested URL, and whether shutdown was
-     clean.
+   - Report the tested URL and whether shutdown was clean.
 
 ## Guardrails
 

--- a/.codex/skills/headless-browser-check/SKILL.md
+++ b/.codex/skills/headless-browser-check/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: headless-browser-check
-description: Use when a user needs a manual browser check of this gwt project, asks to launch gwt in headless or serve mode, or wants the agent to monitor logs while they inspect the UI.
+description: Use when a user needs a manual browser check of this gwt project, asks to launch gwt in headless or serve mode, or needs a served browser URL for UI inspection.
 ---
 
 # Headless Browser Check
 
 Run the gwt GUI as a headless browser-served app, hand the browser URL to the
-user, and stay on log watch while the user checks the UI.
+user, and wait for the user's visual confirmation.
 
 ## Scope
 
@@ -44,29 +44,19 @@ not use it for CI-only Playwright runs or generic web app servers.
    - The URL.
    - The log file path.
    - That the startup/stdout log may stay quiet during normal UI actions.
-   - That the agent is also watching recent project structured logs under
-     `~/.gwt/projects/*/logs/gwt.log.<date>` for backend events, access logs,
-     warnings, and errors.
    - Ask them to report what they see, or say when they are done.
-7. Monitor until the user is done:
+7. Wait until the user is done:
    - Keep the exec session running.
-   - Poll output about every 30 seconds.
-   - Also locate and tail recently modified structured logs:
-     `find ~/.gwt/projects -path "*/logs/gwt.log.$(date -u +%F)" -mmin -30 -print | while IFS= read -r log; do tail -n 200 "$log"; done`.
-   - Watch for `panic`, `ERROR`, `WARN`, `failed`, `refused`, `500`, WebSocket
-     failures, asset load failures, and unexpected process exit.
-   - Do not promise that every window open or click will be logged. Normal UI
-     actions may show only HTTP/WebSocket/access activity, not semantic window
-     names.
-   - Summarize only meaningful new log events. If nothing changed, say so
-     briefly.
-   - If the user reports a UI problem, immediately inspect recent server output
-     and the log file before proposing fixes.
+   - Do not poll or tail logs on a timer while the user inspects the UI.
+   - Do not run periodic structured-log checks under
+     `~/.gwt/projects/*/logs/gwt.log.<date>`.
+   - If the user reports a UI problem, inspect recent server output, the
+     startup/stdout log file, and then relevant structured logs before
+     proposing fixes.
 8. Shutdown:
    - When the user says the check is finished, send Ctrl-C to the headless
      process and wait for it to exit.
-   - Report any observed log issues, the tested URL, and whether shutdown was
-     clean.
+   - Report the tested URL and whether shutdown was clean.
 
 ## Guardrails
 

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -856,7 +856,7 @@ mod tests {
         // is false so we do not flip isReady while hidden, and (b) only
         // mark the runtime ready after activation succeeds.
         let handshake_helper = regex::Regex::new(
-            r#"(?s)function completeInitialFitHandshake\(windowId\) \{[\s\S]*?if \(!runtime \|\| runtime\.isReady\) \{[\s\S]*?return;[\s\S]*?\}[\s\S]*?if \(!canRefreshTerminalViewport\(windowId\)\) \{[\s\S]*?return;[\s\S]*?\}[\s\S]*?runTerminalActivationSequence\(\{[\s\S]*?\}\);\s*runtime\.isReady = true;[\s\S]*?const snapshot = pendingSnapshotMap\.get\(windowId\);[\s\S]*?const pending = pendingOutputMap\.get\(windowId\);[\s\S]*?if \(runtime\.deferredWrites\.length\) \{[\s\S]*?for \(const chunk of flush\) \{[\s\S]*?writeOutput\(windowId, chunk\);[\s\S]*?\}[\s\S]*?\}"#,
+            r#"(?s)function completeInitialFitHandshake\(windowId\) \{[\s\S]*?if \(!runtime \|\| runtime\.isReady\) \{[\s\S]*?return;[\s\S]*?\}[\s\S]*?if \(!canRefreshTerminalViewport\(windowId\)\) \{[\s\S]*?return;[\s\S]*?\}[\s\S]*?const activation = runTerminalActivationSequence\(\{[\s\S]*?\}\);\s*if \(!activation\.ran\) \{[\s\S]*?retryInitialFitHandshake\(windowId, runtime,[\s\S]*?return;[\s\S]*?\}\s*runtime\.handshakeAttempts = 0;\s*runtime\.isReady = true;[\s\S]*?const snapshot = pendingSnapshotMap\.get\(windowId\);[\s\S]*?const pending = pendingOutputMap\.get\(windowId\);[\s\S]*?if \(runtime\.deferredWrites\.length\) \{[\s\S]*?for \(const chunk of flush\) \{[\s\S]*?writeOutput\(windowId, chunk\);[\s\S]*?\}[\s\S]*?\}"#,
         )
         .expect("valid regex");
         // Hidden → visible activation path also needs to drive the
@@ -919,7 +919,7 @@ mod tests {
         // resize-recovers-on-move signature documented in
         // tasks/lessons.md 2026-05-13.
         let layout_box_gate = regex::Regex::new(
-            r#"(?s)function completeInitialFitHandshake\(windowId\) \{[\s\S]*?if \(!canRefreshTerminalViewport\(windowId\)\) \{[\s\S]*?return;[\s\S]*?\}[\s\S]*?if \(!terminalContainerHasLayoutBox\(windowId\)\) \{\s*runtime\.handshakeAttempts = \(runtime\.handshakeAttempts \|\| 0\) \+ 1;[\s\S]*?if \(runtime\.handshakeAttempts <= HANDSHAKE_RETRY_LIMIT\) \{\s*requestAnimationFrame\(\(\) => completeInitialFitHandshake\(windowId\)\);\s*return;\s*\}"#,
+            r#"(?s)function completeInitialFitHandshake\(windowId\) \{[\s\S]*?if \(!canRefreshTerminalViewport\(windowId\)\) \{[\s\S]*?return;[\s\S]*?\}[\s\S]*?if \(!terminalContainerHasLayoutBox\(windowId\)\) \{\s*retryInitialFitHandshake\(windowId, runtime,[\s\S]*?\);\s*return;\s*\}"#,
         )
         .expect("valid regex");
         assert!(
@@ -933,6 +933,11 @@ mod tests {
         assert!(
             html.contains("function terminalContainerHasLayoutBox(windowId)"),
             "expected app.js to expose terminalContainerHasLayoutBox so the handshake can gate on layout (Issue #2832)",
+        );
+        assert!(
+            html.contains("const terminalHost = runtime?.terminal?.element?.parentElement;")
+                && html.contains("return elementHasLayoutBox(terminalHost);"),
+            "expected terminalContainerHasLayoutBox to measure the actual xterm host before falling back to the outer workspace window (Issue #2839)",
         );
         assert!(
             html.contains("const HANDSHAKE_RETRY_LIMIT ="),

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -5418,6 +5418,9 @@ mod tests {
 
     #[test]
     fn docker_launch_plan_and_helper_logic_cover_defaults_and_errors() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let temp = tempdir().expect("tempdir");
         let project = temp.path().join("project");
         let devcontainer_dir = project.join(".devcontainer");
@@ -5547,6 +5550,9 @@ mod tests {
     fn wizard_docker_context_detection_does_not_spawn_docker_cli() {
         use std::os::unix::fs::PermissionsExt;
 
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let temp = tempdir().expect("tempdir");
         let project = temp.path().join("project");
         fs::create_dir_all(&project).expect("project dir");
@@ -5592,6 +5598,9 @@ mod tests {
 
     #[test]
     fn finalize_docker_agent_launch_config_wraps_runtime_command_in_compose_exec() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let temp = tempdir().expect("tempdir");
         let project = temp.path().join("project");
         fs::create_dir_all(&project).expect("create project");
@@ -5636,6 +5645,9 @@ mod tests {
 
     #[test]
     fn finalize_docker_agent_launch_config_includes_override_file_when_present() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let temp = tempdir().expect("tempdir");
         let project = temp.path().join("project");
         fs::create_dir_all(&project).expect("create project");

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -956,7 +956,10 @@ test("xterm content stays on the dark Operator palette across app theme changes"
 
 test("xterm developer readability defaults use larger font metrics", () => {
   assert.ok(terminalOptionNumber("fontSize") >= 14, "xterm fontSize must be at least 14px");
-  assert.ok(terminalOptionNumber("lineHeight") >= 1.25, "xterm lineHeight must be at least 1.25");
+  assert.ok(
+    terminalOptionNumber("lineHeight") >= 1.3,
+    "xterm lineHeight must be at least 1.30 to avoid cramped SS.mov output",
+  );
 });
 
 test("operator-shell wires hover-reveal chrome and Mission Briefing early dismiss", () => {

--- a/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
@@ -172,6 +172,8 @@ test("runTerminalActivationSequence renders before fit and emits geometry (T-199
   const callOrder = [];
   let layoutFlushed = 0;
   const parent = {
+    clientWidth: 800,
+    clientHeight: 480,
     getBoundingClientRect: () => {
       callOrder.push("flush-layout");
       layoutFlushed += 1;
@@ -238,6 +240,80 @@ test("runTerminalActivationSequence honours shouldFocus / shouldPersistGeometry 
   // sendGeometry / focus are suppressed by the flags.
   assert.deepEqual(callOrder, ["refresh", "fit"]);
   assert.equal(result.ran, true);
+});
+
+test("runTerminalActivationSequence waits for the terminal host layout box before fitting (#2839)", () => {
+  const callOrder = [];
+  const runtime = {
+    terminal: {
+      cols: 80,
+      rows: 24,
+      element: {
+        parentElement: {
+          clientWidth: 0,
+          clientHeight: 360,
+          getBoundingClientRect: () => {
+            callOrder.push("flush-layout");
+            return { width: 0, height: 360 };
+          },
+        },
+      },
+      refresh: () => callOrder.push("refresh"),
+      focus: () => callOrder.push("focus"),
+    },
+    fitAddon: {
+      fit: () => callOrder.push("fit"),
+      proposeDimensions: () => ({ cols: 100, rows: 28 }),
+    },
+  };
+
+  const result = runTerminalActivationSequence({
+    runtime,
+    windowId: "win-layout-pending",
+    sendGeometry: () => callOrder.push("sendGeometry"),
+  });
+
+  assert.deepEqual(callOrder, [], "0-size terminal host must not fit, send geometry, or focus");
+  assert.deepEqual(result, { ran: false, cols: 80, rows: 24 });
+});
+
+test("runTerminalActivationSequence waits when xterm fit dimensions are unavailable (#2839)", () => {
+  const callOrder = [];
+  const runtime = {
+    terminal: {
+      cols: 80,
+      rows: 24,
+      element: {
+        parentElement: {
+          clientWidth: 800,
+          clientHeight: 420,
+          getBoundingClientRect: () => {
+            callOrder.push("flush-layout");
+            return { width: 800, height: 420 };
+          },
+        },
+      },
+      refresh: () => callOrder.push("refresh"),
+      focus: () => callOrder.push("focus"),
+    },
+    fitAddon: {
+      fit: () => callOrder.push("fit"),
+      proposeDimensions: () => undefined,
+    },
+  };
+
+  const result = runTerminalActivationSequence({
+    runtime,
+    windowId: "win-cell-pending",
+    sendGeometry: () => callOrder.push("sendGeometry"),
+  });
+
+  assert.deepEqual(
+    callOrder,
+    ["refresh", "flush-layout"],
+    "unresolved xterm cell metrics must not fit, send geometry, or focus",
+  );
+  assert.deepEqual(result, { ran: false, cols: 80, rows: 24 });
 });
 
 test("runTerminalActivationSequence is a no-op when runtime is missing pieces (T-199)", () => {
@@ -387,6 +463,11 @@ test("app.js wires the reflow controller for resize, transition, and predicate",
     appSource,
     /terminalContainerHasLayoutBox\(windowId\)/,
     "completeInitialFitHandshake must consult terminalContainerHasLayoutBox",
+  );
+  assert.match(
+    appSource,
+    /function terminalContainerHasLayoutBox\(windowId\) \{[\s\S]*?terminalMap\.get\(windowId\)[\s\S]*?parentElement[\s\S]*?elementHasLayoutBox/,
+    "terminalContainerHasLayoutBox must measure the actual xterm host, not only the outer workspace window",
   );
   assert.match(
     appSource,

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -2077,11 +2077,27 @@
       const HANDSHAKE_RETRY_LIMIT = 60;
 
       function terminalContainerHasLayoutBox(windowId) {
+        const runtime = terminalMap.get(windowId);
+        const terminalHost = runtime?.terminal?.element?.parentElement;
+        if (terminalHost) {
+          return elementHasLayoutBox(terminalHost);
+        }
         const element = windowMap.get(windowId);
         // Fall through to true when the element is not registered yet — the
         // initial-fit handshake is gated by canRefreshTerminalViewport which
         // already short-circuits the no-element case.
         return elementHasLayoutBox(element);
+      }
+
+      function retryInitialFitHandshake(windowId, runtime, reason) {
+        runtime.handshakeAttempts = (runtime.handshakeAttempts || 0) + 1;
+        if (runtime.handshakeAttempts <= HANDSHAKE_RETRY_LIMIT) {
+          requestAnimationFrame(() => completeInitialFitHandshake(windowId));
+          return;
+        }
+        console.warn(
+          `[gwt] terminal ${windowId} initial-fit handshake gave up after ${HANDSHAKE_RETRY_LIMIT} attempts; ${reason}.`,
+        );
       }
 
       function fitTerminal(windowId, persist = false) {
@@ -2100,11 +2116,13 @@
               }
               return;
             }
-            runtime.fitAddon.fit();
-            if (!persist) {
-              return;
-            }
-            sendGeometry(windowId, runtime.terminal.cols, runtime.terminal.rows);
+            runTerminalActivationSequence({
+              runtime,
+              windowId,
+              shouldFocus: false,
+              shouldPersistGeometry: persist,
+              sendGeometry,
+            });
           }
         );
       }
@@ -3373,7 +3391,7 @@
           fontFamily:
             "var(--font-mono), ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
           fontSize: 14,
-          lineHeight: 1.28,
+          lineHeight: 1.3,
           scrollback: 5000,
         });
         const fitAddon = new FitAddon();
@@ -3483,23 +3501,22 @@
         // non-zero box, with an attempt ceiling so a perma-hidden window
         // can not pin the loop.
         if (!terminalContainerHasLayoutBox(windowId)) {
-          runtime.handshakeAttempts = (runtime.handshakeAttempts || 0) + 1;
-          if (runtime.handshakeAttempts <= HANDSHAKE_RETRY_LIMIT) {
-            requestAnimationFrame(() => completeInitialFitHandshake(windowId));
-            return;
-          }
-          console.warn(
-            `[gwt] terminal ${windowId} initial-fit handshake gave up after ${HANDSHAKE_RETRY_LIMIT} attempts; container stayed 0-size. Falling back to immediate activation.`,
-          );
+          retryInitialFitHandshake(windowId, runtime, "terminal host stayed 0-size");
+          return;
         }
 
-        runTerminalActivationSequence({
+        const activation = runTerminalActivationSequence({
           runtime,
           windowId,
           shouldFocus: false,
           shouldPersistGeometry: true,
           sendGeometry,
         });
+        if (!activation.ran) {
+          retryInitialFitHandshake(windowId, runtime, "xterm fit dimensions stayed unavailable");
+          return;
+        }
+        runtime.handshakeAttempts = 0;
         runtime.isReady = true;
 
         const snapshot = pendingSnapshotMap.get(windowId);

--- a/crates/gwt/web/terminal-viewport-reflow.js
+++ b/crates/gwt/web/terminal-viewport-reflow.js
@@ -141,6 +141,25 @@ export function elementHasLayoutBox(element) {
   return true;
 }
 
+function currentTerminalGrid(terminal) {
+  return {
+    cols: typeof terminal?.cols === "number" ? terminal.cols : 0,
+    rows: typeof terminal?.rows === "number" ? terminal.rows : 0,
+  };
+}
+
+function fitAddonCanResolveDimensions(fitAddon) {
+  if (typeof fitAddon?.proposeDimensions !== "function") return true;
+  const dimensions = fitAddon.proposeDimensions();
+  return (
+    !!dimensions &&
+    Number.isFinite(dimensions.cols) &&
+    Number.isFinite(dimensions.rows) &&
+    dimensions.cols > 0 &&
+    dimensions.rows > 0
+  );
+}
+
 /**
  * SPEC-2008 Phase 26.B / FR-056 — terminal activation must render BEFORE
  * fit. Phase 24 activation called fitAddon.fit() first, then scheduled a
@@ -181,11 +200,18 @@ export function runTerminalActivationSequence({
     return { ran: false, cols: 0, rows: 0 };
   }
   const { terminal, fitAddon } = runtime;
+  const currentGrid = currentTerminalGrid(terminal);
+  const parent = terminal.element && terminal.element.parentElement;
+  if (parent && !elementHasLayoutBox(parent)) {
+    return { ran: false, cols: currentGrid.cols, rows: currentGrid.rows };
+  }
   const rowsForRefresh = Math.max((terminal.rows || 1) - 1, 0);
   terminal.refresh(0, rowsForRefresh);
-  const parent = terminal.element && terminal.element.parentElement;
   if (parent && typeof parent.getBoundingClientRect === "function") {
     parent.getBoundingClientRect();
+  }
+  if (!fitAddonCanResolveDimensions(fitAddon)) {
+    return { ran: false, cols: currentGrid.cols, rows: currentGrid.rows };
   }
   fitAddon.fit();
   if (shouldPersistGeometry && typeof sendGeometry === "function") {


### PR DESCRIPTION
## Summary

Stabilize the terminal's initial layout readiness and fit flow so xterm does not render against incomplete metrics, then update the headless browser check skill to remove continuous log polling while a user visually inspects the UI.

## Changes

- Gate terminal readiness on concrete terminal host/root metrics before flushing deferred writes and snapshots.
- Serialize Docker runtime environment tests that mutate process-wide environment state.
- Remove periodic structured-log polling from the `headless-browser-check` skill in both Codex and Claude skill surfaces.
- Keep log inspection available only for startup failures or user-reported UI problems.

## Testing

- `pnpm run test:frontend-unit`
- `pnpm run test:frontend-bundle`
- `cargo test -p gwt-core -p gwt --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build -p gwt --bin gwt --bin gwtd`
- `bash scripts/validate-skill-frontmatter.sh`
- `git diff --check`
- `bunx commitlint --from origin/develop --to HEAD`
- `git push origin HEAD` pre-push CI-equivalent checks, including filtered coverage 90.48%

## Closing Issues

Closes #2839

## Related Issues

- #2832

## Checklist

- [x] Branch pushed to origin.
- [x] Commit messages pass commitlint for `origin/develop..HEAD`.
- [x] Skill instructions updated for both Codex and Claude surfaces.
- [x] User confirmed the headless UI check was OK before the skill-only update.
- [x] `SS.mov` remains local evidence and is not included in the PR.
