### PR TITLE
fix(gui): normalize Recent Projects entries to workspace home (#2867)

### DIFF
--- a/.claude/skills/headless-browser-check/SKILL.md
+++ b/.claude/skills/headless-browser-check/SKILL.md
@@ -68,3 +68,11 @@ not use it for CI-only Playwright runs or generic web app servers.
   the user required that exact port.
 - Keep user-facing status messages concise and in Japanese. Keep command names
   and log identifiers as-is.
+- **Never stop, kill, or ask the user to quit the user's production gwt /
+  `GWT.app` instance** (`/Applications/GWT.app`, any locally installed gwt
+  GUI, or any long-running `gwt` process the user did not launch in this
+  session). `gwt serve` is launched as a separate process from this skill;
+  let the production instance keep running. If a shared-state concern
+  arises (`~/.gwt/session.json`, `~/.gwt/app-instance.lock`, port
+  conflicts), point it out and let the user decide — never preempt that
+  decision by stopping their app.

--- a/.codex/skills/headless-browser-check/SKILL.md
+++ b/.codex/skills/headless-browser-check/SKILL.md
@@ -68,3 +68,11 @@ not use it for CI-only Playwright runs or generic web app servers.
   the user required that exact port.
 - Keep user-facing status messages concise and in Japanese. Keep command names
   and log identifiers as-is.
+- **Never stop, kill, or ask the user to quit the user's production gwt /
+  `GWT.app` instance** (`/Applications/GWT.app`, any locally installed gwt
+  GUI, or any long-running `gwt` process the user did not launch in this
+  session). `gwt serve` is launched as a separate process from this skill;
+  let the production instance keep running. If a shared-state concern
+  arises (`~/.gwt/session.json`, `~/.gwt/app-instance.lock`, port
+  conflicts), point it out and let the user decide — never preempt that
+  decision by stopping their app.

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -2691,7 +2691,7 @@ impl AppRuntime {
             tabs,
             active_tab_id,
             recent_projects: prune_missing_recent_projects(dedupe_recent_projects(
-                persisted.recent_projects,
+                normalize_recent_projects(persisted.recent_projects),
             )),
             profile_selections: HashMap::new(),
             profile_config_path: None,
@@ -4226,14 +4226,24 @@ impl AppRuntime {
     }
 
     /// SPEC-1934 FR-019: user accepted the migration confirmation modal.
+    ///
+    /// Issue #2867: Recent Projects は同一プロジェクトの worktree で埋め尽く
+    /// されないよう、`target.project_root` を workspace home に正規化してから
+    /// 登録する。タブ open 時の direct-pick semantics は `target` 側で保持。
     pub(crate) fn remember_recent_project(&mut self, target: &ProjectOpenTarget) {
+        let recent_path = normalize_recent_project_path(&target.project_root);
+        let recent_title = if recent_path == target.project_root {
+            target.title.clone()
+        } else {
+            gwt::project_title_from_path(&recent_path)
+        };
         self.recent_projects
-            .retain(|entry| !same_worktree_path(&entry.path, &target.project_root));
+            .retain(|entry| !same_worktree_path(&entry.path, &recent_path));
         self.recent_projects.insert(
             0,
             gwt::RecentProjectEntry {
-                path: target.project_root.clone(),
-                title: target.title.clone(),
+                path: recent_path,
+                title: recent_title,
                 kind: target.kind,
             },
         );
@@ -17257,6 +17267,137 @@ exit 1
                 event: BackendEvent::WorkspaceState { .. },
             }
         )));
