### PR TITLE
feat(launch-wizard): add start methods flow

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -10018,9 +10018,25 @@ exit 1
             .view();
         assert_eq!(view.mode, gwt::LaunchWizardMode::Branch);
         assert_eq!(view.branch_name, "work/20260504-1234");
-        assert!(view.show_branch_controls);
+        assert!(view.show_start_methods);
+        assert!(!view.show_branch_controls);
         assert_eq!(view.live_sessions.len(), 1);
         assert_eq!(view.live_sessions[0].name, "Codex");
+
+        let _ = runtime.handle_launch_wizard_action(
+            gwt::LaunchWizardAction::UseStartMethod {
+                method: gwt::LaunchWizardStartMethodKind::ConfigureAndStart,
+            },
+            None,
+        );
+        let configured_view = runtime
+            .launch_wizard
+            .as_ref()
+            .expect("configured active work launch wizard")
+            .wizard
+            .view();
+        assert!(!configured_view.show_start_methods);
+        assert!(configured_view.show_branch_controls);
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1142,6 +1142,12 @@ impl LaunchWizardMemoryCache {
             .cloned()
     }
 
+    fn session_by_id(&self, session_id: &str) -> Option<&gwt_agent::Session> {
+        self.sessions
+            .iter()
+            .find(|session| session.id == session_id)
+    }
+
     fn agent_preferences(&self) -> gwt::LaunchWizardPreviousProfiles {
         gwt::launch_wizard::previous_launch_profiles_from_sessions(&self.sessions)
     }
@@ -6076,7 +6082,23 @@ impl AppRuntime {
                     .unwrap_or(WindowProcessStatus::Running),
             })
             .collect::<Vec<_>>();
-        entries.sort_by(|left, right| left.name.cmp(&right.name));
+        entries.sort_by(|left, right| {
+            match (
+                self.launch_wizard_cache.session_by_id(&left.session_id),
+                self.launch_wizard_cache.session_by_id(&right.session_id),
+            ) {
+                (Some(left_session), Some(right_session)) => right_session
+                    .last_activity_at
+                    .cmp(&left_session.last_activity_at)
+                    .then_with(|| right_session.updated_at.cmp(&left_session.updated_at))
+                    .then_with(|| right_session.created_at.cmp(&left_session.created_at))
+                    .then_with(|| right_session.id.cmp(&left_session.id)),
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (None, None) => left.name.cmp(&right.name),
+            }
+            .then_with(|| left.name.cmp(&right.name))
+        });
         entries
     }
 
