### PR TITLE
fix(gui): keep agent role badge visible

### DIFF
--- a/crates/gwt/playwright/tests/agent-title-badge.spec.ts
+++ b/crates/gwt/playwright/tests/agent-title-badge.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test } from "@playwright/test";
+import { APP_URL, installEmbeddedRoutes } from "./_helpers/embedded-frontend";
+
+test.describe("Agent title role badge", () => {
+  test.use({
+    deviceScaleFactor: 1,
+    viewport: { width: 1440, height: 900 },
+  });
+
+  test("fallback runtime title still displays the Agent runtime badge", async ({
+    page,
+  }, testInfo) => {
+    await installEmbeddedRoutes(page);
+    await installAgentTitleBadgeBackend(page);
+
+    await page.goto(APP_URL);
+
+    const agentWindow = page.locator(".workspace-window[data-id='agent-1']");
+    await expect(agentWindow).toBeVisible({ timeout: 10_000 });
+    await expect(agentWindow.locator(".title-text")).toHaveText("Codex");
+
+    const badge = agentWindow.locator(".window-role-badge").first();
+    await expect(badge).toBeVisible();
+    await expect(badge).toHaveText("Codex");
+
+    await agentWindow.screenshot({
+      path:
+        process.env.GWT_AGENT_BADGE_SCREENSHOT_PATH ||
+        testInfo.outputPath("agent-title-badge.png"),
+    });
+  });
+});
+
+async function installAgentTitleBadgeBackend(page) {
+  await page.addInitScript(() => {
+    const workspaceState = {
+      kind: "workspace_state",
+      workspace: {
+        app_version: "playwright",
+        tabs: [
+          {
+            id: "tab-1",
+            title: "Agent Badge Fixture",
+            project_root: "/fixture",
+            kind: "git",
+            workspace: {
+              viewport: { x: 0, y: 0, zoom: 1 },
+              windows: [
+                {
+                  id: "agent-1",
+                  title: "Codex",
+                  preset: "agent",
+                  geometry: { x: 180, y: 120, width: 720, height: 360 },
+                  geometry_revision: 0,
+                  z_index: 1,
+                  status: "idle",
+                  minimized: false,
+                  maximized: false,
+                  pre_maximize_geometry: null,
+                  persist: true,
+                  purpose_title: null,
+                  dynamic_title: null,
+                  dynamic_title_detail: null,
+                  agent_id: "codex",
+                  agent_color: "cyan",
+                  tab_group_id: null,
+                  tab_group_active: false,
+                },
+              ],
+            },
+          },
+        ],
+        active_tab_id: "tab-1",
+        recent_projects: [],
+      },
+    };
+
+    class FixtureWebSocket extends EventTarget {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+
+      constructor(url) {
+        super();
+        this.url = url;
+        this.readyState = FixtureWebSocket.CONNECTING;
+        setTimeout(() => {
+          this.readyState = FixtureWebSocket.OPEN;
+          this.dispatchEvent(new Event("open"));
+          this.emit(workspaceState);
+        }, 0);
+      }
+
+      send() {}
+
+      close() {
+        this.readyState = FixtureWebSocket.CLOSED;
+        this.dispatchEvent(new CloseEvent("close"));
+      }
+
+      emit(payload) {
+        setTimeout(() => {
+          this.dispatchEvent(
+            new MessageEvent("message", { data: JSON.stringify(payload) }),
+          );
+        }, 0);
+      }
+    }
+
+    Object.defineProperty(window, "WebSocket", {
+      configurable: true,
+      value: FixtureWebSocket,
+    });
+  });
+}

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -6588,6 +6588,9 @@ impl AppRuntime {
                 .workspace
                 .set_purpose_title(&window.id, Some(purpose_title));
         }
+        let _ = tab
+            .workspace
+            .set_agent_id(&window.id, config.agent_id.command().to_string());
         self.register_window(tab_id, &window.id);
         let window_id = combined_window_id(tab_id, &window.id);
 
@@ -15320,6 +15323,48 @@ exit 1
             Some("SPEC: Workspace purpose titles")
         );
         assert_eq!(agent_window.title, "Codex");