+    }
+
+    #[test]
+    fn open_project_path_for_worktree_remembers_workspace_home_only() {
+        // Issue #2867: open_project_path で worktree path を渡したとき、tab は
+        // worktree で開く (direct-pick) が、recent_projects は workspace home
+        // (bare repo の親) に正規化されて 1 件だけ残る。同じ workspace の
+        // 別 worktree を続けて開いても recent_projects は増えない。
+        let temp = tempdir().expect("tempdir");
+        let workspace_home = temp.path().join("workspace");
+        let bare_repo = workspace_home.join("repo.git");
+        fs::create_dir_all(&workspace_home).expect("workspace home");
+        let output = gwt_core::process::hidden_command("git")
+            .args(["init", "--bare", bare_repo.to_str().expect("bare path")])
+            .output()
+            .expect("git init --bare");
+        assert!(
+            output.status.success(),
+            "git init --bare failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let bootstrap = workspace_home.join(".bootstrap");
+        let clone = gwt_core::process::hidden_command("git")
+            .args([
+                "clone",
+                bare_repo.to_str().unwrap(),
+                bootstrap.to_str().unwrap(),
+            ])
+            .output()
+            .expect("git clone");
+        assert!(clone.status.success(), "git clone failed");
+        for (key, value) in [
+            ("user.email", "test@example.com"),
+            ("user.name", "Test User"),
+        ] {
+            let cfg = gwt_core::process::hidden_command("git")
+                .args(["config", key, value])
+                .current_dir(&bootstrap)
+                .output()
+                .expect("git config");
+            assert!(cfg.status.success(), "git config {key} failed");
+        }
+        for args in [
+            vec!["checkout", "-b", "develop"],
+            vec!["commit", "--allow-empty", "-m", "init"],
+            vec!["push", "origin", "develop"],
+        ] {
+            let out = gwt_core::process::hidden_command("git")
+                .args(&args)
+                .current_dir(&bootstrap)
+                .output()
+                .expect("git command");
+            assert!(out.status.success(), "git {args:?} failed");
+        }
+        fs::remove_dir_all(&bootstrap).expect("remove bootstrap");
+
+        let develop_worktree = workspace_home.join("develop");
+        let feature_worktree = workspace_home.join("feature/alpha");
+        for (path, branch_args) in [
+            (
+                &develop_worktree,
+                vec!["worktree", "add", "@PATH@", "develop"],
+            ),
+            (
+                &feature_worktree,
+                vec![
+                    "worktree",
+                    "add",
+                    "-b",
+                    "feature/alpha",
+                    "@PATH@",
+                    "develop",
+                ],
+            ),
+        ] {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).expect("worktree parent");
+            }
+            let path_str = path.to_str().unwrap().to_string();
+            let resolved: Vec<&str> = branch_args
+                .iter()
+                .map(|a| {
+                    if *a == "@PATH@" {
+                        path_str.as_str()
+                    } else {
+                        *a
+                    }
+                })
+                .collect();
+            let out = gwt_core::process::hidden_command("git")
+                .args(&resolved)
+                .current_dir(&bare_repo)
+                .output()
+                .expect("git worktree add");
+            assert!(
+                out.status.success(),
+                "git {resolved:?} failed: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+
+        let mut runtime = sample_runtime(temp.path(), Vec::new(), None);
+        let canonical_home = dunce::canonicalize(&workspace_home).unwrap();
+
+        runtime
+            .open_project_path(develop_worktree.clone())
+            .expect("open develop worktree");
+        assert_eq!(runtime.tabs.len(), 1);
+        assert_eq!(
+            runtime.tabs[0].project_root,
+            dunce::canonicalize(&develop_worktree).unwrap(),
+            "tab must open at the chosen worktree (SC-035 direct-pick preserved)"
+        );
+        assert_eq!(runtime.recent_projects.len(), 1);
+        assert_eq!(
+            runtime.recent_projects[0].path, canonical_home,
+            "recent_projects must collapse to workspace home, not worktree path (Issue #2867)"
+        );
+
+        runtime
+            .open_project_path(feature_worktree.clone())
+            .expect("open feature worktree");
+        assert_eq!(
+            runtime.recent_projects.len(),
+            1,
+            "opening another worktree in the same workspace must not add a new recent entry"
+        );
+        assert_eq!(
+            runtime.recent_projects[0].path, canonical_home,
+            "second worktree open must keep workspace home as the canonical recent entry"
+        );
     }
 
     #[test]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -97,10 +97,10 @@ pub(crate) use runtime_support::{
     current_git_branch, dedupe_recent_projects, fallback_project_target,
     first_available_worktree_path, front_door_route, geometry_to_pty_size,
     knowledge_kind_for_preset, local_branch_exists, normalize_active_tab_id, normalize_branch_name,
-    origin_remote_ref, prune_missing_recent_projects, resolve_launch_spec_with_fallback,
-    resolve_project_target, run_cli, same_worktree_path, should_auto_close_agent_window,
-    should_auto_start_restored_window, synthetic_branch_entry, usable_worktree_path_for_branch,
-    worktrees_have_stale_branch_entry,
+    normalize_recent_project_path, normalize_recent_projects, origin_remote_ref,
+    prune_missing_recent_projects, resolve_launch_spec_with_fallback, resolve_project_target,
+    run_cli, same_worktree_path, should_auto_close_agent_window, should_auto_start_restored_window,
+    synthetic_branch_entry, usable_worktree_path_for_branch, worktrees_have_stale_branch_entry,
 };
 pub(crate) use update_front_door::{apply_update_state_and_exit, spawn_startup_update_check};
 #[cfg(test)]

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -161,6 +161,51 @@ pub fn dedupe_recent_projects(
     deduped
 }
 
