### PR TITLE
fix(launch): defer runtime worktree materialization

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -9874,6 +9874,95 @@ exit 1
     }
 
     #[test]
+    fn app_runtime_launch_wizard_continue_does_not_materialize_missing_worktree() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let _origin = init_git_clone_with_origin(&repo);
+        fs::write(
+            repo.join("docker-compose.yml"),
+            "services:\n  app:\n    image: alpine:3.20\n",
+        )
+        .expect("compose");
+        run_git(&repo, &["add", "docker-compose.yml"]);
+        run_git(&repo, &["commit", "-qm", "add compose"]);
+        run_git(&repo, &["push", "origin", "develop"]);
+
+        let branch_name = "work/runtime-deferral";
+        let expected_worktree = gwt_git::worktree::sibling_worktree_path(&repo, branch_name);
+        assert!(
+            !expected_worktree.exists(),
+            "fixture branch worktree should start absent"
+        );
+
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            repo.clone(),
+            ProjectKind::Git,
+            &[WindowPreset::Branches],
+        );
+        let (mut runtime, recorded_events) =
+            sample_runtime_with_events(temp.path(), vec![tab], Some("tab-1"));
+
+        runtime
+            .open_launch_wizard_for_branch("tab-1", &repo, branch_name, None, None)
+            .expect("open launch wizard");
+
+        let events = runtime.handle_launch_wizard_action(LaunchWizardAction::Submit, None);
+        assert_eq!(events.len(), 1);
+        let pending_view = runtime
+            .launch_wizard
+            .as_ref()
+            .expect("wizard")
+            .wizard
+            .view();
+        assert!(pending_view.runtime_resolution_pending);
+        assert_eq!(
+            pending_view.runtime_resolution_message.as_deref(),
+            Some("Preparing runtime context...")
+        );
+
+        wait_for_recorded_event(
+            "launch wizard runtime deferral",
+            &recorded_events,
+            |events| {
+                events
+                    .iter()
+                    .any(|event| matches!(event, UserEvent::LaunchWizardRuntimeResolved { .. }))
+            },
+        );
+        let resolved_event = {
+            let mut events = recorded_events.lock().expect("event log");
+            events
+                .iter()
+                .position(|event| matches!(event, UserEvent::LaunchWizardRuntimeResolved { .. }))
+                .map(|index| events.remove(index))
+                .expect("runtime resolved event")
+        };
+        let UserEvent::LaunchWizardRuntimeResolved { wizard_id, result } = resolved_event else {
+            unreachable!("matched above")
+        };
+        let resolved_events = runtime.handle_launch_wizard_runtime_resolved(wizard_id, *result);
+        assert_eq!(resolved_events.len(), 1);
+
+        let wizard = &runtime.launch_wizard.as_ref().expect("wizard").wizard;
+        assert!(
+            wizard.context.worktree_path.is_none(),
+            "runtime confirmation should not resolve a newly-created target worktree"
+        );
+        assert!(
+            !expected_worktree.exists(),
+            "Runtime confirmation must not create {expected_worktree:?}"
+        );
+        let view = wizard.view();
+        assert!(!view.runtime_resolution_pending);
+        assert!(view.runtime_context_resolved);
+        assert!(view.show_runtime_target);
+        assert_eq!(view.selected_runtime_target, "docker");
+        assert_eq!(view.selected_docker_service.as_deref(), Some("app"));
+    }
+
+    #[test]
     fn app_runtime_launch_wizard_continue_falls_back_to_host_without_resolved_docker_context() {
         let temp = tempdir().expect("tempdir");
         let repo = temp.path().join("repo");

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -63,14 +63,15 @@ fn start_work_open_error(client_id: &str, message: impl Into<String>) -> Vec<Out
 use super::{
     build_shell_process_launch, combined_window_id, detect_wizard_docker_context_and_status,
     knowledge_error_event, knowledge_kind_for_preset, list_branch_entries_with_active_sessions,
-    normalize_branch_name, preferred_issue_launch_branch, resolve_launch_worktree,
-    resolve_shell_launch_worktree, synthetic_branch_entry, workspace_projection_for_current_resume,
+    normalize_branch_name, preferred_issue_launch_branch, resolve_shell_launch_worktree,
+    synthetic_branch_entry, workspace_projection_for_current_resume,
     workspace_resume_branch_exists, workspace_resume_branch_from_journal_project_root,
     workspace_resume_context_from_journal, workspace_resume_context_from_projection,
     workspace_resume_owner_issue_number, AppEventProxy, AppRuntime, BackendEvent,
     IssueLaunchWizardPrepared, LaunchWizardMemoryCache, LaunchWizardSession, OutboundEvent,
     WindowPreset, WindowProcessStatus, WorkspaceResumeContext, WORKSPACE_OVERVIEW_JOURNAL_LIMIT,
 };
+use crate::usable_worktree_path_for_branch;
 
 impl AppRuntime {
     pub(crate) fn launch_wizard_state_outbound(&self) -> OutboundEvent {
@@ -1074,7 +1075,7 @@ impl AppRuntime {
                 let proxy = self.proxy.clone();
                 session
                     .wizard
-                    .mark_runtime_resolution_pending("Preparing worktree...");
+                    .mark_runtime_resolution_pending("Preparing runtime context...");
                 thread::spawn(move || {
                     let result = resolve_launch_wizard_runtime_context_hydration(
                         &project_root,
@@ -1194,42 +1195,45 @@ impl AppRuntime {
 
 fn resolve_launch_wizard_runtime_context_hydration(
     project_root: &Path,
-    mut config: LaunchWizardLaunchRequest,
+    _config: LaunchWizardLaunchRequest,
     branch_name: String,
     cache: LaunchWizardMemoryCache,
 ) -> Result<LaunchWizardHydration, String> {
-    let worktree_path = match &mut config {
-        LaunchWizardLaunchRequest::Agent(config) => {
-            resolve_launch_worktree(project_root, config)?;
-            config
-                .working_dir
-                .clone()
-                .unwrap_or_else(|| project_root.to_path_buf())
-        }
-        LaunchWizardLaunchRequest::Shell(config) => {
-            resolve_shell_launch_worktree(project_root, config)?;
-            config
-                .working_dir
-                .clone()
-                .unwrap_or_else(|| project_root.to_path_buf())
-        }
-    };
-    let quick_start_entries = cache.quick_start_entries(&worktree_path, &branch_name);
-    let previous_profiles = cache.previous_profiles(&worktree_path);
+    let (context_path, resolved_worktree_path) =
+        launch_runtime_context_paths(project_root, &branch_name);
+    let quick_start_entries = cache.quick_start_entries(&context_path, &branch_name);
+    let previous_profiles = cache.previous_profiles(&context_path);
     let agent_options = cache.agent_options();
     let (docker_context, docker_service_status) =
-        detect_wizard_docker_context_and_status(&worktree_path);
+        detect_wizard_docker_context_and_status(&context_path);
     Ok(LaunchWizardHydration {
         selected_branch: None,
         normalized_branch_name: branch_name,
-        worktree_path: Some(worktree_path.clone()),
-        quick_start_root: worktree_path,
+        worktree_path: resolved_worktree_path,
+        quick_start_root: context_path,
         docker_context,
         docker_service_status,
         agent_options,
         quick_start_entries,
         previous_profiles: Some(previous_profiles),
     })
+}
+
+fn launch_runtime_context_paths(
+    project_root: &Path,
+    branch_name: &str,
+) -> (PathBuf, Option<PathBuf>) {
+    if let Some(worktree_path) = existing_launch_worktree_path(project_root, branch_name) {
+        return (worktree_path.clone(), Some(worktree_path));
+    }
+    (project_root.to_path_buf(), None)
+}
+
+fn existing_launch_worktree_path(project_root: &Path, branch_name: &str) -> Option<PathBuf> {
+    let main_repo_path = gwt_git::worktree::main_worktree_root(project_root).ok()?;
+    let manager = gwt_git::WorktreeManager::new(&main_repo_path);
+    let worktrees = manager.list().ok()?;
+    usable_worktree_path_for_branch(&worktrees, branch_name)
 }
 
 impl AppRuntime {

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -414,9 +414,10 @@ pub fn previous_launch_profile_from_sessions(
     repo_path: &Path,
     sessions: &[gwt_agent::Session],
 ) -> Option<LaunchWizardPreviousProfile> {
+    let mut repo_scope = LaunchProfileRepoScope::new(repo_path);
     sessions
         .iter()
-        .filter(|session| same_launch_profile_repo(repo_path, session))
+        .filter(|session| repo_scope.matches_session(session))
         .max_by(|left, right| launch_profile_session_cmp(left, right))
         .cloned()
         .map(previous_profile_from_session)
@@ -496,10 +497,11 @@ pub fn quick_start_entries_from_sessions(
     branch_name: &str,
     sessions: &[gwt_agent::Session],
 ) -> Vec<QuickStartEntry> {
+    let mut repo_scope = LaunchProfileRepoScope::new(repo_path);
     let sessions = sessions
         .iter()
         .filter(|session| session.branch == branch_name)
-        .filter(|session| same_launch_profile_repo(repo_path, session))
+        .filter(|session| repo_scope.matches_session(session))
         .cloned()
         .map(|mut session| {
             session.worktree_path = repo_path.to_path_buf();
@@ -530,28 +532,107 @@ fn previous_profile_from_session(session: gwt_agent::Session) -> LaunchWizardPre
     }
 }
 
-fn same_launch_profile_repo(repo_path: &Path, session: &gwt_agent::Session) -> bool {
-    let session_worktree_path = &session.worktree_path;
-    if same_path_or_exact(repo_path, session_worktree_path) {
-        return true;
-    }
+struct LaunchProfileRepoScope {
+    repo_path: PathBuf,
+    canonical_repo_path: Option<PathBuf>,
+    repo_hash: Option<String>,
+    repo_root_resolved: bool,
+    repo_root: Option<PathBuf>,
+    canonical_repo_root: Option<PathBuf>,
+    session_root_cache: HashMap<PathBuf, Option<PathBuf>>,
+}
 
-    if let (Some(current_repo_hash), Some(session_repo_hash)) = (
-        repo_hash_for_existing_path(repo_path),
-        session.repo_hash.as_deref(),
-    ) {
-        if current_repo_hash == session_repo_hash {
-            return true;
+impl LaunchProfileRepoScope {
+    fn new(repo_path: &Path) -> Self {
+        Self {
+            repo_path: repo_path.to_path_buf(),
+            canonical_repo_path: std::fs::canonicalize(repo_path).ok(),
+            repo_hash: repo_hash_for_existing_path(repo_path),
+            repo_root_resolved: false,
+            repo_root: None,
+            canonical_repo_root: None,
+            session_root_cache: HashMap::new(),
         }
     }
 
-    let Ok(repo_root) = gwt_git::worktree::main_worktree_root(repo_path) else {
-        return false;
-    };
-    let Ok(session_root) = gwt_git::worktree::main_worktree_root(session_worktree_path) else {
-        return false;
-    };
-    same_path_or_exact(&repo_root, &session_root)
+    fn matches_session(&mut self, session: &gwt_agent::Session) -> bool {
+        let session_worktree_path = &session.worktree_path;
+        if self.same_repo_path(session_worktree_path) {
+            return true;
+        }
+
+        if let (Some(current_repo_hash), Some(session_repo_hash)) =
+            (self.repo_hash.as_deref(), session.repo_hash.as_deref())
+        {
+            return current_repo_hash == session_repo_hash;
+        }
+
+        if !session_worktree_path.exists() {
+            return false;
+        }
+
+        let Some(repo_root) = self.repo_root() else {
+            return false;
+        };
+        let Some(session_root) = self.session_main_worktree_root(session_worktree_path) else {
+            return false;
+        };
+        self.same_repo_root(&repo_root, &session_root)
+    }
+
+    fn same_repo_path(&self, candidate: &Path) -> bool {
+        if self.repo_path == candidate {
+            return true;
+        }
+        if !candidate.exists() {
+            return false;
+        }
+
+        match (
+            self.canonical_repo_path.as_ref(),
+            std::fs::canonicalize(candidate).ok(),
+        ) {
+            (Some(repo_path), Some(candidate)) => repo_path == &candidate,
+            _ => false,
+        }
+    }
+
+    fn repo_root(&mut self) -> Option<PathBuf> {
+        if !self.repo_root_resolved {
+            self.repo_root = gwt_git::worktree::main_worktree_root(&self.repo_path).ok();
+            self.canonical_repo_root = self
+                .repo_root
+                .as_ref()
+                .and_then(|path| std::fs::canonicalize(path).ok());
+            self.repo_root_resolved = true;
+        }
+        self.repo_root.clone()
+    }
+
+    fn same_repo_root(&self, repo_root: &Path, session_root: &Path) -> bool {
+        if repo_root == session_root {
+            return true;
+        }
+
+        match (
+            self.canonical_repo_root.as_ref(),
+            std::fs::canonicalize(session_root).ok(),
+        ) {
+            (Some(repo_root), Some(session_root)) => repo_root == &session_root,
+            _ => false,
+        }
+    }
+
+    fn session_main_worktree_root(&mut self, path: &Path) -> Option<PathBuf> {
+        if let Some(cached) = self.session_root_cache.get(path) {
+            return cached.clone();
+        }
+
+        let root = gwt_git::worktree::main_worktree_root(path).ok();
+        self.session_root_cache
+            .insert(path.to_path_buf(), root.clone());
+        root
+    }
 }
 
 fn repo_hash_for_existing_path(path: &Path) -> Option<String> {
@@ -562,17 +643,6 @@ fn repo_hash_for_existing_path(path: &Path) -> Option<String> {
                 .and_then(|root| gwt_core::repo_hash::detect_repo_hash(&root))
         })
         .map(|hash| hash.as_str().to_string())
-}
-
-fn same_path_or_exact(left: &Path, right: &Path) -> bool {
-    if left == right {
-        return true;
-    }
-
-    match (std::fs::canonicalize(left), std::fs::canonicalize(right)) {
-        (Ok(left), Ok(right)) => left == right,
-        _ => false,
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -1162,8 +1232,10 @@ impl LaunchWizardState {
 
     pub fn apply_runtime_context(&mut self, hydration: LaunchWizardHydration) {
         self.apply_hydration(hydration);
-        self.is_new_branch = false;
-        self.base_branch_name = None;
+        if self.context.worktree_path.is_some() {
+            self.is_new_branch = false;
+            self.base_branch_name = None;
+        }
         self.runtime_context_resolved = true;
         self.runtime_resolution_pending = false;
         self.runtime_resolution_message = None;
@@ -4515,6 +4587,33 @@ mod tests {
     }
 
     #[test]
+    fn previous_launch_profile_treats_mismatched_repo_hash_as_authoritative() {
+        let dir = tempdir().expect("tempdir");
+        let repo = dir.path().join("repo");
+        init_repo_with_origin(&repo, "https://github.com/example/project.git");
+        let nested_path = repo.join("nested");
+        std::fs::create_dir_all(&nested_path).expect("nested dir");
+
+        let mut session = sample_session_record(
+            "feature/wrong-repo",
+            &nested_path,
+            gwt_agent::AgentId::Codex,
+            Utc.with_ymd_and_hms(2026, 5, 22, 10, 0, 0).unwrap(),
+            None,
+        );
+        session.repo_hash = Some(
+            gwt_core::repo_hash::compute_repo_hash("https://github.com/example/other.git")
+                .as_str()
+                .to_string(),
+        );
+
+        assert!(
+            previous_launch_profile_from_sessions(&repo, &[session]).is_none(),
+            "repo_hash mismatch must not fall back to legacy root matching"
+        );
+    }
+
+    #[test]
     fn branch_action_create_new_from_selected_sets_base_branch() {
         let mut state = LaunchWizardState::open_with(
             context(branch("feature/gui"), "feature/gui"),
@@ -5244,6 +5343,50 @@ mod tests {
             config.working_dir.is_none(),
             "Start Work must defer worktree materialization until launch confirmation"
         );
+    }
+
+    #[test]
+    fn runtime_confirmation_without_worktree_preserves_start_work_base_branch() {
+        let mut state = LaunchWizardState::open_start_work_with_previous_profile(
+            context(branch("origin/develop"), "work/20260504-1234"),
+            "origin/develop".to_string(),
+            sample_agent_options(),
+            Vec::new(),
+            None,
+        );
+        state.mark_runtime_context_unresolved();
+
+        state.apply(LaunchWizardAction::Submit);
+        assert!(matches!(
+            state.completion,
+            Some(LaunchWizardCompletion::ResolveRuntime(_))
+        ));
+        state.completion = None;
+        state.apply_runtime_context(LaunchWizardHydration {
+            selected_branch: None,
+            normalized_branch_name: "work/20260504-1234".to_string(),
+            worktree_path: None,
+            quick_start_root: PathBuf::from("/tmp/repo"),
+            docker_context: None,
+            docker_service_status: gwt_docker::ComposeServiceStatus::NotFound,
+            agent_options: sample_agent_options(),
+            quick_start_entries: Vec::new(),
+            previous_profiles: Some(Default::default()),
+        });
+
+        state.apply(LaunchWizardAction::Submit);
+
+        assert!(matches!(
+            state.completion.as_ref(),
+            Some(LaunchWizardCompletion::Launch(config))
+                if matches!(
+                    config.as_ref(),
+                    LaunchWizardLaunchRequest::Agent(config)
+                        if config.branch.as_deref() == Some("work/20260504-1234")
+                            && config.base_branch.as_deref() == Some("origin/develop")
+                            && config.working_dir.is_none()
+                )
+        ));
     }
 
     #[test]

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6032,3 +6032,10 @@ Type: lesson
 Context: Issue #2867 の Recent Projects pollution 修正で headless 確認を行う際、私が独断で「production GWT.app (PID 9569) を終了してください」と要求した。ユーザーから skill にそのような手順は無いと指摘され、誤って kill されると困るとの再発防止依頼を受けた。
 Learning: headless-browser-check skill は 'gwt serve を別プロセスとして起動する' という前提で、ユーザーの常用 gwt / GWT.app を停止する手順は含まない。session.json や app-instance.lock の競合懸念があっても、エージェントが自動で停止判断をしてはならない。
 Future Action: headless 起動時に共有 state (session.json / app-instance.lock / port) の懸念がある場合は、懸念点を明示してユーザーに判断を委ねる。production gwt を停止する選択肢は提示してよいが、エージェント側で前提化したり、依頼したりしない。skill の guardrail にも明文化済み (.claude/.codex の SKILL.md 両方)。
+
+## 2026-05-22 — Launch Runtime confirmation must stay side-effect free and cached
+
+Type: lesson
+Context: User reported that Launch Agent Runtime felt slow and asked whether Runtime startup was creating a worktree. During SPEC-2014 follow-up, Runtime confirmation called resolve_launch_worktree and also scanned thousands of stale session records through legacy git root matching.
+Learning: Runtime confirmation should only inspect an existing target worktree or project root for Docker/runtime context; final Launch owns materialization. Session repo matching must cache current repo identity, treat mismatched repo_hash as authoritative, and avoid git root probes for missing session paths.
+Future Action: When changing Launch Wizard Runtime hydration or previous-profile/Quick Start matching, add tests that missing target worktrees are not created and that stale session history does not fan out per-session git probes.


### PR DESCRIPTION
## Summary

- Defers Launch Agent runtime worktree materialization until the user actually launches, reducing the long wait in the Runtime confirmation step.
- Hydrates Docker/runtime context from the existing project root or an already-existing worktree, while preserving Start Work base branch state for new branches.
- Adds regressions and memory notes for the Launch Wizard runtime path so this behavior does not reintroduce eager worktree creation.

## Changes

- `crates/gwt/src/app_runtime/wizard.rs`: Runtime confirmation now builds launch runtime context without creating the missing target worktree; final Launch still materializes as before.
- `crates/gwt/src/launch_wizard.rs`: Runtime context application preserves new-branch/base-branch state unless a real worktree path exists, and previous-profile repository matching now treats `repo_hash` as authoritative.
- `crates/gwt/src/app_runtime/mod.rs`: Adds app-runtime regression coverage proving Continue from Runtime confirmation does not materialize a missing Launch worktree.
- `tasks/memory.md`: Records the prevention note for avoiding eager worktree creation during Runtime confirmation.

## Testing

- [x] `cargo fmt -- --check` — passed.
- [x] `git diff --check` — passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed.
- [x] Focused regression tests for previous launch profiles, quick-start deleted worktree matching, and app runtime Launch Wizard Continue — passed.
- [x] Local WebSocket smoke for Runtime confirmation hydration — `Preparing runtime context...` resolved in 170ms.
- [x] Manual UI verification — user opened the served app and confirmed the Runtime confirmation behavior looked good.
- [ ] `/Applications/GWT.app/Contents/MacOS/gwtd gwt-verify --mode pre-pr` — blocked because this binary reports `gwtd: unknown command 'gwt-verify'`.

## PR Readiness

- State: Draft
- Releaseable slice: No for Ready review, because the required `gwt-verify --mode pre-pr` Ready gate cannot be executed with the currently installed `gwtd` binary.
- Known blockers: `gwt-verify --mode pre-pr` is unavailable (`gwtd: unknown command 'gwt-verify'`); GitHub CI still needs to run on the Draft PR.
- Remaining acceptance: Re-run the Ready PR gate when `gwt-verify` is available and confirm PR checks are green.

## Closing Issues

- None

## Related Issues / Links

- #2014

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (memory note added; user-facing README not required)
- [x] Migration/backfill plan included (N/A: no schema or data migration)
- [x] CHANGELOG impact considered (patch-level `fix:` commit)

## Context

- SPEC #2014 covers the Launch Wizard / Runtime confirmation flow where startup felt slow because the Runtime step could eagerly create the Launch worktree before the user pressed Launch.

## Risk / Impact

- **Affected areas**: Launch Wizard runtime confirmation, Docker/runtime context hydration, previous launch profile matching.
- **Rollback plan**: Revert this PR; Launch worktree materialization will return to the previous eager Runtime confirmation behavior.

## Screenshots

- Manual visual verification was performed locally through the served gwt UI, and the user confirmed the improved Runtime confirmation behavior.
