### PR TITLE
fix(gui): recover branches refresh after reconnect

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -4703,7 +4703,6 @@ impl AppRuntime {
 
         spawn_branch_load_async(
             self.proxy.clone(),
-            client_id.to_string(),
             id.to_string(),
             tab.project_root.clone(),
             self.active_session_branches_for_tab(&address.tab_id),

--- a/crates/gwt/src/repo_browser.rs
+++ b/crates/gwt/src/repo_browser.rs
@@ -4,7 +4,7 @@ use std::{
     thread,
 };
 
-use crate::{AppEventProxy, ClientId, OutboundEvent, UserEvent};
+use crate::{AppEventProxy, OutboundEvent, UserEvent};
 use gwt::{
     hydrate_branch_entries_with_active_sessions, list_branch_inventory, BackendEvent,
     BranchEntriesPhase, BranchListEntry, BranchScope,
@@ -12,7 +12,6 @@ use gwt::{
 
 pub fn spawn_branch_load_async(
     proxy: AppEventProxy,
-    client_id: ClientId,
     window_id: String,
     project_root: PathBuf,
     active_session_branches: HashSet<String>,
@@ -20,7 +19,6 @@ pub fn spawn_branch_load_async(
     thread::spawn(move || {
         dispatch_branch_load_progressive(
             &proxy,
-            &client_id,
             &window_id,
             &project_root,
             &active_session_branches,
@@ -48,7 +46,6 @@ pub fn preferred_issue_launch_branch(entries: &[BranchListEntry]) -> Option<Stri
 
 fn dispatch_branch_load_progressive(
     proxy: &AppEventProxy,
-    client_id: &ClientId,
     window_id: &str,
     project_root: &Path,
     active_session_branches: &HashSet<String>,
@@ -57,14 +54,11 @@ fn dispatch_branch_load_progressive(
         Ok(entries) => {
             dispatch_async_events(
                 proxy,
-                vec![OutboundEvent::reply(
-                    client_id.clone(),
-                    BackendEvent::BranchEntries {
-                        id: window_id.to_string(),
-                        phase: BranchEntriesPhase::Inventory,
-                        entries: entries.clone(),
-                    },
-                )],
+                vec![OutboundEvent::broadcast(BackendEvent::BranchEntries {
+                    id: window_id.to_string(),
+                    phase: BranchEntriesPhase::Inventory,
+                    entries: entries.clone(),
+                })],
             );
             match hydrate_branch_entries_with_active_sessions(
                 project_root,
@@ -73,36 +67,27 @@ fn dispatch_branch_load_progressive(
             ) {
                 Ok(entries) => dispatch_async_events(
                     proxy,
-                    vec![OutboundEvent::reply(
-                        client_id.clone(),
-                        BackendEvent::BranchEntries {
-                            id: window_id.to_string(),
-                            phase: BranchEntriesPhase::Hydrated,
-                            entries,
-                        },
-                    )],
+                    vec![OutboundEvent::broadcast(BackendEvent::BranchEntries {
+                        id: window_id.to_string(),
+                        phase: BranchEntriesPhase::Hydrated,
+                        entries,
+                    })],
                 ),
                 Err(error) => dispatch_async_events(
                     proxy,
-                    vec![OutboundEvent::reply(
-                        client_id.clone(),
-                        BackendEvent::BranchError {
-                            id: window_id.to_string(),
-                            message: error.to_string(),
-                        },
-                    )],
+                    vec![OutboundEvent::broadcast(BackendEvent::BranchError {
+                        id: window_id.to_string(),
+                        message: error.to_string(),
+                    })],
                 ),
             }
         }
         Err(error) => dispatch_async_events(
             proxy,
-            vec![OutboundEvent::reply(
-                client_id.clone(),
-                BackendEvent::BranchError {
-                    id: window_id.to_string(),
-                    message: error.to_string(),
-                },
-            )],
+            vec![OutboundEvent::broadcast(BackendEvent::BranchError {
+                id: window_id.to_string(),
+                message: error.to_string(),
+            })],
         ),
     }
 }
@@ -172,5 +157,41 @@ mod tests {
         ];
 
         assert_eq!(preferred_issue_launch_branch(&entries), None);
+    }
+
+    #[test]
+    fn async_branch_load_results_are_broadcast_not_bound_to_a_stale_websocket_client() {
+        let source = include_str!("repo_browser.rs");
+        let production_source = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production source before tests");
+
+        assert_async_branch_event_is_broadcast_only(production_source, "BranchEntries");
+        assert_async_branch_event_is_broadcast_only(production_source, "BranchError");
+    }
+
+    fn assert_async_branch_event_is_broadcast_only(production_source: &str, event: &str) {
+        let event_marker = format!("BackendEvent::{event}");
+        let positions = production_source
+            .match_indices(&event_marker)
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+
+        assert!(
+            !positions.is_empty(),
+            "async branch {event} must still be dispatched"
+        );
+
+        for position in positions {
+            let prefix = &production_source[..position];
+            let last_broadcast = prefix.rfind("OutboundEvent::broadcast(");
+            let last_reply = prefix.rfind("OutboundEvent::reply(");
+
+            assert!(
+                last_broadcast.is_some() && last_broadcast > last_reply,
+                "async branch {event} must be broadcast by window id, not targeted to a transient websocket client id",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Broadcast asynchronous Branches refresh results by window id so reconnecting browser clients receive refreshed branch rows.
- Preserve client-scoped validation errors while preventing stale WebSocket replies from leaving Branches stuck in a loading or connection-lost state.

## Changes

- `crates/gwt/src/repo_browser.rs`: removed transient `ClientId` coupling from async branch loading, broadcast `BranchEntries` and `BranchError` events by window id, and added a regression guard for the dispatch contract.
- `crates/gwt/src/app_runtime/mod.rs`: stopped passing the current WebSocket client id into the async Branches refresh path.

## Testing

- [x] `cargo fmt --check` — PASS.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — PASS.
- [x] `cargo test -p gwt --bin gwt branch` — PASS, 27 tests.
- [x] `cargo test -p gwt-core -p gwt --all-features` — PASS, including gwt/gwt-core unit, integration, and doc tests.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — PASS.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — PASS.
- [x] `headless-browser-check` — PASS; the served GUI loaded at `http://127.0.0.1:51177/`, and the user confirmed the Branches list was visible without `Connection lost while loading branches`.

## Closing Issues

None

## Related Issues / Links

- None

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (not needed: no documented user workflow or CLI surface changed)
- [ ] Migration/backfill plan included (not needed: no schema or persisted data change)
- [x] CHANGELOG impact considered (patch-level `fix:` commit)

## Context

- The previous fix recovered some Branches loading paths, but logs showed `load_branches` could still complete after `/ws` reconnected. The old async result was addressed to the stale client id, so the fresh browser connection could remain on the loading/error state despite git branch inventory succeeding.

## Screenshots

| Before | After |
|--------|-------|
| Branches could show `Connection lost while loading branches` after refresh/reconnect. | User-confirmed headless check showed Branches rows rendered normally on the served GUI. |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal branch loading event delivery mechanism for consistency.

* **Tests**
  * Extended test coverage to verify branch loading operations dispatch correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2854?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->