+/// Issue #2867: Recent Projects は worktree path ではなく workspace home に
+/// 正規化する。Bare layout なら bare repo の親 (例 `…/gwt`)、normal Git repo
+/// なら repo root をそのまま返す。Git でない、または resolution に失敗した
+/// 場合 (NonRepo、git 未インストール、不正パスなど) は入力 path をそのまま
+/// 返す。タブ open 時の direct-pick semantics (worktree path で開く) には
+/// 影響しない。Recent Projects 登録経路と persisted state load 経路の双方で
+/// 使う。
+pub fn normalize_recent_project_path(path: &Path) -> PathBuf {
+    let Ok(layout_root) = gwt_git::worktree::main_worktree_root(path) else {
+        return path.to_path_buf();
+    };
+    if is_bare_repo_dir(&layout_root) {
+        layout_root
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| path.to_path_buf())
+    } else {
+        layout_root
+    }
+}
+
+fn is_bare_repo_dir(path: &Path) -> bool {
+    path.join("HEAD").exists() && path.join("objects").exists() && path.join("refs").exists()
+}
+
+/// Normalize every Recent Projects entry via [`normalize_recent_project_path`]
+/// and re-derive its title when the path changes. Combine with
+/// [`dedupe_recent_projects`] to collapse repeated worktrees down to a single
+/// workspace home entry.
+pub fn normalize_recent_projects(
+    entries: Vec<gwt::RecentProjectEntry>,
+) -> Vec<gwt::RecentProjectEntry> {
+    entries
+        .into_iter()
+        .map(|mut entry| {
+            let normalized = normalize_recent_project_path(&entry.path);
+            if normalized != entry.path {
+                entry.title = gwt::project_title_from_path(&normalized);
+                entry.path = normalized;
+            }
+            entry
+        })
+        .collect()
+}
+
 /// Issue #1678: drop recent project entries whose paths no longer exist on
 /// disk. Called once at load time so subsequent `persist()` writes a clean
 /// list back. A separate function (rather than baked into `dedupe_*`) so
@@ -1209,6 +1254,156 @@ upstream\tgit@github.com:anthropics/example.git (push)
         run_git(&repo, &["commit", "--allow-empty", "-m", "init"]);
 
         assert!(super::branch_worktree_path(&repo, "feature/never-exists").is_none());
