### PR TITLE
feat(workspace): 復元可能なエージェントセッションを自動再開する

### DIFF
--- a/crates/gwt-agent/src/lib.rs
+++ b/crates/gwt-agent/src/lib.rs
@@ -49,11 +49,12 @@ pub use presets::{
     PresetDefinition, PresetError, PresetId,
 };
 pub use session::{
-    persist_agent_session_id, persist_session_status, reset_runtime_state_dir,
-    reset_runtime_state_dir_for_pid, runtime_state_dir_for_pid, runtime_state_path,
-    runtime_state_path_for_pid, sessions_dir_from_runtime_path, PendingDiscussionResume, Session,
-    SessionRuntimeState, GWT_BIN_PATH_ENV, GWT_HOOK_FORWARD_TOKEN_ENV, GWT_HOOK_FORWARD_URL_ENV,
-    GWT_SESSION_ID_ENV, GWT_SESSION_RUNTIME_PATH_ENV,
+    persist_agent_session_id, persist_session_completed_stop, persist_session_hook_event,
+    persist_session_status, reset_runtime_state_dir, reset_runtime_state_dir_for_pid,
+    runtime_state_dir_for_pid, runtime_state_path, runtime_state_path_for_pid,
+    sessions_dir_from_runtime_path, PendingDiscussionResume, Session, SessionRuntimeState,
+    GWT_BIN_PATH_ENV, GWT_HOOK_FORWARD_TOKEN_ENV, GWT_HOOK_FORWARD_URL_ENV, GWT_SESSION_ID_ENV,
+    GWT_SESSION_RUNTIME_PATH_ENV,
 };
 pub use store::{
     load_custom_agents_from_path, load_stored_custom_agents_from_path,

--- a/crates/gwt-agent/src/session.rs
+++ b/crates/gwt-agent/src/session.rs
@@ -85,6 +85,12 @@ pub struct Session {
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub last_activity_at: DateTime<Utc>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_hook_event: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_hook_event_at: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_completed_stop_at: Option<DateTime<Utc>>,
     pub display_name: String,
 }
 
@@ -113,7 +119,7 @@ impl Session {
     /// Current persisted session schema version. SPEC-1921 Phase 53 / FR-066.
     /// Bump when adding a new migration in `migrate_legacy_launch_args` and
     /// ensure the new migration is idempotent relative to this value.
-    pub const CURRENT_SCHEMA_VERSION: u32 = 2;
+    pub const CURRENT_SCHEMA_VERSION: u32 = 3;
 
     /// Create a new session with a generated UUID.
     pub fn new(
@@ -153,6 +159,9 @@ impl Session {
             created_at: now,
             updated_at: now,
             last_activity_at: now,
+            last_hook_event: None,
+            last_hook_event_at: None,
+            last_completed_stop_at: None,
             display_name,
         }
     }
@@ -194,6 +203,61 @@ impl Session {
         if status == AgentStatus::Running || status == AgentStatus::WaitingInput {
             self.last_activity_at = now;
         }
+    }
+
+    /// Persist that a managed runtime hook was observed for this session.
+    pub fn record_hook_event(&mut self, event: &str) {
+        let now = Utc::now();
+        self.last_hook_event = Some(event.to_string());
+        self.last_hook_event_at = Some(now);
+        self.updated_at = now;
+        if let Some(status) = hook_event_status(event) {
+            self.update_status(status);
+        }
+    }
+
+    /// Persist that the latest Stop hook was allowed to complete.
+    pub fn record_completed_stop(&mut self) {
+        let now = Utc::now();
+        self.last_completed_stop_at = Some(now);
+        self.updated_at = now;
+        if self.last_hook_event.as_deref() != Some("Stop") {
+            self.last_hook_event = Some("Stop".to_string());
+            self.last_hook_event_at = Some(now);
+        }
+        self.update_status(AgentStatus::WaitingInput);
+    }
+
+    /// Whether the latest hook lifecycle indicates the session did not reach a
+    /// completed Stop boundary.
+    pub fn should_mark_interrupted_from_lifecycle(&self) -> bool {
+        if self.status == AgentStatus::Stopped {
+            return false;
+        }
+        let Some(last_hook_event_at) = self.last_hook_event_at else {
+            return false;
+        };
+        if self.last_hook_event.as_deref() != Some("Stop") {
+            return true;
+        }
+        self.last_completed_stop_at
+            .is_none_or(|completed_at| completed_at < last_hook_event_at)
+    }
+
+    pub fn interrupted_recovery_candidate(&self) -> bool {
+        self.status == AgentStatus::Interrupted && self.worktree_path.exists()
+    }
+
+    pub fn exact_auto_resume_candidate(&self) -> bool {
+        matches!(
+            self.status,
+            AgentStatus::Running | AgentStatus::WaitingInput | AgentStatus::Interrupted
+        ) && self.worktree_path.exists()
+            && self
+                .agent_session_id
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|value| !value.is_empty())
     }
 
     /// Check if the session should be marked as stopped due to idle timeout.
@@ -253,6 +317,13 @@ impl Session {
         if self.schema_version < 2 {
             scrub_legacy_codex_hooks_enablement(&self.agent_id, &mut self.launch_args);
             self.schema_version = 2;
+        }
+
+        if self.schema_version < 3 {
+            if self.worktree_path.exists() {
+                self.status = AgentStatus::Interrupted;
+            }
+            self.schema_version = 3;
         }
     }
 }
