### PR TITLE
fix(gui): make Console window plain terminal-style and enforce PR verification gate (SPEC-2809 follow-up)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,17 @@
 - 「進めて」等の承認指示は、承認済みタスクを自律的に完了まで進める指示である。不要な中間確認を挟まず、完了まで一気に進める
 - **変更規模の大小に関わらず `feat` / `fix` / `refactor` は仕様策定（GitHub Issue-backed SPEC）・TDD を省略しない。** 「軽微だから省略」は禁止。適用除外は `docs:` / `chore:` / typo修正 / AGENTS.md / CLAUDE.md / README.md 更新のみ
 
+### PR 作成ルール（必須）
+
+> 🚨 **エージェントは、ユーザーの視覚検証結果が `confirmed` になる前に PR を `create` / `update` してはならない。**
+
+- `gwt-verify --mode pre-pr` の **`User Verification Result`** が `confirmed` または `n/a`（UI 影響が無い変更で視覚検証不要な場合に限る）のいずれかになるまで PR 作成・更新を行わない。`pending` / 未確認のまま `gwtd pr create` / `gwtd pr edit` を呼ばない。
+- ユーザーが視覚検証できない状態（例: Open Project picker のクリックがブロックされている、splash から進めない、サーバーが起動しない 等）に遭遇した場合、エージェントの独断で `skipped(<reason>)` に倒さない。**まずブロッカーの根本原因を特定して解消し、ユーザーが実際に視覚確認できる状態を再現してから verification を依頼する**。
+- `skipped(<reason>)` を許容するのは、ユーザーが `AskUserQuestion` 等で明示的に "Skip — proceed to PR" を選択した場合のみ。エージェントが「自動テスト全 PASS だから skip 妥当」と判断して skip するのは禁止。
+- 「進めて」「OK」等の承認指示は、**既に verification 結果を持つ作業**を完了まで進める指示であり、verification 自体の skip 承認ではない。verification 動線がブロックされている時に「進めて」と言われた場合は、ブロッカー解消の作業を進める指示として解釈する。
+- 万が一誤って PR を作成してしまった場合、即座に PR タイトルへ `[DO NOT MERGE — user verification pending]` を付与し、ブロック comment を投稿してマージを物理的に阻止する。verification が `confirmed` になってからタイトルを戻す。
+- 過去事例: PR #2857（SPEC-2809）で `User Verification Result: skipped(reason: develop 側 picker regression)` をエージェントが独断で倒して PR を作成したのは skill 違反だった。原因は picker click-blocking という visualization blocker をエージェントが解消せずに skip に倒したこと。今後は同じ skip 判断を繰り返さない。
+
 ### コミットメッセージポリシー
 
 > 🚨 **コミットログはリリースワークフローがバージョン判定に使用する唯一の真実であり、ここに齟齬があるとリリースバージョン・CHANGELOG 生成が即座に破綻します。commitlint を素通りさせることは絶対に許されません。**

--- a/crates/gwt-core/src/logging/init.rs
+++ b/crates/gwt-core/src/logging/init.rs
@@ -14,7 +14,6 @@ use tracing_subscriber::{
 
 use super::{
     config::{LogLevel, LoggingConfig},
-    console_tee::ConsoleTeeLayer,
     fmt_layer, housekeep,
     ui_forwarder::UiForwarderLayer,
     writer, LogEvent,
@@ -139,22 +138,26 @@ pub fn init(config: LoggingConfig) -> Result<LoggingHandles, String> {
     }));
     let ui = UiForwarderLayer::new(ui_tx.clone());
 
-    // Install the hub BEFORE the subscriber so the ConsoleTeeLayer's
-    // first event finds the real hub instead of an orphan instance.
+    // Install the hub before the subscriber so any caller invoking
+    // `spawn_logged` / `run_git_logged` during early startup pushes to
+    // the real hub instance.
     let process_console_hub = ProcessConsoleHub::new();
     let _ = crate::process_console::set_global(process_console_hub.clone());
 
-    // SPEC-2809: ConsoleTeeLayer mirrors gwt-domain tracing events
-    // (target prefix → ProcessKind) into the ProcessConsoleHub so the
-    // Console window tabs see both actual command spawns and gwt-side
-    // operational notes (VS Code Output Panel parity).
-    let tee = ConsoleTeeLayer::new();
-
+    // SPEC-2809 revised — the Console window mirrors actual subprocess
+    // stdout/stderr (via `spawn_logged` / `run_git_logged` → hub push)
+    // and synthetic `$ <command>` banners + `→ exit=...` footers. We
+    // intentionally do NOT tee gwt-domain tracing events
+    // (`gwt::index`, `gwt::git`, etc.) into the Console hub: those are
+    // structured tracing for the Logs window, and surfacing them in
+    // Console with `[target] message (field=value)` prefixes broke the
+    // "terminal-like output" mental model. The canonical JSONL log
+    // file still receives every tracing event via the `fmt` layer
+    // above, and the Logs window reads from that file.
     Registry::default()
         .with(reloadable_filter)
         .with(fmt)
         .with(ui)