+    }
+
+    // -------------------------------------------------------------------
+    // Issue #2867: Recent Projects worktree pollution
+    // normalize_recent_project_path must collapse worktree paths under a
+    // bare layout down to the workspace home so the Recent Projects list
+    // does not fill up with repeated entries for the same project.
+    // -------------------------------------------------------------------
+
+    fn make_bare_workspace_with_worktrees(tmp: &std::path::Path, worktrees: &[&str]) {
+        let bare = tmp.join("repo.git");
+        std::fs::create_dir_all(&bare).expect("bare dir");
+        run_git(&bare, &["init", "--bare"]);
+
+        let bootstrap = tmp.join(".bootstrap");
+        run_git(tmp, &["clone", bare.to_str().unwrap(), ".bootstrap"]);
+        seed_git_identity(&bootstrap);
+        run_git(&bootstrap, &["checkout", "-b", "develop"]);
+        run_git(&bootstrap, &["commit", "--allow-empty", "-m", "init"]);
+        run_git(&bootstrap, &["push", "origin", "develop"]);
+
+        for (index, worktree) in worktrees.iter().enumerate() {
+            let path = tmp.join(worktree);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("worktree parent");
+            }
+            // First worktree reuses `develop`; subsequent worktrees create
+            // unique branches so `git worktree add` doesn't reject them.
+            if index == 0 {
+                run_git(
+                    &bare,
+                    &["worktree", "add", path.to_str().unwrap(), "develop"],
+                );
+            } else {
+                let branch = format!("feature/wt-{index}");
+                run_git(
+                    &bare,
+                    &[
+                        "worktree",
+                        "add",
+                        "-b",
+                        &branch,
+                        path.to_str().unwrap(),
+                        "develop",
+                    ],
+                );
+            }
+        }
+        std::fs::remove_dir_all(&bootstrap).expect("remove bootstrap");
+    }
+
+    #[test]
+    fn normalize_recent_project_path_returns_workspace_home_for_bare_worktree() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        make_bare_workspace_with_worktrees(tmp.path(), &["develop"]);
+        let worktree = tmp.path().join("develop");
+
+        let normalized = super::normalize_recent_project_path(&worktree);
+
+        let expected = std::fs::canonicalize(tmp.path()).expect("canonical workspace home");
+        assert_eq!(
+            std::fs::canonicalize(&normalized).expect("canonical normalized"),
+            expected,
+            "worktree path must normalize to workspace home (Issue #2867)"
+        );
+    }
+
+    #[test]
+    fn normalize_recent_project_path_keeps_workspace_home_for_bare_layout() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        make_bare_workspace_with_worktrees(tmp.path(), &["develop"]);
+
+        let normalized = super::normalize_recent_project_path(tmp.path());
+
+        let expected = std::fs::canonicalize(tmp.path()).expect("canonical");
+        assert_eq!(
+            std::fs::canonicalize(&normalized).expect("canonical normalized"),
+            expected,
+            "workspace home itself must stay as workspace home"
+        );
+    }
+
+    #[test]
+    fn normalize_recent_project_path_returns_repo_root_for_normal_repo() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo dir");
+        run_git(&repo, &["init"]);
+        seed_git_identity(&repo);
+        run_git(&repo, &["commit", "--allow-empty", "-m", "init"]);
+
+        let normalized = super::normalize_recent_project_path(&repo);
+
+        assert_eq!(
+            std::fs::canonicalize(&normalized).expect("canonical normalized"),
+            std::fs::canonicalize(&repo).expect("canonical repo"),
+            "normal repo root must normalize to itself"
+        );
+    }
+
+    #[test]
+    fn normalize_recent_project_path_returns_input_for_non_repo() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let plain = tmp.path().join("plain");
+        std::fs::create_dir_all(&plain).expect("plain dir");
+
+        let normalized = super::normalize_recent_project_path(&plain);
+
+        assert_eq!(
+            normalized, plain,
+            "non-repo path must be returned unchanged"
+        );
+    }
+
+    #[test]
+    fn normalize_recent_projects_collapses_worktrees_into_single_workspace_home() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        make_bare_workspace_with_worktrees(tmp.path(), &["develop", "work/20260518"]);
+
+        let entries = vec![
+            gwt::RecentProjectEntry {
+                path: tmp.path().to_path_buf(),
+                title: "workspace".to_string(),
+                kind: gwt::ProjectKind::Git,
+            },
+            gwt::RecentProjectEntry {
+                path: tmp.path().join("develop"),
+                title: "develop".to_string(),
+                kind: gwt::ProjectKind::Git,
+            },
+            gwt::RecentProjectEntry {
+                path: tmp.path().join("work/20260518"),
+                title: "20260518".to_string(),
+                kind: gwt::ProjectKind::Git,
+            },
+        ];
+
+        let normalized = super::dedupe_recent_projects(super::normalize_recent_projects(entries));
+
+        assert_eq!(
+            normalized.len(),
+            1,
+            "all three entries must collapse to the single workspace home"
+        );
+        let expected = std::fs::canonicalize(tmp.path()).expect("canonical workspace home");
+        assert_eq!(
+            std::fs::canonicalize(&normalized[0].path).expect("canonical normalized entry"),
+            expected,
+            "remaining entry must be the workspace home, not a worktree"
+        );
     }
 
     #[test]

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6025,3 +6025,10 @@ hook integration tests が `CODEX_THREAD_ID` / `GWT_SESSION_ID` /
    `GWT_SESSION_RUNTIME_PATH` を unset して現在の agent session を汚染しない。
 3. Codex payload の `session_id` を使う tests では placeholder の `agent-session` を避け、
    実 resume 可能 ID を表す別値を使う。
+
+## 2026-05-22 — headless-browser-check はユーザーの production gwt / GWT.app を絶対に停止させない
+
+Type: lesson
+Context: Issue #2867 の Recent Projects pollution 修正で headless 確認を行う際、私が独断で「production GWT.app (PID 9569) を終了してください」と要求した。ユーザーから skill にそのような手順は無いと指摘され、誤って kill されると困るとの再発防止依頼を受けた。
+Learning: headless-browser-check skill は 'gwt serve を別プロセスとして起動する' という前提で、ユーザーの常用 gwt / GWT.app を停止する手順は含まない。session.json や app-instance.lock の競合懸念があっても、エージェントが自動で停止判断をしてはならない。
+Future Action: headless 起動時に共有 state (session.json / app-instance.lock / port) の懸念がある場合は、懸念点を明示してユーザーに判断を委ねる。production gwt を停止する選択肢は提示してよいが、エージェント側で前提化したり、依頼したりしない。skill の guardrail にも明文化済み (.claude/.codex の SKILL.md 両方)。


