### PR TITLE
fix(agent): normalize lifecycle status

### DIFF
--- a/.claude/skills/gwt-build-spec/SKILL.md
+++ b/.claude/skills/gwt-build-spec/SKILL.md
@@ -44,7 +44,8 @@ active. Register the skill lifecycle with the exit CLI:
 - `gwtd build start --spec <n>` when the skill starts an implementation pass
 - `gwtd build phase --spec <n> --label <red|green|refactor|verify|pr>` at each
   TDD milestone (logging only)
-- `gwtd build complete --spec <n>` once the PR is open and verification passed
+- `gwtd build complete --spec <n>` once the Ready PR Gate is satisfied for a
+  releaseable slice and verification passed
 - `gwtd build abort --spec <n> --reason '<text>'` when implementation cannot
   proceed without a product decision or blocking merge conflict
 
@@ -158,7 +159,12 @@ Handle PR operations autonomously using the `gwt-manage-pr` skill:
 - If the current PR has CI failures, conflicts, or review blockers, use `gwt-manage-pr` to fix.
 - Let `gwt-manage-pr` handle routine merge/push/fix loops.
 
-Do not create a PR until Phase 3 verification passes.
+Do not create or update a Ready for review PR until Phase 3 verification
+passes and the Ready PR Gate confirms a releaseable slice. If work is
+intentionally incomplete or blocked but needs shared CI/early review,
+`gwt-manage-pr` may create/update only a Draft PR that lists known
+blockers and Remaining acceptance. Draft PR does not satisfy build
+completion.
 
 ## Phase 5: Completion Gate
 
@@ -173,6 +179,8 @@ Required checks:
 - tasks セクションの TDD チェックボックスが実際の検証エビデンスを反映している
 - tasks セクションの完了マーカーがコードで裏付けられていない完了を主張していない
 - If artifacts disagree, return to `gwt-discussion` — do not proceed to PR
+- Ready PR Gate passed for a releaseable slice. An incomplete Draft PR
+  handoff must be reported separately and does not satisfy completion.
 
 Update execution tracking:
 
@@ -189,6 +197,11 @@ Update execution tracking:
 ### Chain suggestion
 
 On completion, suggest `gwt-arch-review` for code review if available, or proceed to `gwt-manage-pr` if not already done.
+
+Only call `gwtd build complete --spec <n>` after the Ready PR Gate is
+satisfied for a releaseable slice. A Draft PR handoff must keep the
+remaining work visible in the report and must not be represented as a
+completed build.
 
 ## Stop conditions
 

--- a/.claude/skills/gwt-manage-pr/SKILL.md
+++ b/.claude/skills/gwt-manage-pr/SKILL.md
@@ -81,34 +81,62 @@ impossible.**
    use **FIX** immediately instead of push-only/create. Outside that
    override, PR state (MERGED / CLOSED) is not consulted.
 
-## Pre-PR Verification (mandatory)
+## Ready PR Gate and Pre-PR Verification (mandatory)
 
-Before any push, PR create, or PR update operation, invoke
-`gwt-verify --mode pre-pr` and require `Overall: PASS` in the evidence
-bundle. `gwt-verify` is a project-agnostic Generic Verification Contract:
-it autodetects the host project's test runners (Cargo.toml /
-package.json / pyproject.toml / go.mod / ProjectSettings / *.sln / etc.),
-runs the appropriate unit / integration / E2E / visual tests for the
-changed surfaces, emits a Test Inventory naming exactly which tests
-were executed, and hands off to the user with a 4-step 導線 + Check
-Items before finalizing the report. Project-local AGENTS.md / README
-testing instructions always take precedence over the generic matrix.
+Use the Ready PR Gate before any push, PR create, PR update, or state
+change that would present the branch as Ready for review. A PR may be
+Ready for review only when all of the following are true:
 
-The push / PR-write gate **fails** when any of:
+- the PR scope is a releaseable slice: it can be merged and shipped by
+  itself without exposing incomplete behavior or breaking existing users
+- all acceptance criteria for the PR scope are satisfied
+- no known blockers remain for the PR scope
+- rollback / follow-up boundaries are explained in the PR body when relevant
+- `gwt-verify --mode pre-pr` returns `Overall: PASS`
+- `User Verification Result` is `confirmed`, `n/a`, or
+  `skipped(<reason>)`
+- every PR body checklist item is checked or explicitly marked N/A with
+  a reason
+
+`gwt-verify` is a project-agnostic Generic Verification Contract: it
+autodetects the host project's test runners (Cargo.toml / package.json /
+pyproject.toml / go.mod / ProjectSettings / *.sln / etc.), runs the
+appropriate unit / integration / E2E / visual tests for the changed
+surfaces, emits a Test Inventory naming exactly which tests were
+executed, and hands off to the user with a 4-step 導線 + Check Items
+before finalizing the report. Project-local AGENTS.md / README testing
+instructions always take precedence over the generic matrix.
+
+Draft PR is the only allowed PR state for unfinished, partially
+verified, acceptance-incomplete, or blocker-bearing work. Draft PR is
+allowed for CI, shared visibility, and early review, but the PR body
+must set `State: Draft`, list known blockers, list Remaining acceptance,
+and avoid any claim that the change is complete or a releaseable slice.
+Full `gwt-verify --mode pre-pr` is not required solely to create or
+update a Draft PR, but the agent must include the exact verification
+that was run and the reason full Ready verification is not yet claimed.
+
+The Ready PR Gate **fails** when any of:
 
 - `gwt-verify --mode pre-pr` returns `Overall: FAIL`
 - `failed: tooling-missing` is recorded
 - `User Verification Result` is `pending` (handoff never completed) or
   `rejected(<reason>)` (user declined). The user's reason is preserved
   in the evidence bundle.
+- the PR body lists known blockers or Remaining acceptance for the PR
+  scope
+- the PR is not a releaseable slice
 
-On failure, do not push, do not create a PR, and do not update an
-existing PR. Route the failure for repair (back to the TDD loop or
-`gwt-discussion`) and re-run pre-pr verification before retrying.
+On Ready PR Gate failure, do not push a Ready/non-draft update, do not
+create a Ready PR, and do not mark an existing Draft PR as Ready for
+review. Either keep/create the PR as Draft PR with explicit blockers, or
+return **NO ACTION** and route the failure for repair (back to the TDD
+loop or `gwt-discussion`) before retrying.
 
-This applies equally to Create and Fix modes — every code-changing
-re-push must be preceded by a fresh `gwt-verify --mode pre-pr` PASS
-with a satisfied `User Verification Result`.
+This applies equally to Create and Fix modes. Every code-changing
+re-push to a Ready/non-draft PR must be preceded by a fresh
+`gwt-verify --mode pre-pr` PASS with a satisfied
+`User Verification Result`.
 
 ## Mode: Create
 
@@ -120,9 +148,10 @@ Create mode is entered from the Preflight 2×2 matrix when `N > 0`.
 
 1. **Do not create or switch branches.** Always use the current branch as head.
 2. **If open PR exists and is `CONFLICTING` / `DIRTY` / `BEHIND`** → enter Fix mode before any push-only path.
-3. **If open PR exists and merge state is clean** → push only, return existing PR URL, enter Fix mode.
-4. **If no open PR** → create new PR.
-5. **Branch sync:** If behind `origin/$base`, merge `origin/$base` first (never rebase). Push after merge.
+3. **If the work fails the Ready PR Gate** → create/update only as Draft PR, or return NO ACTION if the user explicitly rejects Draft.
+4. **If open PR exists and merge state is clean** → push only, return existing PR URL, enter Fix mode. A Ready/non-draft PR still requires the Ready PR Gate.
+5. **If no open PR** → create new PR; pass `--draft` unless the Ready PR Gate is satisfied.
+6. **Branch sync:** If behind `origin/$base`, merge `origin/$base` first (never rebase). Push after merge.
 
 ### PR Title Rules
 
@@ -134,7 +163,7 @@ Create mode is entered from the Preflight 2×2 matrix when `N > 0`.
 ### PR Body Rules
 
 - Template: `.claude/skills/gwt-manage-pr/references/pr-body-template.md`
-- Required sections: Summary, Changes, Testing, Closing Issues, Related Issues, Checklist
+- Required sections: Summary, Changes, Testing, PR Readiness, Closing Issues, Related Issues, Checklist
 - Conditional sections (remove if N/A): Context, Risk/Impact, Screenshots, Deployment
 - Remove all `<!-- GUIDE: ... -->` comments from final output
 - No `TODO` in required sections; derive content from diff/Issues/SPECs before asking user

--- a/.claude/skills/gwt-manage-pr/references/create-flow.md
+++ b/.claude/skills/gwt-manage-pr/references/create-flow.md
@@ -49,18 +49,33 @@
 6. **No open unmerged PR; at least one merged** --> treat `git rev-list --count "origin/$base..HEAD"` as the source of truth for new work.
 7. **Only closed unmerged PRs** --> create a new PR.
 
-## Step 6: Ensure the head branch is pushed
+## Step 6: Decide PR readiness before pushing
 
+- Apply the Ready PR Gate from the main skill before any push or PR write
+  that would create/update a Ready for review PR.
+- If the change is not a releaseable slice, has known blockers, has
+  Remaining acceptance, or lacks `gwt-verify --mode pre-pr` PASS evidence,
+  the PR state must be Draft.
+- If the user requested Ready for review but the gate fails, do not create
+  or update a Ready/non-draft PR. Create/update only as Draft if the user
+  accepts that state; otherwise return NO ACTION.
+
+## Step 7: Ensure the head branch is pushed
+
+- If creating/updating a Ready for review PR, push only after the Ready PR
+  Gate passes.
+- If creating/updating a Draft PR, push with the draft intent recorded in
+  the PR body and include the exact verification already run.
 - If no upstream: `git push -u origin <head>`
 - Otherwise: `git push`
 
-## Step 7: Collect PR inputs
+## Step 8: Collect PR inputs
 
-- Title, Summary, Context, Changes, Testing, Risk/Impact, Deployment, Screenshots, Related Links, Notes
+- Title, Summary, Context, Changes, Testing, PR Readiness, Risk/Impact, Deployment, Screenshots, Related Links, Notes
 - Optional: labels, reviewers, assignees, draft
 - Derive missing sections from the diff, linked Issues/SPECs, and executed tests before asking the user.
 
-## Step 8: Build PR body from template
+## Step 9: Build PR body from template
 
 - Template path: `.claude/skills/gwt-manage-pr/references/pr-body-template.md`
 - Fill all required placeholders.
@@ -75,6 +90,7 @@
 | Summary | **YES** | 1-3 bullet points. Include both the what and the why. |
 | Changes | **YES** | Enumerate changes by file or module. |
 | Testing | **YES** | List commands or exact manual test steps. |
+| PR Readiness | **YES** | State Ready for review or Draft. Include releaseable slice, Known blockers, and Remaining acceptance. |
 | Closing Issues | **YES** | `Closes #N` or `None`. |
 | Related Issues / Links | **YES** | Reference-only. `#N` or URL or `None`. |
 | Checklist | **YES** | Review every item; mark checked or N/A with reason. |
@@ -90,14 +106,17 @@
 2. Each Summary bullet must be a single sentence. No vague wording.
 3. Changes must reference specific file or module names.
 4. Testing must be reproducible. No vague "tested."
-5. Add a reason comment to every unchecked checklist item.
-6. Closing Issues: `Closes #N` or `None` only. Bare `#N` without keyword is forbidden.
-7. If `#N` in Related Issues should auto-close, it must also appear in Closing Issues as `Closes #N`.
+5. PR Readiness must be Ready for review only when the Ready PR Gate passed; otherwise it must be Draft with explicit blockers.
+6. Add a reason comment to every unchecked checklist item.
+7. Closing Issues: `Closes #N` or `None` only. Bare `#N` without keyword is forbidden.
+8. If `#N` in Related Issues should auto-close, it must also appear in Closing Issues as `Closes #N`.
 
 ## Step 10: Create or update the PR
 
 - Canonical path:
   - Create: `gwtd pr create --base <base> [--head <head>] --title "<title>" -f <file> [--label <label>]* [--draft]`