-        .with(tee)
         .try_init()
         .map_err(|e| format!("subscriber init failed: {e}"))?;
 

--- a/crates/gwt-core/tests/logging_init.rs
+++ b/crates/gwt-core/tests/logging_init.rs
@@ -32,10 +32,11 @@ fn init_writes_tracing_events_as_jsonl_to_gwt_log() {
     );
     tracing::warn!(target: "gwt_core::logging::test", "warning sample");
 
-    // SPEC-2809 — ConsoleTeeLayer should map `gwt::index` events into
-    // the IndexRunner ring buffer so the Console window's Runner tab
-    // shows operational notes even when the chroma runner is not
-    // currently spawning a subprocess.
+    // SPEC-2809 revised — the Console window only shows actual
+    // subprocess stdout/stderr (terminal-like view); gwt-domain
+    // tracing events like `gwt::index` must NOT be teed into the
+    // ProcessConsoleHub. They are surfaced by the Logs window via the
+    // canonical JSONL log file. This assertion guards the contract.
     tracing::info!(
         target: "gwt::index",
         worktree = "test-wt",
@@ -46,10 +47,8 @@ fn init_writes_tracing_events_as_jsonl_to_gwt_log() {
         .process_console_hub
         .snapshot_kind(ProcessKind::IndexRunner);
     assert!(
-        hub_snapshot_runner
-            .iter()
-            .any(|line| line.message.contains("index status runner kicked")),
-        "expected ConsoleTeeLayer to push gwt::index event into IndexRunner buffer; got: {:?}",
+        hub_snapshot_runner.is_empty(),
+        "expected IndexRunner hub buffer to remain empty (no tee from `gwt::index` tracing), got: {:?}",
         hub_snapshot_runner
             .iter()
             .map(|l| l.message.as_str())

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -4048,19 +4048,14 @@ kbd.op-kbd {
   border-radius: var(--radius-md);
 }
 
+/* SPEC-2809 — "$ <command>" banner and "→ exit=..." footer lines.
+   Rendered as plain terminal-style monospace text in a muted color so
+   they read like the prompt / exit hint a user would see in iTerm
+   while still distinguishing them from real stdout/stderr. No
+   uppercase, no bold, no block margins. */
 .console-window__invocation-header {
   display: block;
   color: var(--color-text-muted);
-  margin-top: 10px;
-  margin-bottom: 4px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: var(--tracking-mono);
-  font-size: var(--type-2xs, 11px);
-}
-
-.console-window__invocation-header:first-child {
-  margin-top: 0;
 }
 
 .console-window__line {

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,5 +1,42 @@
 # Lessons Learned
 
+## 2026-05-21 — PR 作成前に `User Verification Result: confirmed` を必ず取得する
+
+### 事象
+
+SPEC-2809（Console window）の修正で、`gwt-verify --mode pre-pr` の自動テストが全 PASS した
+段階で、ユーザーの視覚確認が click-blocking regression によって実行不能だった。
+エージェントは独断で `User Verification Result: skipped(reason: develop 側 picker regression)`
+に倒して `gwtd pr create` を実行。PR #2857 がユーザー承認なしに作成された。
+ユーザーから「私のチェック前に PR を出した」と指摘された。
+
+### 原因
+
+1. `gwt-verify` skill contract は `User Verification Result ∈ {confirmed, n/a, skipped(<reason>)}`
+   を要求するが、`skipped` は **ユーザーが明示的に選択した場合のみ** 許容される。エージェントが
+   「自動テスト全 PASS だから skip 妥当」と判断して skip に倒したのは contract 違反。
+2. 視覚検証の動線がブロックされた（Open Project picker click 不能 / app_runtime panic）状態を
+   エージェントが skipped の reason として記録するだけで、ブロッカーそのものを解消せずに次の
+   ステップに進めた。「verification が実行不能」は skip 理由ではなく、解消すべき blocker である。
+3. 「進めて」というユーザー指示を、verification 自体の skip 承認と誤解釈した。本来は
+   「verification 結果が出ている作業を完了まで進めて」という意味で、verification をスキップ
+   する許可ではない。
+
+### 再発防止策
+
+1. AGENTS.md "PR 作成ルール（必須）" セクションを新設し、`gwt-verify` の
+   `User Verification Result` が `confirmed` / `n/a` になるまで `gwtd pr create` / `gwtd pr edit`
+   を呼ばないことを明文化した。`pending` / エージェント独断の `skipped` は禁止。
+2. 視覚検証動線がブロックされた場合は、`skipped` に倒す前にブロッカーの根本原因を特定して
+   解消する。今回のケースなら Open Project picker の panic 修正を先にやり、再起動後に
+   verification を依頼する順番にすべきだった。
+3. 「進めて」を解釈する際は、現在の作業 phase で何が `pending` なのかを明確にしてから動く。
+   verification 待ちなら verification を完了させる作業（= ブロッカー解消）に進む。
+4. 万一誤って PR を作成してしまった場合の rollback 手順: タイトルへ
+   `[DO NOT MERGE — user verification pending]` を即座に付与し、PR comment で
+   `gwtd pr comment <n>` を使ってブロックの理由とブロッカー解消予定を告知する。
+   verification が `confirmed` になった後にタイトルを戻し、ブロック comment を resolve する。
+
 ## 2026-05-21 — startup CPU / power は「起動プロセス数」と「hot payload サイズ」を同時に見る
 
 ### 事象


### PR DESCRIPTION
## Summary

PR #2857 で SPEC-2809 Console window を develop に merge 済みだが、user verification 後の修正 commit（`72c2f81cc fix(gui): render Console banner/footer as plain terminal text`）が PR auto-merge のタイミングで取り込まれず、develop には pivot 前の状態（uppercase + `[gwt::index]` tee）が残った。本 PR で修正版と AGENTS.md 運用ルール強化を一緒に develop に届ける。

## Changes

- **`fix(gui): render Console banner/footer as plain terminal text (SPEC-2809)`**
  - `ConsoleTeeLayer` を `tracing` Registry から外し、`[gwt::index] ...` 等の gwt-domain tracing を Console hub に流さない。Console は実 subprocess の stdout/stderr 専用のターミナル風 surface へ。canonical JSONL log + Logs window で読む既存導線に集約。
  - `.console-window__invocation-header` CSS から `text-transform: uppercase` / `font-weight: 600` / `letter-spacing` / 上下 margin / `font-size: 2xs` を削除。残るのは `display: block` と `color: text-muted` のみ。`$ git ...` banner と `→ exit=... (..ms)` footer が iTerm のプロンプトのように lowercase で穏やかに混ざる。
  - `logging_init` 統合テスト assertion 反転：`tracing::info!(target: "gwt::index", ...)` が Hub の `IndexRunner` ring buffer に push されないこと（snapshot 空）を contract として守る。
- **`docs(agents): require user verification confirmed before PR create/update`**
  - AGENTS.md に "PR 作成ルール（必須）" subsection 新設。`gwt-verify --mode pre-pr` の `User Verification Result` が `confirmed` / `n/a` になるまで `gwtd pr create` / `gwtd pr edit` を呼ばないことを明文化。視覚検証動線がブロックされた場合は skip せずブロッカー解消を優先。誤って PR 作成した場合の rollback 手順（`[DO NOT MERGE]` 付与 + ブロック comment）を文書化。
  - tasks/lessons.md に PR #2857 事象 / 原因 / 再発防止策を記録。

## Testing

- `cargo fmt --check` — PASS
- `cargo test -p gwt-core --test logging_init` — PASS（ConsoleTeeLayer 非 tee の assertion 含む）
- `node --test crates/gwt/web/__tests__/console-window.test.mjs` — PASS（11 件）
- Pre-push hook（cargo build / cargo test / coverage 90% threshold / markdownlint / SKILL.md frontmatter validate / clippy / fmt）— **All pre-push checks passed**
- User visual check on http://127.0.0.1:62252/ — **confirmed** （lowercase / 薄い grey banner+footer / `[gwt::index]` 混在なし）

## Closing Issues

None

## Related Issues

- SPEC-2809 (Console window)
- PR #2857 follow-up（auto-merge が pivot push に追従しなかった）

## Checklist

- [x] Conventional Commits 準拠
- [x] テスト追加・全通過
- [x] markdownlint / clippy / fmt 通過
- [x] coverage 90% 維持
- [x] User Verification Result: confirmed（http://127.0.0.1:62252/ で視覚確認済み）