### PR DESCRIPTION
## Summary

- Recent Projects 一覧が同一 project の worktree (`develop` や `work/<timestamp>`) で埋まる pollution を解消し、Open Project の Recent / split-button menu に **workspace home だけ** が並ぶようにする (Issue #2867)。
- `headless-browser-check` skill にユーザーの常用 `GWT.app` を停止する手順は無いことを明文化し、エージェントが独断で kill 要求を出さないよう guardrail を追加。

## Changes

- `crates/gwt/src/runtime_support.rs`: `normalize_recent_project_path` / `normalize_recent_projects` を追加。`gwt_git::worktree::main_worktree_root` 経由で bare layout の worktree を workspace home に解決、normal repo はそのまま、解決不能ケースは入力 path を返す。タイトルも正規化後 path から再導出。新規 5 unit tests を追加。
- `crates/gwt/src/app_runtime/mod.rs`: `remember_recent_project` で normalize を適用して登録時の workspace-home pinning を行い、persisted state load 経路 (`prune_missing_recent_projects(dedupe_recent_projects(normalize_recent_projects(persisted.recent_projects)))`) にも組み込み、既存 worktree pollution を次回起動時に自動的に dedupe。新規 1 integration test (`open_project_path_for_worktree_remembers_workspace_home_only`) を追加。
- `crates/gwt/src/main.rs`: 新 helper 2 件を `pub(crate) use` で公開。
- `.claude/skills/headless-browser-check/SKILL.md` / `.codex/skills/headless-browser-check/SKILL.md`: Guardrails セクションに「ユーザーの production gwt / `GWT.app` を停止・kill しない、要求もしない」ルールを明文追加。
- `tasks/memory.md`: 同じ再発防止指針を `gwtd memory add` で追記。

## Testing

- [x] `cargo test -p gwt-core -p gwt --all-features` — gwt-core 739 + gwt 438 + 各 crate 全 PASS。新規 6 件 (`normalize_recent_project_path_*` x4 / `normalize_recent_projects_collapses_*` x1 / `open_project_path_for_worktree_remembers_workspace_home_only` x1) も含む。
- [x] `cargo clippy -p gwt -p gwt-core --all-targets --all-features -- -D warnings` — clean。
- [x] `cargo fmt --check -p gwt -p gwt-core` — clean。
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — release build PASS。
- [x] Headless `./target/debug/gwt serve` を 127.0.0.1 上で起動し、Open Project → Recent が workspace home に正規化されることをユーザーが視覚確認済み (production `GWT.app` は停止せず別プロセスで起動)。

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — Recent Projects 正規化と skill guardrail はそれぞれ単独で配信可能。既存機能の挙動 (タブ open 時の direct-pick semantics、Clone Project の workspace home 登録) は保持。
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- Closes #2867

## Related Issues / Links

- None

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (if user-facing change) — skill SKILL.md と tasks/memory.md を更新。ユーザー向け README には Recent Projects 仕様の記載が無いため変更不要。
- [x] Migration/backfill plan included (if schema/data change) — `normalize_recent_projects` を load 経路に組み込み、既存 `~/.gwt/session.json` の worktree entry は次回起動時に自動 dedupe。専用 migration 不要。
- [x] CHANGELOG impact considered (breaking change flagged in commit) — `fix` のみで breaking change なし。

## Notes

- 既存ユーザーの `~/.gwt/session.json` は dev binary 初回起動時に load-time normalize で workspace home へ collapse する。dedupe 後に `persist()` が走るため、stale な worktree entry は永続化されない。
- タブ open 時の direct-pick semantics (SC-035) は `resolve_project_target` 側の挙動を保持しており、worktree path を直接渡せばタブはその worktree で開く。Recent Projects 登録だけが workspace home に正規化される。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guardrail guidance and lessons for headless-browser-check skill best practices.

* **New Features**
  * Enhanced headless-browser-check skill guardrails to prevent interference with production instances and clarify shared-state conflict handling.

* **Bug Fixes**
  * Fixed recent projects tracking to properly consolidate worktree entries under their workspace homes, eliminating duplicate entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->