@@ -399,6 +470,27 @@ pub fn persist_session_status(
     session.update_status(status);
     session.save(sessions_dir)?;
     SessionRuntimeState::new(status).save(&runtime_state_path(sessions_dir, session_id))
+}
+
+pub fn persist_session_hook_event(
+    sessions_dir: &Path,
+    session_id: &str,
+    event: &str,
+) -> std::io::Result<()> {
+    let session_path = sessions_dir.join(format!("{session_id}.toml"));
+    let mut session = Session::load_and_migrate(&session_path)?;
+    session.record_hook_event(event);
+    session.save(sessions_dir)
+}
+
+pub fn persist_session_completed_stop(
+    sessions_dir: &Path,
+    session_id: &str,
+) -> std::io::Result<()> {
+    let session_path = sessions_dir.join(format!("{session_id}.toml"));
+    let mut session = Session::load_and_migrate(&session_path)?;
+    session.record_completed_stop();
+    session.save(sessions_dir)
 }
 
 /// Persist the backing agent session id into the session TOML so quick-start
@@ -1127,6 +1219,70 @@ display_name = "Claude Code"
         assert_eq!(session.windows_shell, Some(WindowsShellKind::PowerShell7));
         assert_eq!(session.launch_command, "pwsh");
         assert_eq!(session.launch_args, config.args);
+    }
+
+    #[test]
+    fn load_and_migrate_marks_legacy_existing_worktree_interrupted() {
+        let dir = tempfile::tempdir().unwrap();
+        let worktree = dir.path().join("repo-worktree");
+        std::fs::create_dir_all(&worktree).unwrap();
+        let path = dir.path().join("legacy.toml");
+        let mut session = Session::new(&worktree, "feature/recover", AgentId::Codex);
+        session.status = AgentStatus::Running;
+        session.schema_version = 2;
+        let mut value = toml::Value::try_from(&session)
+            .unwrap()
+            .as_table()
+            .unwrap()
+            .clone();
+        value.remove("last_hook_event");
+        value.remove("last_hook_event_at");
+        value.remove("last_completed_stop_at");
+        std::fs::write(&path, toml::to_string(&value).unwrap()).unwrap();
+
+        let loaded = Session::load_and_migrate(&path).unwrap();
+
+        assert_eq!(loaded.schema_version, Session::CURRENT_SCHEMA_VERSION);
+        assert_eq!(loaded.status, AgentStatus::Interrupted);
+        assert!(loaded.interrupted_recovery_candidate());
+    }
+
+    #[test]
+    fn lifecycle_events_drive_interrupted_recovery_candidate() {
+        let dir = tempfile::tempdir().unwrap();
+        let worktree = dir.path().join("repo-worktree");
+        std::fs::create_dir_all(&worktree).unwrap();
+        let mut session = Session::new(&worktree, "feature/recover", AgentId::Codex);
+
+        session.record_hook_event("UserPromptSubmit");
+        assert!(session.should_mark_interrupted_from_lifecycle());
+
+        session.record_hook_event("Stop");
+        assert!(session.should_mark_interrupted_from_lifecycle());
+
+        session.record_completed_stop();
+        assert!(!session.should_mark_interrupted_from_lifecycle());
+    }
+
+    #[test]
+    fn completed_stop_session_remains_exact_auto_resume_candidate() {
+        let dir = tempfile::tempdir().unwrap();
+        let worktree = dir.path().join("repo-worktree");
+        std::fs::create_dir_all(&worktree).unwrap();
+        let mut session = Session::new(&worktree, "feature/recover", AgentId::Codex);
+        session.agent_session_id = Some("codex-native-session".to_string());
+
+        session.record_hook_event("Stop");
+        session.record_completed_stop();
+
+        assert!(!session.should_mark_interrupted_from_lifecycle());
+        assert!(session.exact_auto_resume_candidate());
+
+        std::fs::remove_dir_all(&worktree).unwrap();
+        assert!(!session.exact_auto_resume_candidate());
+        std::fs::create_dir_all(&worktree).unwrap();
+        session.update_status(AgentStatus::Stopped);
+        assert!(!session.exact_auto_resume_candidate());
     }
 
     #[test]

--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -266,6 +266,8 @@ pub enum AgentStatus {
     WaitingInput,
     #[serde(alias = "stopped", alias = "Stopped")]
     Stopped,
+    #[serde(alias = "interrupted", alias = "Interrupted")]
+    Interrupted,
 }
 
 /// Session start mode.

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -171,6 +171,82 @@ fn dispatch_agent_launch_success<F>(
     spawn_project_index_bootstrap(proxy, project_index_root);
 }
 
