### PR TITLE
chore(release): v9.42.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.42.2] - 2026-05-21
+
+### Bug Fixes
+
+- **gui:** Recover Branches refresh after reconnect
+
 ## [9.42.1] - 2026-05-21
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.42.1"
+version = "9.42.2"
 dependencies = [
  "ammonia",
  "axum",
@@ -1379,7 +1379,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.42.1"
+version = "9.42.2"
 dependencies = [
  "chrono",
  "dunce",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.42.1"
+version = "9.42.2"
 dependencies = [
  "reqwest",
  "serde",
@@ -1415,7 +1415,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.42.1"
+version = "9.42.2"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.42.1"
+version = "9.42.2"
 dependencies = [
  "dirs",
  "serde",
@@ -1436,7 +1436,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.42.1"
+version = "9.42.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -1469,7 +1469,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.42.1"
+version = "9.42.2"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.42.1"
+version = "9.42.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -1495,7 +1495,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.42.1"
+version = "9.42.2"
 dependencies = [
  "gwt-core",
  "regex",
@@ -1508,7 +1508,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.42.1"
+version = "9.42.2"
 dependencies = [
  "chrono",
  "fs2",
@@ -1525,7 +1525,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.42.1"
+version = "9.42.2"
 dependencies = [
  "libc",
  "nix 0.31.3",
@@ -1541,7 +1541,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.42.1"
+version = "9.42.2"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.42.1"
+version = "9.42.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -4703,7 +4703,6 @@ impl AppRuntime {
 
         spawn_branch_load_async(
             self.proxy.clone(),
-            client_id.to_string(),
             id.to_string(),
             tab.project_root.clone(),
             self.active_session_branches_for_tab(&address.tab_id),

--- a/crates/gwt/src/repo_browser.rs
+++ b/crates/gwt/src/repo_browser.rs
@@ -4,7 +4,7 @@ use std::{
     thread,
 };
 
-use crate::{AppEventProxy, ClientId, OutboundEvent, UserEvent};
+use crate::{AppEventProxy, OutboundEvent, UserEvent};
 use gwt::{
     hydrate_branch_entries_with_active_sessions, list_branch_inventory, BackendEvent,
     BranchEntriesPhase, BranchListEntry, BranchScope,
@@ -12,7 +12,6 @@ use gwt::{
 
 pub fn spawn_branch_load_async(
     proxy: AppEventProxy,
-    client_id: ClientId,
     window_id: String,
     project_root: PathBuf,
     active_session_branches: HashSet<String>,
@@ -20,7 +19,6 @@ pub fn spawn_branch_load_async(
     thread::spawn(move || {
         dispatch_branch_load_progressive(
             &proxy,
-            &client_id,
             &window_id,
             &project_root,
             &active_session_branches,
@@ -48,7 +46,6 @@ pub fn preferred_issue_launch_branch(entries: &[BranchListEntry]) -> Option<Stri
 
 fn dispatch_branch_load_progressive(
     proxy: &AppEventProxy,
-    client_id: &ClientId,
     window_id: &str,
     project_root: &Path,
     active_session_branches: &HashSet<String>,
@@ -57,14 +54,11 @@ fn dispatch_branch_load_progressive(
         Ok(entries) => {
             dispatch_async_events(
                 proxy,
-                vec![OutboundEvent::reply(
-                    client_id.clone(),
-                    BackendEvent::BranchEntries {
-                        id: window_id.to_string(),
-                        phase: BranchEntriesPhase::Inventory,
-                        entries: entries.clone(),
-                    },
-                )],
+                vec![OutboundEvent::broadcast(BackendEvent::BranchEntries {
+                    id: window_id.to_string(),
+                    phase: BranchEntriesPhase::Inventory,
+                    entries: entries.clone(),
+                })],
             );
             match hydrate_branch_entries_with_active_sessions(
                 project_root,
@@ -73,36 +67,27 @@ fn dispatch_branch_load_progressive(
             ) {
                 Ok(entries) => dispatch_async_events(
                     proxy,
-                    vec![OutboundEvent::reply(
-                        client_id.clone(),
-                        BackendEvent::BranchEntries {
-                            id: window_id.to_string(),
-                            phase: BranchEntriesPhase::Hydrated,
-                            entries,
-                        },
-                    )],
+                    vec![OutboundEvent::broadcast(BackendEvent::BranchEntries {
+                        id: window_id.to_string(),
+                        phase: BranchEntriesPhase::Hydrated,
+                        entries,
+                    })],
                 ),
                 Err(error) => dispatch_async_events(
                     proxy,
-                    vec![OutboundEvent::reply(
-                        client_id.clone(),
-                        BackendEvent::BranchError {
-                            id: window_id.to_string(),
-                            message: error.to_string(),
-                        },
-                    )],
+                    vec![OutboundEvent::broadcast(BackendEvent::BranchError {
+                        id: window_id.to_string(),
+                        message: error.to_string(),
+                    })],
                 ),
             }
         }
         Err(error) => dispatch_async_events(
             proxy,
-            vec![OutboundEvent::reply(
-                client_id.clone(),
-                BackendEvent::BranchError {
-                    id: window_id.to_string(),
-                    message: error.to_string(),
-                },
-            )],
+            vec![OutboundEvent::broadcast(BackendEvent::BranchError {
+                id: window_id.to_string(),
+                message: error.to_string(),
+            })],
         ),
     }
 }
@@ -172,5 +157,41 @@ mod tests {
         ];
 
         assert_eq!(preferred_issue_launch_branch(&entries), None);
+    }
+
+    #[test]
+    fn async_branch_load_results_are_broadcast_not_bound_to_a_stale_websocket_client() {
+        let source = include_str!("repo_browser.rs");
+        let production_source = source
+            .split("#[cfg(test)]")
+            .next()
+            .expect("production source before tests");
+
+        assert_async_branch_event_is_broadcast_only(production_source, "BranchEntries");
+        assert_async_branch_event_is_broadcast_only(production_source, "BranchError");
+    }
+
+    fn assert_async_branch_event_is_broadcast_only(production_source: &str, event: &str) {
+        let event_marker = format!("BackendEvent::{event}");
+        let positions = production_source
+            .match_indices(&event_marker)
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+
+        assert!(
+            !positions.is_empty(),
+            "async branch {event} must still be dispatched"
+        );
+
+        for position in positions {
+            let prefix = &production_source[..position];
+            let last_broadcast = prefix.rfind("OutboundEvent::broadcast(");
+            let last_reply = prefix.rfind("OutboundEvent::reply(");
+
+            assert!(
+                last_broadcast.is_some() && last_broadcast > last_reply,
+                "async branch {event} must be broadcast by window id, not targeted to a transient websocket client id",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Prepare the v9.42.2 patch release.
- Include the Branches refresh reconnect fix that prevents refreshed branch rows from being lost after WebSocket reconnects.

## Changes

- Version updated from v9.42.1 to v9.42.2.
- CHANGELOG updated with the v9.42.2 bug fix entry.
- Release range includes PR #2854: `fix(gui): recover Branches refresh after reconnect`.

## Version

v9.42.2

## Closing Issues

None

## Related Issues / Links

None