+    - Omit `--draft` only after the Ready PR Gate passes.
+    - Include `--draft` when the PR Readiness state is Draft.
   - Update: `gwtd pr edit <number> [--title "<title>"] [-f <file>] [--add-label <label>]*`
 - Transport note: the current implementation may still use GitHub REST / `gh` internally, but agent-facing workflow should stay on the `gwtd pr` surface.
 
@@ -175,7 +194,11 @@ fi
 case "$action" in
   create)
     git push -u origin "$head"
-    gwtd pr create --base "$base" --head "$head" --title "..." -f /tmp/pr-body.md
+    if grep -q 'State: Draft' /tmp/pr-body.md; then
+      gwtd pr create --base "$base" --head "$head" --title "..." -f /tmp/pr-body.md --draft
+    else
+      gwtd pr create --base "$base" --head "$head" --title "..." -f /tmp/pr-body.md
+    fi
     ;;
   fix)
     printf '%s\n' "$pr_summary"

--- a/.claude/skills/gwt-manage-pr/references/pr-body-template.md
+++ b/.claude/skills/gwt-manage-pr/references/pr-body-template.md
@@ -2,7 +2,7 @@
 PR Body Template — gwt-manage-pr skill
 
 Rules:
-- REQUIRED sections: Summary, Changes, Testing, Closing Issues, Related Issues, Checklist
+- REQUIRED sections: Summary, Changes, Testing, PR Readiness, Closing Issues, Related Issues, Checklist
 - CONDITIONAL sections: Context, Risk/Impact, Screenshots, Deployment
 - OPTIONAL sections: Notes
 - Remove CONDITIONAL sections entirely if not applicable
@@ -27,6 +27,15 @@ Rules:
 <!-- GUIDE: Provide reproducible steps. Include exact commands, expected output, or manual verification steps. "Tested" alone is NOT acceptable. -->
 
 - [ ] `{command}` — {expected result}
+
+## PR Readiness
+
+<!-- GUIDE: Choose exactly one State. Ready for review requires a releaseable slice, no known blockers, completed acceptance for this PR scope, and pre-PR verification evidence. Draft is allowed only for incomplete CI/shared review and must not claim release readiness. -->
+
+- State: Ready for review | Draft
+- Releaseable slice: {yes/no + reason}
+- Known blockers: {None or list}
+- Remaining acceptance: {None or list}
 
 ## Closing Issues
 

--- a/.codex/skills/gwt-build-spec/SKILL.md
+++ b/.codex/skills/gwt-build-spec/SKILL.md
@@ -44,7 +44,8 @@ active. Register the skill lifecycle with the exit CLI:
 - `gwtd build start --spec <n>` when the skill starts an implementation pass
 - `gwtd build phase --spec <n> --label <red|green|refactor|verify|pr>` at each
   TDD milestone (logging only)
-- `gwtd build complete --spec <n>` once the PR is open and verification passed
+- `gwtd build complete --spec <n>` once the Ready PR Gate is satisfied for a
+  releaseable slice and verification passed
 - `gwtd build abort --spec <n> --reason '<text>'` when implementation cannot
   proceed without a product decision or blocking merge conflict
 
@@ -176,7 +177,12 @@ Handle PR operations autonomously using the `gwt-manage-pr` skill:
 - If the current PR has CI failures, conflicts, or review blockers, use `gwt-manage-pr` to fix.
 - Let `gwt-manage-pr` handle routine merge/push/fix loops.
 
-Do not create a PR until Phase 3 verification passes.
+Do not create or update a Ready for review PR until Phase 3 verification
+passes and the Ready PR Gate confirms a releaseable slice. If work is
+intentionally incomplete or blocked but needs shared CI/early review,
+`gwt-manage-pr` may create/update only a Draft PR that lists known
+blockers and Remaining acceptance. Draft PR does not satisfy build
+completion.
 
 ## Phase 5: Completion Gate
 
@@ -191,6 +197,8 @@ Required checks:
 - tasks セクションの TDD チェックボックスが実際の検証エビデンスを反映している
 - tasks セクションの完了マーカーがコードで裏付けられていない完了を主張していない
 - If artifacts disagree, return to `gwt-discussion` — do not proceed to PR
+- Ready PR Gate passed for a releaseable slice. An incomplete Draft PR
+  handoff must be reported separately and does not satisfy completion.
 
 Update execution tracking:
 
@@ -207,6 +215,11 @@ Update execution tracking:
 ### Chain suggestion
 
 On completion, suggest `gwt-arch-review` for code review if available, or proceed to `gwt-manage-pr` if not already done.
+
+Only call `gwtd build complete --spec <n>` after the Ready PR Gate is
+satisfied for a releaseable slice. A Draft PR handoff must keep the
+remaining work visible in the report and must not be represented as a
+completed build.
 
 ## Stop conditions
 

--- a/.codex/skills/gwt-manage-pr/SKILL.md
+++ b/.codex/skills/gwt-manage-pr/SKILL.md
@@ -123,34 +123,62 @@ impossible.**
    use **FIX** immediately instead of push-only/create. Outside that
    override, PR state (MERGED / CLOSED) is not consulted.
 
-## Pre-PR Verification (mandatory)
+## Ready PR Gate and Pre-PR Verification (mandatory)
 
-Before any push, PR create, or PR update operation, invoke
-`gwt-verify --mode pre-pr` and require `Overall: PASS` in the evidence
-bundle. `gwt-verify` is a project-agnostic Generic Verification Contract:
-it autodetects the host project's test runners (Cargo.toml /
-package.json / pyproject.toml / go.mod / ProjectSettings / *.sln / etc.),
-runs the appropriate unit / integration / E2E / visual tests for the
-changed surfaces, emits a Test Inventory naming exactly which tests
-were executed, and hands off to the user with a 4-step 導線 + Check
-Items before finalizing the report. Project-local AGENTS.md / README
-testing instructions always take precedence over the generic matrix.
+Use the Ready PR Gate before any push, PR create, PR update, or state
+change that would present the branch as Ready for review. A PR may be
+Ready for review only when all of the following are true:
 
-The push / PR-write gate **fails** when any of:
+- the PR scope is a releaseable slice: it can be merged and shipped by
+  itself without exposing incomplete behavior or breaking existing users
+- all acceptance criteria for the PR scope are satisfied
+- no known blockers remain for the PR scope
+- rollback / follow-up boundaries are explained in the PR body when relevant
+- `gwt-verify --mode pre-pr` returns `Overall: PASS`
+- `User Verification Result` is `confirmed`, `n/a`, or
+  `skipped(<reason>)`
+- every PR body checklist item is checked or explicitly marked N/A with
+  a reason
+
+`gwt-verify` is a project-agnostic Generic Verification Contract: it
+autodetects the host project's test runners (Cargo.toml / package.json /
+pyproject.toml / go.mod / ProjectSettings / *.sln / etc.), runs the
+appropriate unit / integration / E2E / visual tests for the changed
+surfaces, emits a Test Inventory naming exactly which tests were
+executed, and hands off to the user with a 4-step 導線 + Check Items
+before finalizing the report. Project-local AGENTS.md / README testing
+instructions always take precedence over the generic matrix.
+
+Draft PR is the only allowed PR state for unfinished, partially
+verified, acceptance-incomplete, or blocker-bearing work. Draft PR is
+allowed for CI, shared visibility, and early review, but the PR body
+must set `State: Draft`, list known blockers, list Remaining acceptance,
+and avoid any claim that the change is complete or a releaseable slice.
+Full `gwt-verify --mode pre-pr` is not required solely to create or
+update a Draft PR, but the agent must include the exact verification
+that was run and the reason full Ready verification is not yet claimed.
+
+The Ready PR Gate **fails** when any of:
 
 - `gwt-verify --mode pre-pr` returns `Overall: FAIL`
 - `failed: tooling-missing` is recorded
 - `User Verification Result` is `pending` (handoff never completed) or
   `rejected(<reason>)` (user declined). The user's reason is preserved
   in the evidence bundle.
+- the PR body lists known blockers or Remaining acceptance for the PR
+  scope
+- the PR is not a releaseable slice
 
-On failure, do not push, do not create a PR, and do not update an
-existing PR. Route the failure for repair (back to the TDD loop or
-`gwt-discussion`) and re-run pre-pr verification before retrying.
+On Ready PR Gate failure, do not push a Ready/non-draft update, do not
+create a Ready PR, and do not mark an existing Draft PR as Ready for
+review. Either keep/create the PR as Draft PR with explicit blockers, or
+return **NO ACTION** and route the failure for repair (back to the TDD
+loop or `gwt-discussion`) before retrying.
 
-This applies equally to Create and Fix modes — every code-changing
-re-push must be preceded by a fresh `gwt-verify --mode pre-pr` PASS
-with a satisfied `User Verification Result`.
+This applies equally to Create and Fix modes. Every code-changing
+re-push to a Ready/non-draft PR must be preceded by a fresh
+`gwt-verify --mode pre-pr` PASS with a satisfied
+`User Verification Result`.
 
 ## Mode: Create
 
@@ -162,9 +190,10 @@ Create mode is entered from the Preflight 2×2 matrix when `N > 0`.
 
 1. **Do not create or switch branches.** Always use the current branch as head.
 2. **If open PR exists and is `CONFLICTING` / `DIRTY` / `BEHIND`** → enter Fix mode before any push-only path.
-3. **If open PR exists and merge state is clean** → push only, return existing PR URL, enter Fix mode.
-4. **If no open PR** → create new PR.
-5. **Branch sync:** If behind `origin/$base`, merge `origin/$base` first (never rebase). Push after merge.
+3. **If the work fails the Ready PR Gate** → create/update only as Draft PR, or return NO ACTION if the user explicitly rejects Draft.
+4. **If open PR exists and merge state is clean** → push only, return existing PR URL, enter Fix mode. A Ready/non-draft PR still requires the Ready PR Gate.
+5. **If no open PR** → create new PR; pass `--draft` unless the Ready PR Gate is satisfied.
+6. **Branch sync:** If behind `origin/$base`, merge `origin/$base` first (never rebase). Push after merge.
 
 ### PR Title Rules
 
@@ -176,7 +205,7 @@ Create mode is entered from the Preflight 2×2 matrix when `N > 0`.
 ### PR Body Rules
 
 - Template: `.codex/skills/gwt-manage-pr/references/pr-body-template.md`
-- Required sections: Summary, Changes, Testing, Closing Issues, Related Issues, Checklist
+- Required sections: Summary, Changes, Testing, PR Readiness, Closing Issues, Related Issues, Checklist
 - Conditional sections (remove if N/A): Context, Risk/Impact, Screenshots, Deployment
 - Remove all `<!-- GUIDE: ... -->` comments from final output
 - No `TODO` in required sections; derive content from diff/Issues/SPECs before asking user

--- a/.codex/skills/gwt-manage-pr/references/create-flow.md
+++ b/.codex/skills/gwt-manage-pr/references/create-flow.md
@@ -49,18 +49,33 @@
 6. **No open unmerged PR; at least one merged** --> treat `git rev-list --count "origin/$base..HEAD"` as the source of truth for new work.
 7. **Only closed unmerged PRs** --> create a new PR.
 
-## Step 6: Ensure the head branch is pushed
+## Step 6: Decide PR readiness before pushing
 
+- Apply the Ready PR Gate from the main skill before any push or PR write
+  that would create/update a Ready for review PR.
+- If the change is not a releaseable slice, has known blockers, has
+  Remaining acceptance, or lacks `gwt-verify --mode pre-pr` PASS evidence,
+  the PR state must be Draft.
+- If the user requested Ready for review but the gate fails, do not create
+  or update a Ready/non-draft PR. Create/update only as Draft if the user
+  accepts that state; otherwise return NO ACTION.
+
+## Step 7: Ensure the head branch is pushed
+
+- If creating/updating a Ready for review PR, push only after the Ready PR
+  Gate passes.
+- If creating/updating a Draft PR, push with the draft intent recorded in
+  the PR body and include the exact verification already run.
 - If no upstream: `git push -u origin <head>`
 - Otherwise: `git push`
 
-## Step 7: Collect PR inputs
+## Step 8: Collect PR inputs
 