+    }
+
+    #[test]
+    fn app_runtime_agent_window_initial_state_broadcast_includes_agent_id() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        init_repo(&repo);
+        let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let config = gwt_agent::AgentLaunchBuilder::new(gwt_agent::AgentId::ClaudeCode).build();
+
+        let events = runtime
+            .spawn_agent_window("tab-1", config, canvas_bounds(), None)
+            .expect("spawn agent window");
+
+        let workspace = events
+            .iter()
+            .find_map(|event| match &event.event {
+                BackendEvent::WorkspaceState { workspace } => Some(workspace),
+                _ => None,
+            })
+            .expect("initial WorkspaceState broadcast");
+        let tab = workspace
+            .tabs
+            .iter()
+            .find(|tab| tab.id == "tab-1")
+            .expect("tab in WorkspaceState");
+        let agent_window = tab
+            .workspace
+            .windows
+            .iter()
+            .find(|window| window.preset == WindowPreset::Agent)
+            .expect("agent window in WorkspaceState");
+
+        assert_eq!(agent_window.title, "Claude Code");
+        assert_eq!(agent_window.agent_id.as_deref(), Some("claude"));
     }
 
     #[test]

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -221,6 +221,52 @@ test("workspace windows expose role badges and hide panel runtime chips", () => 
   );
 });
 