@@ -7407,7 +7429,8 @@ impl AppRuntime {
             gwt::LaunchWizardAction::ApplyQuickStart { .. } => "quick_start",
             gwt::LaunchWizardAction::SetLaunchPath { .. }
             | gwt::LaunchWizardAction::SelectQuickStart { .. }
-            | gwt::LaunchWizardAction::SelectLiveSession { .. } => "launch_path_select",
+            | gwt::LaunchWizardAction::SelectLiveSession { .. }
+            | gwt::LaunchWizardAction::UseStartMethod { .. } => "launch_path_select",
             gwt::LaunchWizardAction::FocusExistingSession { .. } => "focus_existing_session",
             gwt::LaunchWizardAction::SetAgent { .. } => "agent_select",
             gwt::LaunchWizardAction::SetLaunchTarget { .. } => "launch_target_select",
@@ -7423,6 +7446,7 @@ impl AppRuntime {
             gwt::LaunchWizardAction::Cancel => "cancel",
             gwt::LaunchWizardAction::SubmitText { .. } => "submit_text",
             gwt::LaunchWizardAction::ApplyQuickStart { .. } => "apply_quick_start",
+            gwt::LaunchWizardAction::UseStartMethod { .. } => "use_start_method",
             gwt::LaunchWizardAction::SetLaunchPath { .. } => "set_launch_path",
             gwt::LaunchWizardAction::SelectQuickStart { .. } => "select_quick_start",
             gwt::LaunchWizardAction::SelectLiveSession { .. } => "select_live_session",
@@ -11575,7 +11599,7 @@ exit 1
     }
 
     #[test]
-    fn app_runtime_open_launch_wizard_shows_multiple_resume_candidates_latest_first() {
+    fn app_runtime_open_launch_wizard_shows_only_latest_resume_and_focus_methods() {
         let temp = tempdir().expect("tempdir");
         let repo = temp.path().join("repo");
         fs::create_dir_all(&repo).expect("create repo");
@@ -11595,6 +11619,18 @@ exit 1
             session.created_at = session.last_activity_at;
             session.save(&sessions_dir).expect("save session");
         }
+        for (session_id, hour) in [("session-live-older", 11), ("session-live-newer", 12)] {
+            let mut session =
+                gwt_agent::Session::new(&repo, "work/manual-resume", gwt_agent::AgentId::Codex);
+            session.id = session_id.to_string();
+            session.agent_session_id = None;
+            session.last_activity_at = Utc.with_ymd_and_hms(2026, 5, 21, hour, 0, 0).unwrap();
+            session.updated_at = session.last_activity_at;
+            session.created_at = session.last_activity_at;
+            session
+                .save(&sessions_dir)
+                .expect("save live session metadata");
+        }
 
         let tab = sample_project_tab_with_window_at(
             "tab-1",
@@ -11605,6 +11641,26 @@ exit 1
         );
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
         let window_id = combined_window_id("tab-1", "branches-1");
+        for (window, session, display) in [
+            ("agent-older", "session-live-older", "Codex Older"),
+            ("agent-newer", "session-live-newer", "Codex Newer"),
+        ] {
+            let agent_window_id = combined_window_id("tab-1", window);
+            runtime.active_agent_sessions.insert(
+                agent_window_id.clone(),
+                ActiveAgentSession {
+                    window_id: agent_window_id,
+                    session_id: session.to_string(),
+                    agent_id: "codex".to_string(),
+                    branch_name: "work/manual-resume".to_string(),
+                    display_name: display.to_string(),
+                    worktree_path: PathBuf::from("/tmp/repo"),
+                    agent_project_root: "/tmp/repo".to_string(),
+                    runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                    tab_id: "tab-1".to_string(),
+                },
+            );
+        }
 
         runtime.handle_frontend_event(
             "client-1".to_string(),
@@ -11626,7 +11682,29 @@ exit 1
                 .iter()
                 .map(|entry| entry.resume_session_id.as_deref())
                 .collect::<Vec<_>>(),
-            vec![Some("native-newer"), Some("native-older")]
+            vec![Some("native-newer")]
+        );
+        let continue_method = view
+            .start_methods
+            .iter()
+            .find(|method| method.kind == "continue_last_session")
+            .expect("continue method");
+        assert!(
+            continue_method
+                .detail
+                .as_deref()
+                .unwrap_or("")
+                .contains("native-newer"),
+            "continue method should describe the latest resumable session"
+        );
+        let focus_method = view
+            .start_methods
+            .iter()
+            .find(|method| method.kind == "focus_running_session")
+            .expect("focus method");
+        assert!(
+            focus_method.summary.contains("Codex Newer"),
+            "focus method should target the latest live session"
         );
     }
 

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -2790,7 +2790,7 @@ mod tests {
     }
 
     #[test]
-    fn embedded_web_launch_wizard_flow_redesign_contract() {
+    fn embedded_web_launch_wizard_start_methods_contract() {
         let html = frontend_bundle_source();
 
         assert!(
@@ -2800,14 +2800,19 @@ mod tests {
             "expected Launch Wizard to render a split progress/content layout",
         );
         assert!(
-            html.contains("selected_launch_path")
-                && html.contains("selected_quick_start_index")
+            html.contains("progress_steps")
+                && html.contains("start_methods")
                 && html.contains("primary_action_label"),
-            "expected Launch Wizard renderer to follow backend-selected path and footer label",
+            "expected Launch Wizard renderer to follow backend progress, start methods, and footer label",
         );
         assert!(
-            html.contains(r#"kind: "select_quick_start""#) && !html.contains("quick-start-actions"),
-            "expected Quick Start to be a selectable path submitted by the footer primary button",
+            html.contains("\"Start methods\"")
+                && html.contains("start_methods")
+                && html.contains(r#"kind: "use_start_method""#)
+                && !html.contains("\"Quick start\"")
+                && !html.contains(r#"kind: "select_quick_start""#)
+                && !html.contains("quick-start-actions"),
+            "expected Start methods to render direct actions instead of the old Quick Start selection model",
         );
     }
 

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -2737,6 +2737,13 @@ mod tests {
             "expected footer dismiss control to own the wizard close helper",
         );
         assert!(
+            html.contains(r#"id="wizard-back-button""#)
+                && html.contains("show_back_button")
+                && html.contains("wizardBackButton.addEventListener(\"click\"")
+                && html.contains("kind: \"back\""),
+            "expected footer Back control to be backend-gated and dispatch the canonical back action",
+        );
+        assert!(
             html.contains("function closeLaunchWizardFromChrome()")
                 && html.contains("closeLaunchWizardLocal();")
                 && html.contains("frontendUnits.launchWizardSurface.sendAction({ kind: \"cancel\" });"),

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -2802,6 +2802,7 @@ mod tests {
         assert!(
             html.contains("progress_steps")
                 && html.contains("start_methods")
+                && html.contains("show_start_methods")
                 && html.contains("primary_action_label"),
             "expected Launch Wizard renderer to follow backend progress, start methods, and footer label",
         );
@@ -2832,7 +2833,8 @@ mod tests {
         );
         assert!(
             html.contains("renderWizardSummary();")
-                && html.contains("if (!isRuntimeConfirmation"),
+                && html.contains("const showStartMethods = Boolean(")
+                && html.contains("if (showStartMethods)"),
             "expected Runtime confirmation to keep the read-only summary while hiding selection/setup rows",
         );
         assert!(

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -2,6 +2,7 @@ use std::{
     cmp::Ordering,
     collections::HashMap,
     path::{Path, PathBuf},
+    sync::OnceLock,
 };
 
 use crate::BranchListEntry;
@@ -272,6 +273,7 @@ pub struct LaunchWizardView {
     pub show_skip_permissions: bool,
     pub show_codex_fast_mode: bool,
     pub show_branch_controls: bool,
+    pub show_start_methods: bool,
     pub show_manual_setup: bool,
     pub show_runtime_confirmation: bool,
     // SPEC-2014 Amendment 2026-05-20 (FR-057): gate the Linked issue section
@@ -446,9 +448,10 @@ pub fn previous_launch_profile_from_sessions(
     repo_path: &Path,
     sessions: &[gwt_agent::Session],
 ) -> Option<LaunchWizardPreviousProfile> {
+    let repo_scope = LaunchProfileRepoScope::new(repo_path);
     sessions
         .iter()
-        .filter(|session| same_launch_profile_repo(repo_path, session))
+        .filter(|session| repo_scope.matches(session))
         .max_by(|left, right| launch_profile_session_cmp(left, right))
         .cloned()
         .map(previous_profile_from_session)
@@ -528,10 +531,11 @@ pub fn quick_start_entries_from_sessions(
     branch_name: &str,
     sessions: &[gwt_agent::Session],
 ) -> Vec<QuickStartEntry> {
+    let repo_scope = QuickStartRepoScope::new(repo_path);
     let sessions = sessions
         .iter()
         .filter(|session| session.branch == branch_name)
-        .filter(|session| same_launch_profile_repo(repo_path, session))
+        .filter(|session| repo_scope.matches(session))
         .cloned()
         .map(|mut session| {
             session.worktree_path = repo_path.to_path_buf();
@@ -562,28 +566,86 @@ fn previous_profile_from_session(session: gwt_agent::Session) -> LaunchWizardPre
     }
 }
 
-fn same_launch_profile_repo(repo_path: &Path, session: &gwt_agent::Session) -> bool {
-    let session_worktree_path = &session.worktree_path;
-    if same_path_or_exact(repo_path, session_worktree_path) {
-        return true;
-    }
+struct LaunchProfileRepoScope<'a> {
+    repo_path: &'a Path,
+    repo_hash: Option<String>,
+    repo_root: OnceLock<Option<PathBuf>>,
+}
 
-    if let (Some(current_repo_hash), Some(session_repo_hash)) = (
-        repo_hash_for_existing_path(repo_path),
-        session.repo_hash.as_deref(),
-    ) {
-        if current_repo_hash == session_repo_hash {
-            return true;
+impl<'a> LaunchProfileRepoScope<'a> {
+    fn new(repo_path: &'a Path) -> Self {
+        Self {
+            repo_path,
+            repo_hash: repo_hash_for_existing_path(repo_path),
+            repo_root: OnceLock::new(),
         }
     }
 
-    let Ok(repo_root) = gwt_git::worktree::main_worktree_root(repo_path) else {
-        return false;
-    };
-    let Ok(session_root) = gwt_git::worktree::main_worktree_root(session_worktree_path) else {
-        return false;
-    };
-    same_path_or_exact(&repo_root, &session_root)
+    fn matches(&self, session: &gwt_agent::Session) -> bool {
+        let session_worktree_path = &session.worktree_path;
+        if same_path_or_exact(self.repo_path, session_worktree_path) {
+            return true;
+        }
+
+        if let (Some(current_repo_hash), Some(session_repo_hash)) =
+            (self.repo_hash.as_deref(), session.repo_hash.as_deref())
+        {
+            if current_repo_hash == session_repo_hash {
+                return true;
+            }
+        }
+
+        if !session_worktree_path.exists() {
+            return false;
+        }
+
+        let Some(repo_root) = self.repo_root() else {
+            return false;
+        };
+        let Ok(session_root) = gwt_git::worktree::main_worktree_root(session_worktree_path) else {
+            return false;
+        };
+        same_path_or_exact(repo_root, &session_root)
+    }
+
+    fn repo_root(&self) -> Option<&Path> {
+        self.repo_root
+            .get_or_init(|| gwt_git::worktree::main_worktree_root(self.repo_path).ok())
+            .as_deref()
+    }
+}
+
+struct QuickStartRepoScope<'a> {
+    repo_path: &'a Path,
+    canonical: Option<PathBuf>,
+    repo_hash: Option<String>,
+}
+
+impl<'a> QuickStartRepoScope<'a> {
+    fn new(repo_path: &'a Path) -> Self {
+        Self {
+            repo_path,
+            canonical: repo_path.canonicalize().ok(),
+            repo_hash: repo_hash_for_existing_path(repo_path),
+        }
+    }
+
+    fn matches(&self, session: &gwt_agent::Session) -> bool {
+        let candidate = &session.worktree_path;
+        if candidate == self.repo_path {
+            return true;
+        }
+        if let (Some(expected), Ok(candidate)) = (self.canonical.as_ref(), candidate.canonicalize())
+        {
+            if candidate == *expected {
+                return true;
+            }
+        }
+        matches!(
+            (self.repo_hash.as_deref(), session.repo_hash.as_deref()),
+            (Some(current), Some(session_hash)) if current == session_hash
+        )
+    }
 }
 
 fn repo_hash_for_existing_path(path: &Path) -> Option<String> {
@@ -786,6 +848,7 @@ pub struct LaunchWizardState {
     pub runtime_resolution_message: Option<String>,
     pub hydration_error: Option<String>,
     pub linked_issue_number: Option<u64>,
+    start_method_selected: bool,
 }
 
 impl LaunchWizardState {
@@ -866,6 +929,7 @@ impl LaunchWizardState {
             runtime_resolution_message: None,
             hydration_error: None,
             linked_issue_number: context.linked_issue_number,
+            start_method_selected: false,
         };
         state.branch_name = state.context.normalized_branch_name.clone();
         state.sync_selected_agent_options();
@@ -1009,6 +1073,7 @@ impl LaunchWizardState {
     }
 
     pub fn view(&self) -> LaunchWizardView {
+        let show_start_methods = self.show_start_methods();
         let show_manual_setup = self.show_manual_setup();
         let show_runtime_confirmation = self.show_runtime_confirmation();
         LaunchWizardView {
@@ -1085,6 +1150,7 @@ impl LaunchWizardState {
                 && self.launch_target_is_agent()
                 && self.agent_is_codex(),
             show_branch_controls: show_manual_setup && self.wizard_mode == LaunchWizardMode::Branch,
+            show_start_methods,
             show_manual_setup,
             show_runtime_confirmation,
             show_linked_issue: matches!(
@@ -1707,6 +1773,7 @@ impl LaunchWizardState {
             LaunchWizardStartMethodKind::ConfigureAndStart => {
                 self.apply_latest_start_settings();
                 self.launch_path = LaunchWizardLaunchPath::ManualSetup;
+                self.start_method_selected = true;
                 self.step = LaunchWizardStep::LaunchTarget;
                 self.selected = step_default_selection(self.step, self);
                 self.completion = None;
@@ -1718,6 +1785,7 @@ impl LaunchWizardState {
                 }
                 self.apply_latest_start_settings();
                 self.launch_path = LaunchWizardLaunchPath::QuickStart;
+                self.start_method_selected = true;
                 self.finish_launch_request();
             }
             LaunchWizardStartMethodKind::ContinueLastSession => {
@@ -1768,6 +1836,7 @@ impl LaunchWizardState {
         };
         self.selected_quick_start_index = Some(index);
         self.launch_path = LaunchWizardLaunchPath::QuickStart;
+        self.start_method_selected = true;
         self.launch_target = LaunchTargetKind::Agent;
         self.agent_id = entry.agent_id.clone();
         self.sync_selected_agent_options();
@@ -1791,11 +1860,13 @@ impl LaunchWizardState {
             self.error = Some("No running session is available".to_string());
             return;
         }
+        self.start_method_selected = true;
         self.focus_existing_session(0);
     }
 
     fn apply_quick_start_action(&mut self, index: usize, mode: QuickStartLaunchMode) {
         self.launch_path = LaunchWizardLaunchPath::QuickStart;
+        self.start_method_selected = true;
         self.selected_quick_start_index = Some(index);
         if self.prepare_quick_start_launch(index, mode, false) {
             self.finish_launch_request();
@@ -1911,6 +1982,7 @@ impl LaunchWizardState {
     fn focus_existing_session(&mut self, index: usize) {
         if let Some(entry) = self.context.live_sessions.get(index) {
             self.launch_path = LaunchWizardLaunchPath::FocusSession;
+            self.start_method_selected = true;
             self.selected_live_session_index = Some(index);
             self.completion = Some(LaunchWizardCompletion::FocusWindow {
                 window_id: entry.window_id.clone(),
@@ -1928,10 +2000,12 @@ impl LaunchWizardState {
                     return;
                 }
                 self.launch_path = path;
+                self.start_method_selected = true;
                 self.selected_quick_start_index.get_or_insert(0);
             }
             LaunchWizardLaunchPath::ManualSetup => {
                 self.launch_path = path;
+                self.start_method_selected = true;
             }
             LaunchWizardLaunchPath::FocusSession => {
                 if self.context.live_sessions.is_empty() {
@@ -1939,6 +2013,7 @@ impl LaunchWizardState {
                     return;
                 }
                 self.launch_path = path;
+                self.start_method_selected = true;
                 self.selected_live_session_index.get_or_insert(0);
             }
         }
@@ -2447,7 +2522,14 @@ impl LaunchWizardState {
     }
 
     fn show_manual_setup(&self) -> bool {
-        self.launch_path == LaunchWizardLaunchPath::ManualSetup
+        self.launch_path == LaunchWizardLaunchPath::ManualSetup && !self.show_start_methods()
+    }
+
+    fn show_start_methods(&self) -> bool {
+        !self.start_method_selected
+            && !self.is_hydrating
+            && !self.runtime_resolution_pending
+            && !self.show_runtime_confirmation()
     }
 
     fn show_runtime_confirmation(&self) -> bool {
@@ -2464,6 +2546,9 @@ impl LaunchWizardState {
         }
         if self.runtime_resolution_pending {
             return "Preparing...".to_string();
+        }
+        if self.show_start_methods() {
+            return "Choose start method".to_string();
         }
         match self.launch_path {
             LaunchWizardLaunchPath::FocusSession => "Focus".to_string(),
@@ -2484,7 +2569,7 @@ impl LaunchWizardState {
     }
 
     fn primary_action_enabled(&self) -> bool {
-        if self.is_hydrating || self.runtime_resolution_pending {
+        if self.is_hydrating || self.runtime_resolution_pending || self.show_start_methods() {
             return false;
         }
         match self.launch_path {
@@ -4575,6 +4660,39 @@ mod tests {
     }
 
     #[test]
+    fn start_methods_gate_setup_until_configure_is_selected() {
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            sample_agent_options(),
+            vec![quick_start_entry(
+                "session-newer",
+                "codex",
+                Some("native-newer"),
+                None,
+                gwt_agent::LaunchRuntimeTarget::Host,
+                None,
+            )],
+        );
+        state.mark_runtime_context_unresolved();
+
+        let initial = state.view();
+        assert!(initial.show_start_methods);
+        assert!(!initial.show_manual_setup);
+        assert_eq!(initial.primary_action_label, "Choose start method");
+        assert!(!initial.primary_action_enabled);
+
+        state.apply(LaunchWizardAction::UseStartMethod {
+            method: LaunchWizardStartMethodKind::ConfigureAndStart,
+        });
+
+        let configured = state.view();
+        assert!(!configured.show_start_methods);
+        assert!(configured.show_manual_setup);
+        assert_eq!(configured.primary_action_label, "Continue");
+        assert!(configured.primary_action_enabled);
+    }
+
+    #[test]
     fn start_with_last_settings_launches_new_session_without_resume_id() {
         let mut state = LaunchWizardState::open_with(
             context(branch("feature/gui"), "feature/gui"),
@@ -4834,6 +4952,35 @@ mod tests {
             .expect("profile should match persisted repo identity");
 
         assert_eq!(profile.agent_id, "codex");
+    }
+
+    #[test]
+    fn quick_start_entries_match_deleted_worktree_by_persisted_repo_hash() {
+        let dir = tempdir().expect("tempdir");
+        let repo = dir.path().join("repo");
+        let origin = "https://github.com/example/project.git";
+        init_repo_with_origin(&repo, origin);
+        let removed_worktree = dir.path().join("removed-worktree");
+        let mut session = sample_session_record(
+            "feature/gui",
+            &removed_worktree,
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 4, 14, 10, 0, 0).unwrap(),
+            Some("native-session"),
+        );
+        session.repo_hash = Some(
+            gwt_core::repo_hash::compute_repo_hash(origin)
+                .as_str()
+                .to_string(),
+        );
+
+        let entries = quick_start_entries_from_sessions(&repo, "feature/gui", &[session]);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].resume_session_id.as_deref(),
+            Some("native-session")
+        );
     }
 
     #[test]
@@ -7118,7 +7265,7 @@ mod tests {
     }
 
     #[test]
-    fn quick_start_submit_skips_manual_settings_until_runtime_confirmation() {
+    fn continue_last_session_start_method_skips_manual_settings_until_runtime_confirmation() {
         let mut ctx = context(branch("feature/current"), "feature/current");
         ctx.docker_context = Some(DockerWizardContext {
             services: vec!["app".to_string()],
@@ -7143,11 +7290,14 @@ mod tests {
         let view = state.view();
         assert_eq!(view.selected_launch_path, "quick_start");
         assert_eq!(view.selected_quick_start_index, Some(0));
+        assert!(view.show_start_methods);
         assert!(!view.show_manual_setup);
         assert!(!view.show_runtime_confirmation);
-        assert_eq!(view.primary_action_label, "Continue");
+        assert_eq!(view.primary_action_label, "Choose start method");
 
-        state.apply(LaunchWizardAction::Submit);
+        state.apply(LaunchWizardAction::UseStartMethod {
+            method: LaunchWizardStartMethodKind::ContinueLastSession,
+        });
         assert!(matches!(
             state.completion.as_ref(),
             Some(LaunchWizardCompletion::ResolveRuntime(config))

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -114,6 +114,26 @@ impl LaunchWizardLaunchPath {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LaunchWizardStartMethodKind {
+    ConfigureAndStart,
+    StartWithLastSettings,
+    ContinueLastSession,
+    FocusRunningSession,
+}
+
+impl LaunchWizardStartMethodKind {
+    fn value(self) -> &'static str {
+        match self {
+            LaunchWizardStartMethodKind::ConfigureAndStart => "configure_and_start",
+            LaunchWizardStartMethodKind::StartWithLastSettings => "start_with_last_settings",
+            LaunchWizardStartMethodKind::ContinueLastSession => "continue_last_session",
+            LaunchWizardStartMethodKind::FocusRunningSession => "focus_running_session",
+        }
+    }
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct LaunchWizardQuickStartView {
     pub index: usize,
@@ -121,6 +141,17 @@ pub struct LaunchWizardQuickStartView {
     pub summary: String,
     pub resume_session_id: Option<String>,
     pub reuse_action_label: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct LaunchWizardStartMethodView {
+    pub kind: String,
+    pub label: String,
+    pub badge: String,
+    pub summary: String,
+    pub detail: Option<String>,
+    pub enabled: bool,
+    pub disabled_reason: Option<String>,
 }
 
 /// SPEC-2359 US-42 — Workspace Resume Picker entry.
@@ -200,6 +231,7 @@ pub struct LaunchWizardView {
     pub is_hydrating: bool,
     pub runtime_context_resolved: bool,
     pub hydration_error: Option<String>,
+    pub start_methods: Vec<LaunchWizardStartMethodView>,
     pub quick_start_entries: Vec<LaunchWizardQuickStartView>,
     pub live_sessions: Vec<LaunchWizardLiveSessionView>,
     pub selected_launch_path: String,
@@ -650,6 +682,9 @@ pub enum LaunchWizardAction {
         index: usize,
         mode: QuickStartLaunchMode,
     },
+    UseStartMethod {
+        method: LaunchWizardStartMethodKind,
+    },
     SetLaunchPath {
         path: LaunchWizardLaunchPath,
     },
@@ -989,6 +1024,7 @@ impl LaunchWizardState {
             is_hydrating: self.is_hydrating,
             runtime_context_resolved: self.runtime_context_resolved,
             hydration_error: self.hydration_error.clone(),
+            start_methods: self.start_methods_view(),
             quick_start_entries: self.quick_start_entries_view(),
             live_sessions: self.live_sessions_view(),
             selected_launch_path: self.launch_path.value().to_string(),
@@ -1197,6 +1233,9 @@ impl LaunchWizardState {
             }
             LaunchWizardAction::ApplyQuickStart { index, mode } => {
                 self.apply_quick_start_action(index, mode);
+            }
+            LaunchWizardAction::UseStartMethod { method } => {
+                self.use_start_method(method);
             }
             LaunchWizardAction::SetLaunchPath { path } => {
                 self.set_launch_path_selection(path);
@@ -1663,6 +1702,98 @@ impl LaunchWizardState {
         }
     }
 
+    fn use_start_method(&mut self, method: LaunchWizardStartMethodKind) {
+        match method {
+            LaunchWizardStartMethodKind::ConfigureAndStart => {
+                self.apply_latest_start_settings();
+                self.launch_path = LaunchWizardLaunchPath::ManualSetup;
+                self.step = LaunchWizardStep::LaunchTarget;
+                self.selected = step_default_selection(self.step, self);
+                self.completion = None;
+            }
+            LaunchWizardStartMethodKind::StartWithLastSettings => {
+                if !self.has_previous_start_settings() {
+                    self.error = Some("No previous launch settings are available".to_string());
+                    return;
+                }
+                self.apply_latest_start_settings();
+                self.launch_path = LaunchWizardLaunchPath::QuickStart;
+                self.finish_launch_request();
+            }
+            LaunchWizardStartMethodKind::ContinueLastSession => {
+                self.continue_latest_session();
+            }
+            LaunchWizardStartMethodKind::FocusRunningSession => {
+                self.focus_latest_running_session();
+            }
+        }
+    }
+
+    fn apply_latest_start_settings(&mut self) {
+        if let Some((index, _)) = self.latest_quick_start_entry() {
+            let previous_completion = self.completion.take();
+            let previous_error = self.error.take();
+            let applied =
+                self.prepare_quick_start_launch(index, QuickStartLaunchMode::StartNew, false);
+            if !applied {
+                self.completion = previous_completion;
+                self.error = previous_error;
+                return;
+            }
+            self.completion = previous_completion;
+            self.error = previous_error;
+        } else {
+            self.mode = "normal".to_string();
+            self.resume_session_id = None;
+        }
+    }
+
+    fn has_previous_start_settings(&self) -> bool {
+        self.latest_quick_start_entry().is_some()
+            || self.previous_profiles.preferred_agent_id().is_some()
+            || self.previous_profiles.repo_local().is_some()
+    }
+
+    fn continue_latest_session(&mut self) {
+        let Some((index, entry)) = self
+            .latest_quick_start_entry()
+            .map(|(index, entry)| (index, entry.clone()))
+        else {
+            self.error = Some("No saved session is available".to_string());
+            return;
+        };
+        let Some(resume_session_id) = entry.resume_session_id.clone() else {
+            self.error = Some("No saved session is available".to_string());
+            return;
+        };
+        self.selected_quick_start_index = Some(index);
+        self.launch_path = LaunchWizardLaunchPath::QuickStart;
+        self.launch_target = LaunchTargetKind::Agent;
+        self.agent_id = entry.agent_id.clone();
+        self.sync_selected_agent_options();
+        self.apply_quick_start_runtime_selection(&entry);
+        self.apply_saved_model(entry.model.as_deref());
+        if let Some(reasoning) = entry.reasoning.clone() {
+            self.reasoning = reasoning;
+        }
+        if let Some(version) = entry.version.clone() {
+            self.version = version;
+        }
+        self.skip_permissions = entry.skip_permissions;
+        self.codex_fast_mode = entry.codex_fast_mode && self.agent_is_codex();
+        self.mode = "resume".to_string();
+        self.resume_session_id = Some(resume_session_id);
+        self.finish_launch_request();
+    }
+
+    fn focus_latest_running_session(&mut self) {
+        if self.context.live_sessions.is_empty() {
+            self.error = Some("No running session is available".to_string());
+            return;
+        }
+        self.focus_existing_session(0);
+    }
+
     fn apply_quick_start_action(&mut self, index: usize, mode: QuickStartLaunchMode) {
         self.launch_path = LaunchWizardLaunchPath::QuickStart;
         self.selected_quick_start_index = Some(index);
@@ -2000,6 +2131,112 @@ impl LaunchWizardState {
         } else {
             self.error = Some("Execution mode is unavailable".to_string());
         }
+    }
+
+    fn start_methods_view(&self) -> Vec<LaunchWizardStartMethodView> {
+        let settings_summary = self.start_settings_summary();
+        let has_previous_settings = self.has_previous_start_settings();
+        let latest_resume = self
+            .latest_quick_start_entry()
+            .and_then(|(_, entry)| entry.resume_session_id.as_deref().map(|id| (entry, id)));
+        let latest_live = self.context.live_sessions.first();
+
+        vec![
+            LaunchWizardStartMethodView {
+                kind: LaunchWizardStartMethodKind::ConfigureAndStart
+                    .value()
+                    .to_string(),
+                label: "Configure and start".to_string(),
+                badge: "Settings".to_string(),
+                summary: settings_summary.clone(),
+                detail: Some("Review and edit settings before starting".to_string()),
+                enabled: true,
+                disabled_reason: None,
+            },
+            LaunchWizardStartMethodView {
+                kind: LaunchWizardStartMethodKind::StartWithLastSettings
+                    .value()
+                    .to_string(),
+                label: "Start with last settings".to_string(),
+                badge: "New".to_string(),
+                summary: settings_summary,
+                detail: Some(
+                    "Start a new session without resuming conversation history".to_string(),
+                ),
+                enabled: has_previous_settings,
+                disabled_reason: (!has_previous_settings)
+                    .then(|| "No previous launch settings yet".to_string()),
+            },
+            LaunchWizardStartMethodView {
+                kind: LaunchWizardStartMethodKind::ContinueLastSession
+                    .value()
+                    .to_string(),
+                label: "Continue last session".to_string(),
+                badge: "Session".to_string(),
+                summary: latest_resume
+                    .map(|(entry, _)| quick_start_summary(entry))
+                    .unwrap_or_else(|| "No resumable session".to_string()),
+                detail: latest_resume.map(|(_, resume_id)| format!("Resume ID · {resume_id}")),
+                enabled: latest_resume.is_some(),
+                disabled_reason: latest_resume
+                    .is_none()
+                    .then(|| "No saved session is available".to_string()),
+            },
+            LaunchWizardStartMethodView {
+                kind: LaunchWizardStartMethodKind::FocusRunningSession
+                    .value()
+                    .to_string(),
+                label: "Focus running session".to_string(),
+                badge: "Running".to_string(),
+                summary: latest_live
+                    .map(|session| session.name.clone())
+                    .unwrap_or_else(|| "No running session".to_string()),
+                detail: latest_live.and_then(|session| {
+                    session
+                        .detail
+                        .clone()
+                        .or_else(|| Some(live_session_status_label(session)))
+                }),
+                enabled: latest_live.is_some(),
+                disabled_reason: latest_live
+                    .is_none()
+                    .then(|| "No running session is available".to_string()),
+            },
+        ]
+    }
+
+    fn start_settings_summary(&self) -> String {
+        if let Some((_, entry)) = self.latest_quick_start_entry() {
+            return quick_start_summary(entry);
+        }
+        let mut parts = vec![self
+            .selected_agent()
+            .map(|agent| agent.name.clone())
+            .unwrap_or_else(|| self.effective_agent_id().to_string())];
+        if !self.model.trim().is_empty() {
+            parts.push(self.model.clone());
+        }
+        if !self.reasoning.trim().is_empty() {
+            parts.push(self.reasoning.clone());
+        }
+        if !self.version.trim().is_empty() {
+            parts.push(self.version.clone());
+        }
+        if self.runtime_target == gwt_agent::LaunchRuntimeTarget::Docker {
+            parts.push(
+                self.docker_service
+                    .as_ref()
+                    .map(|service| format!("docker:{service}"))
+                    .unwrap_or_else(|| "docker".to_string()),
+            );
+        } else {
+            parts.push("host".to_string());
+        }
+        parts
+            .into_iter()
+            .filter(|part| !part.trim().is_empty())
+            .collect::<Vec<_>>()
+            .join(" / ")
     }
 
     fn quick_start_entries_view(&self) -> Vec<LaunchWizardQuickStartView> {
@@ -2702,6 +2939,10 @@ impl LaunchWizardState {
             }
             QuickStartAction::FocusExistingSession | QuickStartAction::ChooseDifferent => None,
         }
+    }
+
+    fn latest_quick_start_entry(&self) -> Option<(usize, &QuickStartEntry)> {
+        self.quick_start_entries.iter().enumerate().next()
     }
 
     fn quick_start_actions(&self) -> Vec<QuickStartAction> {
@@ -3833,6 +4074,10 @@ fn window_status_wire(status: crate::WindowProcessStatus) -> &'static str {
     }
 }
 
+fn live_session_status_label(session: &LiveSessionEntry) -> String {
+    format!("Status · {}", window_status_wire(session.runtime_status))
+}
+
 fn docker_lifecycle_value(intent: gwt_agent::DockerLifecycleIntent) -> &'static str {
     match intent {
         gwt_agent::DockerLifecycleIntent::Connect => "connect",
@@ -4282,6 +4527,84 @@ mod tests {
         );
 
         assert_eq!(state.step, LaunchWizardStep::QuickStart);
+    }
+
+    #[test]
+    fn start_methods_view_exposes_four_direct_methods() {
+        let mut ctx = context(branch("feature/gui"), "feature/gui");
+        ctx.live_sessions = vec![LiveSessionEntry {
+            session_id: "session-live".to_string(),
+            window_id: "tab-1:agent-live".to_string(),
+            agent_id: "codex".to_string(),
+            kind: "agent".to_string(),
+            name: "Codex".to_string(),
+            detail: Some("/tmp/repo".to_string()),
+            active: true,
+            runtime_status: crate::WindowProcessStatus::Running,
+        }];
+        let state = LaunchWizardState::open_with(
+            ctx,
+            sample_agent_options(),
+            vec![quick_start_entry(
+                "session-newer",
+                "codex",
+                Some("native-newer"),
+                None,
+                gwt_agent::LaunchRuntimeTarget::Docker,
+                Some("gwt"),
+            )],
+        );
+
+        let methods = state.view().start_methods;
+        assert_eq!(methods.len(), 4);
+        assert_eq!(methods[0].kind, "configure_and_start");
+        assert_eq!(methods[0].label, "Configure and start");
+        assert!(methods[0].summary.contains("Codex"));
+        assert_eq!(methods[1].kind, "start_with_last_settings");
+        assert!(methods[1].summary.contains("docker:gwt"));
+        assert_eq!(methods[2].kind, "continue_last_session");
+        assert_eq!(methods[2].badge, "Session");
+        assert!(methods[2]
+            .detail
+            .as_deref()
+            .unwrap_or("")
+            .contains("native-newer"));
+        assert_eq!(methods[3].kind, "focus_running_session");
+        assert_eq!(methods[3].badge, "Running");
+        assert!(methods.iter().all(|method| method.enabled));
+    }
+
+    #[test]
+    fn start_with_last_settings_launches_new_session_without_resume_id() {
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            sample_agent_options(),
+            vec![quick_start_entry(
+                "session-newer",
+                "codex",
+                Some("native-newer"),
+                None,
+                gwt_agent::LaunchRuntimeTarget::Host,
+                None,
+            )],
+        );
+
+        state.apply(LaunchWizardAction::UseStartMethod {
+            method: LaunchWizardStartMethodKind::StartWithLastSettings,
+        });
+
+        match state.completion.as_ref() {
+            Some(LaunchWizardCompletion::ResolveRuntime(config))
+            | Some(LaunchWizardCompletion::Launch(config)) => match config.as_ref() {
+                LaunchWizardLaunchRequest::Agent(config) => {
+                    assert_eq!(config.agent_id.command(), "codex");
+                    assert_eq!(config.session_mode, gwt_agent::SessionMode::Normal);
+                    assert_eq!(config.resume_session_id, None);
+                }
+                other => panic!("expected agent launch request, got {other:?}"),
+            },
+            other => panic!("expected start method launch completion, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -274,6 +274,7 @@ pub struct LaunchWizardView {
     pub show_codex_fast_mode: bool,
     pub show_branch_controls: bool,
     pub show_start_methods: bool,
+    pub show_back_button: bool,
     pub show_manual_setup: bool,
     pub show_runtime_confirmation: bool,
     // SPEC-2014 Amendment 2026-05-20 (FR-057): gate the Linked issue section
@@ -849,6 +850,7 @@ pub struct LaunchWizardState {
     pub hydration_error: Option<String>,
     pub linked_issue_number: Option<u64>,
     start_method_selected: bool,
+    manual_setup_initialized: bool,
 }
 
 impl LaunchWizardState {
@@ -930,6 +932,7 @@ impl LaunchWizardState {
             hydration_error: None,
             linked_issue_number: context.linked_issue_number,
             start_method_selected: false,
+            manual_setup_initialized: false,
         };
         state.branch_name = state.context.normalized_branch_name.clone();
         state.sync_selected_agent_options();
@@ -1074,6 +1077,7 @@ impl LaunchWizardState {
 
     pub fn view(&self) -> LaunchWizardView {
         let show_start_methods = self.show_start_methods();
+        let show_back_button = self.show_back_button();
         let show_manual_setup = self.show_manual_setup();
         let show_runtime_confirmation = self.show_runtime_confirmation();
         LaunchWizardView {
@@ -1151,6 +1155,7 @@ impl LaunchWizardState {
                 && self.agent_is_codex(),
             show_branch_controls: show_manual_setup && self.wizard_mode == LaunchWizardMode::Branch,
             show_start_methods,
+            show_back_button,
             show_manual_setup,
             show_runtime_confirmation,
             show_linked_issue: matches!(
@@ -1367,7 +1372,16 @@ impl LaunchWizardState {
                 self.codex_fast_mode = enabled && self.agent_is_codex();
             }
             LaunchWizardAction::Back => {
-                if let Some(prev) = prev_step(self.step, self) {
+                if self.show_runtime_confirmation() {
+                    return;
+                }
+                if self.show_back_button() {
+                    self.start_method_selected = false;
+                    self.launch_path = LaunchWizardLaunchPath::ManualSetup;
+                    self.step = LaunchWizardStep::LaunchTarget;
+                    self.selected = step_default_selection(self.step, self);
+                    self.completion = None;
+                } else if let Some(prev) = prev_step(self.step, self) {
                     self.step = prev;
                     self.selected = step_default_selection(prev, self);
                 } else {
@@ -1771,7 +1785,10 @@ impl LaunchWizardState {
     fn use_start_method(&mut self, method: LaunchWizardStartMethodKind) {
         match method {
             LaunchWizardStartMethodKind::ConfigureAndStart => {
-                self.apply_latest_start_settings();
+                if !self.manual_setup_initialized {
+                    self.apply_latest_start_settings();
+                    self.manual_setup_initialized = true;
+                }
                 self.launch_path = LaunchWizardLaunchPath::ManualSetup;
                 self.start_method_selected = true;
                 self.step = LaunchWizardStep::LaunchTarget;
@@ -2523,6 +2540,14 @@ impl LaunchWizardState {
 
     fn show_manual_setup(&self) -> bool {
         self.launch_path == LaunchWizardLaunchPath::ManualSetup && !self.show_start_methods()
+    }
+
+    fn show_back_button(&self) -> bool {
+        self.start_method_selected
+            && self.launch_path == LaunchWizardLaunchPath::ManualSetup
+            && !self.is_hydrating
+            && !self.runtime_resolution_pending
+            && !self.show_runtime_confirmation()
     }
 
     fn show_start_methods(&self) -> bool {
@@ -4690,6 +4715,54 @@ mod tests {
         assert!(configured.show_manual_setup);
         assert_eq!(configured.primary_action_label, "Continue");
         assert!(configured.primary_action_enabled);
+    }
+
+    #[test]
+    fn back_from_configure_returns_to_start_methods_and_preserves_setup_draft() {
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            sample_agent_options(),
+            vec![quick_start_entry(
+                "session-newer",
+                "codex",
+                Some("native-newer"),
+                None,
+                gwt_agent::LaunchRuntimeTarget::Host,
+                None,
+            )],
+        );
+        state.mark_runtime_context_unresolved();
+
+        state.apply(LaunchWizardAction::UseStartMethod {
+            method: LaunchWizardStartMethodKind::ConfigureAndStart,
+        });
+        state.apply(LaunchWizardAction::SetAgent {
+            agent_id: "codex".to_string(),
+        });
+        state.apply(LaunchWizardAction::SetModel {
+            model: "gpt-5.4".to_string(),
+        });
+
+        let configured = state.view();
+        assert!(!configured.show_start_methods);
+        assert!(configured.show_manual_setup);
+        assert_eq!(configured.selected_model, "gpt-5.4");
+
+        state.apply(LaunchWizardAction::Back);
+
+        let backed = state.view();
+        assert!(state.completion.is_none());
+        assert!(backed.show_start_methods);
+        assert!(!backed.show_manual_setup);
+        assert_eq!(backed.selected_model, "gpt-5.4");
+
+        state.apply(LaunchWizardAction::UseStartMethod {
+            method: LaunchWizardStartMethodKind::ConfigureAndStart,
+        });
+        let configured_again = state.view();
+        assert!(!configured_again.show_start_methods);
+        assert!(configured_again.show_manual_setup);
+        assert_eq!(configured_again.selected_model, "gpt-5.4");
     }
 
     #[test]

--- a/crates/gwt/src/launch_wizard/quick_start.rs
+++ b/crates/gwt/src/launch_wizard/quick_start.rs
@@ -1,6 +1,5 @@
 use std::{
     cmp::Ordering,
-    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
 };
 
@@ -32,9 +31,8 @@ pub(super) fn collect_quick_start_entries_from_sessions(
     branch_name: &str,
     sessions: Vec<gwt_agent::Session>,
 ) -> Vec<QuickStartEntry> {
-    let mut resumable_sessions = Vec::new();
-    let mut agents_with_resumable: HashSet<String> = HashSet::new();
-    let mut latest_metadata_only_by_agent: HashMap<String, gwt_agent::Session> = HashMap::new();
+    let mut latest_resumable_session = None::<gwt_agent::Session>;
+    let mut latest_metadata_only_session = None::<gwt_agent::Session>;
     let repo_scope = WorktreePathScope::new(repo_path);
 
     for session in sessions {
@@ -42,31 +40,27 @@ pub(super) fn collect_quick_start_entries_from_sessions(
             continue;
         }
 
-        let agent_key = session.agent_id.command().to_string();
         if agent_session_resume_id(&session).is_some() {
-            agents_with_resumable.insert(agent_key);
-            resumable_sessions.push(session);
-        } else {
-            let replace = latest_metadata_only_by_agent
-                .get(&agent_key)
+            let replace = latest_resumable_session
+                .as_ref()
                 .map(|current| session_is_newer(&session, current))
                 .unwrap_or(true);
             if replace {
-                latest_metadata_only_by_agent.insert(agent_key, session);
+                latest_resumable_session = Some(session);
+            }
+        } else {
+            let replace = latest_metadata_only_session
+                .as_ref()
+                .map(|current| session_is_newer(&session, current))
+                .unwrap_or(true);
+            if replace {
+                latest_metadata_only_session = Some(session);
             }
         }
     }
 
-    let mut sessions = resumable_sessions;
-    sessions.extend(
-        latest_metadata_only_by_agent
-            .into_iter()
-            .filter(|(agent_key, _)| !agents_with_resumable.contains(agent_key))
-            .map(|(_, session)| session),
-    );
-    sessions.sort_by(|left, right| compare_session_recency(right, left));
-
-    sessions
+    latest_resumable_session
+        .or(latest_metadata_only_session)
         .into_iter()
         .map(|session| QuickStartEntry {
             session_id: session.id.clone(),
@@ -208,7 +202,7 @@ mod tests {
     }
 
     #[test]
-    fn load_quick_start_entries_orders_resumable_sessions_latest_first() {
+    fn load_quick_start_entries_uses_latest_resumable_session_profile() {
         let dir = tempdir().expect("tempdir");
         let worktree = dir.path().join("repo");
         std::fs::create_dir_all(&worktree).expect("repo dir");
@@ -230,14 +224,14 @@ mod tests {
         );
 
         let entries = load_quick_start_entries(&worktree, dir.path(), "feature/gui");
-        assert_eq!(entries.len(), 2);
+        assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].agent_id, "codex");
         assert_eq!(entries[0].resume_session_id.as_deref(), Some("newer"));
         assert_eq!(entries[0].docker_service.as_deref(), Some("gwt"));
     }
 
     #[test]
-    fn load_quick_start_entries_keeps_multiple_resumable_sessions_latest_first() {
+    fn load_quick_start_entries_keeps_only_latest_resumable_session() {
         let dir = tempdir().expect("tempdir");
         let worktree = dir.path().join("repo");
         std::fs::create_dir_all(&worktree).expect("repo dir");
@@ -262,15 +256,15 @@ mod tests {
 
         assert_eq!(
             entries.len(),
-            2,
-            "Launch Agent must expose each resumable session instead of collapsing by agent"
+            1,
+            "Launch Agent start methods must expose only the latest resumable session"
         );
         assert_eq!(
             entries
                 .iter()
                 .map(|entry| entry.resume_session_id.as_deref())
                 .collect::<Vec<_>>(),
-            vec![Some("newer-resume"), Some("older-resume")]
+            vec![Some("newer-resume")]
         );
     }
 

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -88,8 +88,9 @@ pub use launch_wizard::{
     LaunchWizardHydration, LaunchWizardLaunchPath, LaunchWizardLaunchRequest,
     LaunchWizardLiveSessionView, LaunchWizardMode, LaunchWizardOptionView,
     LaunchWizardPreviousProfile, LaunchWizardPreviousProfiles, LaunchWizardProgressStepView,
-    LaunchWizardQuickStartView, LaunchWizardState, LaunchWizardStep, LaunchWizardSummaryView,
-    LaunchWizardView, LinkedIssueKind, LiveSessionEntry, QuickStartEntry, QuickStartLaunchMode,
+    LaunchWizardQuickStartView, LaunchWizardStartMethodKind, LaunchWizardStartMethodView,
+    LaunchWizardState, LaunchWizardStep, LaunchWizardSummaryView, LaunchWizardView,
+    LinkedIssueKind, LiveSessionEntry, QuickStartEntry, QuickStartLaunchMode,
     ResumableAgentLifecycleStatus, ResumableAgentResumeKind, ResumableAgentView, ShellLaunchConfig,
 };
 pub use managed_assets::{

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1324,6 +1324,28 @@ test("Launch wizard uses one visible dismiss control in the footer", () => {
   );
 });
 
+test("Launch wizard renders a backend-gated Back control in the footer", () => {
+  assert.ok(
+    document.getElementById("wizard-back-button"),
+    "Launch wizard footer must expose a Back button for returning to Start methods",
+  );
+  assert.match(
+    appSource,
+    /const wizardBackButton = document\.getElementById\("wizard-back-button"\)/,
+    "expected app.js to bind the footer Back button",
+  );
+  assert.match(
+    appSource,
+    /wizardBackButton\.hidden\s*=\s*!launchWizard\.show_back_button/,
+    "expected Back visibility to be controlled by backend view state",
+  );
+  assert.match(
+    appSource,
+    /wizardBackButton\.addEventListener\("click",\s*\(\)\s*=>\s*\{[\s\S]*?kind:\s*"back"/,
+    "expected Back to dispatch the canonical backend action",
+  );
+});
+
 test("File tree rows are keyboard-navigable (tabindex + role + keydown)", () => {
   // <div>-based rows can't be Tab'd to or activated with the keyboard
   // unless explicitly opted in. Add tabindex, role="button", and a

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -388,16 +388,16 @@ test("Active Work sidebar only renders while live Agent windows are focusable", 
   );
 });
 
-test("Launch Wizard live sessions render window runtime status", () => {
+test("Launch Wizard focus start method renders backend-provided running session detail", () => {
   assert.match(
     appSource,
-    /function\s+liveSessionStatusLabel\(session\)[\s\S]+session\.runtime_status[\s\S]+windowRuntimeLabel\(runtimeState\)[\s\S]+window/,
-    "expected live-session rows to label Running/Idle/Error from runtime_status",
+    /for\s*\(\s*const method of launchWizard\.start_methods \|\| \[\]\s*\)/,
+    "expected Launch Wizard to render backend-provided start methods",
   );
   assert.match(
     appSource,
-    /createNode\(\s*"div",\s*"live-session-status",\s*liveSessionStatusLabel\(session\),?\s*\)/,
-    "expected Launch Wizard live-session status copy to use runtime_status instead of active boolean copy",
+    /const detail = method\.enabled === false[\s\S]*?method\.disabled_reason[\s\S]*?: method\.detail;[\s\S]*?createNode\("div", "start-method-detail", detail\)/,
+    "expected running-session Focus details to come from the backend start method payload",
   );
 });
 
@@ -1464,8 +1464,8 @@ test("Launch wizard runtime confirmation shows summary without setup forms", () 
   );
   assert.match(
     appSource,
-    /if\s*\(\s*!isRuntimeConfirmation\s*&&\s*\(\s*\(launchWizard\.quick_start_entries \|\| \[\]\)\.length > 0/,
-    "expected Quick Start selection rows to be hidden during Runtime confirmation",
+    /if\s*\(\s*!isRuntimeConfirmation\s*&&\s*\(launchWizard\.start_methods \|\| \[\]\)\.length > 0\)/,
+    "expected Start methods rows to be hidden during Runtime confirmation",
   );
   assert.match(
     appSource,
@@ -1568,29 +1568,43 @@ test("Launch wizard renders centered split flow without backdrop dismissal", () 
   );
 });
 
-test("Launch wizard selected quick start hover preserves selected styling", () => {
+test("Launch wizard start methods keep disabled and hover states distinct", () => {
   assert.match(
     inlineStyle,
-    /\.quick-start-card:hover:not\(\.selected\),\r?\n\.live-session-button:hover:not\(\.selected\)/,
-    "selected quick start and live session rows must not use the unselected hover background",
+    /\.start-method-button:hover:not\(:disabled\)/,
+    "enabled start method rows should expose a hover state",
+  );
+  assert.match(
+    inlineStyle,
+    /\.start-method-button:disabled/,
+    "disabled start method rows should expose a disabled state",
   );
 });
 
-test("Launch wizard quick start is selected before footer submit", () => {
+test("Launch wizard renders start methods as direct actions", () => {
   assert.ok(
-    appSource.includes('kind: "select_quick_start"'),
-    "expected quick start rows to update wizard selection instead of launching inline",
+    appSource.includes('"Start methods"'),
+    "expected Launch Wizard to label the first section as Start methods",
   );
   assert.ok(
-    appSource.includes("selected_launch_path")
-      && appSource.includes("selected_quick_start_index")
-      && appSource.includes("primary_action_label"),
-    "expected frontend to render the backend-selected launch path and footer primary label",
+    appSource.includes("start_methods")
+      && appSource.includes('kind: "use_start_method"'),
+    "expected start method rows to dispatch direct backend actions",
+  );
+  assert.equal(
+    appSource.includes('"Quick start"'),
+    false,
+    "Launch Wizard must not expose the old Quick start heading",
+  );
+  assert.equal(
+    appSource.includes('kind: "select_quick_start"'),
+    false,
+    "start methods should not use the old selection-before-footer-submit model",
   );
   assert.equal(
     appSource.includes("quick-start-actions"),
     false,
-    "quick start rows should not render multiple inline action buttons",
+    "start methods should not render multiple inline action buttons",
   );
 });
 

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1444,7 +1444,7 @@ test("Launch wizard separates launch settings from runtime controls", () => {
 test("Launch wizard runtime confirmation shows summary without setup forms", () => {
   assert.match(
     appSource,
-    /const showManualSetup = launchWizard\.show_manual_setup !== false;[\s\S]*?const isRuntimeConfirmation = Boolean\([\s\S]*?const showSetupForms = showManualSetup && !isRuntimeConfirmation;/,
+    /const showManualSetup = launchWizard\.show_manual_setup !== false;[\s\S]*?const isRuntimeConfirmation = Boolean\([\s\S]*?const showStartMethods = Boolean\([\s\S]*?launchWizard\.show_start_methods[\s\S]*?const showSetupForms = showManualSetup && !isRuntimeConfirmation;/,
     "expected showManualSetup to be initialized before Runtime confirmation setup gating",
   );
   assert.match(
@@ -1464,8 +1464,8 @@ test("Launch wizard runtime confirmation shows summary without setup forms", () 
   );
   assert.match(
     appSource,
-    /if\s*\(\s*!isRuntimeConfirmation\s*&&\s*\(launchWizard\.start_methods \|\| \[\]\)\.length > 0\)/,
-    "expected Start methods rows to be hidden during Runtime confirmation",
+    /if\s*\(\s*showStartMethods\s*\)/,
+    "expected Start methods rows to be gated by backend start-method state",
   );
   assert.match(
     appSource,
@@ -1588,6 +1588,7 @@ test("Launch wizard renders start methods as direct actions", () => {
   );
   assert.ok(
     appSource.includes("start_methods")
+      && appSource.includes("show_start_methods")
       && appSource.includes('kind: "use_start_method"'),
     "expected start method rows to dispatch direct backend actions",
   );

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -148,6 +148,7 @@
       const wizardSummary = document.getElementById("wizard-summary");
       const wizardBody = document.getElementById("wizard-body");
       const wizardError = document.getElementById("wizard-error");
+      const wizardBackButton = document.getElementById("wizard-back-button");
       const wizardCancelButton = document.getElementById("wizard-cancel-button");
       const wizardSubmitButton = document.getElementById("wizard-submit-button");
       const cloneProjectModal = document.getElementById("clone-project-modal");
@@ -7098,6 +7099,8 @@
           wizardSubmitButton.textContent = "Launch";
           wizardSubmitButton.disabled = false;
           wizardSubmitButton.hidden = false;
+          wizardBackButton.hidden = true;
+          wizardBackButton.disabled = false;
           wizardCancelButton.textContent = "Cancel";
           wizardCancelButton.disabled = false;
           syncWizardDraftState();
@@ -7134,6 +7137,8 @@
             launchWizardOpenError.title === "Start Work"
               ? "Workspace launch"
               : "Launch Agent";
+          wizardBackButton.hidden = true;
+          wizardBackButton.disabled = false;
           wizardSubmitButton.hidden = true;
           wizardSubmitButton.disabled = true;
           wizardCancelButton.textContent = "Close";
@@ -7147,6 +7152,12 @@
         }
 
         wizardSubmitButton.hidden = false;
+        wizardBackButton.hidden = !launchWizard.show_back_button;
+        wizardBackButton.disabled = Boolean(
+          launchWizard.is_hydrating
+            || launchWizard.runtime_resolution_pending
+            || !launchWizard.show_back_button,
+        );
         wizardCancelButton.textContent = "Cancel";
         if (wizardTitle) wizardTitle.textContent = launchWizard.title || "Launch Agent";
         wizardMeta.textContent = launchWizard.show_branch_controls === false
@@ -12480,6 +12491,13 @@
         }
       });
       wizardCancelButton.addEventListener("click", closeLaunchWizardFromChrome);
+      wizardBackButton.addEventListener("click", () => {
+        if (launchWizardOpenError || wizardBackButton.disabled) {
+          return;
+        }
+        frontendUnits.launchWizardSurface.flushBranchDraft();
+        frontendUnits.launchWizardSurface.sendAction({ kind: "back" });
+      });
       wizardSubmitButton.addEventListener("click", () => {
         if (launchWizardOpenError) {
           return;

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -7185,6 +7185,12 @@
           launchWizard.runtime_context_resolved
           && launchWizard.show_runtime_confirmation
         );
+        const showStartMethods = Boolean(
+          launchWizard.show_start_methods
+            && !isRuntimeConfirmation
+            && !launchWizard.runtime_resolution_pending
+            && (launchWizard.start_methods || []).length > 0,
+        );
         const showSetupForms = showManualSetup && !isRuntimeConfirmation;
         wizardBody.innerHTML = "";
         const wizardMain = createNode("div", "wizard-main");
@@ -7212,7 +7218,7 @@
           );
         }
 
-        if (!isRuntimeConfirmation && (launchWizard.start_methods || []).length > 0) {
+        if (showStartMethods) {
           const section = createLaunchSection(
             "Start methods",
             "Choose how this agent should start on the selected branch.",

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -2994,15 +2994,6 @@
         return agentStatusLabel(agent.status_category);
       }
 
-      function liveSessionStatusLabel(session) {
-        const fallback = session.active ? "running" : "stopped";
-        const runtimeState = normalizeWindowRuntimeState(
-          session.runtime_status || fallback,
-          "agent",
-        );
-        return `${windowRuntimeLabel(runtimeState)} window`;
-      }
-
       function focusActiveWorkAgentWindow(agent) {
         if (!agent?.window_id) return;
         const windowData = workspaceWindowById(agent.window_id);
@@ -7221,117 +7212,44 @@
           );
         }
 
-        if (!isRuntimeConfirmation && (
-          (launchWizard.quick_start_entries || []).length > 0 ||
-          (launchWizard.live_sessions || []).length > 0
-        )) {
+        if (!isRuntimeConfirmation && (launchWizard.start_methods || []).length > 0) {
           const section = createLaunchSection(
-            "Quick start",
-            "Reuse a recent launch profile or jump to a running window.",
+            "Start methods",
+            "Choose how this agent should start on the selected branch.",
           );
 
-          if ((launchWizard.quick_start_entries || []).length > 0) {
-            const quickStartGrid = createNode("div", "quick-start-grid");
-            for (const entry of launchWizard.quick_start_entries) {
-              const card = createNode("button", "quick-start-card");
-              card.type = "button";
-              const selected =
-                launchWizard.selected_launch_path === "quick_start"
-                && launchWizard.selected_quick_start_index === entry.index;
-              card.setAttribute("aria-pressed", selected ? "true" : "false");
-              if (selected) {
-                card.classList.add("selected");
-              }
-              const head = createNode("div", "quick-start-head");
-              head.appendChild(
-                createNode("div", "quick-start-title", entry.tool_label),
-              );
-              head.appendChild(
-                createNode("div", "quick-start-meta", entry.summary),
-              );
-              if (entry.resume_session_id) {
-                head.appendChild(
-                  createNode(
-                    "div",
-                    "quick-start-secondary",
-                    `Resume ID · ${entry.resume_session_id}`,
-                  ),
-                );
-              }
-              card.appendChild(head);
-              card.addEventListener("click", () => {
-                sendWizardAction({
-                  kind: "select_quick_start",
-                  index: entry.index,
-                });
-              });
-              quickStartGrid.appendChild(card);
+          const methodList = createNode("div", "start-method-list");
+          for (const method of launchWizard.start_methods || []) {
+            const button = createNode("button", "start-method-button");
+            button.type = "button";
+            button.disabled = method.enabled === false;
+            const head = createNode("div", "start-method-head");
+            head.appendChild(createNode("div", "start-method-title", method.label));
+            if (method.badge) {
+              head.appendChild(createNode("div", "start-method-badge", method.badge));
             }
-            section.appendChild(quickStartGrid);
-          }
-
-          if ((launchWizard.live_sessions || []).length > 0) {
-            const liveSection = createNode("div", "live-session-list");
-            for (const session of launchWizard.live_sessions) {
-              const button = createNode("button", "live-session-button");
-              button.type = "button";
-              const selected =
-                launchWizard.selected_launch_path === "focus_session"
-                && launchWizard.selected_live_session_index === session.index;
-              button.setAttribute("aria-pressed", selected ? "true" : "false");
-              if (selected) {
-                button.classList.add("selected");
-              }
-              button.appendChild(
-                createNode("div", "live-session-name", session.name),
-              );
-              button.appendChild(
-                createNode(
-                  "div",
-                  "live-session-status",
-                  liveSessionStatusLabel(session),
-                ),
-              );
-              if (session.detail) {
-                button.appendChild(
-                  createNode("div", "live-session-detail", session.detail),
-                );
-              }
-              button.addEventListener("click", () => {
-                sendWizardAction({
-                  kind: "select_live_session",
-                  index: session.index,
-                });
-              });
-              liveSection.appendChild(button);
+            button.appendChild(head);
+            button.appendChild(
+              createNode("div", "start-method-summary", method.summary || ""),
+            );
+            const detail = method.enabled === false
+              ? method.disabled_reason
+              : method.detail;
+            if (detail) {
+              button.appendChild(createNode("div", "start-method-detail", detail));
             }
-            section.appendChild(liveSection);
-          }
-
-          const manualButton = createNode("button", "quick-start-card manual");
-          manualButton.type = "button";
-          const manualSelected = launchWizard.selected_launch_path === "manual_setup";
-          manualButton.setAttribute("aria-pressed", manualSelected ? "true" : "false");
-          if (manualSelected) {
-            manualButton.classList.add("selected");
-          }
-          const manualHead = createNode("div", "quick-start-head");
-          manualHead.appendChild(createNode("div", "quick-start-title", "Configure launch"));
-          manualHead.appendChild(
-            createNode(
-              "div",
-              "quick-start-meta",
-              "Choose branch, agent, model, and runtime.",
-            ),
-          );
-          manualButton.appendChild(manualHead);
-          manualButton.addEventListener("click", () => {
-            sendWizardAction({
-              kind: "set_launch_path",
-              path: "manual_setup",
+            button.addEventListener("click", () => {
+              if (button.disabled) {
+                return;
+              }
+              sendWizardAction({
+                kind: "use_start_method",
+                method: method.kind,
+              });
             });
-          });
-          section.appendChild(manualButton);
+            methodList.appendChild(button);
+          }
+          section.appendChild(methodList);
 
           panel.appendChild(section);
         }

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -516,6 +516,7 @@
           <div class="modal-body" id="wizard-body"></div>
           <div class="modal-footer wizard-footer">
             <div class="wizard-actions">
+              <button class="wizard-button" id="wizard-back-button" hidden>Back</button>
               <button class="wizard-button" id="wizard-cancel-button">Cancel</button>
               <button class="wizard-button primary" id="wizard-submit-button">Launch</button>
             </div>

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -3581,87 +3581,78 @@ body {
   color: var(--color-text-muted);
 }
 
-.quick-start-grid,
-.live-session-list {
+.start-method-list {
   display: grid;
   gap: 8px;
 }
 
-.quick-start-grid {
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-}
-
-.quick-start-card {
+.start-method-button {
+  min-width: 0;
   display: grid;
-  gap: 10px;
+  gap: 6px;
   width: 100%;
-  padding: 12px;
+  padding: 10px 12px;
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
-  background: var(--color-surface-elevated);
+  background: var(--color-surface);
   color: var(--color-text);
-  cursor: pointer;
+  font-family: var(--font-body);
   text-align: left;
+  cursor: pointer;
 }
 
-.quick-start-card.selected,
-.live-session-button.selected {
-  border-color: var(--color-focus-ring);
-  background: color-mix(in oklab, var(--color-state-active) 14%, var(--color-surface));
-}
-
-.quick-start-card:hover:not(.selected),
-.live-session-button:hover:not(.selected) {
-  border-color: var(--color-focus-ring);
+.start-method-button:hover:not(:disabled) {
+  border-color: var(--color-border-strong);
   background: var(--color-surface-elevated);
 }
 
-.quick-start-head {
-  display: grid;
-  gap: 4px;
+.start-method-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
 }
 
-.quick-start-title {
-  font-family: var(--font-display);
-  font-stretch: 75%;
+.start-method-head {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.start-method-title {
+  min-width: 0;
+  font-family: var(--font-mono);
   font-size: var(--type-sm);
   font-weight: 700;
-  letter-spacing: var(--tracking-display);
-  text-transform: uppercase;
-  color: var(--color-display-fg);
+  color: var(--color-text-strong);
 }
 
-.quick-start-meta,
-.quick-start-secondary,
-.live-session-detail,
+.start-method-badge {
+  flex: 0 0 auto;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-elevated);
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  color: var(--color-text-muted);
+}
+
+.start-method-summary,
+.start-method-detail {
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  color: var(--color-text-muted);
+  overflow-wrap: anywhere;
+}
+
 .launch-note {
   font-family: var(--font-mono);
   font-size: var(--type-xs);
   letter-spacing: var(--tracking-mono);
   color: var(--color-text-muted);
   overflow-wrap: anywhere;
-}
-
-.quick-start-secondary,
-.launch-note {
-  font-size: var(--type-xs);
-}
-
-.live-session-button {
-  width: 100%;
-  display: grid;
-  gap: 4px;
-  padding: 12px;
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  background: var(--color-surface);
-  color: var(--color-text);
-  cursor: pointer;
-  text-align: left;
-}
-.live-session-button:hover:not(.selected) {
-  border-color: var(--color-focus-ring);
-  background: var(--color-surface-elevated);
 }
 
 @media (max-width: 760px) {
@@ -3672,21 +3663,6 @@ body {
   .wizard-progress-rail {
     grid-template-columns: repeat(auto-fit, minmax(112px, 1fr));
   }
-}
-
-.live-session-name {
-  font-family: var(--font-mono);
-  font-size: var(--type-sm);
-  font-weight: 700;
-  color: var(--color-text-strong);
-}
-
-.live-session-status {
-  font-family: var(--font-mono);
-  font-size: var(--type-xs);
-  letter-spacing: var(--tracking-mono);
-  font-weight: 600;
-  color: var(--color-state-active);
 }
 
 .launch-toggle-row {

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6025,3 +6025,10 @@ hook integration tests が `CODEX_THREAD_ID` / `GWT_SESSION_ID` /
    `GWT_SESSION_RUNTIME_PATH` を unset して現在の agent session を汚染しない。
 3. Codex payload の `session_id` を使う tests では placeholder の `agent-session` を避け、
    実 resume 可能 ID を表す別値を使う。
+
+## 2026-05-22 — SPEC section edit stdin must be validated before piping to gwtd
+
+Type: failure-pattern
+Context: While updating SPEC-2014 tasks, a malformed perl append command produced no stdout, but the downstream `gwtd issue spec 2014 --edit tasks -f -` still wrote an empty tasks section.
+Learning: Pipelines into section-edit commands can erase canonical SPEC content when the producer fails; pipefail alone is not enough if the consumer accepts empty stdin.
+Future Action: For `gwtd issue spec --edit <section> -f -`, first materialize or generate the new section content with a size/header check, then edit; after editing, immediately reread the section and verify nonzero size plus expected tail.


### PR DESCRIPTION
## Summary

- Adds the Launch Wizard Start methods flow so users choose the start path before setup fields are shown.
- Adds latest-only resume/focus behavior and faster Start methods session matching for real workspace data.
- Adds a footer Back button so users can return from Configure and start to Start methods without losing draft setup choices.

## Changes

- `crates/gwt/src/launch_wizard.rs`: adds Start methods view state/actions, latest-session matching, setup gating, and Back navigation with draft preservation.
- `crates/gwt/src/app_runtime/mod.rs`: updates Launch Wizard runtime expectations for the Start methods first screen.
- `crates/gwt/src/embedded_web.rs`: extends embedded frontend contract tests for Start methods, Back, and runtime confirmation gating.
- `crates/gwt/web/app.js` and `crates/gwt/web/index.html`: renders Start methods as direct actions and adds the backend-gated footer Back button.
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: updates frontend structure coverage for Start methods and Back.
- `tasks/memory.md`: records the SPEC section edit recovery lesson.

## Testing

- [x] `cargo fmt -- --check` — passed after merging `origin/develop`.
- [x] `git diff --check` — passed after merging `origin/develop`.
- [x] `bash scripts/run-node-tests-with-linkedom.sh crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — passed after merge, 102 tests.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed after merge.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed after merge.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed after merge.
- [x] `curl -fsS -I http://127.0.0.1:60480/` — returned HTTP 200 during local serve smoke.
- [x] WebSocket smoke — confirmed Configure -> Back returns to Start methods while preserving the selected agent draft.
- [x] User visual verification — confirmed by user on 2026-05-22 with "OKです".

## PR Readiness

- State: Ready for review
- Releaseable slice: yes; the Start methods flow, setup gating, latest resume/focus behavior, and Back navigation are complete for the Launch Wizard scope.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- #2014

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC #2014 tasks updated)
- [x] Migration/backfill plan included (N/A: no schema/data migration)
- [x] CHANGELOG impact considered (feature/fix commits use Conventional Commits)

## Context

- This follows SPEC #2014 feedback that Quick Start should become an explicit Start methods screen with latest-only session choices and a way to return from setup.
- `origin/develop` was merged before PR creation using a merge commit; the only conflict was in `tasks/memory.md`, resolved by preserving both memory entries.

## Risk / Impact

- **Affected areas**: Launch Wizard backend state, embedded frontend renderer, Start methods session selection, and frontend contract tests.
- **Rollback plan**: Revert this PR to restore the prior Launch Wizard setup-first behavior.

## Screenshots

| Before | After |
|--------|-------|
| Start methods and setup fields were effectively part of the same wizard surface. | Local serve visual verification confirmed Start methods first, Configure and start opens setup, and Back returns to Start methods while preserving the draft. |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Start Methods" section to the Launch Wizard allowing users to select how to launch agents (configure & start, start with saved settings, continue previous session, or focus running session).
  * Added a "Back" button to the wizard footer for navigating back while preserving configuration.

* **Improvements**
  * Agent sessions are now ordered by activity timestamp for better visibility of recently active sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2870?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->