-- Title, Summary, Context, Changes, Testing, Risk/Impact, Deployment, Screenshots, Related Links, Notes
+- Title, Summary, Context, Changes, Testing, PR Readiness, Risk/Impact, Deployment, Screenshots, Related Links, Notes
 - Optional: labels, reviewers, assignees, draft
 - Derive missing sections from the diff, linked Issues/SPECs, and executed tests before asking the user.
 
-## Step 8: Build PR body from template
+## Step 9: Build PR body from template
 
 - Template path: `.codex/skills/gwt-manage-pr/references/pr-body-template.md`
 - Fill all required placeholders.
@@ -75,6 +90,7 @@
 | Summary | **YES** | 1-3 bullet points. Include both the what and the why. |
 | Changes | **YES** | Enumerate changes by file or module. |
 | Testing | **YES** | List commands or exact manual test steps. |
+| PR Readiness | **YES** | State Ready for review or Draft. Include releaseable slice, Known blockers, and Remaining acceptance. |
 | Closing Issues | **YES** | `Closes #N` or `None`. |
 | Related Issues / Links | **YES** | Reference-only. `#N` or URL or `None`. |
 | Checklist | **YES** | Review every item; mark checked or N/A with reason. |
@@ -90,14 +106,17 @@
 2. Each Summary bullet must be a single sentence. No vague wording.
 3. Changes must reference specific file or module names.
 4. Testing must be reproducible. No vague "tested."
-5. Add a reason comment to every unchecked checklist item.
-6. Closing Issues: `Closes #N` or `None` only. Bare `#N` without keyword is forbidden.
-7. If `#N` in Related Issues should auto-close, it must also appear in Closing Issues as `Closes #N`.
+5. PR Readiness must be Ready for review only when the Ready PR Gate passed; otherwise it must be Draft with explicit blockers.
+6. Add a reason comment to every unchecked checklist item.
+7. Closing Issues: `Closes #N` or `None` only. Bare `#N` without keyword is forbidden.
+8. If `#N` in Related Issues should auto-close, it must also appear in Closing Issues as `Closes #N`.
 
 ## Step 10: Create or update the PR
 
 - Canonical path:
   - Create: `gwtd pr create --base <base> [--head <head>] --title "<title>" -f <file> [--label <label>]* [--draft]`
+    - Omit `--draft` only after the Ready PR Gate passes.
+    - Include `--draft` when the PR Readiness state is Draft.
   - Update: `gwtd pr edit <number> [--title "<title>"] [-f <file>] [--add-label <label>]*`
 - Transport note: the current implementation may still use GitHub REST / `gh` internally, but agent-facing workflow should stay on the `gwtd pr` surface.
 
@@ -175,7 +194,11 @@ fi
 case "$action" in
   create)
     git push -u origin "$head"
-    gwtd pr create --base "$base" --head "$head" --title "..." -f /tmp/pr-body.md
+    if grep -q 'State: Draft' /tmp/pr-body.md; then
+      gwtd pr create --base "$base" --head "$head" --title "..." -f /tmp/pr-body.md --draft
+    else
+      gwtd pr create --base "$base" --head "$head" --title "..." -f /tmp/pr-body.md
+    fi
     ;;
   fix)
     printf '%s\n' "$pr_summary"

--- a/.codex/skills/gwt-manage-pr/references/pr-body-template.md
+++ b/.codex/skills/gwt-manage-pr/references/pr-body-template.md
@@ -2,7 +2,7 @@
 PR Body Template — gwt-manage-pr skill
 
 Rules:
-- REQUIRED sections: Summary, Changes, Testing, Closing Issues, Related Issues, Checklist
+- REQUIRED sections: Summary, Changes, Testing, PR Readiness, Closing Issues, Related Issues, Checklist
 - CONDITIONAL sections: Context, Risk/Impact, Screenshots, Deployment
 - OPTIONAL sections: Notes
 - Remove CONDITIONAL sections entirely if not applicable
@@ -27,6 +27,15 @@ Rules:
 <!-- GUIDE: Provide reproducible steps. Include exact commands, expected output, or manual verification steps. "Tested" alone is NOT acceptable. -->
 
 - [ ] `{command}` — {expected result}
+
+## PR Readiness
+
+<!-- GUIDE: Choose exactly one State. Ready for review requires a releaseable slice, no known blockers, completed acceptance for this PR scope, and pre-PR verification evidence. Draft is allowed only for incomplete CI/shared review and must not claim release readiness. -->
+
+- State: Ready for review | Draft
+- Releaseable slice: {yes/no + reason}
+- Known blockers: {None or list}
+- Remaining acceptance: {None or list}
 
 ## Closing Issues
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,15 @@
   - [ ] 未実装・TODO が残っていないか
   - [ ] コミット＆プッシュ済みか
 
+### Ready PR Gate（Draft / Ready 運用）
+
+- `feat` / `fix` / `refactor` の途中成果は **Draft PR** のみ許可する。未完了・未検証・受け入れ未達・既知 blocker ありの変更は **Ready PR 禁止**。
+- Ready PR は、その PR スコープが**単独で配信可能**であり、残件が配信 blocker ではない後続タスクとして明確な場合だけ許可する。
+- 単独で配信可能とは、既存機能を壊さず、ユーザーに見える中途半端な挙動を出さず、rollback / follow-up 境界を PR 本文で説明できる状態を指す。
+- Draft PR は CI / 共有 / 早期レビュー用とし、PR 本文に未完了項目、既知 blocker、Remaining acceptance を明記する。Draft PR で完了や配信可能性を主張しない。
+- Ready 化前に `gwt-verify --mode pre-pr` の `Overall: PASS`、`User Verification Result` の確定、PR 本文 checklist 完了、既知 blocker なしを確認する。
+- Gate を満たさない場合は Draft のまま維持するか、Ready 化せず No Action として報告する。
+
 ## 開発ワークフロー
 
 ### 実装前ワークフロー（必須）

--- a/crates/gwt-agent/src/session.rs
+++ b/crates/gwt-agent/src/session.rs
@@ -201,7 +201,10 @@ impl Session {
         self.status = status;
         let now = Utc::now();
         self.updated_at = now;
-        if status == AgentStatus::Running || status == AgentStatus::WaitingInput {
+        if matches!(
+            status,
+            AgentStatus::Running | AgentStatus::Idle | AgentStatus::WaitingInput
+        ) {
             self.last_activity_at = now;
         }
     }
@@ -226,7 +229,7 @@ impl Session {
             self.last_hook_event = Some("Stop".to_string());
             self.last_hook_event_at = Some(now);
         }
-        self.update_status(AgentStatus::WaitingInput);
+        self.update_status(AgentStatus::Idle);
     }
 
     /// Whether the latest hook lifecycle indicates the session did not reach a