+test("Agent title role badges resolve runtime identity instead of generic presets", () => {
+  assert.match(
+    appSource,
+    /const\s+AGENT_ROLE_LABELS\s*=\s*Object\.freeze\(\{[\s\S]*claude:\s*"Claude Code"[\s\S]*codex:\s*"Codex"/,
+    "expected Agent role badges to map runtime ids to display names",
+  );
+  assert.match(
+    appSource,
+    /function\s+agentRoleLabel\(windowData\)[\s\S]+windowData\?\.agent_id[\s\S]+AGENT_ROLE_LABELS/,
+    "expected Agent role badge labels to resolve from window.agent_id",
+  );
+  assert.match(
+    appSource,
+    /function\s+windowRoleBadgeLabel\(windowData\)[\s\S]+agentRoleLabel\(windowData\)/,
+    "expected titlebar and list role badges to share an Agent-aware label helper",
+  );
+  assert.doesNotMatch(
+    appSource,
+    /window-role-badge"\)\.textContent\s*=\s*presetRoleLabel\(windowData\.preset\)/,
+    "titlebar role badge must not show the generic Agent preset label",
+  );
+  assert.doesNotMatch(
+    appSource,
+    /window-list-role">\$\{presetRoleLabel\(entry\.preset\)\}/,
+    "window list role badge must not show the generic Agent preset label",
+  );
+});
+
+test("Non-Agent duplicate title role badges are omitted", () => {
+  assert.match(
+    appSource,
+    /function\s+windowRoleBadgeLabel\(windowData\)[\s\S]+windowDisplayTitle\(windowData\)[\s\S]+return\s+""/,
+    "expected duplicate role badges such as Branches / Branches to be suppressed",
+  );
+  assert.match(
+    appSource,
+    /function\s+setWindowRoleBadge\(badgeElement,\s*windowData\)[\s\S]+badgeElement\.hidden\s*=\s*!label/,
+    "expected titlebar role badge updates to hide empty labels",
+  );
+  assert.match(
+    inlineStyle,
+    /\.window-role-badge\[hidden\]\s*\{[\s\S]*display:\s*none/,
+    "hidden role badges must stay hidden even though .window-role-badge uses inline-flex",
+  );
+});
+
 test("Memo is not exposed as a workspace window feature", () => {
   assert.equal(
     document.querySelector('.preset-button[data-preset="memo"]'),

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -267,6 +267,24 @@ test("Non-Agent duplicate title role badges are omitted", () => {
   );
 });
 
+test("Agent fallback runtime titles still show Agent role badges", () => {
+  assert.match(
+    appSource,
+    /function\s+windowRoleBadgeLabel\(windowData\)[\s\S]+const\s+isAgentWindow\s*=\s*isAgentWindowPreset\(windowData\?\.preset\)/,
+    "expected duplicate suppression to distinguish Agent windows from static panels",
+  );
+  assert.match(
+    appSource,
+    /if\s*\(!isAgentWindow\s*&&\s*label\s*===\s*displayTitle\)\s*return\s+""/,
+    "Agent role badges must remain visible when the fallback title is the same runtime name",
+  );
+  assert.doesNotMatch(
+    appSource,
+    /if\s*\(!label\s*\|\|\s*label\s*===\s*displayTitle\)\s*return\s+""/,
+    "generic duplicate suppression must not hide Agent role badges",
+  );
+});
+
 test("Memo is not exposed as a workspace window feature", () => {
   assert.equal(
     document.querySelector('.preset-button[data-preset="memo"]'),

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1587,6 +1587,76 @@
         return labels[preset] || presetLabel(preset);
       }
 
+      const AGENT_ROLE_LABELS = Object.freeze({
+        claude: "Claude Code",
+        "claude-code": "Claude Code",
+        claudecode: "Claude Code",
+        "claude code": "Claude Code",
+        claude_code: "Claude Code",
+        codex: "Codex",
+        gemini: "Gemini CLI",
+        "gemini-cli": "Gemini CLI",
+        "gemini cli": "Gemini CLI",
+        gemini_cli: "Gemini CLI",
+        opencode: "OpenCode",
+        "open-code": "OpenCode",
+        open_code: "OpenCode",
+        openclaw: "OpenClaw",
+        "open-claw": "OpenClaw",
+        open_claw: "OpenClaw",
+        hermes: "Hermes Agent",
+        "hermes-agent": "Hermes Agent",
+        "hermes agent": "Hermes Agent",
+        hermes_agent: "Hermes Agent",
+        gh: "GitHub Copilot",
+        copilot: "GitHub Copilot",
+        "github-copilot": "GitHub Copilot",
+        "github copilot": "GitHub Copilot",
+        github_copilot: "GitHub Copilot",
+      });
+
+      const GENERIC_AGENT_ROLE_LABELS = new Set(["agent", "window"]);
+
+      function normalizedAgentRoleKey(value) {
+        return String(value || "").trim().toLowerCase();
+      }
+
+      function isGenericAgentRoleLabel(value) {
+        return GENERIC_AGENT_ROLE_LABELS.has(normalizedAgentRoleKey(value));
+      }
+
+      function isAgentWindowPreset(preset) {
+        return preset === "agent" || preset === "claude" || preset === "codex";
+      }
+
+      function agentRoleLabel(windowData) {
+        const agentIdLabel =
+          AGENT_ROLE_LABELS[normalizedAgentRoleKey(windowData?.agent_id)] || "";
+        if (agentIdLabel) return agentIdLabel;
+        const presetLabel =
+          AGENT_ROLE_LABELS[normalizedAgentRoleKey(windowData?.preset)] || "";
+        if (presetLabel) return presetLabel;
+        const launchTitle = String(windowData?.title || "").trim();
+        if (launchTitle && !isGenericAgentRoleLabel(launchTitle)) return launchTitle;
+        return "";
+      }
+
+      function windowRoleBadgeLabel(windowData) {
+        const displayTitle = windowDisplayTitle(windowData);
+        const label = isAgentWindowPreset(windowData?.preset)
+          ? agentRoleLabel(windowData)
+          : presetRoleLabel(windowData?.preset || "");
+        if (!label || label === displayTitle) return "";
+        return label;
+      }
+
+      function setWindowRoleBadge(badgeElement, windowData) {
+        if (!badgeElement) return;
+        const label = windowRoleBadgeLabel(windowData);
+        badgeElement.textContent = label;
+        badgeElement.hidden = !label;
+      }
+
       function shouldShowRuntimeStatus(windowData) {
         return presetSurface(windowData?.preset) === "terminal";
       }
@@ -1722,11 +1792,15 @@
                 <span class="status-label">${runtimeLabel}</span>
               </span>`
             : "";
+          const roleBadgeLabel = windowRoleBadgeLabel(entry);
+          const roleBadge = roleBadgeLabel
+            ? `<span class="window-role-badge window-list-role">${escapeHtml(roleBadgeLabel)}</span>`
+            : "";
           row.innerHTML = `
             <div class="window-list-copy">
               <div class="window-list-title">${escapeHtml(windowDisplayTitle(entry))}</div>
               <div class="window-list-meta">
-                <span class="window-role-badge window-list-role">${presetRoleLabel(entry.preset)}</span>
+                ${roleBadge}
                 <span class="window-list-geometry">${geometryLabel}</span>
               </div>
             </div>
@@ -10659,7 +10733,7 @@
         element.querySelector(".title-text").textContent = windowDisplayTitle(windowData);
         const titleText = element.querySelector(".title-text");
         titleText.title = windowTitleTooltip(windowData);
-        element.querySelector(".window-role-badge").textContent = presetRoleLabel(windowData.preset);
+        setWindowRoleBadge(element.querySelector(".window-role-badge"), windowData);
         renderWindowTabs(windowData, element);
         if (windowData.agent_color) {
           element.dataset.agentColor = windowData.agent_color;

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1643,10 +1643,12 @@
 
       function windowRoleBadgeLabel(windowData) {
         const displayTitle = windowDisplayTitle(windowData);
-        const label = isAgentWindowPreset(windowData?.preset)
+        const isAgentWindow = isAgentWindowPreset(windowData?.preset);
+        const label = isAgentWindow
           ? agentRoleLabel(windowData)
           : presetRoleLabel(windowData?.preset || "");
-        if (!label || label === displayTitle) return "";
+        if (!label) return "";
+        if (!isAgentWindow && label === displayTitle) return "";
         return label;
       }
 

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -690,6 +690,10 @@ body {
   white-space: nowrap;
 }
 
+.window-role-badge[hidden] {
+  display: none;
+}
+
 .window-list-role {
   min-height: 18px;
   padding-inline: 6px;


### PR DESCRIPTION
## Summary

- Agent window role badges now show the concrete runtime name such as `Codex` or `Claude Code` instead of the generic `Agent`.
- Agent fallback titles keep the runtime role badge visible even when the title and badge text are both `Codex`.
- Non-Agent windows still omit meaningless duplicate role badges such as `Branches` / `Branches`.

## Changes

- `crates/gwt/src/app_runtime/mod.rs`: persists the selected launch runtime into existing Agent window `agent_id` state before broadcasting workspace state.
- `crates/gwt/web/app.js`: centralizes semantic role-badge rendering, keeps Agent badges runtime-specific, and limits duplicate-title suppression to non-Agent windows.
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: adds regression coverage for Codex / Claude Code badges, primary task-title precedence, duplicate non-Agent badge omission, and Agent fallback badge visibility.
- `crates/gwt/playwright/tests/agent-title-badge.spec.ts`: adds a browser regression for the fallback `title=Codex` / `agent_id=codex` state.
- `crates/gwt/web/styles/app.css`: styles the compact role badge used in titlebars and window lists.

## Testing

- [x] `bash scripts/run-frontend-unit-tests.sh` — 546 passed.
- [x] `bash scripts/check-frontend-bundle.sh` — passed.
- [x] `node --check crates/gwt/web/app.js` — passed.
- [x] `bash scripts/run-visual-tests.sh --project=chromium-light crates/gwt/playwright/tests/agent-title-badge.spec.ts` — 1 passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed after merging `origin/develop`.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo fmt -- --check` — passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed.
- [x] `git diff --check` — passed.
- [x] `bunx commitlint --from origin/develop --to HEAD` — passed.
- [x] Manual headed E2E screenshot inspection — confirmed title `CODEX`, separate role badge `Codex`, and status `Idle`.
- [x] User visual verification via `target/debug/gwt serve` at `http://127.0.0.1:50970/` — confirmed OK; serve process stopped.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes; this is a contained GUI/runtime identity fix with automated regression coverage and completed visual verification.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- #2359

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`)
- [x] Documentation updated (if user-facing change) — N/A, UI behavior fix only.
- [x] Migration/backfill plan included (if schema/data change) — N/A, existing `agent_id` field reused.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- SPEC-2359 tracks Workspace / Agent window title behavior. The primary Agent title is the work summary, while the role badge identifies the runtime.
- A user-provided screenshot showed the `Codex` role badge missing when the fallback Agent title was also `Codex`; the root cause was generic duplicate-title suppression applying to Agent windows.

## Risk / Impact

- **Affected areas**: Agent window titlebars, Window list labels, Launch Wizard runtime identity persistence.
- **Rollback plan**: Revert this PR; no schema migration or data backfill is required.

## Screenshots

| Before | After |
|--------|-------|
| User screenshot showed fallback Agent title `Codex` with no role badge. | Headed Playwright screenshot confirmed title `CODEX`, separate `Codex` role badge, and `Idle` status. |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent windows now display a title role badge showing the agent's name/title
  * Role badges intelligently use agent-specific labels instead of generic preset labels
  * Added logic to suppress duplicate title badges for improved visual clarity

* **Tests**
  * Added end-to-end tests for agent title badge display and visibility
  * Added unit tests verifying agent-specific badge behavior and duplicate-suppression logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2869?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->