### PR TITLE
fix(perf): reduce startup CPU and power load

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -626,6 +626,11 @@ fn frontend_user_action_log(event: &FrontendEvent) -> Option<FrontendUserActionL
         FrontendEvent::ResumeWorkspaceAgent { session_id, .. } => {
             FrontendUserActionLog::new("resume_workspace_agent", "workspace").target(session_id)
         }
+        FrontendEvent::ResumeBranchLatestAgent {
+            id, branch_name, ..
+        } => FrontendUserActionLog::new("resume_branch_latest_agent", "launch")
+            .window(id)
+            .target(branch_name),
         FrontendEvent::OpenLaunchWizard {
             id,
             branch_name,
@@ -1043,6 +1048,21 @@ impl LaunchWizardMemoryCache {
             branch_name,
             &self.sessions,
         )
+    }
+
+    fn latest_resumable_branch_session(
+        &self,
+        repo_path: &Path,
+        branch_name: &str,
+    ) -> Option<gwt_agent::Session> {
+        let entry = self
+            .quick_start_entries(repo_path, branch_name)
+            .into_iter()
+            .find(|entry| entry.resume_session_id.is_some())?;
+        self.sessions
+            .iter()
+            .find(|session| session.id == entry.session_id)
+            .cloned()
     }
 
     fn agent_preferences(&self) -> gwt::LaunchWizardPreviousProfiles {
@@ -3125,6 +3145,11 @@ impl AppRuntime {
             FrontendEvent::ResumeWorkspaceAgent { session_id, bounds } => {
                 self.resume_workspace_agent_events(&client_id, session_id, bounds)
             }
+            FrontendEvent::ResumeBranchLatestAgent {
+                id,
+                branch_name,
+                bounds,
+            } => self.resume_branch_latest_agent_events(&client_id, &id, &branch_name, bounds),
             FrontendEvent::OpenLaunchWizard {
                 id,
                 branch_name,
@@ -5788,6 +5813,16 @@ fn clear_workspace_cleanup_git_details_event(project_root: &Path) -> Option<Outb
 }
 
 impl AppRuntime {
+    fn latest_resumable_branch_session(
+        &self,
+        project_root: &Path,
+        branch_name: &str,
+    ) -> Option<gwt_agent::Session> {
+        let normalized_branch_name = normalize_branch_name(branch_name);
+        self.launch_wizard_cache
+            .latest_resumable_branch_session(project_root, &normalized_branch_name)
+    }
+
     pub(crate) fn live_sessions_for_branch(
         &self,
         tab_id: &str,
@@ -7619,6 +7654,7 @@ mod tests {
     use tempfile::tempdir;
 
     use base64::Engine;
+    use chrono::{TimeZone, Utc};
     use gwt::{
         empty_workspace_state, load_restored_workspace_state, load_session_state, BackendEvent,
         BranchCleanupInfo, BranchListEntry, BranchScope, FrontendEvent, LaunchWizardAction,
@@ -11004,6 +11040,140 @@ exit 1
             &event.event,
             BackendEvent::WorkspaceResumeAgentError { session_id, message }
                 if session_id == "missing-session" && !message.is_empty()
+        ));
+    }
+
+    #[test]
+    fn app_runtime_latest_branch_resume_picks_newest_resumable_session() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let sessions_dir = temp.path().join("sessions");
+        fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+        let mut older =
+            gwt_agent::Session::new(&repo, "work/manual-resume", gwt_agent::AgentId::Codex);
+        older.id = "session-older".to_string();
+        older.agent_session_id = Some("native-older".to_string());
+        older.last_activity_at = Utc.with_ymd_and_hms(2026, 5, 21, 9, 0, 0).unwrap();
+        older.updated_at = older.last_activity_at;
+        older.created_at = older.last_activity_at;
+        older.save(&sessions_dir).expect("save older session");
+
+        let mut newer =
+            gwt_agent::Session::new(&repo, "work/manual-resume", gwt_agent::AgentId::Codex);
+        newer.id = "session-newer".to_string();
+        newer.agent_session_id = Some("native-newer".to_string());
+        newer.last_activity_at = Utc.with_ymd_and_hms(2026, 5, 21, 10, 0, 0).unwrap();
+        newer.updated_at = newer.last_activity_at;
+        newer.created_at = newer.last_activity_at;
+        newer.save(&sessions_dir).expect("save newer session");
+
+        let mut metadata_only =
+            gwt_agent::Session::new(&repo, "work/manual-resume", gwt_agent::AgentId::Codex);
+        metadata_only.id = "session-metadata-only".to_string();
+        metadata_only.agent_session_id = None;
+        metadata_only.last_activity_at = Utc.with_ymd_and_hms(2026, 5, 21, 11, 0, 0).unwrap();
+        metadata_only.updated_at = metadata_only.last_activity_at;
+        metadata_only.created_at = metadata_only.last_activity_at;
+        metadata_only
+            .save(&sessions_dir)
+            .expect("save metadata-only session");
+
+        let runtime = sample_runtime(temp.path(), Vec::new(), None);
+
+        let selected = runtime
+            .latest_resumable_branch_session(&repo, "work/manual-resume")
+            .expect("latest resumable session");
+
+        assert_eq!(selected.id, "session-newer");
+        assert_eq!(selected.agent_session_id.as_deref(), Some("native-newer"));
+    }
+
+    #[test]
+    fn app_runtime_open_launch_wizard_shows_multiple_resume_candidates_latest_first() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let sessions_dir = temp.path().join("sessions");
+        fs::create_dir_all(&sessions_dir).expect("sessions dir");
+
+        for (session_id, native_session_id, hour) in [
+            ("session-older", "native-older", 9),
+            ("session-newer", "native-newer", 10),
+        ] {
+            let mut session =
+                gwt_agent::Session::new(&repo, "work/manual-resume", gwt_agent::AgentId::Codex);
+            session.id = session_id.to_string();
+            session.agent_session_id = Some(native_session_id.to_string());
+            session.last_activity_at = Utc.with_ymd_and_hms(2026, 5, 21, hour, 0, 0).unwrap();
+            session.updated_at = session.last_activity_at;
+            session.created_at = session.last_activity_at;
+            session.save(&sessions_dir).expect("save session");
+        }
+
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "branches-1",
+            repo,
+            WindowPreset::Branches,
+            WindowProcessStatus::Ready,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "branches-1");
+
+        runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::OpenLaunchWizard {
+                id: window_id,
+                branch_name: "work/manual-resume".to_string(),
+                linked_issue_number: None,
+            },
+        );
+
+        let view = runtime
+            .launch_wizard
+            .as_ref()
+            .expect("launch wizard")
+            .wizard
+            .view();
+        assert_eq!(
+            view.quick_start_entries
+                .iter()
+                .map(|entry| entry.resume_session_id.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("native-newer"), Some("native-older")]
+        );
+    }
+
+    #[test]
+    fn app_runtime_resume_branch_latest_returns_branch_error_when_no_resumable_session_exists() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "branches-1",
+            repo,
+            WindowPreset::Branches,
+            WindowProcessStatus::Ready,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "branches-1");
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::ResumeBranchLatestAgent {
+                id: window_id.clone(),
+                branch_name: "work/manual-resume".to_string(),
+                bounds: canvas_bounds(),
+            },
+        );
+
+        assert!(matches!(
+            events.first().map(|event| &event.event),
+            Some(BackendEvent::BranchError { id, message })
+                if id == &window_id && message.contains("No resumable session")
         ));
     }
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -228,7 +228,6 @@ fn launch_config_from_persisted_session(session: &gwt_agent::Session) -> gwt_age
     config
 }
 