@@ -252,7 +255,10 @@ impl Session {
     pub fn exact_auto_resume_candidate(&self) -> bool {
         matches!(
             self.status,
-            AgentStatus::Running | AgentStatus::WaitingInput | AgentStatus::Interrupted
+            AgentStatus::Running
+                | AgentStatus::Idle
+                | AgentStatus::WaitingInput
+                | AgentStatus::Interrupted
         ) && self.has_lifecycle_recovery_evidence()
             && self.worktree_path.exists()
             && self.has_exact_resume_session_id()
@@ -533,10 +539,8 @@ pub fn persist_agent_session_id(
 
 fn hook_event_status(event: &str) -> Option<AgentStatus> {
     match event {
-        "SessionStart" | "UserPromptSubmit" | "PreToolUse" | "PostToolUse" => {
-            Some(AgentStatus::Running)
-        }
-        "Stop" => Some(AgentStatus::WaitingInput),
+        "SessionStart" | "Stop" => Some(AgentStatus::Idle),
+        "UserPromptSubmit" | "PreToolUse" | "PostToolUse" => Some(AgentStatus::Running),
         _ => None,
     }
 }
@@ -1103,7 +1107,7 @@ display_name = "Claude Code"
     }
 
     #[test]
-    fn hook_runtime_state_maps_running_and_waiting_events() {
+    fn hook_runtime_state_maps_idle_and_running_events() {
         for event in ["UserPromptSubmit", "PreToolUse", "PostToolUse"] {
             let runtime = SessionRuntimeState::from_hook_event(event).expect("running event");
             assert_eq!(runtime.status, AgentStatus::Running, "{event}");
@@ -1112,12 +1116,15 @@ display_name = "Claude Code"
 
         let session_start =
             SessionRuntimeState::from_hook_event("SessionStart").expect("session start event");
-        assert_eq!(session_start.status, AgentStatus::Running);
+        assert_eq!(
+            serde_json::to_string(&session_start.status).unwrap(),
+            "\"Idle\""
+        );
         assert_eq!(session_start.source_event.as_deref(), Some("SessionStart"));
 
-        let waiting = SessionRuntimeState::from_hook_event("Stop").expect("waiting event");
-        assert_eq!(waiting.status, AgentStatus::WaitingInput);
-        assert_eq!(waiting.source_event.as_deref(), Some("Stop"));
+        let idle = SessionRuntimeState::from_hook_event("Stop").expect("idle event");
+        assert_eq!(serde_json::to_string(&idle.status).unwrap(), "\"Idle\"");
+        assert_eq!(idle.source_event.as_deref(), Some("Stop"));
 
         assert!(SessionRuntimeState::from_hook_event("Notification").is_none());
     }
@@ -1129,11 +1136,11 @@ display_name = "Claude Code"
         let first = SessionRuntimeState::new(AgentStatus::Running);
         first.save(&path).unwrap();
 
-        let second = SessionRuntimeState::new(AgentStatus::WaitingInput);
+        let second = SessionRuntimeState::new(AgentStatus::Idle);
         second.save(&path).unwrap();
 
         let loaded = SessionRuntimeState::load(&path).unwrap();
-        assert_eq!(loaded.status, AgentStatus::WaitingInput);
+        assert_eq!(serde_json::to_string(&loaded.status).unwrap(), "\"Idle\"");
     }
 
     #[test]

--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -256,6 +256,8 @@ pub enum AgentStatus {
     Unknown,
     #[serde(alias = "running", alias = "Running")]
     Running,
+    #[serde(alias = "idle", alias = "Idle")]
+    Idle,
     #[serde(
         rename = "Waiting",
         alias = "waiting",
@@ -419,6 +421,17 @@ mod tests {
         ] {
             let parsed: AgentStatus = serde_json::from_str(raw).unwrap();
             assert_eq!(parsed, AgentStatus::WaitingInput, "{raw}");
+        }
+    }
+
+    #[test]
+    fn agent_status_idle_preserves_wire_contract_and_aliases() {
+        let json = serde_json::to_string(&AgentStatus::Idle).unwrap();
+        assert_eq!(json, "\"Idle\"");
+
+        for raw in ["\"Idle\"", "\"idle\""] {
+            let parsed: AgentStatus = serde_json::from_str(raw).unwrap();
+            assert_eq!(parsed, AgentStatus::Idle, "{raw}");
         }
     }
 

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -2076,4 +2076,90 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn ready_pr_gate_is_documented_in_agents_and_pr_skills() {
+        let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+
+        let agents = std::fs::read_to_string(workspace_root.join("AGENTS.md"))
+            .unwrap_or_else(|err| panic!("failed to read AGENTS.md: {err}"));
+        for required in [
+            "Ready PR Gate",
+            "Draft PR",
+            "単独で配信可能",
+            "Ready PR 禁止",
+        ] {
+            assert!(
+                agents.contains(required),
+                "AGENTS.md must document Ready PR Gate phrase: {required}"
+            );
+        }
+
+        for relative in [
+            ".claude/skills/gwt-manage-pr/SKILL.md",
+            ".codex/skills/gwt-manage-pr/SKILL.md",
+        ] {
+            let content = std::fs::read_to_string(workspace_root.join(relative))
+                .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+            for required in [
+                "Ready PR Gate",
+                "Draft PR",
+                "releaseable slice",
+                "Ready for review",
+                "known blockers",
+            ] {
+                assert!(
+                    content.contains(required),
+                    "{relative} must document Ready/Draft PR gate phrase: {required}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn build_spec_does_not_treat_draft_pr_as_completion() {
+        let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+        for relative in [
+            ".claude/skills/gwt-build-spec/SKILL.md",
+            ".codex/skills/gwt-build-spec/SKILL.md",
+        ] {
+            let content = std::fs::read_to_string(workspace_root.join(relative))
+                .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+            for required in [
+                "Draft PR",
+                "does not satisfy",
+                "Ready PR Gate",
+                "releaseable slice",
+            ] {
+                assert!(
+                    content.contains(required),
+                    "{relative} must make Draft PR handoffs distinct from completion: {required}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn pr_body_template_surfaces_ready_and_draft_state() {
+        let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+        for relative in [
+            ".claude/skills/gwt-manage-pr/references/pr-body-template.md",
+            ".codex/skills/gwt-manage-pr/references/pr-body-template.md",
+        ] {
+            let content = std::fs::read_to_string(workspace_root.join(relative))
+                .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
+            for required in [
+                "PR Readiness",
+                "Ready for review",
+                "Draft",
+                "Known blockers",
+                "Remaining acceptance",
+            ] {
+                assert!(
+                    content.contains(required),
+                    "{relative} must expose PR readiness fields: {required}"
+                );
+            }
+        }
+    }
 }

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -6946,8 +6946,11 @@ impl AppRuntime {
             })?;
         let hook_state = self.window_hook_states.get(window_id).copied();
         let preset = self.window_preset(window_id)?;
-        Some(gwt::window_state::compose_window_state(
-            pty_state, preset, hook_state,
+        Some(gwt::window_state::compose_window_state_with_active_session(
+            pty_state,
+            preset,
+            hook_state,
+            self.active_agent_sessions.contains_key(window_id),
         ))
     }
 
@@ -7094,7 +7097,12 @@ impl AppRuntime {
             .or_else(|| self.window_status(window_id))?;
         let hook_state = self.window_hook_states.get(window_id).copied();
         let preset = self.window_preset(window_id)?;
-        let composed = gwt::window_state::compose_window_state(pty_state, preset, hook_state);
+        let composed = gwt::window_state::compose_window_state_with_active_session(
+            pty_state,
+            preset,
+            hook_state,
+            self.active_agent_sessions.contains_key(window_id),
+        );
         let address = self.window_lookup.get(window_id)?.clone();
         if let Some(tab) = self.tab_mut(&address.tab_id) {
             let _ = tab.workspace.set_status(&address.raw_id, composed);
@@ -9749,7 +9757,7 @@ exit 1
     }
 
     #[test]
-    fn app_runtime_live_sessions_report_not_started_before_session_start() {
+    fn app_runtime_live_sessions_report_idle_after_launch_before_first_hook() {
         let temp = tempdir().expect("tempdir");
         let tab = sample_project_tab_with_window(
             "tab-1",
@@ -9777,7 +9785,7 @@ exit 1
         let sessions = runtime.live_sessions_for_branch("tab-1", "work/20260504-1234");
 
         assert_eq!(sessions.len(), 1);
-        assert_eq!(sessions[0].runtime_status, WindowProcessStatus::NotStarted);
+        assert_eq!(sessions[0].runtime_status, WindowProcessStatus::Idle);
 
         runtime.handle_runtime_hook_event(runtime_hook_state_for_event(
             "Idle",
@@ -9787,6 +9795,44 @@ exit 1
         let sessions = runtime.live_sessions_for_branch("tab-1", "work/20260504-1234");
 
         assert_eq!(sessions[0].runtime_status, WindowProcessStatus::Idle);
+    }
+
+    #[test]
+    fn app_runtime_workspace_state_reports_idle_for_launched_agent_without_hook_state() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab_with_window(
+            "tab-1",
+            "agent-1",
+            WindowPreset::Codex,
+            WindowProcessStatus::Running,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "agent-1");
+        runtime.active_agent_sessions.insert(
+            window_id.clone(),
+            ActiveAgentSession {
+                window_id: window_id.clone(),
+                session_id: "session-1".to_string(),
+                agent_id: "codex".to_string(),
+                branch_name: "work/20260504-1234".to_string(),
+                display_name: "Codex".to_string(),
+                worktree_path: PathBuf::from("E:/gwt/test-repo"),
+                agent_project_root: "E:/gwt/test-repo".to_string(),
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                tab_id: "tab-1".to_string(),
+            },
+        );
+
+        let view = runtime.app_state_view();
+        let tab = view.tabs.iter().find(|tab| tab.id == "tab-1").unwrap();
+        let window = tab
+            .workspace
+            .windows
+            .iter()
+            .find(|window| window.id == "tab-1::agent-1")
+            .unwrap();
+
+        assert_eq!(window.status, WindowProcessStatus::Idle);
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -9657,7 +9657,7 @@ exit 1
     }
 
     #[test]
-    fn app_runtime_live_sessions_report_composed_waiting_runtime_status() {
+    fn app_runtime_live_sessions_report_composed_idle_runtime_status() {
         let temp = tempdir().expect("tempdir");
         let tab = sample_project_tab_with_window(
             "tab-1",
@@ -9682,11 +9682,11 @@ exit 1
             },
         );
 
-        runtime.handle_runtime_hook_event(runtime_hook_state("Waiting", "session-1"));
+        runtime.handle_runtime_hook_event(runtime_hook_state("Idle", "session-1"));
         let sessions = runtime.live_sessions_for_branch("tab-1", "work/20260504-1234");
 
         assert_eq!(sessions.len(), 1);
-        assert_eq!(sessions[0].runtime_status, WindowProcessStatus::Waiting);
+        assert_eq!(sessions[0].runtime_status, WindowProcessStatus::Idle);
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -6038,11 +6038,10 @@ impl AppRuntime {
                                 }
                             }
                         }
-                        events.extend(Self::status_events(
-                            window_id,
-                            WindowProcessStatus::Running,
-                            None,
-                        ));
+                        let composed_status = self
+                            .window_status(&window_id)
+                            .unwrap_or(WindowProcessStatus::Running);
+                        events.extend(Self::status_events(window_id, composed_status, None));
                         events
                     }
                     Err(error) => self.launch_error_events(window_id, error),
@@ -6096,11 +6095,10 @@ impl AppRuntime {
                     Ok(()) => {
                         emit_agent_launch_stage(stage_id, "ready", "PTY handoff complete");
                         let mut events = vec![self.workspace_state_broadcast()];
-                        events.extend(Self::status_events(
-                            window_id,
-                            WindowProcessStatus::Running,
-                            None,
-                        ));
+                        let composed_status = self
+                            .window_status(&window_id)
+                            .unwrap_or(WindowProcessStatus::Running);
+                        events.extend(Self::status_events(window_id, composed_status, None));
                         events
                     }
                     Err(error) => {
@@ -6210,7 +6208,10 @@ impl AppRuntime {
                 if let Some(id) = stage_id {
                     emit_agent_launch_stage(id, "ready", "PTY handoff complete");
                 }
-                Self::status_events(window_id, WindowProcessStatus::Running, None)
+                let composed_status = self
+                    .window_status(&window_id)
+                    .unwrap_or(WindowProcessStatus::Running);
+                Self::status_events(window_id, composed_status, None)
             }
             Err(error) => {
                 if let Some(id) = stage_id {
@@ -6327,9 +6328,12 @@ impl AppRuntime {
         self.window_hook_states.remove(&window_id);
 
         let mut events = vec![self.workspace_state_broadcast()];
+        let composed_status = self
+            .window_status(&window_id)
+            .unwrap_or(WindowProcessStatus::Running);
         events.extend(Self::status_events(
             window_id.clone(),
-            WindowProcessStatus::Running,
+            composed_status,
             Some("Launching...".to_string()),
         ));
 
@@ -6859,11 +6863,59 @@ impl AppRuntime {
     }
 
     pub(crate) fn app_state_view(&self) -> gwt::AppStateView {
-        app_state_view_from_parts(
-            &self.tabs,
-            self.active_tab_id.as_deref(),
-            &self.recent_projects,
-        )
+        gwt::AppStateView {
+            app_version: crate::runtime_support::current_app_version().to_string(),
+            tabs: self
+                .tabs
+                .iter()
+                .map(|tab| {
+                    let workspace = self.workspace_view_for_tab(tab);
+                    let running_agents =
+                        crate::runtime_support::collect_running_agents(&workspace.windows);
+                    gwt::ProjectTabView {
+                        id: tab.id.clone(),
+                        title: tab.title.clone(),
+                        project_root: tab.project_root.display().to_string(),
+                        kind: tab.kind,
+                        workspace,
+                        running_agent_count: running_agents.len() as u32,
+                        running_agents,
+                    }
+                })
+                .collect(),
+            active_tab_id: self.active_tab_id.clone(),
+            recent_projects: self
+                .recent_projects
+                .iter()
+                .map(|project| gwt::RecentProjectView {
+                    path: project.path.display().to_string(),
+                    title: project.title.clone(),
+                    kind: project.kind,
+                })
+                .collect(),
+        }
+    }
+
+    fn workspace_view_for_tab(&self, tab: &ProjectTabRuntime) -> gwt::WorkspaceView {
+        gwt::WorkspaceView {
+            viewport: tab.workspace.persisted().viewport.clone(),
+            windows: tab
+                .workspace
+                .persisted()
+                .windows
+                .iter()
+                .cloned()
+                .map(|mut window| {
+                    let raw_id = window.id.clone();
+                    window.id = combined_window_id(&tab.id, &raw_id);
+                    if let Some(status) = self.window_status(&window.id) {
+                        window.status = status;
+                    }
+                    window
+                })
+                .collect(),
+            work_items: Vec::new(),
+        }
     }
 
     pub(crate) fn workspace_state_broadcast(&self) -> OutboundEvent {
@@ -8385,9 +8437,17 @@ exit 1
     }
 
     fn runtime_hook_state(status: &str, session_id: &str) -> gwt::RuntimeHookEvent {
+        runtime_hook_state_for_event(status, "Stop", session_id)
+    }
+
+    fn runtime_hook_state_for_event(
+        status: &str,
+        source_event: &str,
+        session_id: &str,
+    ) -> gwt::RuntimeHookEvent {
         gwt::RuntimeHookEvent {
             kind: gwt::RuntimeHookEventKind::RuntimeState,
-            source_event: Some("Stop".to_string()),
+            source_event: Some(source_event.to_string()),
             gwt_session_id: Some(session_id.to_string()),
             agent_session_id: Some("agent-session-1".to_string()),
             project_root: Some("E:/gwt/test-repo".to_string()),
@@ -9687,6 +9747,94 @@ exit 1
 
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].runtime_status, WindowProcessStatus::Idle);
+    }
+
+    #[test]
+    fn app_runtime_live_sessions_report_not_started_before_session_start() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab_with_window(
+            "tab-1",
+            "agent-1",
+            WindowPreset::Codex,
+            WindowProcessStatus::Running,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "agent-1");
+        runtime.active_agent_sessions.insert(
+            window_id.clone(),
+            ActiveAgentSession {
+                window_id: window_id.clone(),
+                session_id: "session-1".to_string(),
+                agent_id: "codex".to_string(),
+                branch_name: "work/20260504-1234".to_string(),
+                display_name: "Codex".to_string(),
+                worktree_path: PathBuf::from("E:/gwt/test-repo"),
+                agent_project_root: "E:/gwt/test-repo".to_string(),
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                tab_id: "tab-1".to_string(),
+            },
+        );
+
+        let sessions = runtime.live_sessions_for_branch("tab-1", "work/20260504-1234");
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].runtime_status, WindowProcessStatus::NotStarted);
+
+        runtime.handle_runtime_hook_event(runtime_hook_state_for_event(
+            "Idle",
+            "SessionStart",
+            "session-1",
+        ));
+        let sessions = runtime.live_sessions_for_branch("tab-1", "work/20260504-1234");
+
+        assert_eq!(sessions[0].runtime_status, WindowProcessStatus::Idle);
+    }
+
+    #[test]
+    fn app_runtime_workspace_state_normalizes_pre_lifecycle_agent_windows() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab_with_window(
+            "tab-1",
+            "agent-1",
+            WindowPreset::Codex,
+            WindowProcessStatus::Running,
+        );
+        let runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+
+        let view = runtime.app_state_view();
+        let tab = view.tabs.iter().find(|tab| tab.id == "tab-1").unwrap();
+        let window = tab
+            .workspace
+            .windows
+            .iter()
+            .find(|window| window.id == "tab-1::agent-1")
+            .unwrap();
+
+        assert_eq!(window.status, WindowProcessStatus::NotStarted);
+        assert_eq!(tab.running_agent_count, 0);
+        assert!(tab.running_agents.is_empty());
+    }
+
+    #[test]
+    fn app_runtime_window_list_normalizes_pre_lifecycle_agent_windows() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab_with_window(
+            "tab-1",
+            "agent-1",
+            WindowPreset::Codex,
+            WindowProcessStatus::Running,
+        );
+        let runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+
+        let BackendEvent::WindowList { windows } = runtime.list_windows_event() else {
+            panic!("expected window list");
+        };
+        let window = windows
+            .iter()
+            .find(|window| window.id == "tab-1::agent-1")
+            .unwrap();
+
+        assert_eq!(window.status, WindowProcessStatus::NotStarted);
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/window.rs
+++ b/crates/gwt/src/app_runtime/window.rs
@@ -24,8 +24,8 @@
 use gwt::{ArrangeMode, CanvasViewport, FocusCycleDirection};
 
 use super::{
-    close_window_from_workspace, combined_window_id, workspace_view_for_tab, AppRuntime,
-    BackendEvent, OutboundEvent, WindowGeometry, WindowPreset,
+    close_window_from_workspace, combined_window_id, AppRuntime, BackendEvent, OutboundEvent,
+    WindowGeometry, WindowPreset,
 };
 
 impl AppRuntime {
@@ -370,7 +370,7 @@ impl AppRuntime {
             .active_tab_id
             .as_ref()
             .and_then(|tab_id| self.tab(tab_id))
-            .map(|tab| workspace_view_for_tab(tab).windows)
+            .map(|tab| self.workspace_view_for_tab(tab).windows)
             .unwrap_or_default();
         BackendEvent::WindowList { windows }
     }

--- a/crates/gwt/src/cli/hook/event_dispatcher.rs
+++ b/crates/gwt/src/cli/hook/event_dispatcher.rs
@@ -127,6 +127,9 @@ fn handle_stop(
         }),
     ] {
         if matches!(output, HookOutput::StopBlock { .. }) {
+            run_step(event, "blocked-stop-runtime-state", || {
+                crate::daemon_runtime::handle_blocked_stop_runtime_state(input)
+            })?;
             return Ok(output);
         }
     }

--- a/crates/gwt/src/cli/hook/runtime_state.rs
+++ b/crates/gwt/src/cli/hook/runtime_state.rs
@@ -12,7 +12,9 @@ use std::{
 };
 
 use chrono::{SecondsFormat, Utc};
-use gwt_agent::{persist_agent_session_id, PendingDiscussionResume, Session};
+use gwt_agent::{
+    persist_agent_session_id, persist_session_status, AgentStatus, PendingDiscussionResume, Session,
+};
 use serde::Serialize;
 
 use super::{
@@ -41,6 +43,7 @@ pub struct RuntimeState {
 pub fn status_for_event(event: &str) -> Option<&'static str> {
     match window_state_for_hook_event(event)? {
         crate::persistence::WindowState::Running => Some("Running"),
+        crate::persistence::WindowState::Idle => Some("Idle"),
         crate::persistence::WindowState::Waiting => Some("Waiting"),
         crate::persistence::WindowState::Stopped => Some("Stopped"),
         crate::persistence::WindowState::Error => Some("Error"),
@@ -70,7 +73,15 @@ fn write_for_event_with_pending_discussion(
 ) -> Result<(), HookError> {
     let status =
         status_for_event(event).ok_or_else(|| HookError::InvalidEvent(event.to_string()))?;
+    write_state_with_status(path, event, status, pending_discussion)
+}
 
+fn write_state_with_status(
+    path: &Path,
+    event: &str,
+    status: &str,
+    pending_discussion: Option<PendingDiscussionResume>,
+) -> Result<(), HookError> {
     let now = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
     let state = RuntimeState {
         status: status.to_string(),
@@ -217,6 +228,27 @@ pub fn record_completed_stop_from_env() -> Result<(), HookError> {
         .unwrap_or_else(gwt_core::paths::gwt_sessions_dir);
     gwt_agent::persist_session_completed_stop(&sessions_dir, gwt_session_id.as_str())?;
     Ok(())
+}
+
+pub fn record_blocked_stop_from_env() -> Result<(), HookError> {
+    let Some(gwt_session_id) = GwtSessionId::from_env() else {
+        return Ok(());
+    };
+    let Some(runtime_path) = std::env::var_os(gwt_agent::GWT_SESSION_RUNTIME_PATH_ENV) else {
+        return Ok(());
+    };
+    let runtime_path = PathBuf::from(runtime_path);
+    let sessions_dir = sessions_dir_for_runtime_path(&runtime_path);
+    let session = current_session_for_id(&sessions_dir, &gwt_session_id)?;
+    if session.is_some() {
+        persist_session_status(&sessions_dir, gwt_session_id.as_str(), AgentStatus::Running)?;
+    }
+    let pending_discussion = session.as_ref().and_then(|session| {
+        pending_discussion_for_session(&sessions_dir, &session.id)
+            .ok()
+            .flatten()
+    });
+    write_state_with_status(&runtime_path, "Stop", "Running", pending_discussion)
 }
 
 fn sessions_dir_for_runtime_path(runtime_path: &Path) -> PathBuf {
@@ -370,7 +402,7 @@ mod tests {
 
         let raw = std::fs::read_to_string(&path).unwrap();
         let state: RuntimeState = serde_json::from_str(&raw).unwrap();
-        assert_eq!(state.status, "Waiting");
+        assert_eq!(state.status, "Idle");
         assert_eq!(state.source_event, "Stop");
         assert_eq!(
             state.pending_discussion,
@@ -383,12 +415,12 @@ mod tests {
     }
 
     #[test]
-    fn status_for_event_maps_stop_to_waiting_and_runtime_events_to_running() {
-        assert_eq!(status_for_event("SessionStart"), Some("Running"));
+    fn status_for_event_maps_idle_and_running_lifecycle_events() {
+        assert_eq!(status_for_event("SessionStart"), Some("Idle"));
         assert_eq!(status_for_event("UserPromptSubmit"), Some("Running"));
         assert_eq!(status_for_event("PreToolUse"), Some("Running"));
         assert_eq!(status_for_event("PostToolUse"), Some("Running"));
-        assert_eq!(status_for_event("Stop"), Some("Waiting"));
+        assert_eq!(status_for_event("Stop"), Some("Idle"));
     }
 
     #[test]
@@ -653,7 +685,7 @@ mod tests {
 
         assert_eq!(loaded.last_hook_event.as_deref(), Some("Stop"));
         assert!(loaded.last_completed_stop_at.is_some());
-        assert_eq!(loaded.status, gwt_agent::AgentStatus::WaitingInput);
+        assert_eq!(serde_json::to_string(&loaded.status).unwrap(), "\"Idle\"");
         assert!(!loaded.should_mark_interrupted_from_lifecycle());
     }
 }

--- a/crates/gwt/src/cli/hook/runtime_state.rs
+++ b/crates/gwt/src/cli/hook/runtime_state.rs
@@ -43,6 +43,7 @@ pub struct RuntimeState {
 pub fn status_for_event(event: &str) -> Option<&'static str> {
     match window_state_for_hook_event(event)? {
         crate::persistence::WindowState::Running => Some("Running"),
+        crate::persistence::WindowState::NotStarted => Some("NotStarted"),
         crate::persistence::WindowState::Idle => Some("Idle"),
         crate::persistence::WindowState::Waiting => Some("Waiting"),
         crate::persistence::WindowState::Stopped => Some("Stopped"),

--- a/crates/gwt/src/cli/pane.rs
+++ b/crates/gwt/src/cli/pane.rs
@@ -389,6 +389,7 @@ fn resolve_window_id<'a>(
 fn status_label(status: WindowState) -> &'static str {
     match status {
         WindowState::Running => "running",
+        WindowState::NotStarted => "not-started",
         WindowState::Idle => "idle",
         WindowState::Waiting => "waiting",
         WindowState::Stopped => "stopped",
@@ -502,6 +503,16 @@ mod tests {
         assert!(!rendered.contains("shell-1"));
         assert!(rendered.contains("tab-1::codex-1\trunning\tcodex"));
         assert!(rendered.contains("tab-1::agent-1\trunning\tcustom"));
+    }
+
+    #[test]
+    fn render_pane_list_labels_pre_lifecycle_agents_not_started() {
+        let mut windows = vec![window("tab-1::codex-1", WindowPreset::Codex, Some("codex"))];
+        windows[0].status = WindowState::NotStarted;
+
+        let rendered = render_pane_list(&windows);
+
+        assert!(rendered.contains("tab-1::codex-1\tnot-started\tcodex"));
     }
 
     #[test]

--- a/crates/gwt/src/cli/pane.rs
+++ b/crates/gwt/src/cli/pane.rs
@@ -389,6 +389,7 @@ fn resolve_window_id<'a>(
 fn status_label(status: WindowState) -> &'static str {
     match status {
         WindowState::Running => "running",
+        WindowState::Idle => "idle",
         WindowState::Waiting => "waiting",
         WindowState::Stopped => "stopped",
         WindowState::Error => "error",

--- a/crates/gwt/src/daemon_runtime.rs
+++ b/crates/gwt/src/daemon_runtime.rs
@@ -99,6 +99,22 @@ pub fn handle_runtime_state(event: &str, input: &str) -> Result<(), HookError> {
     Ok(())
 }
 
+pub fn handle_blocked_stop_runtime_state(input: &str) -> Result<(), HookError> {
+    if std::env::var_os(GWT_SESSION_RUNTIME_PATH_ENV).is_none() {
+        return Ok(());
+    }
+    runtime_state::record_blocked_stop_from_env()?;
+    emit_live_event_fail_open(RuntimeHookEvent::from_hook(
+        RuntimeHookEventKind::RuntimeState,
+        Some("Stop"),
+        Some("Running".to_string()),
+        Some("blocked-stop".to_string()),
+        current_session_from_env()?,
+        parse_hook_event_best_effort(input),
+    ));
+    Ok(())
+}
+
 pub fn handle_coordination_event(event: &str, input: &str) -> Result<(), HookError> {
     coordination_event::handle(event)?;
     emit_live_event_fail_open(RuntimeHookEvent::from_hook(

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -1649,6 +1649,25 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_agent_runtime_maps_not_started_separately() {
+        let js = app_js();
+        let html = frontend_styles_bundle();
+
+        assert!(
+            js.contains("not_started: \"Not Started\""),
+            "expected embedded js to expose a Not Started runtime label",
+        );
+        assert!(
+            js.contains("case \"not_started\":") && js.contains("return \"not_started\";"),
+            "expected embedded js to keep pre-lifecycle agent telemetry separate",
+        );
+        assert!(
+            html.contains(".status-chip.not_started .status-dot"),
+            "expected embedded html to define a not_started status chip variant",
+        );
+    }
+
+    #[test]
     fn embedded_web_window_role_badges_identify_every_window_surface() {
         let html = frontend_styles_bundle();
         let js = app_js();

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -1462,12 +1462,12 @@ mod tests {
     }
 
     #[test]
-    fn embedded_web_window_status_chip_uses_running_waiting_stopped_error_variants() {
+    fn embedded_web_window_status_chip_uses_running_idle_stopped_error_variants() {
         let html = frontend_styles_bundle();
 
         assert!(
-            html.contains(".status-chip.waiting .status-dot"),
-            "expected embedded html to define a waiting variant for window status chips",
+            html.contains(".status-chip.idle .status-dot"),
+            "expected embedded html to define an idle variant for window status chips",
         );
         assert!(
             html.contains(".status-chip.stopped .status-dot"),
@@ -1631,6 +1631,20 @@ mod tests {
                 "if (!presetSupportsWaitingStatus(preset) && normalizedState === \"waiting\")"
             ) && js.contains("return \"running\";"),
             "expected embedded js to downgrade waiting to running for shell-like presets",
+        );
+    }
+
+    #[test]
+    fn embedded_web_agent_runtime_maps_idle_to_idle_telemetry() {
+        let js = app_js();
+
+        assert!(
+            js.contains("idle: \"Idle\""),
+            "expected embedded js to expose an Idle runtime label",
+        );
+        assert!(
+            js.contains("case \"idle\":") && js.contains("return \"idle\";"),
+            "expected embedded js to count idle runtime states as idle telemetry",
         );
     }
 

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -3824,6 +3824,7 @@ fn runtime_target_value(target: gwt_agent::LaunchRuntimeTarget) -> &'static str 
 fn window_status_wire(status: crate::WindowProcessStatus) -> &'static str {
     match status {
         crate::WindowProcessStatus::Running => "running",
+        crate::WindowProcessStatus::Idle => "idle",
         crate::WindowProcessStatus::Waiting => "waiting",
         crate::WindowProcessStatus::Stopped => "stopped",
         crate::WindowProcessStatus::Error => "error",
@@ -4910,14 +4911,14 @@ mod tests {
             name: "Codex".to_string(),
             detail: Some("/tmp/repo".to_string()),
             active: true,
-            runtime_status: crate::WindowProcessStatus::Waiting,
+            runtime_status: crate::WindowProcessStatus::Idle,
         }];
 
         let state = LaunchWizardState::open_with(ctx, sample_agent_options(), Vec::new());
         let view = state.view();
 
         assert_eq!(view.live_sessions.len(), 1);
-        assert_eq!(view.live_sessions[0].runtime_status, "waiting");
+        assert_eq!(view.live_sessions[0].runtime_status, "idle");
     }
 
     #[test]

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -3824,6 +3824,7 @@ fn runtime_target_value(target: gwt_agent::LaunchRuntimeTarget) -> &'static str 
 fn window_status_wire(status: crate::WindowProcessStatus) -> &'static str {
     match status {
         crate::WindowProcessStatus::Running => "running",
+        crate::WindowProcessStatus::NotStarted => "not_started",
         crate::WindowProcessStatus::Idle => "idle",
         crate::WindowProcessStatus::Waiting => "waiting",
         crate::WindowProcessStatus::Stopped => "stopped",

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -87,19 +87,20 @@ pub(crate) use launch_runtime::{
     install_launch_gwt_bin_env_with_lookup, probe_host_package_runner_with_timeout,
     resolve_launch_worktree_request,
 };
+#[cfg(test)]
 pub(crate) use runtime_support::{
-    app_state_view_from_parts, attach_parent_console_for_cli, close_window_from_workspace,
-    combined_window_id, current_git_branch, dedupe_recent_projects, fallback_project_target,
+    app_state_view_from_parts, parse_github_remote_url, spawn_env, suffixed_worktree_path,
+    worktree_path_is_occupied,
+};
+pub(crate) use runtime_support::{
+    attach_parent_console_for_cli, close_window_from_workspace, combined_window_id,
+    current_git_branch, dedupe_recent_projects, fallback_project_target,
     first_available_worktree_path, front_door_route, geometry_to_pty_size,
     knowledge_kind_for_preset, local_branch_exists, normalize_active_tab_id, normalize_branch_name,
     origin_remote_ref, prune_missing_recent_projects, resolve_launch_spec_with_fallback,
     resolve_project_target, run_cli, same_worktree_path, should_auto_close_agent_window,
     should_auto_start_restored_window, synthetic_branch_entry, usable_worktree_path_for_branch,
-    workspace_view_for_tab, worktrees_have_stale_branch_entry,
-};
-#[cfg(test)]
-pub(crate) use runtime_support::{
-    parse_github_remote_url, spawn_env, suffixed_worktree_path, worktree_path_is_occupied,
+    worktrees_have_stale_branch_entry,
 };
 pub(crate) use update_front_door::{apply_update_state_and_exit, spawn_startup_update_check};
 #[cfg(test)]

--- a/crates/gwt/src/persistence.rs
+++ b/crates/gwt/src/persistence.rs
@@ -36,6 +36,8 @@ pub fn default_canvas_viewport() -> CanvasViewport {
 pub enum WindowState {
     #[serde(alias = "starting", alias = "ready")]
     Running,
+    #[serde(alias = "not-started", alias = "notStarted", alias = "NotStarted")]
+    NotStarted,
     Idle,
     Waiting,
     #[serde(alias = "exited")]
@@ -1112,12 +1114,19 @@ mod tests {
     #[test]
     fn window_state_round_trips_modern_variants_and_accepts_legacy_status_names() {
         let waiting = serde_json::from_str::<WindowState>(r#""waiting""#).expect("waiting");
+        let not_started =
+            serde_json::from_str::<WindowState>(r#""not_started""#).expect("not started");
         let idle = serde_json::from_str::<WindowState>(r#""idle""#).expect("idle");
         let running = serde_json::from_str::<WindowState>(r#""running""#).expect("running");
         let stopped = serde_json::from_str::<WindowState>(r#""stopped""#).expect("stopped");
         let error = serde_json::from_str::<WindowState>(r#""error""#).expect("error");
 
         assert_eq!(waiting, WindowState::Waiting);
+        assert_eq!(not_started, WindowState::NotStarted);
+        assert_eq!(
+            serde_json::to_string(&not_started).expect("serialize not started"),
+            r#""not_started""#
+        );
         assert_eq!(idle, WindowState::Idle);
         assert_eq!(
             serde_json::to_string(&idle).expect("serialize idle"),

--- a/crates/gwt/src/persistence.rs
+++ b/crates/gwt/src/persistence.rs
@@ -36,6 +36,7 @@ pub fn default_canvas_viewport() -> CanvasViewport {
 pub enum WindowState {
     #[serde(alias = "starting", alias = "ready")]
     Running,
+    Idle,
     Waiting,
     #[serde(alias = "exited")]
     Stopped,
@@ -1111,11 +1112,17 @@ mod tests {
     #[test]
     fn window_state_round_trips_modern_variants_and_accepts_legacy_status_names() {
         let waiting = serde_json::from_str::<WindowState>(r#""waiting""#).expect("waiting");
+        let idle = serde_json::from_str::<WindowState>(r#""idle""#).expect("idle");
         let running = serde_json::from_str::<WindowState>(r#""running""#).expect("running");
         let stopped = serde_json::from_str::<WindowState>(r#""stopped""#).expect("stopped");
         let error = serde_json::from_str::<WindowState>(r#""error""#).expect("error");
 
         assert_eq!(waiting, WindowState::Waiting);
+        assert_eq!(idle, WindowState::Idle);
+        assert_eq!(
+            serde_json::to_string(&idle).expect("serialize idle"),
+            r#""idle""#
+        );
         assert_eq!(running, WindowState::Running);
         assert_eq!(stopped, WindowState::Stopped);
         assert_eq!(error, WindowState::Error);

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -77,6 +77,7 @@ pub fn current_app_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
 }
 
+#[cfg(test)]
 pub fn workspace_view_for_tab(tab: &ProjectTabRuntime) -> gwt::WorkspaceView {
     gwt::WorkspaceView {
         viewport: tab.workspace.persisted().viewport.clone(),
@@ -95,6 +96,7 @@ pub fn workspace_view_for_tab(tab: &ProjectTabRuntime) -> gwt::WorkspaceView {
     }
 }
 
+#[cfg(test)]
 pub fn app_state_view_from_parts(
     tabs: &[ProjectTabRuntime],
     active_tab_id: Option<&str>,

--- a/crates/gwt/src/window_state.rs
+++ b/crates/gwt/src/window_state.rs
@@ -14,7 +14,7 @@ pub fn compose_window_state(
         return pty_state;
     }
     if uses_agent_hook_state(preset) {
-        return hook_state.unwrap_or(WindowState::Running);
+        return hook_state.unwrap_or(WindowState::Idle);
     }
     pty_state
 }
@@ -23,16 +23,15 @@ pub fn runtime_hook_window_state(event: &RuntimeHookEvent) -> Option<WindowState
     if event.kind != RuntimeHookEventKind::RuntimeState {
         return None;
     }
-    event
-        .status
-        .as_deref()
-        .and_then(parse_runtime_status)
-        .or_else(|| {
-            event
-                .source_event
-                .as_deref()
-                .and_then(window_state_for_hook_event)
-        })
+    let source_event = event.source_event.as_deref();
+    if source_event == Some("SessionStart") {
+        return Some(WindowState::Idle);
+    }
+    let status_state = event.status.as_deref().and_then(parse_runtime_status);
+    if source_event == Some("Stop") && status_state == Some(WindowState::Waiting) {
+        return Some(WindowState::Idle);
+    }
+    status_state.or_else(|| source_event.and_then(window_state_for_hook_event))
 }
 
 pub fn window_state_from_pane_status(status: &PaneStatus) -> WindowState {
@@ -52,10 +51,8 @@ pub fn uses_agent_hook_state(preset: WindowPreset) -> bool {
 
 pub fn window_state_for_hook_event(event: &str) -> Option<WindowState> {
     match event {
-        "SessionStart" | "UserPromptSubmit" | "PreToolUse" | "PostToolUse" => {
-            Some(WindowState::Running)
-        }
-        "Stop" => Some(WindowState::Waiting),
+        "SessionStart" | "Stop" => Some(WindowState::Idle),
+        "UserPromptSubmit" | "PreToolUse" | "PostToolUse" => Some(WindowState::Running),
         _ => None,
     }
 }
@@ -63,6 +60,7 @@ pub fn window_state_for_hook_event(event: &str) -> Option<WindowState> {
 fn parse_runtime_status(status: &str) -> Option<WindowState> {
     match status.trim().to_ascii_lowercase().as_str() {
         "running" | "starting" | "ready" => Some(WindowState::Running),
+        "idle" => Some(WindowState::Idle),
         "waiting" | "waitinginput" | "waiting_input" => Some(WindowState::Waiting),
         "stopped" | "exited" => Some(WindowState::Stopped),
         "error" => Some(WindowState::Error),
@@ -127,7 +125,7 @@ mod tests {
         );
         assert_eq!(
             compose_window_state(WindowState::Running, WindowPreset::Agent, None),
-            WindowState::Running
+            WindowState::Idle
         );
         assert_eq!(
             compose_window_state(
@@ -140,23 +138,39 @@ mod tests {
     }
 
     #[test]
-    fn runtime_hook_window_state_maps_runtime_events_to_running_and_waiting() {
+    fn runtime_hook_window_state_maps_runtime_events_to_running_and_idle() {
         assert_eq!(
             runtime_hook_window_state(&runtime_event(Some("Running"), Some("PreToolUse"))),
             Some(WindowState::Running)
         );
         assert_eq!(
-            runtime_hook_window_state(&runtime_event(Some("Waiting"), Some("Stop"))),
-            Some(WindowState::Waiting)
+            serde_json::to_string(
+                &runtime_hook_window_state(&runtime_event(Some("Idle"), Some("Stop"))).unwrap()
+            )
+            .unwrap(),
+            "\"idle\""
         );
         assert_eq!(
-            runtime_hook_window_state(&runtime_event(None, Some("SessionStart"))),
-            Some(WindowState::Running)
+            serde_json::to_string(
+                &runtime_hook_window_state(&runtime_event(None, Some("SessionStart"))).unwrap()
+            )
+            .unwrap(),
+            "\"idle\""
         );
         assert_eq!(
-            runtime_hook_window_state(&runtime_event(None, Some("Stop"))),
-            Some(WindowState::Waiting)
+            serde_json::to_string(
+                &runtime_hook_window_state(&runtime_event(None, Some("Stop"))).unwrap()
+            )
+            .unwrap(),
+            "\"idle\""
         );
+    }
+
+    #[test]
+    fn compose_window_state_defaults_live_agent_without_hook_state_to_idle() {
+        let composed = compose_window_state(WindowState::Running, WindowPreset::Agent, None);
+
+        assert_eq!(serde_json::to_string(&composed).unwrap(), "\"idle\"");
     }
 
     #[test]

--- a/crates/gwt/src/window_state.rs
+++ b/crates/gwt/src/window_state.rs
@@ -14,7 +14,7 @@ pub fn compose_window_state(
         return pty_state;
     }
     if uses_agent_hook_state(preset) {
-        return hook_state.unwrap_or(WindowState::Idle);
+        return hook_state.unwrap_or(WindowState::NotStarted);
     }
     pty_state
 }
@@ -60,6 +60,9 @@ pub fn window_state_for_hook_event(event: &str) -> Option<WindowState> {
 fn parse_runtime_status(status: &str) -> Option<WindowState> {
     match status.trim().to_ascii_lowercase().as_str() {
         "running" | "starting" | "ready" => Some(WindowState::Running),
+        "notstarted" | "not_started" | "not-started" | "not started" => {
+            Some(WindowState::NotStarted)
+        }
         "idle" => Some(WindowState::Idle),
         "waiting" | "waitinginput" | "waiting_input" => Some(WindowState::Waiting),
         "stopped" | "exited" => Some(WindowState::Stopped),
@@ -125,7 +128,7 @@ mod tests {
         );
         assert_eq!(
             compose_window_state(WindowState::Running, WindowPreset::Agent, None),
-            WindowState::Idle
+            WindowState::NotStarted
         );
         assert_eq!(
             compose_window_state(
@@ -167,10 +170,11 @@ mod tests {
     }
 
     #[test]
-    fn compose_window_state_defaults_live_agent_without_hook_state_to_idle() {
+    fn compose_window_state_defaults_live_agent_without_hook_state_to_not_started() {
         let composed = compose_window_state(WindowState::Running, WindowPreset::Agent, None);
 
-        assert_eq!(serde_json::to_string(&composed).unwrap(), "\"idle\"");
+        assert_eq!(composed, WindowState::NotStarted);
+        assert_eq!(serde_json::to_string(&composed).unwrap(), "\"not_started\"");
     }
 
     #[test]

--- a/crates/gwt/src/window_state.rs
+++ b/crates/gwt/src/window_state.rs
@@ -10,11 +10,24 @@ pub fn compose_window_state(
     preset: WindowPreset,
     hook_state: Option<WindowState>,
 ) -> WindowState {
+    compose_window_state_with_active_session(pty_state, preset, hook_state, false)
+}
+
+pub fn compose_window_state_with_active_session(
+    pty_state: WindowState,
+    preset: WindowPreset,
+    hook_state: Option<WindowState>,
+    has_active_agent_session: bool,
+) -> WindowState {
     if matches!(pty_state, WindowState::Stopped | WindowState::Error) {
         return pty_state;
     }
     if uses_agent_hook_state(preset) {
-        return hook_state.unwrap_or(WindowState::NotStarted);
+        return hook_state.unwrap_or(if has_active_agent_session {
+            WindowState::Idle
+        } else {
+            WindowState::NotStarted
+        });
     }
     pty_state
 }
@@ -73,7 +86,10 @@ fn parse_runtime_status(status: &str) -> Option<WindowState> {
 
 #[cfg(test)]
 mod tests {
-    use super::{compose_window_state, runtime_hook_window_state, window_state_from_pane_status};
+    use super::{
+        compose_window_state, compose_window_state_with_active_session, runtime_hook_window_state,
+        window_state_from_pane_status,
+    };
     use crate::{
         daemon_runtime::{RuntimeHookEvent, RuntimeHookEventKind},
         persistence::WindowState,
@@ -175,6 +191,19 @@ mod tests {
 
         assert_eq!(composed, WindowState::NotStarted);
         assert_eq!(serde_json::to_string(&composed).unwrap(), "\"not_started\"");
+    }
+
+    #[test]
+    fn compose_window_state_defaults_active_agent_without_hook_state_to_idle() {
+        let composed = compose_window_state_with_active_session(
+            WindowState::Running,
+            WindowPreset::Agent,
+            None,
+            true,
+        );
+
+        assert_eq!(composed, WindowState::Idle);
+        assert_eq!(serde_json::to_string(&composed).unwrap(), "\"idle\"");
     }
 
     #[test]

--- a/crates/gwt/tests/hook_diagnostics_test.rs
+++ b/crates/gwt/tests/hook_diagnostics_test.rs
@@ -23,6 +23,12 @@ impl ScopedEnvVar {
         std::env::set_var(key, value);
         Self { key, previous }
     }
+
+    fn unset(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::remove_var(key);
+        Self { key, previous }
+    }
 }
 
 impl Drop for ScopedEnvVar {
@@ -43,6 +49,9 @@ fn hook_event_writes_opt_in_handler_timing_without_stdout_noise() {
     let tmp = tempfile::tempdir().unwrap();
     let profile_path = tmp.path().join("hook-profile.jsonl");
     let _profile = ScopedEnvVar::set("GWT_HOOK_PROFILE_PATH", &profile_path);
+    let _gwt_session_id = ScopedEnvVar::unset("GWT_SESSION_ID");
+    let _runtime_path = ScopedEnvVar::unset("GWT_SESSION_RUNTIME_PATH");
+    let _codex_thread_id = ScopedEnvVar::unset("CODEX_THREAD_ID");
 
     let mut env = TestEnv::new(tmp.path().to_path_buf());
     env.stdin = serde_json::json!({

--- a/crates/gwt/tests/hook_exit_codes_test.rs
+++ b/crates/gwt/tests/hook_exit_codes_test.rs
@@ -272,6 +272,7 @@ fn event_dispatcher_keeps_blocked_stop_runtime_state_running() {
     let runtime_path = gwt_agent::runtime_state_path(&sessions_dir, &session_id);
     let _session_id = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session_id);
     let _runtime_path = ScopedEnvVar::set(GWT_SESSION_RUNTIME_PATH_ENV, &runtime_path);
+    let _codex_thread_id = ScopedEnvVar::unset("CODEX_THREAD_ID");
 
     skill_state::save(
         tmp.path(),
@@ -286,8 +287,13 @@ fn event_dispatcher_keeps_blocked_stop_runtime_state_running() {
     )
     .unwrap();
 
-    let output = event_dispatcher::handle_with_input("Stop", "{}", tmp.path(), Some(&session_id))
-        .expect("blocked Stop should still dispatch");
+    let output = event_dispatcher::handle_with_input(
+        "Stop",
+        r#"{"session_id":"agent-123"}"#,
+        tmp.path(),
+        Some(&session_id),
+    )
+    .expect("blocked Stop should still dispatch");
 
     assert!(matches!(output, HookOutput::StopBlock { .. }));
     let runtime_raw = std::fs::read_to_string(&runtime_path).unwrap();

--- a/crates/gwt/tests/hook_exit_codes_test.rs
+++ b/crates/gwt/tests/hook_exit_codes_test.rs
@@ -14,8 +14,11 @@
 //! - Block hook returning `None`       → 0 (allow)
 //! - Block hook returning `Some(..)`   → 2 (block + stdout JSON)
 
-use gwt::cli::hook::{event_dispatcher, HookOutput};
+use chrono::Utc;
+use gwt::cli::hook::{event_dispatcher, runtime_state::RuntimeState, HookOutput};
 use gwt::cli::{dispatch, TestEnv};
+use gwt_agent::{AgentId, Session, GWT_SESSION_ID_ENV, GWT_SESSION_RUNTIME_PATH_ENV};
+use gwt_core::skill_state::{self, SkillState};
 
 fn argv(strs: &[&str]) -> Vec<String> {
     strs.iter().map(std::string::ToString::to_string).collect()
@@ -253,4 +256,48 @@ fn event_dispatcher_non_blocking_events_are_silent_without_live_runtime() {
             event_dispatcher::handle_with_input(event, "", tmp.path(), Some("sess-1")).unwrap();
         assert_eq!(output, HookOutput::Silent);
     }
+}
+
+#[test]
+fn event_dispatcher_keeps_blocked_stop_runtime_state_running() {
+    let _env_lock = env_test_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join(".gwt").join("sessions");
+    let mut session = Session::new(tmp.path(), "feature/demo", AgentId::Codex);
+    session.agent_session_id = Some("agent-123".to_string());
+    let session_id = session.id.clone();
+    session.save(&sessions_dir).unwrap();
+    let runtime_path = gwt_agent::runtime_state_path(&sessions_dir, &session_id);
+    let _session_id = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session_id);
+    let _runtime_path = ScopedEnvVar::set(GWT_SESSION_RUNTIME_PATH_ENV, &runtime_path);
+
+    skill_state::save(
+        tmp.path(),
+        "build-spec",
+        &SkillState {
+            active: true,
+            owner_spec: Some(2077),
+            started_at: Utc::now(),
+            phase: Some("red".to_string()),
+            session_id: session_id.clone(),
+        },
+    )
+    .unwrap();
+
+    let output = event_dispatcher::handle_with_input("Stop", "{}", tmp.path(), Some(&session_id))
+        .expect("blocked Stop should still dispatch");
+
+    assert!(matches!(output, HookOutput::StopBlock { .. }));
+    let runtime_raw = std::fs::read_to_string(&runtime_path).unwrap();
+    let runtime_state: RuntimeState = serde_json::from_str(&runtime_raw).unwrap();
+    assert_eq!(runtime_state.status, "Running");
+    assert_eq!(runtime_state.source_event, "Stop");
+
+    let loaded = Session::load(&sessions_dir.join(format!("{session_id}.toml"))).unwrap();
+    assert_eq!(
+        serde_json::to_string(&loaded.status).unwrap(),
+        "\"Running\""
+    );
 }

--- a/crates/gwt/tests/hook_runtime_state_test.rs
+++ b/crates/gwt/tests/hook_runtime_state_test.rs
@@ -4,8 +4,8 @@
 //! JSON file at `$GWT_SESSION_RUNTIME_PATH` that the Branches tab polls to
 //! render per-session status badges. This test pins:
 //!
-//! - the event → status mapping (`SessionStart`/`PreToolUse` → `Running`,
-//!   `Stop` → `Waiting`),
+//! - the event → status mapping (`SessionStart`/`Stop` → `Idle`,
+//!   `PreToolUse` → `Running`),
 //! - that writes are crash-safe (no `.tmp-*` residue after success),
 //! - that the active-file is rewritten, not appended, on repeat calls,
 //! - that unknown events surface as `HookError::InvalidEvent`,
@@ -38,7 +38,7 @@ fn write_for_event_pretooluse_maps_to_running() {
 }
 
 #[test]
-fn write_for_event_stop_maps_to_waiting() {
+fn write_for_event_stop_maps_to_idle() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("runtime-state.json");
 
@@ -46,12 +46,12 @@ fn write_for_event_stop_maps_to_waiting() {
 
     let raw = fs::read_to_string(&path).unwrap();
     let state: RuntimeState = serde_json::from_str(&raw).unwrap();
-    assert_eq!(state.status, "Waiting");
+    assert_eq!(state.status, "Idle");
     assert_eq!(state.source_event, "Stop");
 }
 
 #[test]
-fn write_for_event_session_start_maps_to_running() {
+fn write_for_event_session_start_maps_to_idle() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("runtime-state.json");
 
@@ -59,7 +59,7 @@ fn write_for_event_session_start_maps_to_running() {
 
     let raw = fs::read_to_string(&path).unwrap();
     let state: RuntimeState = serde_json::from_str(&raw).unwrap();
-    assert_eq!(state.status, "Running");
+    assert_eq!(state.status, "Idle");
     assert_eq!(state.source_event, "SessionStart");
 }
 

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -2053,9 +2053,9 @@ test("op-drawer scaffold honors prefers-reduced-motion (parity with legacy is-dr
   assert.ok(opDrawerCovered, ".op-drawer scaffold must drop its transition under reduced-motion");
 });
 
-test("mapAgentTelemetryState emits only the four Living Telemetry states CSS handles", () => {
+test("mapAgentTelemetryState emits only Living Telemetry states CSS handles", () => {
   // app.js has a closure-scoped runtime→Living Telemetry mapper. CSS only
-  // styles `[data-agent-state]` for active/idle/blocked/done — any drift
+  // styles `[data-agent-state]` for declared telemetry states — any drift
   // (e.g. emitting "warn" or "exited") would silently render no rim. Pin
   // the contract so refactors can't introduce undeclared states.
   const mapperBlock = appSource.match(
@@ -2066,7 +2066,7 @@ test("mapAgentTelemetryState emits only the four Living Telemetry states CSS han
   for (const m of mapperBlock[0].matchAll(/return\s+"([^"]+)"/g)) {
     returnedStates.add(m[1]);
   }
-  const allowed = new Set(["active", "idle", "blocked", "done"]);
+  const allowed = new Set(["active", "not_started", "idle", "blocked", "done"]);
   for (const state of returnedStates) {
     assert.ok(allowed.has(state), `mapAgentTelemetryState returned undeclared state: ${state}`);
   }

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -393,7 +393,7 @@ test("Launch Wizard live sessions render window runtime status", () => {
   assert.match(
     appSource,
     /function\s+liveSessionStatusLabel\(session\)[\s\S]+session\.runtime_status[\s\S]+windowRuntimeLabel\(runtimeState\)[\s\S]+window/,
-    "expected live-session rows to label Running/Waiting/Error from runtime_status",
+    "expected live-session rows to label Running/Idle/Error from runtime_status",
   );
   assert.match(
     appSource,

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1154,6 +1154,7 @@
 
       const WINDOW_RUNTIME_STATE_LABELS = Object.freeze({
         running: "Running",
+        not_started: "Not Started",
         idle: "Idle",
         waiting: "Waiting",
         stopped: "Stopped",
@@ -1162,6 +1163,8 @@
 
       const LEGACY_WINDOW_RUNTIME_STATE_ALIASES = Object.freeze({
         starting: "running",
+        notstarted: "not_started",
+        "not-started": "not_started",
         ready: "idle",
         exited: "stopped",
       });
@@ -2807,6 +2810,8 @@
           case "starting":
           case "running":
             return "active";
+          case "not_started":
+            return "not_started";
           case "ready":
           case "idle":
           case "waiting":
@@ -2833,6 +2838,7 @@
               detailMap.set(windowId, detail);
             } else if (
               runtimeState === "running" ||
+              runtimeState === "not_started" ||
               runtimeState === "idle" ||
               runtimeState === "waiting"
             ) {
@@ -2851,6 +2857,7 @@
             chip.classList.remove(
               "starting",
               "running",
+              "not_started",
               "ready",
               "idle",
               "waiting",

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1154,6 +1154,7 @@
 
       const WINDOW_RUNTIME_STATE_LABELS = Object.freeze({
         running: "Running",
+        idle: "Idle",
         waiting: "Waiting",
         stopped: "Stopped",
         error: "Error",
@@ -1161,7 +1162,7 @@
 
       const LEGACY_WINDOW_RUNTIME_STATE_ALIASES = Object.freeze({
         starting: "running",
-        ready: "waiting",
+        ready: "idle",
         exited: "stopped",
       });
 
@@ -2805,9 +2806,10 @@
         switch (runtimeState) {
           case "starting":
           case "running":
-          case "waiting":
             return "active";
           case "ready":
+          case "idle":
+          case "waiting":
             return "idle";
           case "stopped":
           case "exited":
@@ -2829,7 +2831,11 @@
             windowRuntimeStateMap.set(windowId, runtimeState);
             if (detail) {
               detailMap.set(windowId, detail);
-            } else if (runtimeState === "running" || runtimeState === "waiting") {
+            } else if (
+              runtimeState === "running" ||
+              runtimeState === "idle" ||
+              runtimeState === "waiting"
+            ) {
               detailMap.delete(windowId);
             }
             const element = windowMap.get(windowId);
@@ -2846,6 +2852,7 @@
               "starting",
               "running",
               "ready",
+              "idle",
               "waiting",
               "stopped",
               "exited",

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -736,8 +736,12 @@ body {
   background: var(--color-state-active);
 }
 
+.status-chip.idle .status-dot {
+  background: var(--color-state-idle);
+}
+
 .status-chip.waiting .status-dot {
-  background: var(--color-state-active);
+  background: var(--color-state-idle);
 }
 
 .status-chip.error .status-dot {

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -736,6 +736,10 @@ body {
   background: var(--color-state-active);
 }
 
+.status-chip.not_started .status-dot {
+  background: var(--color-state-idle);
+}
+
 .status-chip.idle .status-dot {
   background: var(--color-state-idle);
 }

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1051,6 +1051,12 @@ body::after {
   opacity: 0.82;
 }
 
+[data-agent-state="not_started"] {
+  --agent-color: color-mix(in oklab, var(--current-agent, var(--color-state-idle)) 35%, var(--color-border));
+  box-shadow: 0 0 0 1px var(--agent-color);
+  opacity: 0.72;
+}
+
 [data-agent-state="blocked"] {
   --agent-color: var(--color-state-blocked);
   box-shadow: 0 0 0 1px var(--agent-color),
@@ -1844,6 +1850,7 @@ kbd.op-kbd {
 }
 :root[data-theme] .status-chip.starting,
 :root[data-theme] .status-chip.running { color: var(--color-state-active); border-color: var(--color-state-active); }
+:root[data-theme] .status-chip.not_started,
 :root[data-theme] .status-chip.ready,
 :root[data-theme] .status-chip.idle,
 :root[data-theme] .status-chip.waiting { color: var(--color-state-idle); border-color: var(--color-state-idle); }

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1843,9 +1843,10 @@ kbd.op-kbd {
   letter-spacing: var(--tracking-mono);
 }
 :root[data-theme] .status-chip.starting,
-:root[data-theme] .status-chip.running,
-:root[data-theme] .status-chip.waiting { color: var(--color-state-active); border-color: var(--color-state-active); }
-:root[data-theme] .status-chip.ready { color: var(--color-state-idle); border-color: var(--color-state-idle); }
+:root[data-theme] .status-chip.running { color: var(--color-state-active); border-color: var(--color-state-active); }
+:root[data-theme] .status-chip.ready,
+:root[data-theme] .status-chip.idle,
+:root[data-theme] .status-chip.waiting { color: var(--color-state-idle); border-color: var(--color-state-idle); }
 :root[data-theme] .status-chip.error { color: var(--color-state-blocked); border-color: var(--color-state-blocked); }
 :root[data-theme] .status-chip.stopped,
 :root[data-theme] .status-chip.exited { color: var(--color-state-done); border-color: var(--color-state-done); }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -5966,3 +5966,26 @@ Release PR の `cargo test -p gwt-core -p gwt --all-features` で、
    先に lock を取る可能性がある。
 3. env lock を使う巻き添え側の tests は、`lock().unwrap()` ではなく poisoned lock を回復する helper を使い、
    先行 panic の調査を `PoisonError` のノイズで隠さない。
+
+## Hook tests は親エージェントの Codex env を暗黙に使わない
+
+### 事象
+
+PR #2861 の Linux CI で `event_dispatcher_keeps_blocked_stop_runtime_state_running` が失敗した。
+ローカルでは同じ test が通っていたが、これは実行中の Codex agent 由来の `CODEX_THREAD_ID` が
+process env に残っていたためだった。
+
+### 原因
+
+hook integration tests が `CODEX_THREAD_ID` / `GWT_SESSION_ID` /
+`GWT_SESSION_RUNTIME_PATH` などの親プロセス環境を明示的に固定していなかった。
+さらに Codex の placeholder session id (`agent-session`) と実 session id の違いを test payload が
+曖昧にしていたため、CI の clean env でだけ missing `session_id` と判定された。
+
+### 再発防止策
+
+1. Codex hook identity を扱う tests は、`CODEX_THREAD_ID` を明示的に unset または set して期待条件を固定する。
+2. hook diagnostics など runtime state が主目的ではない tests は、`GWT_SESSION_ID` /
+   `GWT_SESSION_RUNTIME_PATH` を unset して現在の agent session を汚染しない。
+3. Codex payload の `session_id` を使う tests では placeholder の `agent-session` を避け、
+   実 resume 可能 ID を表す別値を使う。


### PR DESCRIPTION
## Summary

- Normalize agent lifecycle status so restored/pre-launch agent windows are shown as Not Started, not Running.
- Treat launched managed agent sessions with no lifecycle hook yet as Idle, matching Codex's initial prompt behavior when no waiting-input hook exists.
- Keep SessionStart/Stop mapped to Idle and user/tool hook processing mapped to Running.
- Add Ready PR Gate guidance to managed skills so incomplete or unverified work stays Draft.

## Changes

- `crates/gwt/src/window_state.rs`: add active-session-aware status composition so hook-less launched agents fall back to Idle while hook-less non-active windows remain Not Started.
- `crates/gwt/src/app_runtime/*`, `crates/gwt/src/cli/pane.rs`: normalize `workspace_state`, `window_list`, live session summaries, and `gwtd pane list` through the composed lifecycle status path.
- `crates/gwt/src/cli/hook/*`, `crates/gwt-agent/src/*`: keep hook runtime state mappings aligned for SessionStart, Stop, user prompt, and tool hook events.
- `crates/gwt/web/*`: add `not_started` status labels, telemetry mapping, chip styling, and frontend regression coverage.
- `.codex/skills/*`, `.claude/skills/*`, `AGENTS.md`, `crates/gwt-skills/src/lib.rs`: add managed guidance for Draft/Ready PR gating.

## Testing

- [x] `cargo fmt --check` - passed
- [x] `git diff --check` - passed
- [x] `cargo build -p gwt --bin gwt --bin gwtd` - passed
- [x] `cargo test -p gwt compose_window_state_defaults_active_agent_without_hook_state_to_idle` - passed
- [x] `cargo test -p gwt app_runtime_live_sessions_report_idle_after_launch_before_first_hook` - passed
- [x] `cargo test -p gwt app_runtime_workspace_state_reports_idle_for_launched_agent_without_hook_state` - passed
- [x] `env -u CODEX_THREAD_ID cargo test -p gwt-core -p gwt --all-features` - passed
- [x] `bash scripts/check-frontend-bundle.sh` - passed in earlier PR verification for this branch
- [x] `bash scripts/run-frontend-unit-tests.sh` - passed in earlier PR verification for this branch (`538 passed`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - passed
- [x] `bunx commitlint --from origin/develop --to HEAD` - passed
- [x] `bunx commitlint --from HEAD~1 --to HEAD` - passed
- [x] `target/debug/gwt serve` + `curl -fsS -I http://127.0.0.1:54030/` - passed with `HTTP/1.1 200 OK`
- [x] User visual verification via served browser URL - confirmed on 2026-05-21; server stopped after confirmation
- [x] `GWT_PANE_WS_URL=ws://127.0.0.1:<port>/ws GWT_PROJECT_ROOT=/Users/akiojin/Workbench/gwt/work/20260521-0523 target/debug/gwtd pane list` - restored pre-lifecycle agents displayed as `not-started` in earlier PR verification
- [x] GitHub checks - passed: Build, Cargo Deny, Check (Windows), Check (macOS), Clippy & Rustfmt, Commit Message Lint, Operator Design System (Playwright), Test (Python runner), Test (Rust), Test (Rust, Windows), CodeRabbit

## PR Readiness

- State: Ready
- Releaseable slice: Yes. The PR scope is limited to lifecycle status normalization, hook-state fallback behavior, UI labels, and managed PR guidance.
- Known blockers: None
- Remaining acceptance: None
- User Verification Result: confirmed on 2026-05-21 after manual browser check of the served gwt UI
- `gwt-verify --mode pre-pr` contract: Overall PASS based on the executed automated checks above, successful GitHub checks, and confirmed user verification

## Closing Issues

- None

## Related Issues / Links

- #2077

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (managed skill guidance and AGENTS.md Ready PR gate guidance)
- [x] Migration/backfill plan included (N/A: no schema or data migration)
- [x] CHANGELOG impact considered (fix commits are patch-level; no breaking change)

## Context

- This PR addresses lifecycle gaps where an agent pane could be displayed as Running before SessionStart, and where Codex could remain Not Started after the managed agent session had launched but before any hook event had arrived.
- Codex in this scenario produced a live managed session (`GWT_SESSION_ID` and PTY were present) without a SessionStart hook, so the UI must distinguish active launched sessions from restored/pre-launch windows.
- It also updates managed PR workflow guidance so incomplete or not-yet-human-verified work remains Draft instead of being presented as Ready.

## Risk / Impact

- **Affected areas**: agent window status composition, hook runtime status forwarding, `gwtd pane list`, WebView status chip/telemetry, managed skill guidance.
- **Rollback plan**: revert this PR to restore the previous Running/Idle-only agent display behavior and prior PR guidance.

## Screenshots

- Manual browser verification was completed by the user on 2026-05-21 using the served gwt UI at `http://127.0.0.1:54030/`. No screenshot is attached.
