### PR TITLE
fix(gui): restore agent windows on startup

### DIFF
--- a/crates/gwt-agent/src/lib.rs
+++ b/crates/gwt-agent/src/lib.rs
@@ -50,11 +50,11 @@ pub use presets::{
 };
 pub use session::{
     persist_agent_session_id, persist_session_completed_stop, persist_session_hook_event,
-    persist_session_status, reset_runtime_state_dir, reset_runtime_state_dir_for_pid,
-    runtime_state_dir_for_pid, runtime_state_path, runtime_state_path_for_pid,
-    sessions_dir_from_runtime_path, PendingDiscussionResume, Session, SessionRuntimeState,
-    GWT_BIN_PATH_ENV, GWT_HOOK_FORWARD_TOKEN_ENV, GWT_HOOK_FORWARD_URL_ENV, GWT_SESSION_ID_ENV,
-    GWT_SESSION_RUNTIME_PATH_ENV,
+    persist_session_restore_window_on_startup, persist_session_status, reset_runtime_state_dir,
+    reset_runtime_state_dir_for_pid, runtime_state_dir_for_pid, runtime_state_path,
+    runtime_state_path_for_pid, sessions_dir_from_runtime_path, PendingDiscussionResume, Session,
+    SessionRuntimeState, GWT_BIN_PATH_ENV, GWT_HOOK_FORWARD_TOKEN_ENV, GWT_HOOK_FORWARD_URL_ENV,
+    GWT_SESSION_ID_ENV, GWT_SESSION_RUNTIME_PATH_ENV,
 };
 pub use store::{
     load_custom_agents_from_path, load_stored_custom_agents_from_path,

--- a/crates/gwt-agent/src/session.rs
+++ b/crates/gwt-agent/src/session.rs
@@ -70,6 +70,10 @@ pub struct Session {
     pub launch_command: String,
     #[serde(default)]
     pub launch_args: Vec<String>,
+    /// GUI window lifecycle flag used by startup restore. Conversation
+    /// history alone must not reopen a window after the user closed it.
+    #[serde(default)]
+    pub restore_window_on_startup: bool,
     /// Active backend override id, if any (SPEC-1921 FR-102).
     /// `None` means the agent launched against its default upstream
     /// (no env override). Set only for built-in agents that support
@@ -154,6 +158,7 @@ impl Session {
             workflow_bypass: None,
             launch_command: String::new(),
             launch_args: Vec::new(),
+            restore_window_on_startup: false,
             backend_id: None,
             windows_shell: None,
             schema_version: Self::CURRENT_SCHEMA_VERSION,
@@ -531,6 +536,24 @@ pub fn persist_agent_session_id(
     session.save(sessions_dir)
 }
 
+/// Persist whether the GUI should recreate this session's agent window during
+/// startup. This is intentionally separate from agent status/conversation
+/// persistence so manual close can opt out without deleting history.
+pub fn persist_session_restore_window_on_startup(
+    sessions_dir: &Path,
+    session_id: &str,
+    restore: bool,
+) -> std::io::Result<()> {
+    let session_path = sessions_dir.join(format!("{session_id}.toml"));
+    let mut session = Session::load_and_migrate(&session_path)?;
+    if session.restore_window_on_startup == restore {
+        return Ok(());
+    }
+    session.restore_window_on_startup = restore;
+    session.updated_at = Utc::now();
+    session.save(sessions_dir)
+}
+
 fn hook_event_status(event: &str) -> Option<AgentStatus> {
     match event {
         "SessionStart" | "UserPromptSubmit" | "PreToolUse" | "PostToolUse" => {
@@ -573,8 +596,41 @@ mod tests {
             DockerLifecycleIntent::Connect
         );
         assert!(session.workflow_bypass.is_none());
+        assert!(!session.restore_window_on_startup);
         // SPEC-1921 FR-102: new sessions default to no backend override.
         assert!(session.backend_id.is_none());
+    }
+
+    #[test]
+    fn legacy_session_toml_without_restore_window_flag_defaults_to_false() {
+        let legacy = r#"
+id = "1d3d2d2d-3333-4444-5555-777777777777"
+worktree_path = "/tmp/wt"
+branch = "main"
+agent_id = { type = "Codex" }
+agent_session_id = "abc"
+status = "WaitingInput"
+launch_command = "codex"
+launch_args = []
+created_at = "2026-05-18T00:00:00Z"
+updated_at = "2026-05-18T00:00:00Z"
+last_activity_at = "2026-05-18T00:00:00Z"
+display_name = "Codex"
+"#;
+        let session: Session = toml::from_str(legacy).expect("deserialize legacy");
+
+        assert!(!session.restore_window_on_startup);
+    }
+
+    #[test]
+    fn restore_window_on_startup_round_trips() {
+        let mut session = Session::new("/tmp/wt", "main", AgentId::Codex);
+        session.restore_window_on_startup = true;
+
+        let serialized = toml::to_string(&session).expect("serialize");
+        assert!(serialized.contains("restore_window_on_startup = true"));
+        let parsed: Session = toml::from_str(&serialized).expect("deserialize");
+        assert!(parsed.restore_window_on_startup);
     }
 
     #[test]
@@ -778,6 +834,24 @@ display_name = "Claude Code"
 
         let loaded = Session::load(&dir.path().join(format!("{session_id}.toml"))).unwrap();
         assert_eq!(loaded.agent_session_id.as_deref(), Some("agent-123"));
+    }
+
+    #[test]
+    fn persist_session_restore_window_on_startup_updates_session_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let session = Session::new("/tmp/wt", "feature/x", AgentId::Codex);
+        let session_id = session.id.clone();
+        session.save(dir.path()).unwrap();
+
+        persist_session_restore_window_on_startup(dir.path(), &session_id, true).unwrap();
+
+        let loaded = Session::load(&dir.path().join(format!("{session_id}.toml"))).unwrap();
+        assert!(loaded.restore_window_on_startup);
+
+        persist_session_restore_window_on_startup(dir.path(), &session_id, false).unwrap();
+
+        let loaded = Session::load(&dir.path().join(format!("{session_id}.toml"))).unwrap();
+        assert!(!loaded.restore_window_on_startup);
     }
 
     // SPEC-1921 Phase 53 / FR-066: Session::load must not silently rewrite

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -224,14 +224,26 @@ fn launch_config_from_persisted_session(session: &gwt_agent::Session) -> gwt_age
 }
 
 const STARTUP_AUTO_RESUME_STALE_AFTER_SECS: i64 = 24 * 60 * 60;
+const STARTUP_AUTO_RESUME_STACK_OFFSET_X: f64 = 28.0;
+const STARTUP_AUTO_RESUME_STACK_OFFSET_Y: f64 = 24.0;
 
-fn auto_resume_window_bounds(index: usize) -> gwt::WindowGeometry {
-    let offset = ((index % 6) as f64) * 28.0;
+fn startup_auto_resume_window_geometry(
+    index: usize,
+    total: usize,
+    bounds: gwt::WindowGeometry,
+) -> gwt::WindowGeometry {
+    let (width, height) = WindowPreset::Agent.default_size();
+    let stack_steps = total.saturating_sub(1) as f64;
+    let index = index as f64;
     gwt::WindowGeometry {
-        x: 48.0 + offset,
-        y: 48.0 + offset,
-        width: 960.0,
-        height: 620.0,
+        x: bounds.x + (bounds.width - width) / 2.0
+            - (stack_steps * STARTUP_AUTO_RESUME_STACK_OFFSET_X) / 2.0
+            + index * STARTUP_AUTO_RESUME_STACK_OFFSET_X,
+        y: bounds.y + (bounds.height - height) / 2.0
+            - (stack_steps * STARTUP_AUTO_RESUME_STACK_OFFSET_Y) / 2.0
+            + index * STARTUP_AUTO_RESUME_STACK_OFFSET_Y,
+        width,
+        height,
     }
 }
 
@@ -264,6 +276,7 @@ fn mark_auto_resume_source_completed(sessions_dir: &Path, session_id: &str) {
         return;
     };
     session.update_status(gwt_agent::AgentStatus::Stopped);
+    session.restore_window_on_startup = false;
     let _ = session.save(sessions_dir);
 }
 
@@ -788,7 +801,8 @@ fn frontend_user_action_log(event: &FrontendEvent) -> Option<FrontendUserActionL
         }
         // These events can contain high-volume, high-frequency, or sensitive
         // payloads. They are handled by more specific logs or diagnostics.
-        FrontendEvent::UpdateViewport { .. }
+        FrontendEvent::StartupAutoResumeReady { .. }
+        | FrontendEvent::UpdateViewport { .. }
         | FrontendEvent::UpdateWindowGeometry { .. }
         | FrontendEvent::TerminalInput { .. }
         | FrontendEvent::PasteImage { .. } => return None,
@@ -850,6 +864,19 @@ impl WorkspaceResumeContext {
             .filter(|value| !value.is_empty())
             .map(str::to_string)
     }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PendingStartupAutoResumeSession {
+    pub(crate) tab_id: String,
+    pub(crate) session: gwt_agent::Session,
+    pub(crate) workspace_resume_context: Option<WorkspaceResumeContext>,
+}
+
+#[derive(Debug, Clone)]
+enum AgentWindowPlacement {
+    Centered(WindowGeometry),
+    Exact(WindowGeometry),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2544,6 +2571,7 @@ pub struct AppRuntime {
     pub(crate) launch_wizard: Option<LaunchWizardSession>,
     pub(crate) pending_workspace_resume_contexts: HashMap<String, WorkspaceResumeContext>,
     pub(crate) pending_auto_resume_sources: HashMap<String, String>,
+    pub(crate) pending_startup_auto_resume_sessions: Vec<PendingStartupAutoResumeSession>,
     pub(crate) active_agent_sessions: HashMap<String, ActiveAgentSession>,
     pub(crate) window_pty_statuses: HashMap<String, WindowProcessStatus>,
     pub(crate) window_hook_states: HashMap<String, WindowProcessStatus>,
@@ -2640,6 +2668,7 @@ impl AppRuntime {
             launch_wizard: None,
             pending_workspace_resume_contexts: HashMap::new(),
             pending_auto_resume_sources: HashMap::new(),
+            pending_startup_auto_resume_sessions: Vec::new(),
             active_agent_sessions: HashMap::new(),
             window_pty_statuses: HashMap::new(),
             window_hook_states: HashMap::new(),
@@ -2690,7 +2719,7 @@ impl AppRuntime {
             );
         }
 
-        self.auto_resume_recoverable_agent_sessions();
+        self.queue_startup_auto_resume_sessions();
 
         let windows = self
             .tabs
@@ -2714,7 +2743,8 @@ impl AppRuntime {
         let _ = self.persist();
     }
 
-    fn auto_resume_recoverable_agent_sessions(&mut self) {
+    fn queue_startup_auto_resume_sessions(&mut self) {
+        self.pending_startup_auto_resume_sessions.clear();
         let mut sessions = self.load_recovery_sessions();
         sessions.sort_by(|left, right| {
             right
@@ -2724,9 +2754,11 @@ impl AppRuntime {
         });
 
         let now = chrono::Utc::now();
-        let mut launched = 0usize;
         let mut resumed_native_sessions = std::collections::HashSet::new();
         for session in sessions {
+            if !session.restore_window_on_startup {
+                continue;
+            }
             if !session.exact_auto_resume_candidate() {
                 continue;
             }
@@ -2759,26 +2791,51 @@ impl AppRuntime {
             if config.session_mode != gwt_agent::SessionMode::Resume {
                 continue;
             }
-            let existing_windows = self
-                .window_lookup
-                .keys()
-                .cloned()
-                .collect::<std::collections::HashSet<_>>();
             let workspace_resume_context =
                 gwt_core::workspace_projection::load_workspace_projection(&session.worktree_path)
                     .ok()
                     .flatten()
                     .map(|projection| workspace_resume_context_from_projection(&projection));
-            if self
-                .spawn_agent_window(
-                    &tab_id,
-                    config,
-                    auto_resume_window_bounds(launched),
+            self.pending_startup_auto_resume_sessions
+                .push(PendingStartupAutoResumeSession {
+                    tab_id,
+                    session,
                     workspace_resume_context,
-                )
-                .is_err()
-            {
-                continue;
+                });
+        }
+    }
+
+    fn startup_auto_resume_ready_events(&mut self, bounds: WindowGeometry) -> Vec<OutboundEvent> {
+        if self.pending_startup_auto_resume_sessions.is_empty() {
+            return Vec::new();
+        }
+
+        let pending = std::mem::take(&mut self.pending_startup_auto_resume_sessions);
+        let total = pending.len();
+        let mut events = Vec::new();
+        for (index, pending_session) in pending.into_iter().enumerate() {
+            let config = launch_config_from_persisted_session(&pending_session.session);
+            let existing_windows = self
+                .window_lookup
+                .keys()
+                .cloned()
+                .collect::<std::collections::HashSet<_>>();
+            let geometry = startup_auto_resume_window_geometry(index, total, bounds.clone());
+            match self.spawn_agent_window_at_geometry(
+                &pending_session.tab_id,
+                config,
+                geometry,
+                pending_session.workspace_resume_context,
+            ) {
+                Ok(mut spawned_events) => events.append(&mut spawned_events),
+                Err(error) => {
+                    tracing::warn!(
+                        session_id = %pending_session.session.id,
+                        error = %error,
+                        "failed to spawn startup auto-resume agent window"
+                    );
+                    continue;
+                }
             }
             if let Some(window_id) = self
                 .window_lookup
@@ -2787,10 +2844,10 @@ impl AppRuntime {
                 .cloned()
             {
                 self.pending_auto_resume_sources
-                    .insert(window_id, session.id.clone());
+                    .insert(window_id, pending_session.session.id);
             }
-            launched += 1;
         }
+        events
     }
 
     fn auto_resume_tab_id_for_session(&self, session: &gwt_agent::Session) -> Option<String> {
@@ -2854,6 +2911,9 @@ impl AppRuntime {
         log_frontend_user_action(&client_id, &event);
         match event {
             FrontendEvent::FrontendReady => self.frontend_sync_events(&client_id),
+            FrontendEvent::StartupAutoResumeReady { bounds } => {
+                self.startup_auto_resume_ready_events(bounds)
+            }
             FrontendEvent::OpenProjectDialog => self.open_project_dialog_events(),
             FrontendEvent::SelectCloneProjectParent => {
                 self.select_clone_project_parent_events(&client_id)
@@ -4160,6 +4220,7 @@ impl AppRuntime {
             })
             .unwrap_or_default();
         for window_id in window_ids {
+            self.clear_agent_window_startup_restore(&window_id);
             self.stop_window_runtime(&window_id);
             self.remove_window_state_tracking(&window_id);
             self.window_lookup.remove(&window_id);
@@ -5907,6 +5968,7 @@ impl AppRuntime {
                 let tab_id = address.tab_id.clone();
                 let project_root = tab.project_root.clone();
                 let geometry = window.geometry.clone();
+                let session_id_for_restore = session_id.clone();
 
                 self.active_agent_sessions.insert(
                     window_id.clone(),
@@ -5921,6 +5983,11 @@ impl AppRuntime {
                         runtime_target,
                         tab_id: tab_id.clone(),
                     },
+                );
+                let _ = gwt_agent::persist_session_restore_window_on_startup(
+                    &self.sessions_dir,
+                    &session_id_for_restore,
+                    true,
                 );
                 if let Some(source_session_id) = auto_resume_source_session_id {
                     mark_auto_resume_source_completed(&self.sessions_dir, &source_session_id);
@@ -6292,6 +6359,36 @@ impl AppRuntime {
         bounds: WindowGeometry,
         workspace_resume_context: Option<WorkspaceResumeContext>,
     ) -> Result<Vec<OutboundEvent>, String> {
+        self.spawn_agent_window_with_placement(
+            tab_id,
+            config,
+            AgentWindowPlacement::Centered(bounds),
+            workspace_resume_context,
+        )
+    }
+
+    pub(crate) fn spawn_agent_window_at_geometry(
+        &mut self,
+        tab_id: &str,
+        config: gwt_agent::LaunchConfig,
+        geometry: WindowGeometry,
+        workspace_resume_context: Option<WorkspaceResumeContext>,
+    ) -> Result<Vec<OutboundEvent>, String> {
+        self.spawn_agent_window_with_placement(
+            tab_id,
+            config,
+            AgentWindowPlacement::Exact(geometry),
+            workspace_resume_context,
+        )
+    }
+
+    fn spawn_agent_window_with_placement(
+        &mut self,
+        tab_id: &str,
+        config: gwt_agent::LaunchConfig,
+        placement: AgentWindowPlacement,
+        workspace_resume_context: Option<WorkspaceResumeContext>,
+    ) -> Result<Vec<OutboundEvent>, String> {
         let issue_link_cache_dir = self.issue_link_cache_dir.clone();
         let tab = self
             .tab_mut(tab_id)
@@ -6310,9 +6407,15 @@ impl AppRuntime {
                     &issue_link_cache_dir,
                 )
             });
-        let window = tab
-            .workspace
-            .add_window_with_title(WindowPreset::Agent, title, false, bounds);
+        let window = match placement {
+            AgentWindowPlacement::Centered(bounds) => {
+                tab.workspace
+                    .add_window_with_title(WindowPreset::Agent, title, false, bounds)
+            }
+            AgentWindowPlacement::Exact(geometry) => tab
+                .workspace
+                .add_window_at_geometry_with_title(WindowPreset::Agent, title, false, geometry),
+        };
         if let Some(purpose_title) = purpose_title {
             let _ = tab
                 .workspace
@@ -6588,6 +6691,17 @@ impl AppRuntime {
         self.launch_wizard_cache.mark_stopped(&session.session_id);
     }
 
+    pub(crate) fn clear_agent_window_startup_restore(&self, window_id: &str) {
+        let Some(session) = self.active_agent_sessions.get(window_id) else {
+            return;
+        };
+        let _ = gwt_agent::persist_session_restore_window_on_startup(
+            &self.sessions_dir,
+            &session.session_id,
+            false,
+        );
+    }
+
     fn refresh_launch_wizard_session_cache(&mut self, window_id: &str) {
         let Some(session) = self.active_agent_sessions.get(window_id) else {
             return;
@@ -6651,7 +6765,13 @@ impl AppRuntime {
     }
 
     pub(crate) fn stop_window_runtime(&mut self, window_id: &str) {
-        self.mark_agent_session_stopped(window_id);
+        self.stop_window_runtime_inner(window_id, true);
+    }
+
+    fn stop_window_runtime_inner(&mut self, window_id: &str, mark_session_stopped: bool) {
+        if mark_session_stopped {
+            self.mark_agent_session_stopped(window_id);
+        }
         self.remove_window_state_tracking(window_id);
         self.deregister_pty_writer(window_id);
         if let Some(mut runtime) = self.runtimes.remove(window_id) {
@@ -6690,7 +6810,7 @@ impl AppRuntime {
     pub(crate) fn stop_all_runtimes(&mut self) {
         let ids: Vec<String> = self.runtimes.keys().cloned().collect();
         for id in ids {
-            self.stop_window_runtime(&id);
+            self.stop_window_runtime_inner(&id, false);
         }
     }
 
@@ -8440,6 +8560,7 @@ exit 1
             launch_wizard: None,
             pending_workspace_resume_contexts: HashMap::new(),
             pending_auto_resume_sources: HashMap::new(),
+            pending_startup_auto_resume_sessions: Vec::new(),
             active_agent_sessions: HashMap::<String, ActiveAgentSession>::new(),
             window_pty_statuses: HashMap::new(),
             window_hook_states: HashMap::new(),
@@ -11228,6 +11349,7 @@ exit 1
                 gwt_agent::Session::new(&worktree, "work/auto-resume", gwt_agent::AgentId::Codex);
             session.id = session_id.to_string();
             session.agent_session_id = Some(native_session_id.to_string());
+            session.restore_window_on_startup = true;
             session.record_hook_event("Stop");
             session.record_completed_stop();
             session
@@ -11236,6 +11358,12 @@ exit 1
         }
 
         runtime.bootstrap();
+        runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::StartupAutoResumeReady {
+                bounds: canvas_bounds(),
+            },
+        );
 
         assert_eq!(
             runtime.tabs.len(),
@@ -11254,6 +11382,274 @@ exit 1
             agent_windows, 2,
             "all exact-resumable sessions for a worktree should restart"
         );
+    }
+
+    #[test]
+    fn app_runtime_bootstrap_queues_startup_auto_resume_until_canvas_ready() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        init_git_clone_with_origin(&repo);
+        let worktree = temp.path().join("worktrees").join("queued-auto-resume");
+        run_git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "work/queued-auto-resume",
+                worktree.to_str().expect("worktree path"),
+            ],
+        );
+        let tab = sample_project_tab(
+            "tab-auto",
+            "Auto Resume",
+            worktree.clone(),
+            ProjectKind::Git,
+            &[],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-auto"));
+        let mut session = gwt_agent::Session::new(
+            &worktree,
+            "work/queued-auto-resume",
+            gwt_agent::AgentId::Codex,
+        );
+        session.id = "session-queued-auto".to_string();
+        session.agent_session_id = Some("native-queued-auto".to_string());
+        session.restore_window_on_startup = true;
+        session.record_hook_event("Stop");
+        session.record_completed_stop();
+        session
+            .save(&runtime.sessions_dir)
+            .expect("save resumable session");
+
+        runtime.bootstrap();
+
+        assert!(
+            runtime.tabs[0]
+                .workspace
+                .persisted()
+                .windows
+                .iter()
+                .all(|window| window.preset != WindowPreset::Agent),
+            "bootstrap should wait for the frontend canvas bounds before placing restored windows"
+        );
+
+        runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::StartupAutoResumeReady {
+                bounds: canvas_bounds(),
+            },
+        );
+
+        let agent_windows = runtime.tabs[0]
+            .workspace
+            .persisted()
+            .windows
+            .iter()
+            .filter(|window| window.preset == WindowPreset::Agent)
+            .count();
+        assert_eq!(agent_windows, 1);
+        assert_eq!(runtime.pending_auto_resume_sources.len(), 1);
+    }
+
+    #[test]
+    fn app_runtime_startup_auto_resume_uses_centered_stack_bounds() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        init_git_clone_with_origin(&repo);
+        let worktree = temp.path().join("worktrees").join("centered-stack");
+        run_git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "work/centered-stack",
+                worktree.to_str().expect("worktree path"),
+            ],
+        );
+        let tab = sample_project_tab(
+            "tab-auto",
+            "Auto Resume",
+            worktree.clone(),
+            ProjectKind::Git,
+            &[],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-auto"));
+        for (index, native_session_id) in
+            ["native-stack-one", "native-stack-two", "native-stack-three"]
+                .into_iter()
+                .enumerate()
+        {
+            let mut session = gwt_agent::Session::new(
+                &worktree,
+                "work/centered-stack",
+                gwt_agent::AgentId::Codex,
+            );
+            session.id = format!("session-centered-stack-{index}");
+            session.agent_session_id = Some(native_session_id.to_string());
+            session.restore_window_on_startup = true;
+            session.record_hook_event("Stop");
+            session.record_completed_stop();
+            session.last_activity_at = chrono::Utc::now() - chrono::Duration::seconds(index as i64);
+            session.updated_at = session.last_activity_at;
+            session
+                .save(&runtime.sessions_dir)
+                .expect("save resumable session");
+        }
+
+        runtime.bootstrap();
+        runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::StartupAutoResumeReady {
+                bounds: canvas_bounds(),
+            },
+        );
+
+        let geometries = runtime.tabs[0]
+            .workspace
+            .persisted()
+            .windows
+            .iter()
+            .filter(|window| window.preset == WindowPreset::Agent)
+            .map(|window| window.geometry.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(geometries.len(), 3);
+        assert_eq!(
+            geometries
+                .iter()
+                .map(|geometry| (geometry.x, geometry.y, geometry.width, geometry.height))
+                .collect::<Vec<_>>(),
+            vec![
+                (312.0, 216.0, 720.0, 420.0),
+                (340.0, 240.0, 720.0, 420.0),
+                (368.0, 264.0, 720.0, 420.0),
+            ],
+            "restored agent windows should form a stack centered in the startup canvas"
+        );
+    }
+
+    #[test]
+    fn app_runtime_startup_auto_resume_requires_open_window_restore_flag() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        init_git_clone_with_origin(&repo);
+        let worktree = temp.path().join("worktrees").join("restore-flag");
+        run_git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "work/restore-flag",
+                worktree.to_str().expect("worktree path"),
+            ],
+        );
+        let tab = sample_project_tab(
+            "tab-auto",
+            "Auto Resume",
+            worktree.clone(),
+            ProjectKind::Git,
+            &[],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-auto"));
+        for (session_id, native_session_id, restore_window_on_startup) in [
+            ("session-open-window", "native-open-window", true),
+            ("session-closed-window", "native-closed-window", false),
+        ] {
+            let mut session =
+                gwt_agent::Session::new(&worktree, "work/restore-flag", gwt_agent::AgentId::Codex);
+            session.id = session_id.to_string();
+            session.agent_session_id = Some(native_session_id.to_string());
+            session.restore_window_on_startup = restore_window_on_startup;
+            session.record_hook_event("Stop");
+            session.record_completed_stop();
+            session
+                .save(&runtime.sessions_dir)
+                .expect("save resumable session");
+        }
+
+        runtime.bootstrap();
+        runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::StartupAutoResumeReady {
+                bounds: canvas_bounds(),
+            },
+        );
+
+        let resumed_sources = runtime
+            .pending_auto_resume_sources
+            .values()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(
+            resumed_sources,
+            std::collections::HashSet::from(["session-open-window".to_string()])
+        );
+    }
+
+    #[test]
+    fn app_runtime_close_agent_window_clears_startup_restore_eligibility() {
+        let temp = tempdir().expect("tempdir");
+        let worktree = temp.path().join("repo");
+        fs::create_dir_all(&worktree).expect("create worktree");
+        let tab_id = "tab-1";
+        let raw_window_id = "agent-1";
+        let window_id = combined_window_id(tab_id, raw_window_id);
+        let tab = sample_project_tab_with_window_at(
+            tab_id,
+            raw_window_id,
+            worktree.clone(),
+            WindowPreset::Agent,
+            WindowProcessStatus::Running,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some(tab_id));
+        let mut session =
+            gwt_agent::Session::new(&worktree, "work/restore-flag", gwt_agent::AgentId::Codex);
+        session.id = "session-close-clears-restore".to_string();
+        session.restore_window_on_startup = true;
+        session
+            .save(&runtime.sessions_dir)
+            .expect("save active session");
+        runtime.active_agent_sessions.insert(
+            window_id.clone(),
+            ActiveAgentSession {
+                window_id: window_id.clone(),
+                session_id: session.id.clone(),
+                agent_id: "codex".to_string(),
+                branch_name: "work/restore-flag".to_string(),
+                display_name: "Codex".to_string(),
+                worktree_path: worktree.clone(),
+                agent_project_root: worktree.display().to_string(),
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                tab_id: tab_id.to_string(),
+            },
+        );
+
+        runtime.close_window_events(&window_id);
+
+        let loaded = gwt_agent::Session::load(
+            &runtime
+                .sessions_dir
+                .join("session-close-clears-restore.toml"),
+        )
+        .expect("load session");
+        assert!(!loaded.restore_window_on_startup);
     }
 
     #[test]
@@ -11286,6 +11682,7 @@ exit 1
         );
         session.id = "session-same-repo-worktree".to_string();
         session.agent_session_id = Some("native-same-repo-worktree".to_string());
+        session.restore_window_on_startup = true;
         session.record_hook_event("Stop");
         session.record_completed_stop();
         session
@@ -11293,6 +11690,12 @@ exit 1
             .expect("save resumable session");
 
         runtime.bootstrap();
+        runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::StartupAutoResumeReady {
+                bounds: canvas_bounds(),
+            },
+        );
 
         assert_eq!(
             runtime.tabs.len(),
@@ -11343,12 +11746,19 @@ exit 1
         );
         session.id = "session-same-repo-no-lifecycle".to_string();
         session.agent_session_id = Some("native-no-lifecycle".to_string());
+        session.restore_window_on_startup = true;
         session.update_status(gwt_agent::AgentStatus::Running);
         session
             .save(&runtime.sessions_dir)
             .expect("save stale session");
 
         runtime.bootstrap();
+        runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::StartupAutoResumeReady {
+                bounds: canvas_bounds(),
+            },
+        );
 
         let agent_windows = runtime.tabs[0]
             .workspace
@@ -11393,6 +11803,7 @@ exit 1
         );
         session.id = "session-same-repo-placeholder".to_string();
         session.agent_session_id = Some("agent-session".to_string());
+        session.restore_window_on_startup = true;
         session.record_hook_event("Stop");
         session.record_completed_stop();
         session
@@ -11400,6 +11811,12 @@ exit 1
             .expect("save placeholder session");
 
         runtime.bootstrap();
+        runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::StartupAutoResumeReady {
+                bounds: canvas_bounds(),
+            },
+        );
 
         let agent_windows = runtime.tabs[0]
             .workspace
@@ -11443,6 +11860,7 @@ exit 1
         );
         session.id = "session-unlisted-auto".to_string();
         session.agent_session_id = Some("native-unlisted-auto".to_string());
+        session.restore_window_on_startup = true;
         session.record_hook_event("Stop");
         session.record_completed_stop();
         session
@@ -11450,6 +11868,12 @@ exit 1
             .expect("save resumable session");
 
         runtime.bootstrap();
+        runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::StartupAutoResumeReady {
+                bounds: canvas_bounds(),
+            },
+        );
 
         assert!(
             runtime.tabs.is_empty(),
@@ -11507,6 +11931,7 @@ exit 1
             );
             session.id = session_id.to_string();
             session.agent_session_id = Some(native_session_id.to_string());
+            session.restore_window_on_startup = true;
             session.record_hook_event("Stop");
             session.record_completed_stop();
             session.last_activity_at = now - chrono::Duration::seconds(age_secs);
@@ -11517,6 +11942,12 @@ exit 1
         }
 
         runtime.bootstrap();