-const STARTUP_AUTO_RESUME_LIMIT: usize = 3;
 const STARTUP_AUTO_RESUME_STALE_AFTER_SECS: i64 = 24 * 60 * 60;
 
 fn auto_resume_window_bounds(index: usize) -> gwt::WindowGeometry {
@@ -2698,9 +2697,6 @@ impl AppRuntime {
         let mut launched = 0usize;
         let mut resumed_native_sessions = std::collections::HashSet::new();
         for session in sessions {
-            if launched >= STARTUP_AUTO_RESUME_LIMIT {
-                break;
-            }
             if !session.exact_auto_resume_candidate() {
                 continue;
             }
@@ -11070,7 +11066,7 @@ exit 1
     }
 
     #[test]
-    fn app_runtime_bootstrap_auto_resume_caps_dedupes_and_skips_stale_sessions() {
+    fn app_runtime_bootstrap_auto_resume_dedupes_and_skips_stale_without_count_cap() {
         let _env_lock = env_test_lock()
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -11097,7 +11093,7 @@ exit 1
             ("session-duplicate-native-one", "native-one", 2_i64),
             ("session-fresh-2", "native-two", 3_i64),
             ("session-fresh-3", "native-three", 4_i64),
-            ("session-fresh-4-over-cap", "native-four", 5_i64),
+            ("session-fresh-4", "native-four", 5_i64),
             ("session-stale", "native-stale", 60 * 60 * 48_i64),
         ];
         for (session_id, native_session_id, age_secs) in cases {
@@ -11121,8 +11117,8 @@ exit 1
 
         assert_eq!(
             runtime.pending_auto_resume_sources.len(),
-            3,
-            "startup auto-resume must cap launches and avoid spawning every persisted session"
+            4,
+            "startup auto-resume must restore every fresh unique exact-resumable session"
         );
         let resumed_sources = runtime
             .pending_auto_resume_sources
@@ -11138,8 +11134,8 @@ exit 1
             "stale persisted sessions must stay available for manual resume instead of auto-launching"
         );
         assert!(
-            !resumed_sources.contains("session-fresh-4-over-cap"),
-            "only the newest capped set should auto-launch"
+            resumed_sources.contains("session-fresh-4"),
+            "startup auto-resume must not drop fresh unique sessions due to an arbitrary count cap"
         );
     }
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -228,6 +228,9 @@ fn launch_config_from_persisted_session(session: &gwt_agent::Session) -> gwt_age
     config
 }
 
+const STARTUP_AUTO_RESUME_LIMIT: usize = 3;
+const STARTUP_AUTO_RESUME_STALE_AFTER_SECS: i64 = 24 * 60 * 60;
+
 fn auto_resume_window_bounds(index: usize) -> gwt::WindowGeometry {
     let offset = ((index % 6) as f64) * 28.0;
     gwt::WindowGeometry {
@@ -236,6 +239,14 @@ fn auto_resume_window_bounds(index: usize) -> gwt::WindowGeometry {
         width: 960.0,
         height: 620.0,
     }
+}
+
+fn startup_auto_resume_is_fresh(
+    session: &gwt_agent::Session,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    now.signed_duration_since(session.last_activity_at)
+        <= chrono::Duration::seconds(STARTUP_AUTO_RESUME_STALE_AFTER_SECS)
 }
 
 fn mark_auto_resume_source_completed(sessions_dir: &Path, session_id: &str) {
@@ -2677,14 +2688,34 @@ impl AppRuntime {
     fn auto_resume_recoverable_agent_sessions(&mut self) {
         let mut sessions = self.load_recovery_sessions();
         sessions.sort_by(|left, right| {
-            left.last_activity_at
-                .cmp(&right.last_activity_at)
+            right
+                .last_activity_at
+                .cmp(&left.last_activity_at)
                 .then_with(|| left.id.cmp(&right.id))
         });
 
+        let now = chrono::Utc::now();
         let mut launched = 0usize;
+        let mut resumed_native_sessions = std::collections::HashSet::new();
         for session in sessions {
+            if launched >= STARTUP_AUTO_RESUME_LIMIT {
+                break;
+            }
             if !session.exact_auto_resume_candidate() {
+                continue;
+            }
+            if !startup_auto_resume_is_fresh(&session, now) {
+                continue;
+            }
+            let Some(native_session_id) = session
+                .agent_session_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            else {
+                continue;
+            };
+            if !resumed_native_sessions.insert(native_session_id.to_string()) {
                 continue;
             }
             if self
@@ -11039,6 +11070,80 @@ exit 1
     }
 
     #[test]
+    fn app_runtime_bootstrap_auto_resume_caps_dedupes_and_skips_stale_sessions() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        init_git_clone_with_origin(&repo);
+        let worktree = temp.path().join("worktrees").join("auto-resume-guard");
+        run_git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "work/auto-resume-guard",
+                worktree.to_str().expect("worktree path"),
+            ],
+        );
+        let mut runtime = sample_runtime(temp.path(), Vec::new(), None);
+        let now = chrono::Utc::now();
+        let cases = [
+            ("session-fresh-1", "native-one", 1_i64),
+            ("session-duplicate-native-one", "native-one", 2_i64),
+            ("session-fresh-2", "native-two", 3_i64),
+            ("session-fresh-3", "native-three", 4_i64),
+            ("session-fresh-4-over-cap", "native-four", 5_i64),
+            ("session-stale", "native-stale", 60 * 60 * 48_i64),
+        ];
+        for (session_id, native_session_id, age_secs) in cases {
+            let mut session = gwt_agent::Session::new(
+                &worktree,
+                "work/auto-resume-guard",
+                gwt_agent::AgentId::Codex,
+            );
+            session.id = session_id.to_string();
+            session.agent_session_id = Some(native_session_id.to_string());
+            session.record_hook_event("Stop");
+            session.record_completed_stop();
+            session.last_activity_at = now - chrono::Duration::seconds(age_secs);
+            session.updated_at = session.last_activity_at;
+            session
+                .save(&runtime.sessions_dir)
+                .expect("save resumable session");
+        }
+
+        runtime.bootstrap();
+
+        assert_eq!(
+            runtime.pending_auto_resume_sources.len(),
+            3,
+            "startup auto-resume must cap launches and avoid spawning every persisted session"
+        );
+        let resumed_sources = runtime
+            .pending_auto_resume_sources
+            .values()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
+        assert!(
+            !resumed_sources.contains("session-duplicate-native-one"),
+            "duplicate native agent session ids must not launch twice"
+        );
+        assert!(
+            !resumed_sources.contains("session-stale"),
+            "stale persisted sessions must stay available for manual resume instead of auto-launching"
+        );
+        assert!(
+            !resumed_sources.contains("session-fresh-4-over-cap"),
+            "only the newest capped set should auto-launch"
+        );
+    }
+
+    #[test]
     fn app_runtime_resume_workspace_journal_populates_quick_start_entries_from_prior_sessions() {
         // SPEC-2359 US-44 (Issue #2757) follow-on: when the user clicks
         // `Resume` on a Workspace journal card whose branch already has a
@@ -16310,10 +16415,11 @@ exit 1
     }
 
     #[test]
-    fn workspace_view_for_tab_includes_done_work_items_from_disk() {
-        // SPEC-2359 US-37: workspace_state broadcast must carry work_items so
-        // the Workspace Overview Completed column renders without depending on
-        // the limited-trigger active_work_projection broadcast.
+    fn workspace_view_for_tab_omits_work_item_history_from_workspace_state() {
+        // SPEC-2359 CPU/power follow-up: workspace_state is broadcast frequently
+        // and must stay structural. Workspace history/work items are carried by
+        // active_work_projection so every window/status update does not serialize
+        // the full work item event log.
         let _env_guard = env_test_lock().lock().expect("env lock");
         let temp = tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", temp.path());
@@ -16364,14 +16470,8 @@ exit 1
 
         let view = crate::runtime_support::workspace_view_for_tab(&tab);
         assert!(
-            view.work_items
-                .iter()
-                .any(|item| item.id == "work-item-done" && item.status_category == "done"),
-            "WorkspaceView.work_items must include the Done work item persisted on disk so workspace_state broadcast renders the Completed column on startup; got {:?}",
-            view.work_items
-                .iter()
-                .map(|i| (i.id.clone(), i.status_category.clone()))
-                .collect::<Vec<_>>()
+            view.work_items.is_empty(),
+            "WorkspaceView.work_items must stay empty because workspace_state is a hot broadcast path; active_work_projection owns Workspace history"
         );
     }
 

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -168,20 +168,16 @@ impl AppRuntime {
         let live_sessions = self.live_sessions_for_branch(tab_id, &normalized_branch_name);
         let worktree_path = None;
         let quick_start_root = project_root.to_path_buf();
-        // SPEC-2359 US-44 (Issue #2757): when this wizard is opened by a
-        // Workspace Resume action, pre-populate Quick Start entries from
-        // prior sessions on this branch so the user can immediately re-launch
-        // the most recent Claude Code / Codex session via the Quick Start
-        // panel (which carries `resume_session_id` and triggers
-        // `--resume <uuid>` at launch time). Other entry points keep the
-        // deferred path (populated during runtime hydration) so Add Agent /
-        // Branches launch flows stay fast on open.
-        let quick_start_entries = if workspace_resume_context.is_some() {
-            self.launch_wizard_cache
-                .quick_start_entries(&quick_start_root, &normalized_branch_name)
-        } else {
-            Vec::new()
-        };
+        // SPEC-2014 US-27: Branches > Launch Agent must expose all
+        // resumable sessions in Quick Start so users can choose a specific
+        // prior conversation. The cache is already in memory, so this stays
+        // off the GUI hot path's filesystem scan.
+        let mut quick_start_entries = self
+            .launch_wizard_cache
+            .quick_start_entries(&quick_start_root, &normalized_branch_name);
+        if workspace_resume_context.is_none() {
+            quick_start_entries.retain(|entry| entry.resume_session_id.is_some());
+        }
         let previous_profiles = self.launch_wizard_cache.agent_preferences();
         let agent_options = self.launch_wizard_cache.agent_options();
         let docker_context = None;
@@ -604,6 +600,90 @@ impl AppRuntime {
         match self.spawn_agent_window(&tab_id, config, bounds, workspace_resume_context) {
             Ok(events) => events,
             Err(error) => reply_error(error),
+        }
+    }
+
+    pub(crate) fn resume_branch_latest_agent_events(
+        &mut self,
+        client_id: &str,
+        id: &str,
+        branch_name: &str,
+        bounds: WindowGeometry,
+    ) -> Vec<OutboundEvent> {
+        let branch_error = |message: String| {
+            vec![OutboundEvent::reply(
+                client_id.to_string(),
+                BackendEvent::BranchError {
+                    id: id.to_string(),
+                    message,
+                },
+            )]
+        };
+
+        let Some(address) = self.window_lookup.get(id).cloned() else {
+            return branch_error("Window not found".to_string());
+        };
+        let Some(tab) = self.tab(&address.tab_id) else {
+            return branch_error("Project tab not found".to_string());
+        };
+        let Some(window) = tab.workspace.window(&address.raw_id) else {
+            return branch_error("Window not found".to_string());
+        };
+        if window.preset != WindowPreset::Branches {
+            return branch_error("Window is not a branches list".to_string());
+        }
+        if tab.kind != gwt::ProjectKind::Git {
+            return branch_error("Resume requires a Git project".to_string());
+        }
+        if tab.migration_pending {
+            return branch_error(
+                "Complete the project migration before resuming an agent".to_string(),
+            );
+        }
+
+        let tab_id = address.tab_id.clone();
+        let project_root = tab.project_root.clone();
+        let normalized_branch_name = normalize_branch_name(branch_name);
+        let Some(session) =
+            self.latest_resumable_branch_session(&project_root, &normalized_branch_name)
+        else {
+            return branch_error(format!(
+                "No resumable session found for {normalized_branch_name}"
+            ));
+        };
+
+        if let Some(window_id) = self
+            .active_agent_sessions
+            .iter()
+            .find(|(_, active)| active.session_id == session.id)
+            .map(|(window_id, _)| window_id.clone())
+        {
+            if !self.window_lookup.contains_key(&window_id) {
+                return branch_error(format!("Agent window not found for session {}", session.id));
+            }
+            let mut events = self.restore_window_events(&window_id);
+            events.extend(self.focus_window_events(&window_id, Some(bounds)));
+            if events.is_empty() {
+                return vec![self.workspace_state_broadcast()];
+            }
+            return events;
+        }
+
+        let config = super::launch_config_from_persisted_session(&session);
+        if config.session_mode != gwt_agent::SessionMode::Resume {
+            return branch_error(format!(
+                "No resumable session found for {normalized_branch_name}"
+            ));
+        }
+        let workspace_resume_context =
+            gwt_core::workspace_projection::load_workspace_projection(&session.worktree_path)
+                .ok()
+                .flatten()
+                .map(|projection| workspace_resume_context_from_projection(&projection));
+
+        match self.spawn_agent_window(&tab_id, config, bounds, workspace_resume_context) {
+            Ok(events) => events,
+            Err(error) => branch_error(error),
         }
     }
 

--- a/crates/gwt/src/launch_wizard/quick_start.rs
+++ b/crates/gwt/src/launch_wizard/quick_start.rs
@@ -1,5 +1,6 @@
 use std::{
-    collections::HashMap,
+    cmp::Ordering,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
 };
 
@@ -31,8 +32,9 @@ pub(super) fn collect_quick_start_entries_from_sessions(
     branch_name: &str,
     sessions: Vec<gwt_agent::Session>,
 ) -> Vec<QuickStartEntry> {
-    let mut latest_by_agent: HashMap<String, gwt_agent::Session> = HashMap::new();
-    let mut latest_resumable_by_agent: HashMap<String, gwt_agent::Session> = HashMap::new();
+    let mut resumable_sessions = Vec::new();
+    let mut agents_with_resumable: HashSet<String> = HashSet::new();
+    let mut latest_metadata_only_by_agent: HashMap<String, gwt_agent::Session> = HashMap::new();
     let repo_scope = WorktreePathScope::new(repo_path);
 
     for session in sessions {
@@ -42,43 +44,27 @@ pub(super) fn collect_quick_start_entries_from_sessions(
 
         let agent_key = session.agent_id.command().to_string();
         if agent_session_resume_id(&session).is_some() {
-            let replace = latest_resumable_by_agent
+            agents_with_resumable.insert(agent_key);
+            resumable_sessions.push(session);
+        } else {
+            let replace = latest_metadata_only_by_agent
                 .get(&agent_key)
                 .map(|current| session_is_newer(&session, current))
                 .unwrap_or(true);
             if replace {
-                latest_resumable_by_agent.insert(agent_key.clone(), session.clone());
+                latest_metadata_only_by_agent.insert(agent_key, session);
             }
-        }
-
-        let replace = latest_by_agent
-            .get(&agent_key)
-            .map(|current| session_is_newer(&session, current))
-            .unwrap_or(true);
-        if replace {
-            latest_by_agent.insert(agent_key, session);
         }
     }
 
-    let mut sessions = latest_by_agent
-        .into_iter()
-        .map(|(agent_key, latest_session)| {
-            if agent_session_resume_id(&latest_session).is_some() {
-                latest_session
-            } else {
-                latest_resumable_by_agent
-                    .get(&agent_key)
-                    .cloned()
-                    .unwrap_or(latest_session)
-            }
-        })
-        .collect::<Vec<_>>();
-    sessions.sort_by(|left, right| {
-        right
-            .updated_at
-            .cmp(&left.updated_at)
-            .then_with(|| right.created_at.cmp(&left.created_at))
-    });
+    let mut sessions = resumable_sessions;
+    sessions.extend(
+        latest_metadata_only_by_agent
+            .into_iter()
+            .filter(|(agent_key, _)| !agents_with_resumable.contains(agent_key))
+            .map(|(_, session)| session),
+    );
+    sessions.sort_by(|left, right| compare_session_recency(right, left));
 
     sessions
         .into_iter()
@@ -106,8 +92,15 @@ pub(super) fn collect_quick_start_entries_from_sessions(
 }
 
 fn session_is_newer(candidate: &gwt_agent::Session, current: &gwt_agent::Session) -> bool {
-    candidate.updated_at > current.updated_at
-        || (candidate.updated_at == current.updated_at && candidate.created_at > current.created_at)
+    compare_session_recency(candidate, current) == Ordering::Greater
+}
+
+fn compare_session_recency(left: &gwt_agent::Session, right: &gwt_agent::Session) -> Ordering {
+    left.last_activity_at
+        .cmp(&right.last_activity_at)
+        .then_with(|| left.updated_at.cmp(&right.updated_at))
+        .then_with(|| left.created_at.cmp(&right.created_at))
+        .then_with(|| left.id.cmp(&right.id))
 }
 
 fn agent_session_resume_id(session: &gwt_agent::Session) -> Option<String> {
@@ -220,7 +213,7 @@ mod tests {
     }
 
     #[test]
-    fn load_quick_start_entries_prefers_latest_session_per_agent() {
+    fn load_quick_start_entries_orders_resumable_sessions_latest_first() {
         let dir = tempdir().expect("tempdir");
         let worktree = dir.path().join("repo");
         std::fs::create_dir_all(&worktree).expect("repo dir");
@@ -242,10 +235,48 @@ mod tests {
         );
 
         let entries = load_quick_start_entries(&worktree, dir.path(), "feature/gui");
-        assert_eq!(entries.len(), 1);
+        assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].agent_id, "codex");
         assert_eq!(entries[0].resume_session_id.as_deref(), Some("newer"));
         assert_eq!(entries[0].docker_service.as_deref(), Some("gwt"));
+    }
+
+    #[test]
+    fn load_quick_start_entries_keeps_multiple_resumable_sessions_latest_first() {
+        let dir = tempdir().expect("tempdir");
+        let worktree = dir.path().join("repo");
+        std::fs::create_dir_all(&worktree).expect("repo dir");
+        sample_session(
+            dir.path(),
+            "feature/gui",
+            &worktree,
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 4, 14, 9, 0, 0).unwrap(),
+            "older-resume",
+        );
+        sample_session(
+            dir.path(),
+            "feature/gui",
+            &worktree,
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 4, 14, 10, 0, 0).unwrap(),
+            "newer-resume",
+        );
+
+        let entries = load_quick_start_entries(&worktree, dir.path(), "feature/gui");
+
+        assert_eq!(
+            entries.len(),
+            2,
+            "Launch Agent must expose each resumable session instead of collapsing by agent"
+        );
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry.resume_session_id.as_deref())
+                .collect::<Vec<_>>(),
+            vec![Some("newer-resume"), Some("older-resume")]
+        );
     }
 
     #[test]

--- a/crates/gwt/src/project_index_bootstrap.rs
+++ b/crates/gwt/src/project_index_bootstrap.rs
@@ -25,15 +25,21 @@ type StatusProbeFn = dyn Fn(&Path) -> gwt::ProjectIndexStatusView + Send + Sync 
 /// Identifies a unit of background work tracked by
 /// [`ProjectIndexBootstrapService::in_flight`].
 ///
-/// `Bootstrap` covers project-wide bootstrap + status probe. `FullStatusRetry`
-/// covers a queued Settings.Index full-table refresh that should run after an
-/// already in-flight bootstrap releases. `Rebuild` covers per-cell rebuilds
-/// keyed by `(project_root, scope, worktree_hash?)` so different
+/// `Bootstrap` covers startup bootstrap + current-worktree status probe.
+/// `FullStatus` covers Settings.Index full-table refreshes; duplicate full
+/// refresh requests collapse into the in-flight refresh instead of queuing a
+/// second all-worktree probe. `FullStatusRetry` covers a queued Settings.Index
+/// full-table refresh that should run after an already in-flight bootstrap
+/// releases. `Rebuild` covers per-cell rebuilds keyed by `(project_root, scope, worktree_hash?)`
+/// so different
 /// scopes/worktrees can run in parallel while same-key duplicates are
 /// coalesced.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum IndexInFlightKey {
     Bootstrap {
+        project_root: PathBuf,
+    },
+    FullStatus {
         project_root: PathBuf,
     },
     FullStatusRetry {
@@ -97,6 +103,14 @@ impl ProjectIndexBootstrapService {
         status_probe: Arc<StatusProbeFn>,
         retry_delay: Duration,
     ) -> ProjectIndexBootstrapRequest {
+        let project_key = normalize_project_root(&project_root);
+        let bootstrap_key = IndexInFlightKey::Bootstrap {
+            project_root: project_key.clone(),
+        };
+        let bootstrap_was_running = self.is_reserved(&bootstrap_key);
+        let full_status_key = IndexInFlightKey::FullStatus {
+            project_root: project_key,
+        };
         let request = self.spawn_full_status_refresh_once_with(
             proxy.clone(),
             project_root.clone(),
@@ -105,6 +119,11 @@ impl ProjectIndexBootstrapService {
         );
         if request != ProjectIndexBootstrapRequest::AlreadyRunning {
             return request;
+        }
+        let bootstrap_is_running = self.is_reserved(&bootstrap_key);
+        let full_status_is_running = self.is_reserved(&full_status_key);
+        if !bootstrap_was_running && (!bootstrap_is_running || full_status_is_running) {
+            return ProjectIndexBootstrapRequest::AlreadyRunning;
         }
         self.queue_full_status_refresh_retry(
             proxy,
@@ -122,12 +141,110 @@ impl ProjectIndexBootstrapService {
         bootstrap: Arc<BootstrapFn>,
         status_probe: Arc<StatusProbeFn>,
     ) -> ProjectIndexBootstrapRequest {
-        self.spawn_with(
-            proxy,
-            project_root,
-            move |path| bootstrap(path),
-            move |path| status_probe(path),
-        )
+        let project_key = normalize_project_root(&project_root);
+        let project_root_label = project_key.display().to_string();
+        let bootstrap_key = IndexInFlightKey::Bootstrap {
+            project_root: project_key.clone(),
+        };
+        if self.is_reserved(&bootstrap_key) {
+            tracing::debug!(
+                target: "gwt::index",
+                worktree = %project_root_label,
+                "project index full status refresh waiting for startup bootstrap"
+            );
+            return ProjectIndexBootstrapRequest::AlreadyRunning;
+        }
+        let key = IndexInFlightKey::FullStatus {
+            project_root: project_key.clone(),
+        };
+        if !self.try_reserve(key.clone()) {
+            tracing::debug!(
+                target: "gwt::index",
+                worktree = %project_root_label,
+                "project index full status refresh already running"
+            );
+            return ProjectIndexBootstrapRequest::AlreadyRunning;
+        }
+
+        let in_flight = self.in_flight.clone();
+        let key_for_thread = key.clone();
+        let service_for_thread = self.clone();
+        let spawn_result = thread::Builder::new()
+            .name("gwt-index-full-status-refresh".to_string())
+            .spawn(move || {
+                let _guard = InFlightGuard {
+                    in_flight,
+                    key: key_for_thread,
+                };
+                let bootstrap_started = Instant::now();
+                match bootstrap(&project_key) {
+                    Ok(()) => {
+                        let bootstrap_elapsed_ms = bootstrap_started.elapsed().as_millis() as u64;
+                        tracing::info!(
+                            target: "gwt::index",
+                            worktree = %project_root_label,
+                            elapsed_ms = bootstrap_elapsed_ms,
+                            "project index full status refresh bootstrap completed"
+                        );
+
+                        let status_started = Instant::now();
+                        let status = status_probe(&project_key);
+                        tracing::info!(
+                            target: "gwt::index",
+                            worktree = %project_root_label,
+                            elapsed_ms = status_started.elapsed().as_millis() as u64,
+                            state = %status.state,
+                            "project index full status refreshed"
+                        );
+                        let kick_orchestrator =
+                            status.state == gwt::ProjectIndexStatusState::RepairRequired;
+                        proxy.send(UserEvent::ProjectIndexStatus {
+                            project_root: project_root_label.clone(),
+                            status: status.clone(),
+                        });
+                        if kick_orchestrator {
+                            trigger_auto_repair_for_project(
+                                service_for_thread,
+                                proxy.clone(),
+                                project_key.clone(),
+                                &status,
+                            );
+                        }
+                    }
+                    Err(error) => {
+                        let elapsed_ms = bootstrap_started.elapsed().as_millis() as u64;
+                        tracing::warn!(
+                            target: "gwt::index",
+                            worktree = %project_root_label,
+                            elapsed_ms,
+                            error = %error,
+                            "project index full status refresh bootstrap failed"
+                        );
+                        proxy.send(UserEvent::ProjectIndexStatus {
+                            project_root: project_root_label,
+                            status: gwt::ProjectIndexStatusView::new(
+                                gwt::ProjectIndexStatusState::Error,
+                                format!(
+                                    "Project index full status refresh failed after {elapsed_ms} ms: {error}"
+                                ),
+                            ),
+                        });
+                    }
+                }
+            });
+
+        match spawn_result {
+            Ok(_) => ProjectIndexBootstrapRequest::Spawned,
+            Err(error) => {
+                self.release(&key);
+                tracing::warn!(
+                    target: "gwt::index",
+                    error = %error,
+                    "failed to spawn project index full status refresh background task"
+                );
+                ProjectIndexBootstrapRequest::SpawnFailed
+            }
+        }
     }
 
     fn queue_full_status_refresh_retry(
@@ -403,6 +520,13 @@ impl ProjectIndexBootstrapService {
     fn try_reserve(&self, key: IndexInFlightKey) -> bool {
         let mut in_flight = self.in_flight.lock().expect("project index in-flight set");
         in_flight.insert(key)
+    }
+
+    fn is_reserved(&self, key: &IndexInFlightKey) -> bool {
+        self.in_flight
+            .lock()
+            .expect("project index in-flight set")
+            .contains(key)
     }
 
     fn release(&self, key: &IndexInFlightKey) {
@@ -814,6 +938,76 @@ mod tests {
             wait_for_project_status_detail(&events, &expected_project_root, "full table");
         assert_eq!(full_status.state, gwt::ProjectIndexStatusState::Ready);
         assert_eq!(full_probe_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn duplicate_full_status_refresh_requests_collapse_without_queued_second_probe() {
+        let service = super::ProjectIndexBootstrapService::new_for_test();
+        let temp = tempdir().expect("tempdir");
+        let expected_project_root = dunce::canonicalize(temp.path())
+            .unwrap_or_else(|_| temp.path().to_path_buf())
+            .display()
+            .to_string();
+        let (proxy, events) = AppEventProxy::stub();
+        let (full_started_tx, full_started_rx) = mpsc::channel();
+        let (release_full_tx, release_full_rx) = mpsc::channel();
+        let release_full_rx = Arc::new(Mutex::new(release_full_rx));
+        let full_probe_calls = Arc::new(AtomicUsize::new(0));
+        let first_probe_calls = full_probe_calls.clone();
+        let release_full_rx_for_closure = release_full_rx.clone();
+
+        let first = service.spawn_full_status_refresh_with_retry(
+            proxy.clone(),
+            temp.path().to_path_buf(),
+            Arc::new(move |_project_root: &Path| {
+                full_started_tx.send(()).expect("signal full refresh start");
+                release_full_rx_for_closure
+                    .lock()
+                    .expect("release receiver")
+                    .recv_timeout(Duration::from_secs(5))
+                    .expect("release full refresh");
+                Ok(())
+            }),
+            Arc::new(move |_project_root: &Path| {
+                first_probe_calls.fetch_add(1, Ordering::SeqCst);
+                gwt::ProjectIndexStatusView::new(gwt::ProjectIndexStatusState::Ready, "full table")
+            }),
+            Duration::from_millis(5),
+        );
+        assert_eq!(first, super::ProjectIndexBootstrapRequest::Spawned);
+        full_started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("first full refresh should hold the in-flight slot");
+
+        let duplicate_probe_calls = full_probe_calls.clone();
+        let duplicate = service.spawn_full_status_refresh_with_retry(
+            proxy.clone(),
+            temp.path().to_path_buf(),
+            Arc::new(|_project_root: &Path| Ok(())),
+            Arc::new(move |_project_root: &Path| {
+                duplicate_probe_calls.fetch_add(1, Ordering::SeqCst);
+                gwt::ProjectIndexStatusView::new(
+                    gwt::ProjectIndexStatusState::Ready,
+                    "duplicate full table",
+                )
+            }),
+            Duration::from_millis(5),
+        );
+        assert_eq!(
+            duplicate,
+            super::ProjectIndexBootstrapRequest::AlreadyRunning
+        );
+
+        release_full_tx.send(()).expect("release full refresh");
+        let full_status =
+            wait_for_project_status_detail(&events, &expected_project_root, "full table");
+        assert_eq!(full_status.state, gwt::ProjectIndexStatusState::Ready);
+        std::thread::sleep(Duration::from_millis(50));
+        assert_eq!(
+            full_probe_calls.load(Ordering::SeqCst),
+            1,
+            "duplicate Settings.Index refresh requests must collapse into the in-flight full refresh"
+        );
     }
 
     #[test]

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -376,6 +376,11 @@ pub enum FrontendEvent {
         session_id: String,
         bounds: WindowGeometry,
     },
+    ResumeBranchLatestAgent {
+        id: String,
+        branch_name: String,
+        bounds: WindowGeometry,
+    },
     OpenLaunchWizard {
         id: String,
         branch_name: String,

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -618,12 +618,10 @@ fn default_newline() -> Newline {
 pub struct WorkspaceView {
     pub viewport: CanvasViewport,
     pub windows: Vec<PersistedWindowState>,
-    // SPEC-2359 US-37: Workspace Overview Completed カラムは
-    // active_work_projection broadcast に依存していたが、その broadcast
-    // は限定された trigger でしか走らないため起動直後に表示されない
-    // 問題があった。workspace_state は frequently broadcast されるので、
-    // 同 event に work_items を載せて broadcast invariant を 1 本化する。
-    #[serde(default)]
+    // Compatibility field only. Workspace history is intentionally not carried
+    // by frequently-broadcast workspace_state events; active_work_projection is
+    // the owner for work item / history payloads.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub work_items: Vec<WorkspaceHistoryView>,
 }
 

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::app_runtime::workspace_work_item_view_from_item;
 
 pub fn combined_window_id(tab_id: &str, raw_id: &str) -> String {
     format!("{tab_id}::{raw_id}")
@@ -79,20 +78,6 @@ pub fn current_app_version() -> &'static str {
 }
 
 pub fn workspace_view_for_tab(tab: &ProjectTabRuntime) -> gwt::WorkspaceView {
-    // SPEC-2359 US-37: workspace_state broadcast に work_items を含めて
-    // Workspace Overview Completed カラムを populate する。読み込み失敗は
-    // 既存の WorkspaceView semantics (welcome/empty) を壊さないよう空 Vec
-    // に縮退する。
-    let work_items =
-        gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(&tab.project_root)
-            .map(|projection| {
-                projection
-                    .work_items
-                    .iter()
-                    .map(workspace_work_item_view_from_item)
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default();
     gwt::WorkspaceView {
         viewport: tab.workspace.persisted().viewport.clone(),
         windows: tab
@@ -106,7 +91,7 @@ pub fn workspace_view_for_tab(tab: &ProjectTabRuntime) -> gwt::WorkspaceView {
                 window
             })
             .collect(),
-        work_items,
+        work_items: Vec::new(),
     }
 }
 

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1214,7 +1214,12 @@ test("Branch rows are keyboard-navigable with click + dblclick parity", () => {
   );
 });
 
-test("Branches toolbar exposes explicit Launch Agent action for selected branch", () => {
+test("Branches toolbar exposes explicit Resume and Launch Agent actions for selected branch", () => {
+  assert.match(
+    appSource,
+    /data-action="open-branch-resume"/,
+    "expected Branches toolbar to include an explicit Resume action",
+  );
   assert.match(
     appSource,
     /data-action="open-branch-launch"/,
@@ -1222,8 +1227,18 @@ test("Branches toolbar exposes explicit Launch Agent action for selected branch"
   );
   assert.match(
     appSource,
+    /selectedBranchName[\s\S]{0,360}?kind:\s*"resume_branch_latest_agent"|kind:\s*"resume_branch_latest_agent"[\s\S]{0,360}?selectedBranchName/,
+    "expected Branches toolbar Resume action to resume the selected branch",
+  );
+  assert.match(
+    appSource,
     /selectedBranchName[\s\S]{0,300}?kind:\s*"open_launch_wizard"|kind:\s*"open_launch_wizard"[\s\S]{0,300}?selectedBranchName/,
     "expected Branches toolbar Launch Agent action to send selectedBranchName",
+  );
+  assert.match(
+    appSource,
+    /row\.addEventListener\("dblclick",\s*activate\)/,
+    "expected branch row double-click to keep Launch Agent activation",
   );
 });
 

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -10315,37 +10315,6 @@
           case "workspace_state": {
             projectError = "";
             frontendUnits.projectWorkspaceShell.renderAppState(event.workspace);
-            // SPEC-2359 US-37: populate the Workspace Overview Completed
-            // column directly from workspace_state because the
-            // active_work_projection broadcast only fires on tab switch,
-            // user event, title sync, and window ops. Without this, the
-            // Completed column stays empty on startup until the user
-            // happens to switch tabs.
-            const activeTabId = event.workspace && event.workspace.active_tab_id;
-            const activeTab = Array.isArray(event.workspace && event.workspace.tabs)
-              ? event.workspace.tabs.find((tab) => tab.id === activeTabId)
-              : null;
-            const tabWorkItems = activeTab && activeTab.workspace && Array.isArray(activeTab.workspace.work_items)
-              ? activeTab.workspace.work_items
-              : [];
-            if (tabWorkItems.length > 0) {
-              if (!activeWorkProjection) {
-                activeWorkProjection = {
-                  id: activeTabId || "active-tab",
-                  title: (activeTab && activeTab.title) || "Workspace",
-                  workspaces: tabWorkItems,
-                };
-              } else if (
-                !Array.isArray(activeWorkProjection.workspaces) ||
-                activeWorkProjection.workspaces.length === 0
-              ) {
-                activeWorkProjection = {
-                  ...activeWorkProjection,
-                  workspaces: tabWorkItems,
-                };
-              }
-              workspaceKanbanSurface.renderWindows();
-            }
             break;
           }
           case "workspace_projection_prune_result": {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -7540,6 +7540,7 @@
         syncBranchSelectionState(state);
         const list = element.querySelector(".branch-list");
         const notice = element.querySelector(".branch-notice");
+        const resumeButton = element.querySelector("[data-action='open-branch-resume']");
         const launchButton = element.querySelector("[data-action='open-branch-launch']");
         const cleanupButton = element.querySelector("[data-action='open-branch-cleanup']");
         if (!list) {
@@ -7548,6 +7549,9 @@
 
         for (const button of element.querySelectorAll("[data-branch-filter]")) {
           button.classList.toggle("active", button.dataset.branchFilter === state.filter);
+        }
+        if (resumeButton) {
+          resumeButton.disabled = !state.selectedBranchName;
         }
         if (launchButton) {
           launchButton.disabled = !state.selectedBranchName;
@@ -8723,6 +8727,7 @@
                   </div>
                 </div>
                 <div class="branch-toolbar-actions workspace-toolbar-actions">
+                  <button class="wizard-button branch-resume-trigger" type="button" data-action="open-branch-resume" disabled>Resume</button>
                   <button class="wizard-button primary branch-launch-trigger" type="button" data-action="open-branch-launch" disabled>Launch Agent</button>
                   <button class="wizard-button branch-cleanup-trigger" type="button" data-action="open-branch-cleanup">Clean Up</button>
                   <button class="icon-button" data-action="refresh-branches" aria-label="Refresh branches">↻</button>
@@ -8760,6 +8765,23 @@
               frontendUnits.branchesFileTreeSurface.renderBranches(windowData.id);
             });
           }
+          body
+            .querySelector("[data-action='open-branch-resume']")
+            .addEventListener("click", (event) => {
+              event.stopPropagation();
+              const state = frontendUnits.branchesFileTreeSurface.ensureBranchListState(
+                windowData.id,
+              );
+              if (!state.selectedBranchName) {
+                return;
+              }
+              send({
+                kind: "resume_branch_latest_agent",
+                id: windowData.id,
+                branch_name: state.selectedBranchName,
+                bounds: visibleBounds(),
+              });
+            });
           body
             .querySelector("[data-action='open-branch-launch']")
             .addEventListener("click", (event) => {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -10,8 +10,8 @@ project index full status refresh、頻繁な `workspace_state` broadcast が同
 
 ### 原因
 
-- 起動時の auto-resume が recoverable session を無制限に再開し、同一 native
-  agent session 由来の重複も launch 対象になり得た。
+- 起動時の auto-resume が recoverable session を無条件に再開し、同一 native
+  agent session 由来の重複や古い session まで launch 対象になり得た。
 - Settings.Index の full refresh が、startup current-worktree bootstrap と衝突した後の
   retry だけでなく、同時 full refresh 同士でも二重 probe を起こせる in-flight key になっていた。
 - hot path の `workspace_state` が workspace work item 履歴を毎回含み、履歴が増えるほど
@@ -19,8 +19,8 @@ project index full status refresh、頻繁な `workspace_state` broadcast が同
 
 ### 再発防止策
 
-1. startup の自動再開は、件数上限・native session id dedupe・staleness gate を同時に置く。
-   「前回状態を復元する」機能でも、unbounded launch fan-out は performance bug として扱う。
+1. startup の自動再開は、件数上限で復元を落とさない。fresh かつ unique な exact-resumable
+   session は全件復元し、native session id dedupe と staleness gate で不要な二重起動だけを抑える。
 2. startup current-only probe と Settings.Index full refresh は別 key にしつつ、full refresh 同士は
    single-flight で潰す。retry を許すのは startup bootstrap と衝突した場合だけに限定する。
 3. 高頻度 broadcast には履歴 payload を載せない。workspace history は

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,33 @@
 # Lessons Learned
 
+## 2026-05-21 — startup CPU / power は「起動プロセス数」と「hot payload サイズ」を同時に見る
+
+### 事象
+
+gwt 起動中に CPU 使用率と消費電力が高く、macOS ではファンが異様に回るという報告があった。
+`sample` / `ps` / gwt logs を見ると、単一の busy loop ではなく、startup auto-resume、
+project index full status refresh、頻繁な `workspace_state` broadcast が同時に負荷を作っていた。
+
+### 原因
+
+- 起動時の auto-resume が recoverable session を無制限に再開し、同一 native
+  agent session 由来の重複も launch 対象になり得た。
+- Settings.Index の full refresh が、startup current-worktree bootstrap と衝突した後の
+  retry だけでなく、同時 full refresh 同士でも二重 probe を起こせる in-flight key になっていた。
+- hot path の `workspace_state` が workspace work item 履歴を毎回含み、履歴が増えるほど
+  serialize / WebSocket / frontend state update のコストが膨らんだ。
+
+### 再発防止策
+
+1. startup の自動再開は、件数上限・native session id dedupe・staleness gate を同時に置く。
+   「前回状態を復元する」機能でも、unbounded launch fan-out は performance bug として扱う。
+2. startup current-only probe と Settings.Index full refresh は別 key にしつつ、full refresh 同士は
+   single-flight で潰す。retry を許すのは startup bootstrap と衝突した場合だけに限定する。
+3. 高頻度 broadcast には履歴 payload を載せない。workspace history は
+   `active_work_projection` のような用途特化 payload に寄せ、shell state は構造情報だけに保つ。
+4. CPU / power 調査では CPU% だけで結論を出さず、`sample`、子プロセス数、runner 起動ログ、
+   WebSocket payload の大きさを同じタイムラインで見る。
+
 ## 2026-05-20 — Phase 26 の visibility 述語だけでは silent no-op を防げない: layout box が立つまで `isReady` を flip しない (Issue #2832 / SPEC-2008 Phase 26.A regression)
 
 ### 事象


### PR DESCRIPTION
## Summary

- Reduces startup CPU and power spikes by deduping stale/duplicate auto-resume launches while preserving full restoration for fresh unique sessions, and by collapsing duplicate full index status refreshes.
- Keeps frequent `workspace_state` broadcasts lightweight by moving workspace history ownership back to `active_work_projection`.
- Adds manual Worktree `Resume` as a separate action from `Launch Agent`: double-click still opens Launch Agent, the toolbar now has both buttons, direct Resume restores the latest resumable session, and Launch Agent shows multiple Resume candidates.

## Changes

- `crates/gwt/src/app_runtime/mod.rs` / `wizard.rs`: restores every fresh unique exact auto-resume session, dedupes native agent session ids, skips stale sessions, adds `resume_branch_latest_agent`, and focuses an already-live session instead of double-spawning.
- `crates/gwt/src/launch_wizard/quick_start.rs`: keeps multiple resumable sessions visible latest-first instead of collapsing to one per agent; Branches Launch Agent filters initial Quick Start entries to actual resumable sessions.
- `crates/gwt/web/app.js`: adds separate `Resume` and `Launch Agent` actions in the Branches / Worktree toolbar while keeping row double-click as Launch Agent.
- `crates/gwt/src/project_index_bootstrap.rs`: adds a dedicated full-status single-flight key so duplicate Settings.Index refresh requests collapse while startup-bootstrap retry behavior remains intact.
- `crates/gwt/src/runtime_support.rs` and `crates/gwt/src/protocol.rs`: keep `workspace_state.work_items` as an empty compatibility field with serde defaults and add the manual Resume frontend event.
- SPEC tasks updated for #2014 and #2359; `tasks/lessons.md` documents the CPU/power investigation pattern and recurrence prevention.

## Testing

- [x] `node --test crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — frontend Branches toolbar contract passes.
- [x] `cargo test -p gwt --lib load_quick_start_entries_keeps_multiple_resumable_sessions_latest_first -- --nocapture` — multiple resumable Quick Start entries pass.
- [x] `cargo test -p gwt --lib load_quick_start_entries_orders_resumable_sessions_latest_first -- --nocapture` — latest-first Quick Start ordering passes.
- [x] `cargo test -p gwt app_runtime_latest_branch_resume_picks_newest_resumable_session -- --nocapture` — direct Worktree Resume latest-session selection passes.
- [x] `cargo test -p gwt app_runtime_open_launch_wizard_shows_multiple_resume_candidates_latest_first -- --nocapture` — Launch Agent multiple Resume candidates pass.
- [x] `cargo test -p gwt app_runtime_resume_branch_latest_returns_branch_error_when_no_resumable_session_exists -- --nocapture` — no-session visible error path passes.
- [x] `cargo test -p gwt app_runtime_launch_wizard_continue_falls_back_to_host_without_resolved_docker_context -- --nocapture` — metadata-only Quick Start fallback regression passes.
- [x] `cargo test -p gwt app_runtime_bootstrap_auto_resume_dedupes_and_skips_stale_without_count_cap -- --nocapture` — startup auto-resume regression passes.
- [x] `cargo test -p gwt duplicate_full_status_refresh_requests_collapse_without_queued_second_probe -- --nocapture` — duplicate full refresh regression passes.
- [x] `cargo test -p gwt workspace_view_for_tab_omits_work_item_history_from_workspace_state -- --nocapture` — workspace-state hot payload regression passes.
- [x] `cargo test -p gwt-core -p gwt --all-features` — full Rust matrix passes.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clippy passes.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — binaries build.
- [x] `cargo fmt --check` and `git diff --check` — formatting/whitespace pass.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — commit message lint passes.
- [x] pre-push hook — CI-equivalent lint/tests and coverage pass; filtered line coverage 90.61%.

## Closing Issues

- None

## Related Issues / Links

- #1939
- #2014
- #2359

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC tasks and lessons)
- [x] Migration/backfill plan included (not required; `workspace_state.work_items` remains serde-defaulted for compatibility)
- [x] CHANGELOG impact considered (patch-level performance and Worktree Resume fix)

## Context

- The CPU/power investigation found overlapping startup fan-out sources rather than one single busy loop: unbounded exact auto-resume, duplicate full index status refreshes, and oversized hot `workspace_state` payloads.
- Manual Worktree Resume is intentionally separate from startup auto-resume: stale sessions can remain available for explicit user action without being auto-launched at startup.

## Risk / Impact

- **Affected areas**: startup auto-resume, Branches / Worktree actions, Launch Wizard Quick Start, Settings.Index full status refresh, workspace shell broadcasts, Workspace Overview history hydration.
- **Rollback plan**: revert this PR; persisted sessions and workspace history files are not migrated or rewritten by the change.