+fn launch_config_from_persisted_session(session: &gwt_agent::Session) -> gwt_agent::LaunchConfig {
+    let agent_id = session.agent_id.clone();
+    let mut builder = gwt_agent::AgentLaunchBuilder::new(agent_id);
+    builder = builder.working_dir(session.worktree_path.clone());
+    if !session.branch.is_empty() {
+        builder = builder.branch(session.branch.clone());
+    }
+    if let Some(model) = session.model.clone() {
+        builder = builder.model(model);
+    }
+    if let Some(version) = session.tool_version.clone() {
+        builder = builder.version(version);
+    }
+    if let Some(level) = session.reasoning_level.clone() {
+        builder = builder.reasoning_level(level);
+    }
+    if session.skip_permissions {
+        builder = builder.skip_permissions(true);
+    }
+    if session.codex_fast_mode {
+        builder = builder.fast_mode(true);
+    }
+    builder = builder.runtime_target(session.runtime_target);
+    if let Some(service) = session.docker_service.clone() {
+        builder = builder.docker_service(service);
+    }
+    builder = builder.docker_lifecycle_intent(session.docker_lifecycle_intent);
+    if let Some(shell) = session.windows_shell {
+        builder = builder.windows_shell(shell);
+    }
+    if let Some(linked) = session.linked_issue_number {
+        builder = builder.linked_issue_number(linked);
+    }
+
+    if let Some(resume_id) = session
+        .agent_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        builder = builder
+            .session_mode(gwt_agent::SessionMode::Resume)
+            .resume_session_id(resume_id.to_string());
+    } else {
+        builder = builder.session_mode(gwt_agent::SessionMode::Normal);
+    }
+
+    let mut config = builder.build();
+    if let Some(version) = session.tool_version.clone() {
+        config.tool_version = Some(version);
+    }
+    if !session.display_name.is_empty() {
+        config.display_name = session.display_name.clone();
+    }
+    config
+}
+
+fn auto_resume_window_bounds(index: usize) -> gwt::WindowGeometry {
+    let offset = ((index % 6) as f64) * 28.0;
+    gwt::WindowGeometry {
+        x: 48.0 + offset,
+        y: 48.0 + offset,
+        width: 960.0,
+        height: 620.0,
+    }
+}
+
+fn mark_auto_resume_source_completed(sessions_dir: &Path, session_id: &str) {
+    let path = sessions_dir.join(format!("{session_id}.toml"));
+    let Ok(mut session) = gwt_agent::Session::load_and_migrate(&path) else {
+        return;
+    };
+    session.update_status(gwt_agent::AgentStatus::Stopped);
+    let _ = session.save(sessions_dir);
+}
+
 #[derive(Default)]
 struct FrontendUserActionLog {
     action: &'static str,
@@ -2427,6 +2503,7 @@ pub struct AppRuntime {
     pub(crate) launch_wizard_cache: LaunchWizardMemoryCache,
     pub(crate) launch_wizard: Option<LaunchWizardSession>,
     pub(crate) pending_workspace_resume_contexts: HashMap<String, WorkspaceResumeContext>,
+    pub(crate) pending_auto_resume_sources: HashMap<String, String>,
     pub(crate) active_agent_sessions: HashMap<String, ActiveAgentSession>,
     pub(crate) window_pty_statuses: HashMap<String, WindowProcessStatus>,
     pub(crate) window_hook_states: HashMap<String, WindowProcessStatus>,
@@ -2522,6 +2599,7 @@ impl AppRuntime {
             launch_wizard_cache,
             launch_wizard: None,
             pending_workspace_resume_contexts: HashMap::new(),
+            pending_auto_resume_sources: HashMap::new(),
             active_agent_sessions: HashMap::new(),
             window_pty_statuses: HashMap::new(),
             window_hook_states: HashMap::new(),
@@ -2572,6 +2650,8 @@ impl AppRuntime {
             );
         }
 
+        self.auto_resume_recoverable_agent_sessions();
+
         let windows = self
             .tabs
             .iter()
@@ -2592,6 +2672,105 @@ impl AppRuntime {
             let _ = self.start_window(&tab_id, &window.id, window.preset, window.geometry.clone());
         }
         let _ = self.persist();
+    }
+
+    fn auto_resume_recoverable_agent_sessions(&mut self) {
+        let mut sessions = self.load_recovery_sessions();
+        sessions.sort_by(|left, right| {
+            left.last_activity_at
+                .cmp(&right.last_activity_at)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+
+        let mut launched = 0usize;
+        for session in sessions {
+            if !session.exact_auto_resume_candidate() {
+                continue;
+            }
+            if self
+                .active_agent_sessions
+                .values()
+                .any(|active| active.session_id == session.id)
+            {
+                continue;
+            }
+            if self
+                .open_project_path(session.worktree_path.clone())
+                .is_err()
+            {
+                continue;
+            }
+            let Some(tab_id) = self
+                .tabs
+                .iter()
+                .find(|tab| same_worktree_path(&tab.project_root, &session.worktree_path))
+                .map(|tab| tab.id.clone())
+            else {
+                continue;
+            };
+            let Some(tab) = self.tab(&tab_id) else {
+                continue;
+            };
+            if tab.kind != gwt::ProjectKind::Git || tab.migration_pending {
+                continue;
+            }
+            let config = launch_config_from_persisted_session(&session);
+            if config.session_mode != gwt_agent::SessionMode::Resume {
+                continue;
+            }
+            let existing_windows = self
+                .window_lookup
+                .keys()
+                .cloned()
+                .collect::<std::collections::HashSet<_>>();
+            let workspace_resume_context =
+                gwt_core::workspace_projection::load_workspace_projection(&session.worktree_path)
+                    .ok()
+                    .flatten()
+                    .map(|projection| workspace_resume_context_from_projection(&projection));
+            if self
+                .spawn_agent_window(
+                    &tab_id,
+                    config,
+                    auto_resume_window_bounds(launched),
+                    workspace_resume_context,
+                )
+                .is_err()
+            {
+                continue;
+            }
+            if let Some(window_id) = self
+                .window_lookup
+                .keys()
+                .find(|window_id| !existing_windows.contains(*window_id))
+                .cloned()
+            {
+                self.pending_auto_resume_sources
+                    .insert(window_id, session.id.clone());
+            }
+            launched += 1;
+        }
+    }
+
+    fn load_recovery_sessions(&self) -> Vec<gwt_agent::Session> {
+        let Ok(entries) = std::fs::read_dir(&self.sessions_dir) else {
+            return Vec::new();
+        };
+        entries
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("toml"))
+            .filter_map(|path| {
+                let mut session = gwt_agent::Session::load_and_migrate(&path).ok()?;
+                if session.worktree_path.exists()
+                    && session.should_mark_interrupted_from_lifecycle()
+                {
+                    session.update_status(gwt_agent::AgentStatus::Interrupted);
+                }
+                let _ = session.save(&self.sessions_dir);
+                Some(session)
+            })
+            .collect()
     }
 
     pub(crate) fn set_hook_forward_target(&mut self, target: HookForwardTarget) {
@@ -5625,6 +5804,7 @@ impl AppRuntime {
         result: AgentLaunchResult,
     ) -> Vec<OutboundEvent> {
         let workspace_resume_context = self.pending_workspace_resume_contexts.remove(&window_id);
+        let auto_resume_source_session_id = self.pending_auto_resume_sources.remove(&window_id);
         match result {
             Ok((
                 process_launch,
@@ -5666,6 +5846,9 @@ impl AppRuntime {
                         tab_id: tab_id.clone(),
                     },
                 );
+                if let Some(source_session_id) = auto_resume_source_session_id {
+                    mark_auto_resume_source_completed(&self.sessions_dir, &source_session_id);
+                }
                 self.refresh_launch_wizard_session_cache(&window_id);
 
                 // SPEC-2809 — Launch Wizard always spawns an AI agent
@@ -6186,6 +6369,9 @@ impl AppRuntime {
             session.launch_command = config.command.clone();
             session.launch_args = config.args.clone();
             session.windows_shell = config.windows_shell;
+            if session.session_mode == gwt_agent::SessionMode::Resume {
+                session.agent_session_id = config.resume_session_id.clone();
+            }
             session.update_status(gwt_agent::AgentStatus::Running);
 
             let session_id = session.id.clone();
@@ -8176,6 +8362,7 @@ exit 1
             launch_wizard_cache,
             launch_wizard: None,
             pending_workspace_resume_contexts: HashMap::new(),
+            pending_auto_resume_sources: HashMap::new(),
             active_agent_sessions: HashMap::<String, ActiveAgentSession>::new(),
             window_pty_statuses: HashMap::new(),
             window_hook_states: HashMap::new(),
@@ -10791,6 +10978,64 @@ exit 1
             BackendEvent::WorkspaceResumeAgentError { session_id, message }
                 if session_id == "missing-session" && !message.is_empty()
         ));
+    }
+
+    #[test]
+    fn app_runtime_bootstrap_auto_resumes_clean_waiting_input_session() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        init_git_clone_with_origin(&repo);
+        let worktree = temp.path().join("worktrees").join("auto-resume");
+        run_git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "work/auto-resume",
+                worktree.to_str().expect("worktree path"),
+            ],
+        );
+        let mut runtime = sample_runtime(temp.path(), Vec::new(), None);
+        for (session_id, native_session_id) in [
+            ("session-auto-one", "native-session-one"),
+            ("session-auto-two", "native-session-two"),
+        ] {
+            let mut session =
+                gwt_agent::Session::new(&worktree, "work/auto-resume", gwt_agent::AgentId::Codex);
+            session.id = session_id.to_string();
+            session.agent_session_id = Some(native_session_id.to_string());
+            session.record_hook_event("Stop");
+            session.record_completed_stop();
+            session
+                .save(&runtime.sessions_dir)
+                .expect("save resumable session");
+        }
+
+        runtime.bootstrap();
+
+        assert_eq!(
+            runtime.tabs.len(),
+            1,
+            "bootstrap should reopen the worktree tab"
+        );
+        assert!(same_worktree_path(&runtime.tabs[0].project_root, &worktree));
+        let agent_windows = runtime.tabs[0]
+            .workspace
+            .persisted()
+            .windows
+            .iter()
+            .filter(|window| window.preset == WindowPreset::Agent)
+            .count();
+        assert_eq!(
+            agent_windows, 2,
+            "all exact-resumable sessions for a worktree should restart"
+        );
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -654,21 +654,33 @@ impl AppRuntime {
             .filter(|agent| !live_session_ids.contains(agent.session_id.as_str()))
             .filter_map(|agent| {
                 let session_path = sessions_dir.join(format!("{}.toml", agent.session_id));
-                let resume_kind = match gwt_agent::Session::load_and_migrate(&session_path) {
-                    Ok(session) => {
-                        if session
-                            .agent_session_id
-                            .as_deref()
-                            .map(str::trim)
-                            .is_some_and(|value| !value.is_empty())
-                        {
-                            gwt::ResumableAgentResumeKind::Session
-                        } else {
-                            gwt::ResumableAgentResumeKind::MetadataOnly
+                let (resume_kind, lifecycle_status) =
+                    match gwt_agent::Session::load_and_migrate(&session_path) {
+                        Ok(session) => {
+                            let resume_kind = if session
+                                .agent_session_id
+                                .as_deref()
+                                .map(str::trim)
+                                .is_some_and(|value| !value.is_empty())
+                            {
+                                gwt::ResumableAgentResumeKind::Session
+                            } else {
+                                gwt::ResumableAgentResumeKind::MetadataOnly
+                            };
+                            let lifecycle_status = if session
+                                .should_mark_interrupted_from_lifecycle()
+                                || session.status == gwt_agent::AgentStatus::Interrupted
+                            {
+                                Some(gwt::ResumableAgentLifecycleStatus::Interrupted)
+                            } else if session.exact_auto_resume_candidate() {
+                                Some(gwt::ResumableAgentLifecycleStatus::Active)
+                            } else {
+                                None
+                            };
+                            (resume_kind, lifecycle_status)
                         }
-                    }
-                    Err(_) => return None,
-                };
+                        Err(_) => return None,
+                    };
                 Some(gwt::ResumableAgentView {
                     session_id: agent.session_id.clone(),
                     agent_id: agent.agent_id.clone(),
@@ -680,6 +692,7 @@ impl AppRuntime {
                         .map(|path| path.display().to_string()),
                     last_activity_at: Some(agent.updated_at.to_rfc3339()),
                     resume_kind,
+                    lifecycle_status,
                 })
             })
             .collect();

--- a/crates/gwt/src/cli/hook/event_dispatcher.rs
+++ b/crates/gwt/src/cli/hook/event_dispatcher.rs
@@ -131,6 +131,10 @@ fn handle_stop(
         }
     }
 
+    run_step(event, "completed-stop", || {
+        super::runtime_state::record_completed_stop_from_env()
+    })?;
+
     Ok(reminder)
 }
 

--- a/crates/gwt/src/cli/hook/runtime_state.rs
+++ b/crates/gwt/src/cli/hook/runtime_state.rs
@@ -197,6 +197,9 @@ pub fn handle_with_input(event: &str, input: &str) -> Result<(), HookError> {
     if let Some(agent_session_id) = agent_session_id.as_ref() {
         sync_agent_session_id(&sessions_dir, &gwt_session_id, agent_session_id)?;
     }
+    if session.is_some() {
+        gwt_agent::persist_session_hook_event(&sessions_dir, gwt_session_id.as_str(), event)?;
+    }
 
     let pending_discussion = session.as_ref().and_then(|session| {
         pending_discussion_for_session(&sessions_dir, &session.id)
@@ -204,6 +207,18 @@ pub fn handle_with_input(event: &str, input: &str) -> Result<(), HookError> {
             .flatten()
     });
     write_for_event_with_pending_discussion(&runtime_path, event, pending_discussion)
+}
+
+pub fn record_completed_stop_from_env() -> Result<(), HookError> {
+    let Some(gwt_session_id) = GwtSessionId::from_env() else {
+        return Ok(());
+    };
+    let sessions_dir = std::env::var_os(gwt_agent::GWT_SESSION_RUNTIME_PATH_ENV)
+        .map(PathBuf::from)
+        .map(|path| sessions_dir_for_runtime_path(&path))
+        .unwrap_or_else(gwt_core::paths::gwt_sessions_dir);
+    gwt_agent::persist_session_completed_stop(&sessions_dir, gwt_session_id.as_str())?;
+    Ok(())
 }
 
 fn sessions_dir_for_runtime_path(runtime_path: &Path) -> PathBuf {
@@ -556,5 +571,67 @@ mod tests {
         handle_with_input("PreToolUse", r#"{"tool_name":"Bash"}"#).unwrap();
 
         assert!(runtime_path.exists());
+    }
+
+    #[test]
+    fn runtime_state_persists_hook_lifecycle_to_session_toml() {
+        let _lock = env_lock();
+        let mut env = EnvGuard::new();
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join(".gwt").join("sessions");
+        let worktree = dir.path().join("repo");
+        std::fs::create_dir_all(&worktree).unwrap();
+
+        let session = Session::new(&worktree, "feature/demo", AgentId::ClaudeCode);
+        let session_id = session.id.clone();
+        session.save(&sessions_dir).unwrap();
+        let runtime_path = gwt_agent::runtime_state_path(&sessions_dir, &session_id);
+        env.set(GWT_SESSION_ID_ENV, session_id.clone());
+        env.set(
+            gwt_agent::GWT_SESSION_RUNTIME_PATH_ENV,
+            runtime_path.as_os_str().to_os_string(),
+        );
+
+        handle_with_input("PreToolUse", r#"{"tool_name":"Bash"}"#).unwrap();
+        let loaded = Session::load(&sessions_dir.join(format!("{session_id}.toml"))).unwrap();
+
+        assert_eq!(loaded.last_hook_event.as_deref(), Some("PreToolUse"));
+        assert!(loaded.last_hook_event_at.is_some());
+        assert!(loaded.last_completed_stop_at.is_none());
+        assert_eq!(loaded.status, gwt_agent::AgentStatus::Running);
+        assert!(loaded.should_mark_interrupted_from_lifecycle());
+    }
+
+    #[test]
+    fn runtime_state_records_completed_stop_as_clean_boundary() {
+        let _lock = env_lock();
+        let mut env = EnvGuard::new();
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join(".gwt").join("sessions");
+        let worktree = dir.path().join("repo");
+        std::fs::create_dir_all(&worktree).unwrap();
+
+        let session = Session::new(&worktree, "feature/demo", AgentId::ClaudeCode);
+        let session_id = session.id.clone();
+        session.save(&sessions_dir).unwrap();
+        let runtime_path = gwt_agent::runtime_state_path(&sessions_dir, &session_id);
+        env.set(GWT_SESSION_ID_ENV, session_id.clone());
+        env.set(
+            gwt_agent::GWT_SESSION_RUNTIME_PATH_ENV,
+            runtime_path.as_os_str().to_os_string(),
+        );
+
+        handle_with_input("Stop", r#"{}"#).unwrap();
+        let stopped_before_completion =
+            Session::load(&sessions_dir.join(format!("{session_id}.toml"))).unwrap();
+        assert!(stopped_before_completion.should_mark_interrupted_from_lifecycle());
+
+        record_completed_stop_from_env().unwrap();
+        let loaded = Session::load(&sessions_dir.join(format!("{session_id}.toml"))).unwrap();
+
+        assert_eq!(loaded.last_hook_event.as_deref(), Some("Stop"));
+        assert!(loaded.last_completed_stop_at.is_some());
+        assert_eq!(loaded.status, gwt_agent::AgentStatus::WaitingInput);
+        assert!(!loaded.should_mark_interrupted_from_lifecycle());
     }
 }

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -149,6 +149,8 @@ pub struct ResumableAgentView {
     /// for that id), so a fresh agent will be started while preserving
     /// the Workspace title / owner.
     pub resume_kind: ResumableAgentResumeKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lifecycle_status: Option<ResumableAgentLifecycleStatus>,
 }
 
 #[derive(Debug, Clone, Copy, serde::Serialize, PartialEq, Eq)]
@@ -156,6 +158,13 @@ pub struct ResumableAgentView {
 pub enum ResumableAgentResumeKind {
     Session,
     MetadataOnly,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ResumableAgentLifecycleStatus {
+    Active,
+    Interrupted,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -88,7 +88,7 @@ pub use launch_wizard::{
     LaunchWizardPreviousProfile, LaunchWizardPreviousProfiles, LaunchWizardProgressStepView,
     LaunchWizardQuickStartView, LaunchWizardState, LaunchWizardStep, LaunchWizardSummaryView,
     LaunchWizardView, LinkedIssueKind, LiveSessionEntry, QuickStartEntry, QuickStartLaunchMode,
-    ResumableAgentResumeKind, ResumableAgentView, ShellLaunchConfig,
+    ResumableAgentLifecycleStatus, ResumableAgentResumeKind, ResumableAgentView, ShellLaunchConfig,
 };
 pub use managed_assets::{
     refresh_existing_managed_gwt_assets_for_worktree, refresh_managed_gwt_assets_for_agent,

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1946,6 +1946,7 @@ mod tests {
             launch_wizard_cache,
             launch_wizard: None,
             pending_workspace_resume_contexts: HashMap::new(),
+            pending_auto_resume_sources: HashMap::new(),
             active_agent_sessions: HashMap::new(),
             window_pty_statuses: HashMap::new(),
             window_hook_states: HashMap::new(),

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -34,7 +34,9 @@ pub fn close_window_from_workspace(
 }
 
 pub fn should_auto_start_restored_window(window: &gwt::PersistedWindowState) -> bool {
-    window.preset.requires_process() && window.status == WindowProcessStatus::Running
+    window.preset.requires_process()
+        && window.preset != WindowPreset::Agent
+        && window.status == WindowProcessStatus::Running
 }
 
 // SPEC-2013 FR-011: `cli::pane::is_agent_pane` と同じ判定 (`agent_id` 設定済み

--- a/crates/gwt/src/worktree_inventory.rs
+++ b/crates/gwt/src/worktree_inventory.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -21,6 +24,9 @@ pub struct WorktreeEntry {
     /// Human-friendly label (branch name when available, else last path segment).
     pub label: String,
     pub branch: Option<String>,
+    /// Persisted gwt session ids whose recorded worktree path matches this entry.
+    #[serde(default)]
+    pub session_ids: Vec<String>,
     /// True for the worktree that currently anchors the active project tab.
     pub is_active: bool,
 }
@@ -41,6 +47,18 @@ pub fn enumerate_worktrees(
     repo_root: &Path,
     active_root: Option<&Path>,
 ) -> Result<Vec<WorktreeEntry>, InventoryError> {
+    enumerate_worktrees_with_sessions_dir(
+        repo_root,
+        active_root,
+        &gwt_core::paths::gwt_sessions_dir(),
+    )
+}
+
+pub fn enumerate_worktrees_with_sessions_dir(
+    repo_root: &Path,
+    active_root: Option<&Path>,
+    sessions_dir: &Path,
+) -> Result<Vec<WorktreeEntry>, InventoryError> {
     let manager = WorktreeManager::new(repo_root);
     let infos = manager
         .list()
@@ -50,14 +68,22 @@ pub fn enumerate_worktrees(
         .ok()
         .map(|path| canonicalize_or(path.as_path()));
     let canonical_active = active_root.map(canonicalize_or);
+    let session_ids_by_worktree = load_session_ids_by_worktree(sessions_dir);
 
     let mut entries = Vec::new();
     for info in infos {
         if info.prunable {
             continue;
         }
+        let canonical = canonicalize_or(&info.path);
+        let session_ids = session_ids_by_worktree
+            .get(&canonical)
+            .cloned()
+            .unwrap_or_default();
         entries.push(make_entry(
             &info,
+            canonical,
+            session_ids,
             canonical_main.as_deref(),
             canonical_active.as_deref(),
         )?);
@@ -69,10 +95,11 @@ pub fn enumerate_worktrees(
 
 fn make_entry(
     info: &WorktreeInfo,
+    canonical: PathBuf,
+    session_ids: Vec<String>,
     canonical_main: Option<&Path>,
     canonical_active: Option<&Path>,
 ) -> Result<WorktreeEntry, InventoryError> {
-    let canonical = canonicalize_or(&info.path);
     let id = id_for(&canonical)?;
     let kind = if canonical_main
         .map(|main| main == canonical.as_path())
@@ -93,8 +120,34 @@ fn make_entry(
         path: canonical,
         label,
         branch: info.branch.clone(),
+        session_ids,
         is_active,
     })
+}
+
+fn load_session_ids_by_worktree(sessions_dir: &Path) -> HashMap<PathBuf, Vec<String>> {
+    let Ok(entries) = std::fs::read_dir(sessions_dir) else {
+        return HashMap::new();
+    };
+    let mut session_ids_by_worktree: HashMap<PathBuf, Vec<String>> = HashMap::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("toml") {
+            continue;
+        }
+        let Ok(session) = gwt_agent::Session::load_and_migrate(&path) else {
+            continue;
+        };
+        session_ids_by_worktree
+            .entry(canonicalize_or(&session.worktree_path))
+            .or_default()
+            .push(session.id);
+    }
+    for session_ids in session_ids_by_worktree.values_mut() {
+        session_ids.sort();
+        session_ids.dedup();
+    }
+    session_ids_by_worktree
 }
 
 fn id_for(path: &Path) -> Result<String, InventoryError> {

--- a/crates/gwt/tests/worktree_inventory_test.rs
+++ b/crates/gwt/tests/worktree_inventory_test.rs
@@ -1,7 +1,9 @@
 use std::path::Path;
 use std::process::Command;
 
-use gwt::worktree_inventory::{enumerate_worktrees, WorktreeEntryKind};
+use gwt::worktree_inventory::{
+    enumerate_worktrees, enumerate_worktrees_with_sessions_dir, WorktreeEntryKind,
+};
 use tempfile::tempdir;
 
 fn git(args: &[&str], cwd: &Path) {
@@ -99,4 +101,43 @@ fn enumerate_worktrees_skips_prunable_entries() {
     let entries = enumerate_worktrees(&repo, None).expect("inventory");
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].kind, WorktreeEntryKind::BareMain);
+}
+
+#[test]
+fn enumerate_worktrees_includes_session_ids_for_each_worktree() {
+    let dir = tempdir().expect("tempdir");
+    let repo = dir.path().join("repo");
+    init_repo(&repo);
+
+    let worktree_path = dir.path().join("worktrees").join("feature-a");
+    git(
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "feature/a",
+            worktree_path.to_str().expect("path str"),
+        ],
+        &repo,
+    );
+    let sessions_dir = dir.path().join("sessions");
+    std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+    for session_id in ["session-b", "session-a"] {
+        let mut session =
+            gwt_agent::Session::new(&worktree_path, "feature/a", gwt_agent::AgentId::Codex);
+        session.id = session_id.to_string();
+        session.save(&sessions_dir).expect("save session");
+    }
+    let mut main_session = gwt_agent::Session::new(&repo, "main", gwt_agent::AgentId::ClaudeCode);
+    main_session.id = "session-main".to_string();
+    main_session.save(&sessions_dir).expect("save main session");
+
+    let entries = enumerate_worktrees_with_sessions_dir(&repo, Some(&worktree_path), &sessions_dir)
+        .expect("inventory");
+
+    assert_eq!(entries[0].session_ids, vec!["session-main".to_string()]);
+    assert_eq!(
+        entries[1].session_ids,
+        vec!["session-a".to_string(), "session-b".to_string()]
+    );
 }

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -3686,6 +3686,16 @@ kbd.op-kbd {
   color: rgb(203, 213, 225);
 }
 
+:root[data-theme] .workspace-resume-picker-row-tag.is-active {
+  background: rgba(34, 197, 94, 0.12);
+  color: rgb(134, 239, 172);
+}
+
+:root[data-theme] .workspace-resume-picker-row-tag.is-interrupted {
+  background: rgba(251, 146, 60, 0.14);
+  color: rgb(253, 186, 116);
+}
+
 :root[data-theme] .workspace-resume-picker-row-meta {
   display: grid;
   grid-template-columns: max-content 1fr;

--- a/crates/gwt/web/workspace-resume-picker-modal.js
+++ b/crates/gwt/web/workspace-resume-picker-modal.js
@@ -128,14 +128,23 @@ export function renderWorkspaceResumePicker({
           agent.display_name || agent.agent_id,
         ),
       );
-      const tagClass = agent.resume_kind === "metadata_only"
-        ? "workspace-resume-picker-row-tag is-fresh"
-        : "workspace-resume-picker-row-tag is-conversation";
+      const lifecycleTag =
+        agent.lifecycle_status === "interrupted"
+          ? { className: "is-interrupted", label: "Interrupted" }
+          : agent.lifecycle_status === "active"
+            ? { className: "is-active", label: "Active" }
+            : null;
+      const tagClass = lifecycleTag
+        ? `workspace-resume-picker-row-tag ${lifecycleTag.className}`
+        : agent.resume_kind === "metadata_only"
+          ? "workspace-resume-picker-row-tag is-fresh"
+          : "workspace-resume-picker-row-tag is-conversation";
       heading.appendChild(
         createNode(
           "span",
           tagClass,
-          agent.resume_kind === "metadata_only" ? "Fresh start" : "Conversation",
+          lifecycleTag?.label
+            || (agent.resume_kind === "metadata_only" ? "Fresh start" : "Conversation"),
         ),
       );
       row.appendChild(heading);


### PR DESCRIPTION
## Summary

SPEC #2359 のエージェントセッション自動復元を拡張し、Stop 未到達の中断だけでなく、既存の agent session ID を持つ Active / WaitingInput 状態のセッションも起動時に復元できるようにします。

## Changes

- session TOML に hook lifecycle 情報と `Interrupted` status を追加し、schema v3 への migration で既存ローカル worktree の legacy session を復元候補として扱います。
- gwt 起動時に、ローカル worktree が存在し、`agent_session_id` を持つ Running / WaitingInput / Interrupted session を exact resume で自動再開します。
- worktree inventory に worktree ごとの `session_ids` を追加し、同一 worktree に複数 session があるケースを保持します。
- resume picker に `Active` / `Interrupted` tag を表示し、復元対象の状態を UI から判別できるようにします。
- Stop hook は StopBlock を除いた完了 Stop のみ clean boundary として記録し、hook lifecycle がない session は自動復元対象から外します。
- 多数の project tab がある場合でも version / Open Project / theme toggle が画面外に押し出されないよう、project tab strip だけを横スクロールさせます。

## Testing

- `cargo fmt`
- `git diff --check`
- `cargo test -p gwt-agent exact_auto_resume_candidate -- --nocapture`
- `cargo test -p gwt-agent recovery_candidate -- --nocapture`
- `cargo test -p gwt-agent load_and_migrate_marks_legacy_existing_worktree_interrupted -- --nocapture`
- `cargo test -p gwt enumerate_worktrees_includes_session_ids_for_each_worktree --test worktree_inventory_test -- --nocapture`
- `cargo test -p gwt runtime_state_ -- --nocapture`
- `cargo test -p gwt app_runtime_bootstrap_auto_resumes_clean_waiting_input_session -- --nocapture`
- `cargo test -p gwt app_runtime_list_resumable_agents_returns_assigned_with_session_toml -- --nocapture`
- `env -u GWT_SESSION_ID -u GWT_SESSION_RUNTIME_PATH -u GWT_PROJECT_ROOT -u GWT_REPO_HASH -u GWT_WORKTREE_HASH -u GWT_HOOK_FORWARD_URL -u GWT_HOOK_FORWARD_TOKEN cargo test -p gwt-agent -p gwt-core -p gwt --all-features -- --test-threads=1`
- `node --check crates/gwt/web/workspace-resume-picker-modal.js`
- `pnpm test:frontend-bundle`
- `pnpm test:frontend-unit`
- `pnpm exec playwright test --config crates/gwt/playwright/playwright.config.ts --project=chromium-dark crates/gwt/playwright/tests/project-tabs.spec.ts --headed` (RED before fix, GREEN after fix)
- `pnpm exec playwright test --config crates/gwt/playwright/playwright.config.ts crates/gwt/playwright/tests/project-tabs.spec.ts`
- `env -u GWT_SESSION_ID -u GWT_SESSION_RUNTIME_PATH -u GWT_PROJECT_ROOT -u GWT_REPO_HASH -u GWT_WORKTREE_HASH -u GWT_HOOK_FORWARD_URL -u GWT_HOOK_FORWARD_TOKEN cargo build -p gwt --bin gwt --bin gwtd`
- `env -u GWT_SESSION_ID -u GWT_SESSION_RUNTIME_PATH -u GWT_PROJECT_ROOT -u GWT_REPO_HASH -u GWT_WORKTREE_HASH -u GWT_HOOK_FORWARD_URL -u GWT_HOOK_FORWARD_TOKEN cargo build -p gwt --bin gwt`
- `env -u GWT_SESSION_ID -u GWT_SESSION_RUNTIME_PATH -u GWT_PROJECT_ROOT -u GWT_REPO_HASH -u GWT_WORKTREE_HASH -u GWT_HOOK_FORWARD_URL -u GWT_HOOK_FORWARD_TOKEN cargo clippy --all-targets --all-features -- -D warnings`
- live headed E2E against rebuilt `target/debug/gwt serve --no-open` with isolated `HOME`: initial tabs were empty, only `known-project-01..12` opened, version/Open Project stayed within 1440px viewport, and project tab switching passed. Screenshot: `target/live-project-tabs-e2e.png`.
- pre-push hook: all checks passed, filtered line coverage 90.54%.

## Risk/Impact

Automatic resume is intentionally constrained to local worktrees with persisted lifecycle information and an exact `agent_session_id`. Sessions without lifecycle metadata or missing worktrees are not restored.

Project tab overflow is constrained to the tab strip; right-side project actions keep fixed visibility.

## Closing Issues

None

## Related Issues

#2359

## Checklist

- [x] Tests and lint pass locally
- [x] Commit messages passed commitlint
- [x] `SS.mov` remains untracked and excluded from this PR