+        runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::StartupAutoResumeReady {
+                bounds: canvas_bounds(),
+            },
+        );
 
         assert_eq!(
             runtime.pending_auto_resume_sources.len(),

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -270,6 +270,15 @@ fn startup_auto_resume_is_fresh(
         <= chrono::Duration::seconds(STARTUP_AUTO_RESUME_STALE_AFTER_SECS)
 }
 
+fn startup_auto_resume_window_was_open(session: &gwt_agent::Session) -> bool {
+    if session.restore_window_on_startup {
+        return true;
+    }
+    // Compatibility for sessions saved before the explicit GUI restore flag
+    // existed, and for files already migrated once with that flag defaulted.
+    session.status != gwt_agent::AgentStatus::Stopped
+}
+
 fn mark_auto_resume_source_completed(sessions_dir: &Path, session_id: &str) {
     let path = sessions_dir.join(format!("{session_id}.toml"));
     let Ok(mut session) = gwt_agent::Session::load_and_migrate(&path) else {
@@ -2756,7 +2765,7 @@ impl AppRuntime {
         let now = chrono::Utc::now();
         let mut resumed_native_sessions = std::collections::HashSet::new();
         for session in sessions {
-            if !session.restore_window_on_startup {
+            if !startup_auto_resume_window_was_open(&session) {
                 continue;
             }
             if !session.exact_auto_resume_candidate() {
@@ -11540,7 +11549,7 @@ exit 1
     }
 
     #[test]
-    fn app_runtime_startup_auto_resume_requires_open_window_restore_flag() {
+    fn app_runtime_startup_auto_resume_excludes_closed_stopped_windows() {
         let _env_lock = env_test_lock()
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -11568,9 +11577,9 @@ exit 1
             &[],
         );
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-auto"));
-        for (session_id, native_session_id, restore_window_on_startup) in [
-            ("session-open-window", "native-open-window", true),
-            ("session-closed-window", "native-closed-window", false),
+        for (session_id, native_session_id, restore_window_on_startup, stopped) in [
+            ("session-open-window", "native-open-window", true, false),
+            ("session-closed-window", "native-closed-window", false, true),
         ] {
             let mut session =
                 gwt_agent::Session::new(&worktree, "work/restore-flag", gwt_agent::AgentId::Codex);
@@ -11579,6 +11588,9 @@ exit 1
             session.restore_window_on_startup = restore_window_on_startup;
             session.record_hook_event("Stop");
             session.record_completed_stop();
+            if stopped {
+                session.update_status(gwt_agent::AgentStatus::Stopped);
+            }
             session
                 .save(&runtime.sessions_dir)
                 .expect("save resumable session");
@@ -11600,6 +11612,66 @@ exit 1
         assert_eq!(
             resumed_sources,
             std::collections::HashSet::from(["session-open-window".to_string()])
+        );
+    }
+
+    #[test]
+    fn app_runtime_startup_auto_resume_includes_legacy_non_stopped_sessions() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        init_git_clone_with_origin(&repo);
+        let worktree = temp.path().join("worktrees").join("legacy-restore");
+        run_git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "work/legacy-restore",
+                worktree.to_str().expect("worktree path"),
+            ],
+        );
+        let tab = sample_project_tab(
+            "tab-auto",
+            "Auto Resume",
+            worktree.clone(),
+            ProjectKind::Git,
+            &[],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-auto"));
+        let mut session =
+            gwt_agent::Session::new(&worktree, "work/legacy-restore", gwt_agent::AgentId::Codex);
+        session.id = "session-legacy-open-window".to_string();
+        session.agent_session_id = Some("native-legacy-open-window".to_string());
+        session.restore_window_on_startup = false;
+        session.record_hook_event("Stop");
+        session.record_completed_stop();
+        session
+            .save(&runtime.sessions_dir)
+            .expect("save legacy open session");
+
+        runtime.bootstrap();
+        runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::StartupAutoResumeReady {
+                bounds: canvas_bounds(),
+            },
+        );
+
+        let resumed_sources = runtime
+            .pending_auto_resume_sources
+            .values()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(
+            resumed_sources,
+            std::collections::HashSet::from(["session-legacy-open-window".to_string()]),
+            "legacy sessions without the new restore flag should still restore when they were not explicitly stopped"
         );
     }
 

--- a/crates/gwt/src/app_runtime/runtime_events.rs
+++ b/crates/gwt/src/app_runtime/runtime_events.rs
@@ -109,6 +109,7 @@ impl AppRuntime {
             }
         }
         if should_auto_close {
+            self.clear_agent_window_startup_restore(&id);
             self.stop_window_runtime(&id);
             self.remove_window_state_tracking(&id);
             if !close_window_from_workspace(
@@ -192,6 +193,7 @@ impl AppRuntime {
         );
         let detail = self.window_details.get(&window_id).cloned();
         if should_auto_close {
+            self.clear_agent_window_startup_restore(&window_id);
             self.stop_window_runtime(&window_id);
             self.remove_window_state_tracking(&window_id);
             if close_window_from_workspace(

--- a/crates/gwt/src/app_runtime/window.rs
+++ b/crates/gwt/src/app_runtime/window.rs
@@ -346,6 +346,7 @@ impl AppRuntime {
     }
 
     pub(crate) fn close_window_events(&mut self, id: &str) -> Vec<OutboundEvent> {
+        self.clear_agent_window_startup_restore(id);
         self.stop_window_runtime(id);
         self.remove_window_state_tracking(id);
         self.profile_selections.remove(id);

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -1817,6 +1817,29 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_workspace_state_announces_startup_auto_resume_ready_after_render() {
+        let html = frontend_bundle_source();
+        let readiness_flow = regex::Regex::new(
+            r#"case\s+"workspace_state":\s*\{[\s\S]*?projectWorkspaceShell\.renderAppState\(event\.workspace\);[\s\S]*?sendStartupAutoResumeReady\(\);[\s\S]*?break;"#,
+        )
+        .expect("valid regex");
+
+        assert!(
+            html.contains("function sendStartupAutoResumeReady()"),
+            "expected a named one-shot startup auto-resume readiness helper",
+        );
+        assert!(
+            html.contains("kind: \"startup_auto_resume_ready\"")
+                && html.contains("bounds: visibleBounds()"),
+            "expected readiness payload to carry the current visible canvas bounds",
+        );
+        assert!(
+            readiness_flow.is_match(html),
+            "expected workspace_state hydration to render before announcing startup auto-resume readiness",
+        );
+    }
+
+    #[test]
     fn embedded_web_websocket_contract_stays_host_neutral_for_browser_and_native_modes() {
         let html = frontend_bundle_source();
         let websocket_url = regex::Regex::new(

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1947,6 +1947,7 @@ mod tests {
             launch_wizard: None,
             pending_workspace_resume_contexts: HashMap::new(),
             pending_auto_resume_sources: HashMap::new(),
+            pending_startup_auto_resume_sessions: Vec::new(),
             active_agent_sessions: HashMap::new(),
             window_pty_statuses: HashMap::new(),
             window_hook_states: HashMap::new(),

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -90,6 +90,9 @@ pub enum WorkspaceResumeSource {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum FrontendEvent {
     FrontendReady,
+    StartupAutoResumeReady {
+        bounds: WindowGeometry,
+    },
     OpenProjectDialog,
     SelectCloneProjectParent,
     GithubRepositorySearch {
@@ -1946,6 +1949,27 @@ mod tests {
                 base_geometry_revision: Some(7),
                 ..
             } if id == "w-1"
+        ));
+    }
+
+    #[test]
+    fn frontend_event_startup_auto_resume_ready_deserializes_visible_bounds() {
+        let event = serde_json::from_value::<FrontendEvent>(serde_json::json!({
+            "kind": "startup_auto_resume_ready",
+            "bounds": { "x": 8.0, "y": 16.0, "width": 1200.0, "height": 800.0 }
+        }))
+        .expect("deserialize startup auto-resume readiness");
+
+        assert!(matches!(
+            event,
+            FrontendEvent::StartupAutoResumeReady {
+                bounds: WindowGeometry {
+                    x: 8.0,
+                    y: 16.0,
+                    width: 1200.0,
+                    height: 800.0,
+                }
+            }
         ));
     }
 

--- a/crates/gwt/src/workspace.rs
+++ b/crates/gwt/src/workspace.rs
@@ -275,16 +275,41 @@ impl WorkspaceState {
         }
         let step = step as f64;
 
-        let window = PersistedWindowState {
-            id: self.next_window_id(preset),
-            title: title.into(),
+        self.push_window_with_geometry(
             preset,
-            geometry: WindowGeometry {
+            title,
+            persist,
+            WindowGeometry {
                 x: center_x + step * STACK_OFFSET_X,
                 y: center_y + step * STACK_OFFSET_Y,
                 width,
                 height,
             },
+        )
+    }
+
+    pub fn add_window_at_geometry_with_title(
+        &mut self,
+        preset: WindowPreset,
+        title: impl Into<String>,
+        persist: bool,
+        geometry: WindowGeometry,
+    ) -> PersistedWindowState {
+        self.push_window_with_geometry(preset, title, persist, geometry)
+    }
+
+    fn push_window_with_geometry(
+        &mut self,
+        preset: WindowPreset,
+        title: impl Into<String>,
+        persist: bool,
+        geometry: WindowGeometry,
+    ) -> PersistedWindowState {
+        let window = PersistedWindowState {
+            id: self.next_window_id(preset),
+            title: title.into(),
+            preset,
+            geometry,
             geometry_revision: 0,
             z_index: self.persisted.next_z_index,
             status: WindowProcessStatus::Running,

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -180,6 +180,7 @@
       const KNOWLEDGE_AUTO_REFRESH_INTERVAL_MS = 60000;
       let nextKnowledgeLoadRequestId = 1;
       let nextKnowledgeSearchRequestId = 1;
+      let startupAutoResumeReadySent = false;
       const pendingMessages = [];
       // Phase 1B extraction map: each entry names the surface that owns the
       // backing state today. New helpers should mutate state through the owning
@@ -2009,6 +2010,19 @@
           width: canvas.clientWidth / viewport.zoom,
           height: canvas.clientHeight / viewport.zoom,
         };
+      }
+
+      function sendStartupAutoResumeReady() {
+        if (startupAutoResumeReadySent) {
+          return;
+        }
+        startupAutoResumeReadySent = true;
+        requestAnimationFrame(() => {
+          send({
+            kind: "startup_auto_resume_ready",
+            bounds: visibleBounds(),
+          });
+        });
       }
 
       function topmostWindowId(workspace) {
@@ -10337,6 +10351,7 @@
           case "workspace_state": {
             projectError = "";
             frontendUnits.projectWorkspaceShell.renderAppState(event.workspace);
+            sendStartupAutoResumeReady();
             break;
           }
           case "workspace_projection_prune_result": {


### PR DESCRIPTION
## Summary

- Restores open Agent windows on startup only after the frontend reports visible canvas bounds, so restored windows appear as a centered stack instead of arbitrary positions.
- Keeps explicitly closed Agent windows out of startup restore, while preserving compatibility for legacy exact-resumable sessions saved before the restore flag existed.
- Removes stale quiet-work UI scaffolding and records the follow-up verification in SPEC #2359.

## Changes

- `crates/gwt-agent/src/session.rs`: Adds the `restore_window_on_startup` persisted flag and helper for updating the flag in session TOML.
- `crates/gwt/src/app_runtime/mod.rs`: Queues startup auto-resume until `startup_auto_resume_ready`, computes centered stack geometry, clears restore eligibility on close/stop paths, and restores legacy non-Stopped exact-resumable sessions.
- `crates/gwt/web/app.js`: Sends `startup_auto_resume_ready` once after the initial workspace hydration with visible canvas bounds.
- `crates/gwt/src/protocol.rs` and `crates/gwt/src/embedded_web.rs`: Add protocol and embedded frontend coverage for the startup readiness event.
- `crates/gwt/playwright/tests/quiet-work-ui-e2e.spec.ts`: Removes obsolete quiet-work UI E2E coverage no longer aligned with the current operator surface.

## Testing

- [x] `cargo test -p gwt startup_auto_resume -- --nocapture` — focused startup restore tests pass, including centered stack, closed-window exclusion, and legacy non-Stopped session restore.
- [x] `cargo fmt --check` — formatting is clean.
- [x] `git diff --check origin/develop..HEAD` — diff has no whitespace errors.
- [x] `bash scripts/check-frontend-bundle.sh` — frontend bundle syntax checks pass.
- [x] `bash scripts/run-frontend-unit-tests.sh` — 538 frontend unit tests pass.
- [x] `bash scripts/run-frontend-smoke-tests.sh` — 25 frontend smoke tests pass.
- [x] `bash scripts/run-visual-tests.sh` — 40 Playwright tests pass and 38 live-backend tests skip because `GWT_PLAYWRIGHT_BASE_URL` is not set.
- [x] `env -u GWT_SESSION_ID -u GWT_SESSION_RUNTIME_PATH -u GWT_PROJECT_ROOT -u GWT_REPO_HASH -u GWT_WORKTREE_HASH -u GWT_HOOK_FORWARD_URL -u GWT_HOOK_FORWARD_TOKEN cargo build -p gwt --bin gwt --bin gwtd` — build succeeds.
- [x] `env -u GWT_SESSION_ID -u GWT_SESSION_RUNTIME_PATH -u GWT_PROJECT_ROOT -u GWT_REPO_HASH -u GWT_WORKTREE_HASH -u GWT_HOOK_FORWARD_URL -u GWT_HOOK_FORWARD_TOKEN cargo test -p gwt-core -p gwt -p gwt-agent --all-features` — full relevant Rust tests pass.
- [x] `env -u GWT_SESSION_ID -u GWT_SESSION_RUNTIME_PATH -u GWT_PROJECT_ROOT -u GWT_REPO_HASH -u GWT_WORKTREE_HASH -u GWT_HOOK_FORWARD_URL -u GWT_HOOK_FORWARD_TOKEN cargo clippy --all-targets --all-features -- -D warnings` — clippy passes.
- [x] `bunx commitlint --from origin/develop --to HEAD` — commit messages pass.
- [x] `bunx markdownlint-cli@0.44.0 AGENTS.md` — AGENTS.md passes markdownlint.

## Closing Issues

- None

## Related Issues / Links

- #2359

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, frontend checks)
- [x] Documentation updated (SPEC #2359 tasks verification updated; README change not needed)
- [x] Migration/backfill plan included (legacy non-Stopped sessions are handled as compatibility restore candidates)
- [x] CHANGELOG impact considered (patch-level `fix(gui)` commits)

## Context

- User verification found that `gwt serve` restored no Agent windows after the first implementation because existing session files had `restore_window_on_startup = false` by default.
- The follow-up keeps the explicit flag for new windows but treats legacy exact-resumable non-Stopped sessions as previously open windows.

## Risk / Impact

- **Affected areas**: Agent window startup restore, Agent session persistence, frontend startup hydration.
- **Rollback plan**: Revert the two `fix(gui)` commits on this branch.

## Screenshots

- Not attached; this is startup/runtime restoration behavior. Automated frontend, Rust, and Playwright verification passed. Live-backend Playwright checks skipped without `GWT_PLAYWRIGHT_BASE_URL`, and the manual headless server was stopped at user request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent windows now automatically restore on startup when previously left open
  * Windows are recreated at their exact original positions with improved layout handling
  * Enhanced startup synchronization between frontend and backend ensures reliable automatic window recovery

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2862?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->