### PR TITLE
test(e2e): cover quiet work UI surfaces

### DIFF
--- a/crates/gwt/playwright/tests/quiet-work-ui-e2e.spec.ts
+++ b/crates/gwt/playwright/tests/quiet-work-ui-e2e.spec.ts
@@ -1,0 +1,248 @@
+/* SPEC-2356 Phase 10 — Quiet Work UI E2E (embedded-routes).
+ *
+ * Drives the embedded frontend with a stubbed WebSocket so the new
+ * Workspace Overview List+Detail surface and Release Notes modal chrome
+ * can be exercised end-to-end without a live gwt backend.
+ */
+import { expect, test } from "@playwright/test";
+import { APP_URL, installEmbeddedRoutes } from "./_helpers/embedded-frontend";
+
+test.describe("Quiet Work UI surfaces (E2E)", () => {
+  test.use({
+    deviceScaleFactor: 1,
+    viewport: { width: 1600, height: 1000 },
+  });
+
+  test("Workspace Overview window renders List + Detail shell", async ({
+    page,
+  }) => {
+    await installEmbeddedRoutes(page);
+    await installBackend(page);
+    await page.goto(APP_URL);
+
+    const overview = page.locator(".workspace-overview-root");
+    await expect(overview).toBeVisible();
+    await expect(page.locator(".workspace-overview-list-pane")).toBeVisible();
+    await expect(page.locator(".workspace-overview-detail-pane")).toBeVisible();
+    await expect(page.locator(".workspace-kanban-board")).toHaveCount(0);
+    await expect(page.locator("[data-workspace-column]")).toHaveCount(0);
+
+    const rows = page.locator(".workspace-overview-row[data-workspace-id]");
+    await expect(rows).toHaveCount(2);
+    await expect(rows.nth(0)).toHaveAttribute("aria-selected", "true");
+    await expect(rows.nth(0)).toContainText("Quiet Work UI redesign");
+
+    await rows.nth(1).click();
+    await expect(rows.nth(1)).toHaveAttribute("aria-selected", "true");
+    await expect(page.locator(".workspace-detail-title")).toHaveText(
+      "Completed Workspace",
+    );
+  });
+
+  test("Release Notes opens as a modal-style op-global-window", async ({
+    page,
+  }) => {
+    await installEmbeddedRoutes(page);
+    await installBackend(page);
+    await page.goto(APP_URL);
+
+    const trigger = page.locator("#app-version");
+    await expect(trigger).toBeVisible();
+    await trigger.click();
+
+    const release = page.locator("#release-notes-window");
+    await expect(release).toBeVisible();
+    await expect(release).toHaveAttribute("role", "dialog");
+    await expect(release).toHaveClass(/op-global-window/);
+
+    const cssPosition = await release.evaluate(
+      (el) => getComputedStyle(el as HTMLElement).position,
+    );
+    expect(cssPosition).toBe("fixed");
+
+    await expect(
+      release.locator(".release-notes-sidebar-item.is-selected"),
+    ).toHaveAttribute("data-version", "9.42.1");
+    await expect(release.locator(".release-notes-content h2")).toHaveText(
+      "v9.42.1",
+    );
+
+    await page.keyboard.press("Escape");
+    await expect(release).toHaveCount(0);
+  });
+});
+
+async function installBackend(page: any) {
+  await page.addInitScript(() => {
+    const workspaceState = {
+      kind: "workspace_state",
+      workspace: {
+        app_version: "9.42.1",
+        tabs: [
+          {
+            id: "tab-1",
+            title: "Fixture Project",
+            project_root: "/fixture",
+            kind: "git",
+            workspace: {
+              viewport: { x: 0, y: 0, zoom: 1 },
+              windows: [
+                {
+                  id: "workspace-window-1",
+                  title: "Workspace",
+                  preset: "workspace",
+                  geometry: { x: 80, y: 80, width: 1280, height: 760 },
+                  z_index: 1,
+                  status: "running",
+                  minimized: false,
+                  maximized: false,
+                  pre_maximize_geometry: null,
+                  persist: true,
+                  purpose_title: null,
+                  dynamic_title: null,
+                  dynamic_title_detail: null,
+                  agent_id: null,
+                  agent_color: null,
+                  tab_group_id: null,
+                  tab_group_active: false,
+                },
+              ],
+            },
+          },
+        ],
+        active_tab_id: "tab-1",
+        recent_projects: [],
+      },
+    };
+
+    const projection = {
+      kind: "active_work_projection",
+      projection: {
+        id: "workspace-current",
+        title: "Quiet Work UI redesign",
+        status_category: "active",
+        status_text: "Phase 10 implementation",
+        summary: "Quiet Work UI redesign in flight.",
+        owner: "SPEC-2356",
+        branch: "work/20260521-0234",
+        workspaces: [
+          {
+            id: "workspace-current",
+            title: "Quiet Work UI redesign",
+            intent: "Workspace Overview Quiet Work UI",
+            summary: "List + Detail surface validation.",
+            owner: "SPEC-2356",
+            status_category: "active",
+            lifecycle_stage: "active",
+            branch: "work/20260521-0234",
+            worktree_path: "/repo/work/20260521-0234",
+            pr_number: 2856,
+            pr_state: "open",
+            board_refs: ["board-claim-1"],
+            agents: [
+              {
+                session_id: "agent-current",
+                display_name: "Codex",
+                status_category: "active",
+                title_summary: "Phase 10 implementation",
+                current_focus: "Workspace Overview shell",
+              },
+            ],
+            events: [],
+          },
+          {
+            id: "workspace-done",
+            title: "Completed Workspace",
+            summary: "Already merged.",
+            owner: "Issue #2780",
+            status_category: "done",
+            lifecycle_stage: "done",
+            agents: [],
+            events: [],
+          },
+        ],
+        unassigned_agents: [],
+      },
+    };
+
+    const releaseEntries = [
+      {
+        version: "9.42.1",
+        date: "2026-05-21",
+        sections: [
+          {
+            heading: "Fixed",
+            items: ["Quiet Work UI guardrails."],
+          },
+        ],
+      },
+      {
+        version: "9.42.0",
+        date: "2026-05-20",
+        sections: [
+          {
+            heading: "Added",
+            items: ["Workspace auto resume."],
+          },
+        ],
+      },
+    ];
+
+    class FixtureWebSocket extends EventTarget {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+
+      url: string;
+      readyState: number;
+
+      constructor(url: string) {
+        super();
+        this.url = url;
+        this.readyState = FixtureWebSocket.CONNECTING;
+        setTimeout(() => {
+          this.readyState = FixtureWebSocket.OPEN;
+          this.dispatchEvent(new Event("open"));
+        }, 0);
+      }
+
+      send(raw: string) {
+        const message = JSON.parse(raw);
+        if (message.kind === "frontend_ready") {
+          this.emit(workspaceState);
+          setTimeout(() => this.emit(projection), 0);
+          return;
+        }
+        if (message.kind === "open_release_notes") {
+          this.emit({
+            kind: "release_notes_payload",
+            id: message.id,
+            current_version: "9.42.1",
+            focus_version: message.focus_version || "9.42.1",
+            entries: releaseEntries,
+          });
+          return;
+        }
+      }
+
+      close() {
+        this.readyState = FixtureWebSocket.CLOSED;
+        this.dispatchEvent(new CloseEvent("close"));
+      }
+
+      emit(payload: unknown) {
+        setTimeout(() => {
+          this.dispatchEvent(
+            new MessageEvent("message", { data: JSON.stringify(payload) }),
+          );
+        }, 0);
+      }
+    }
+
+    Object.defineProperty(window, "WebSocket", {
+      configurable: true,
+      value: FixtureWebSocket,
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- SPEC-2356 Phase 10 で導入した Quiet Work UI 2 サーフェスを Playwright embedded-routes で end-to-end 検証する spec を追加。live backend 不要で chromium-dark / chromium-light 両プロジェクトで安定実行できる。
- 既存の `quiet-work-ui-contract.test.mjs` (linkedom 単体) と `release-notes-live.spec.ts` (live backend 必須でデフォルトは skip) の中間レイヤとして、ブラウザ環境で実際に WebSocket / DOM / CSS 計算値まで検証する regression guard を提供。

## Changes

- `crates/gwt/playwright/tests/quiet-work-ui-e2e.spec.ts`: 新規 spec。embedded-routes + WebSocket stub で 2 件の E2E を実装。
  - **Workspace Overview**: `.workspace-overview-root` / `.workspace-overview-list-pane` / `.workspace-overview-detail-pane` の描画、`.workspace-kanban-board` / `[data-workspace-column]` の不在、初期選択と行クリックによる Detail title 更新を確認。
  - **Release Notes**: `#app-version` クリックで `#release-notes-window` が `role=dialog` + `op-global-window` class + computed `position: fixed` で出現することを確認し、sidebar 選択 / content H2 / Escape クローズを検証。

## Testing

- [x] `node_modules/.bin/playwright test --config crates/gwt/playwright/playwright.config.ts crates/gwt/playwright/tests/quiet-work-ui-e2e.spec.ts` — 4 passed (chromium-dark / chromium-light 各 2 件)
- [x] pre-push hook — Filtered line coverage 90% threshold met, 37 SKILL.md frontmatter validated

## Closing Issues

- None

## Related Issues / Links

- SPEC-2356 (#2356 — Operator Design System Phase 10)
- 前提 PR: #2856 (`fix(gui): harden quiet work UI surfaces`、merged)

## Checklist

- [x] Tests added/updated (新規 E2E spec 追加)
- [x] Lint/format passed (commitlint warning は footer-leading-blank の軽微指摘のみ、コミット自体は受理済み)
- [x] Documentation updated — 不要（テスト追加のみ）
- [x] Migration/backfill plan included — 不要
- [x] CHANGELOG impact considered — `test:` プレフィックスのため release バージョンには影響なし

## Context

- PR #2856 で Quiet Work UI guardrails を contract test として固定したが、ブラウザ実行環境での挙動（WebSocket → DOM mount → computed CSS）まで通す regression guard が薄かった。
- live backend を必須にすると CI で skip されるため、kanban.spec.ts と同じ embedded-routes パターンを採用して live と単体の中間を埋める。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for Quiet Work UI, covering Workspace Overview rendering and Release Notes modal functionality, including user interactions and UI styling validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2858?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->