### PR TITLE
feat(index): add all-terms search and discussions index

### DIFF
--- a/.claude/commands/gwt-search.md
+++ b/.claude/commands/gwt-search.md
@@ -1,5 +1,5 @@
 ---
-description: Unified semantic search over SPECs, Issues, project source files, and memory
+description: Unified semantic search over SPECs, Issues, project source files, memory, and precision all-terms matching
 author: akiojin
 allowed-tools: Read, Glob, Grep, Bash
 ---
@@ -11,7 +11,7 @@ Unified semantic search over SPEC Issues, GitHub Issues, project source files, a
 ## Usage
 
 ```text
-/gwt:gwt-search [query] [--specs] [--issues] [--files] [--memory]
+/gwt:gwt-search [query] [--specs] [--issues] [--files] [--memory] [--match-mode semantic|all_terms]
 ```
 
 ## Steps
@@ -36,4 +36,8 @@ Unified semantic search over SPEC Issues, GitHub Issues, project source files, a
 
 ```text
 /gwt:gwt-search --memory "watcher debounce"
+```
+
+```text
+/gwt:gwt-search --match-mode all_terms "Workspace 置き換え"
 ```

--- a/.claude/skills/gwt-search/SKILL.md
+++ b/.claude/skills/gwt-search/SKILL.md
@@ -53,6 +53,23 @@ gwt-search --memory "query"    # post-mortem memory only
 | `--files` | Files only | `search-files` |
 | `--memory` | Memory only | `search-memory` |
 
+## Match modes
+
+Use the default semantic mode for broad discovery. Use `--match-mode all_terms`
+when the user or task needs FAQ-style precision and every whitespace-separated
+term or quoted phrase must be present in a strict result.
+
+Examples:
+
+```text
+gwt-search --match-mode all_terms "Workspace 置き換え"
+gwt-search --match-mode all_terms "\"Project State\" migration"
+```
+
+In `all_terms` mode, strict results must satisfy every required term. Semantic
+suggestions may still be returned separately, but they must not be treated as
+strict matches.
+
 ## Environment
 
 When the gwt GUI app (WebView built with `wry + tao + axum WebSocket` and

--- a/.codex/skills/gwt-search/SKILL.md
+++ b/.codex/skills/gwt-search/SKILL.md
@@ -53,6 +53,23 @@ gwt-search --memory "query"    # post-mortem memory only
 | `--files` | Files only | `search-files` |
 | `--memory` | Memory only | `search-memory` |
 
+## Match modes
+
+Use the default semantic mode for broad discovery. Use `--match-mode all_terms`
+when the user or task needs FAQ-style precision and every whitespace-separated
+term or quoted phrase must be present in a strict result.
+
+Examples:
+
+```text
+gwt-search --match-mode all_terms "Workspace 置き換え"
+gwt-search --match-mode all_terms "\"Project State\" migration"
+```
+
+In `all_terms` mode, strict results must satisfy every required term. Semantic
+suggestions may still be returned separately, but they must not be treated as
+strict matches.
+
 ## Environment
 
 When the gwt GUI app (WebView built with `wry + tao + axum WebSocket` and

--- a/crates/gwt-core/runtime/chroma_index_runner.py
+++ b/crates/gwt-core/runtime/chroma_index_runner.py
@@ -2245,7 +2245,7 @@ def action_index_memory_v2(
 
 
 def _extract_discussion_field(body: str, field: str) -> str:
-    match = re.search(rf"(?m)^{re.escape(field)}:\s*(.*?)\s*$", body)
+    match = re.search(rf"(?m)^{re.escape(field)}:[ \t]*([^\r\n]*)", body)
     return match.group(1).strip() if match else ""
 
 

--- a/crates/gwt-core/runtime/chroma_index_runner.py
+++ b/crates/gwt-core/runtime/chroma_index_runner.py
@@ -2703,13 +2703,16 @@ def _format_memory_results(
             continue
         seen.add(key)
         formatted.append(
-            {
-                "date": date,
-                "title": title,
-                "heading": meta.get("heading", ""),
-                "chunk_idx": int(meta.get("chunk_idx", 0)),
-                "distance": it.get("distance"),
-            }
+            _attach_match_fields(
+                {
+                    "date": date,
+                    "title": title,
+                    "heading": meta.get("heading", ""),
+                    "chunk_idx": int(meta.get("chunk_idx", 0)),
+                    "distance": it.get("distance"),
+                },
+                it,
+            )
         )
         if len(formatted) >= n_results:
             break
@@ -2731,19 +2734,22 @@ def _format_discussion_results(
             continue
         seen.add(key)
         formatted.append(
-            {
-                "discussion_id": meta.get("discussion_id", it.get("id", "")),
-                "date": date,
-                "title": title,
-                "status": meta.get("status", ""),
-                "topics": _split_csv_meta(meta.get("topics", "")),
-                "related_specs": _split_csv_meta(meta.get("related_specs", "")),
-                "related_works": _split_csv_meta(meta.get("related_works", "")),
-                "promoted_to": _split_csv_meta(meta.get("promoted_to", "")),
-                "heading": meta.get("heading", ""),
-                "chunk_idx": int(meta.get("chunk_idx", 0)),
-                "distance": it.get("distance"),
-            }
+            _attach_match_fields(
+                {
+                    "discussion_id": meta.get("discussion_id", it.get("id", "")),
+                    "date": date,
+                    "title": title,
+                    "status": meta.get("status", ""),
+                    "topics": _split_csv_meta(meta.get("topics", "")),
+                    "related_specs": _split_csv_meta(meta.get("related_specs", "")),
+                    "related_works": _split_csv_meta(meta.get("related_works", "")),
+                    "promoted_to": _split_csv_meta(meta.get("promoted_to", "")),
+                    "heading": meta.get("heading", ""),
+                    "chunk_idx": int(meta.get("chunk_idx", 0)),
+                    "distance": it.get("distance"),
+                },
+                it,
+            )
         )
         if len(formatted) >= n_results:
             break
@@ -3145,6 +3151,88 @@ def action_index_issues_v2(
 # ---------------------------------------------------------------------
 
 
+def _parse_required_terms(query: str) -> List[str]:
+    terms: List[str] = []
+    for match in re.finditer(r'"([^"]+)"|(\S+)', query):
+        term = (match.group(1) if match.group(1) is not None else match.group(2)).strip()
+        if term:
+            terms.append(term)
+    return terms
+
+
+def _item_match_text(item: Dict[str, Any]) -> str:
+    parts: List[str] = [str(item.get("id", "")), str(item.get("document", ""))]
+
+    def collect(value: Any) -> None:
+        if value is None:
+            return
+        if isinstance(value, dict):
+            for nested in value.values():
+                collect(nested)
+            return
+        if isinstance(value, (list, tuple, set)):
+            for nested in value:
+                collect(nested)
+            return
+        parts.append(str(value))
+
+    collect(item.get("metadata") or {})
+    return "\n".join(parts).casefold()
+
+
+def _copy_with_match_fields(
+    item: Dict[str, Any],
+    match_mode: str,
+    matched_terms: Sequence[str],
+    missing_terms: Sequence[str],
+) -> Dict[str, Any]:
+    enriched = dict(item)
+    enriched["match_mode"] = match_mode
+    enriched["matched_terms"] = list(matched_terms)
+    enriched["missing_terms"] = list(missing_terms)
+    return enriched
+
+
+def _apply_match_mode(
+    items: List[Dict[str, Any]],
+    query: str,
+    match_mode: str,
+) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    if match_mode != "all_terms":
+        return items, []
+    required_terms = _parse_required_terms(query)
+    if not required_terms:
+        return items, []
+
+    strict: List[Dict[str, Any]] = []
+    suggestions: List[Dict[str, Any]] = []
+    for item in items:
+        haystack = _item_match_text(item)
+        matched = [term for term in required_terms if term.casefold() in haystack]
+        missing = [term for term in required_terms if term.casefold() not in haystack]
+        enriched = _copy_with_match_fields(item, match_mode, matched, missing)
+        if missing:
+            suggestions.append(enriched)
+        else:
+            strict.append(enriched)
+    return strict, suggestions
+
+
+def _attach_match_fields(result: Dict[str, Any], item: Dict[str, Any]) -> Dict[str, Any]:
+    if item.get("match_mode"):
+        result["match_mode"] = item.get("match_mode")
+        result["matched_terms"] = list(item.get("matched_terms") or [])
+        result["missing_terms"] = list(item.get("missing_terms") or [])
+    return result
+
+
+def _search_fetch_count(scope: str, n_results: int, match_mode: str) -> int:
+    base = n_results * 5 if scope in ("specs", "memory", "discussions") else n_results
+    if match_mode == "all_terms":
+        return min(max(base, n_results * 5, 50), 200)
+    return base
+
+
 def _search_collection_v2(collection, query: str, n_results: int) -> List[Dict[str, Any]]:
     try:
         count = collection.count()
@@ -3153,7 +3241,11 @@ def _search_collection_v2(collection, query: str, n_results: int) -> List[Dict[s
     if count == 0:
         return []
     actual_n = min(n_results, count)
-    results = collection.query(query_texts=[query], n_results=actual_n)
+    results = collection.query(
+        query_texts=[query],
+        n_results=actual_n,
+        include=["metadatas", "documents", "distances"],
+    )
     items: List[Dict[str, Any]] = []
     if results and results.get("ids") and results["ids"][0]:
         for idx, doc_id in enumerate(results["ids"][0]):
@@ -3163,6 +3255,7 @@ def _search_collection_v2(collection, query: str, n_results: int) -> List[Dict[s
                 {
                     "id": doc_id,
                     "metadata": meta,
+                    "document": results["documents"][0][idx] if results.get("documents") else "",
                     "distance": round(distance, 4) if distance is not None else None,
                 }
             )
@@ -3170,16 +3263,21 @@ def _search_collection_v2(collection, query: str, n_results: int) -> List[Dict[s
 
 
 def _format_file_results(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    return [
-        {
-            "path": (it["metadata"] or {}).get("path", it["id"]),
-            "description": (it["metadata"] or {}).get("description", ""),
-            "distance": it["distance"],
-            "fileType": (it["metadata"] or {}).get("file_type", ""),
-            "size": (it["metadata"] or {}).get("size", 0),
-        }
-        for it in items
-    ]
+    formatted = []
+    for it in items:
+        formatted.append(
+            _attach_match_fields(
+                {
+                    "path": (it["metadata"] or {}).get("path", it["id"]),
+                    "description": (it["metadata"] or {}).get("description", ""),
+                    "distance": it["distance"],
+                    "fileType": (it["metadata"] or {}).get("file_type", ""),
+                    "size": (it["metadata"] or {}).get("size", 0),
+                },
+                it,
+            )
+        )
+    return formatted
 
 
 def _format_spec_results(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -3197,15 +3295,18 @@ def _format_spec_results(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             continue
         seen_spec_ids.add(spec_id)
         formatted.append(
-            {
-                "spec_id": spec_id,
-                "title": meta.get("title", ""),
-                "status": meta.get("status", ""),
-                "phase": meta.get("phase", ""),
-                "dir_name": meta.get("dir_name", ""),
-                "distance": it["distance"],
-                "matched_section": meta.get("chunk_heading", ""),
-            }
+            _attach_match_fields(
+                {
+                    "spec_id": spec_id,
+                    "title": meta.get("title", ""),
+                    "status": meta.get("status", ""),
+                    "phase": meta.get("phase", ""),
+                    "dir_name": meta.get("dir_name", ""),
+                    "distance": it["distance"],
+                    "matched_section": meta.get("chunk_heading", ""),
+                },
+                it,
+            )
         )
     return formatted
 
@@ -3217,14 +3318,17 @@ def _format_issue_results(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         labels_raw = meta.get("labels", "")
         labels = [lb for lb in labels_raw.split(",") if lb] if labels_raw else []
         formatted.append(
-            {
-                "number": meta.get("number", it["id"]),
-                "title": meta.get("title", ""),
-                "url": meta.get("url", ""),
-                "state": meta.get("state", ""),
-                "labels": labels,
-                "distance": it["distance"],
-            }
+            _attach_match_fields(
+                {
+                    "number": meta.get("number", it["id"]),
+                    "title": meta.get("title", ""),
+                    "url": meta.get("url", ""),
+                    "state": meta.get("state", ""),
+                    "labels": labels,
+                    "distance": it["distance"],
+                },
+                it,
+            )
         )
     return formatted
 
@@ -3240,23 +3344,56 @@ def _format_board_results(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     for it in items:
         meta = it["metadata"] or {}
         formatted.append(
-            {
-                "entry_id": meta.get("entry_id", it["id"]),
-                "kind": meta.get("kind", ""),
-                "author": meta.get("author", ""),
-                "title_summary": meta.get("title_summary", ""),
-                "body_preview": meta.get("body_preview", ""),
-                "created_at": meta.get("created_at", ""),
-                "updated_at": meta.get("updated_at", ""),
-                "origin_branch": meta.get("origin_branch", ""),
-                "origin_session_id": meta.get("origin_session_id", ""),
-                "audience": _split_csv_meta(meta.get("audience", "")),
-                "related_topics": _split_csv_meta(meta.get("related_topics", "")),
-                "related_owners": _split_csv_meta(meta.get("related_owners", "")),
-                "distance": it["distance"],
-            }
+            _attach_match_fields(
+                {
+                    "entry_id": meta.get("entry_id", it["id"]),
+                    "kind": meta.get("kind", ""),
+                    "author": meta.get("author", ""),
+                    "title_summary": meta.get("title_summary", ""),
+                    "body_preview": meta.get("body_preview", ""),
+                    "created_at": meta.get("created_at", ""),
+                    "updated_at": meta.get("updated_at", ""),
+                    "origin_branch": meta.get("origin_branch", ""),
+                    "origin_session_id": meta.get("origin_session_id", ""),
+                    "audience": _split_csv_meta(meta.get("audience", "")),
+                    "related_topics": _split_csv_meta(meta.get("related_topics", "")),
+                    "related_owners": _split_csv_meta(meta.get("related_owners", "")),
+                    "distance": it["distance"],
+                },
+                it,
+            )
         )
     return formatted
+
+
+def _scope_result_key(scope: str) -> str:
+    return {
+        "files": "results",
+        "files-docs": "results",
+        "specs": "specResults",
+        "issues": "issueResults",
+        "memory": "memoryResults",
+        "discussions": "discussionResults",
+        "board": "boardResults",
+    }[scope]
+
+
+def _format_scope_results(
+    scope: str,
+    items: List[Dict[str, Any]],
+    n_results: int,
+) -> List[Dict[str, Any]]:
+    if scope in ("files", "files-docs"):
+        return _format_file_results(items)[:n_results]
+    if scope == "specs":
+        return _format_spec_results(items)[:n_results]
+    if scope == "memory":
+        return _format_memory_results(items, n_results)
+    if scope == "discussions":
+        return _format_discussion_results(items, n_results)
+    if scope == "board":
+        return _format_board_results(items)[:n_results]
+    return _format_issue_results(items)[:n_results]
 
 
 def action_search_v2(
@@ -3268,6 +3405,7 @@ def action_search_v2(
     n_results: int = 10,
     no_auto_build: bool = False,
     db_root: Optional[Path] = None,
+    match_mode: str = "semantic",
 ) -> dict:
     """Unified v2 search dispatcher with auto-build fallback."""
     scope_for_action = {
@@ -3366,24 +3504,19 @@ def action_search_v2(
     with acquire_lock(db_path, exclusive=False):
         client, collection = _open_chroma_collection(db_path, _scope_collection_name(scope))
         try:
-            # SPECs / Memory are chunked, so a single owner can span many
-            # Chroma records. Over-fetch by 5x then collapse in the formatter.
-            fetch_n = n_results * 5 if scope in ("specs", "memory", "discussions") else n_results
+            fetch_n = _search_fetch_count(scope, n_results, match_mode)
             items = _search_collection_v2(collection, query, fetch_n)
         finally:
             _close_chroma_client(client)
 
-    if scope in ("files", "files-docs"):
-        return {"ok": True, "results": _format_file_results(items)}
-    if scope == "specs":
-        return {"ok": True, "specResults": _format_spec_results(items)[:n_results]}
-    if scope == "memory":
-        return {"ok": True, "memoryResults": _format_memory_results(items, n_results)}
-    if scope == "discussions":
-        return {"ok": True, "discussionResults": _format_discussion_results(items, n_results)}
-    if scope == "board":
-        return {"ok": True, "boardResults": _format_board_results(items)[:n_results]}
-    return {"ok": True, "issueResults": _format_issue_results(items)}
+    strict_items, suggestion_items = _apply_match_mode(items, query, match_mode)
+    payload = {
+        "ok": True,
+        _scope_result_key(scope): _format_scope_results(scope, strict_items, n_results),
+    }
+    if match_mode == "all_terms":
+        payload["suggestions"] = _format_scope_results(scope, suggestion_items, n_results)
+    return payload
 
 
 def action_search_multi_v2(
@@ -3394,6 +3527,7 @@ def action_search_multi_v2(
     n_results: int,
     scopes: Sequence[str],
     db_root: Optional[Path] = None,
+    match_mode: str = "semantic",
 ) -> Dict[str, Any]:
     """Search multiple v2 scopes inside one Python process.
 
@@ -3428,12 +3562,15 @@ def action_search_multi_v2(
             n_results=n_results,
             no_auto_build=True,
             db_root=db_root,
+            match_mode=match_mode,
         )
         if not result.get("ok"):
             result["scope"] = scope
             return result
         for key, value in result.items():
-            if key != "ok":
+            if key == "suggestions":
+                payload.setdefault("suggestions", {})[scope] = value
+            elif key != "ok":
                 payload[key] = value
     return payload
 
@@ -3521,6 +3658,7 @@ def parse_args() -> argparse.Namespace:
         choices=["", "issues", "specs", "files", "files-docs", "memory", "discussions", "board"],
     )
     parser.add_argument("--scopes", default="")
+    parser.add_argument("--match-mode", default="semantic", choices=["semantic", "all_terms"])
     parser.add_argument("--mode", default="full", choices=["full", "incremental"])
     parser.add_argument("--no-auto-build", dest="no_auto_build", action="store_true")
     parser.add_argument("--respect-ttl", dest="respect_ttl", action="store_true")
@@ -3631,6 +3769,7 @@ def _dispatch_v2(action: str, args: argparse.Namespace) -> int:
                     query=args.query,
                     n_results=args.n_results,
                     scopes=scopes,
+                    match_mode=args.match_mode,
                 )
             )
             return 0
@@ -3656,6 +3795,7 @@ def _dispatch_v2(action: str, args: argparse.Namespace) -> int:
                     query=args.query,
                     n_results=args.n_results,
                     no_auto_build=args.no_auto_build,
+                    match_mode=args.match_mode,
                 )
             )
             return 0

--- a/crates/gwt-core/runtime/chroma_index_runner.py
+++ b/crates/gwt-core/runtime/chroma_index_runner.py
@@ -32,7 +32,7 @@ INDEX_PATH_POLICY_FILE = "index_path_policy.json"
 FALLBACK_INDEX_PATH_POLICY = {
     "schema_version": 1,
     "max_file_size": 1_048_576,
-    "allow_paths": ["tasks/memory.md"],
+    "allow_paths": ["tasks/memory.md", "tasks/discussions.md"],
     "deny_root_prefixes": [
         ".git",
         ".claude",
@@ -1098,7 +1098,7 @@ MANIFEST_FILENAME = "manifest.json"
 LOCK_FILENAME = ".lock"
 META_FILENAME = "meta.json"
 
-V2_SCOPES = ("issues", "specs", "memory", "board", "files", "files-docs")
+V2_SCOPES = ("issues", "specs", "memory", "discussions", "board", "files", "files-docs")
 WORKTREE_SCOPED = {"files", "files-docs"}
 
 V2_FILES_CODE_COLLECTION = "files_code"
@@ -1106,6 +1106,7 @@ V2_FILES_DOCS_COLLECTION = "files_docs"
 V2_SPECS_COLLECTION = "specs"
 V2_ISSUES_COLLECTION = "issues"
 V2_MEMORY_COLLECTION = "memory"
+V2_DISCUSSIONS_COLLECTION = "discussions"
 V2_BOARD_COLLECTION = "board"
 
 
@@ -1130,7 +1131,7 @@ def resolve_db_path(
     root = (db_root or gwt_index_root()).resolve()
     repo_dir = root / repo_hash
 
-    if scope in {"issues", "specs", "memory", "board"}:
+    if scope in {"issues", "specs", "memory", "discussions", "board"}:
         return repo_dir / scope
 
     return repo_dir / "worktrees" / worktree_hash / scope
@@ -1382,7 +1383,15 @@ def _manifest_path(worktree_dir: Path, scope: str) -> Path:
     (`.../worktrees/<wt>/files/`); both are normalized to the worktree
     level so writers and readers always agree on the location.
     """
-    if worktree_dir.name in ("specs", "files", "files-docs", "issues", "memory", "board"):
+    if worktree_dir.name in (
+        "specs",
+        "files",
+        "files-docs",
+        "issues",
+        "memory",
+        "discussions",
+        "board",
+    ):
         return worktree_dir.parent / f"manifest-{scope}.json"
     return worktree_dir / f"manifest-{scope}.json"
 
@@ -2235,6 +2244,233 @@ def action_index_memory_v2(
     return {"ok": True, "scope": "memory", "indexed": indexed}
 
 
+def _extract_discussion_field(body: str, field: str) -> str:
+    match = re.search(rf"(?m)^{re.escape(field)}:\s*(.*?)\s*$", body)
+    return match.group(1).strip() if match else ""
+
+
+def _split_discussion_csv(value: str) -> List[str]:
+    if not value:
+        return []
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def _parse_related_specs(value: str) -> List[str]:
+    specs: List[str] = []
+    for raw in _split_discussion_csv(value):
+        cleaned = raw.strip()
+        if cleaned.startswith("#"):
+            cleaned = cleaned[1:]
+        if cleaned.lower().startswith("spec-"):
+            cleaned = cleaned[5:]
+        if cleaned:
+            specs.append(cleaned)
+    return specs
+
+
+def _load_discussion_documents(
+    project_root: str,
+) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Load ``<project_root>/tasks/discussions.md`` into discussion chunks."""
+    root = Path(project_root)
+    source_path = root / "tasks" / "discussions.md"
+    if not source_path.is_file():
+        return [], []
+
+    try:
+        content = source_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return [], []
+
+    try:
+        stat = source_path.stat()
+    except OSError:
+        return [], []
+    manifest_entries = [
+        {
+            "path": "tasks/discussions.md",
+            "mtime": int(stat.st_mtime),
+            "size": int(stat.st_size),
+        }
+    ]
+
+    chunks = _chunk_spec_content(content)
+    if not chunks:
+        return [], manifest_entries
+
+    discussions: List[Dict[str, Any]] = []
+    grouped: Dict[tuple[str, str], int] = {}
+    for chunk in chunks:
+        heading = chunk["heading"]
+        body = chunk["body"]
+        if not heading.startswith("## "):
+            continue
+
+        date, title = _parse_memory_heading(heading)
+        key = (date, title)
+        chunk_idx = grouped.get(key, 0)
+        grouped[key] = chunk_idx + 1
+        digest_input = f"{heading}\n{body}".encode("utf-8")
+        discussion_id = hashlib.sha1(digest_input).hexdigest()[:12]
+        discussions.append(
+            {
+                "discussion_id": discussion_id,
+                "date": date,
+                "title": title,
+                "status": _extract_discussion_field(body, "Status"),
+                "topics": _split_discussion_csv(_extract_discussion_field(body, "Topics")),
+                "related_specs": _parse_related_specs(
+                    _extract_discussion_field(body, "Related SPECs")
+                ),
+                "related_works": _split_discussion_csv(
+                    _extract_discussion_field(body, "Related Works")
+                ),
+                "promoted_to": _split_discussion_csv(
+                    _extract_discussion_field(body, "Promoted To")
+                ),
+                "heading": heading,
+                "body": body,
+                "chunk_idx": chunk_idx,
+                "total_chunks": 0,
+            }
+        )
+
+    for entry in discussions:
+        key = (entry["date"], entry["title"])
+        entry["total_chunks"] = grouped[key]
+
+    return discussions, manifest_entries
+
+
+def _build_discussion_records(
+    discussions: Sequence[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Materialize Chroma upsert records for the discussions scope."""
+    records: List[Dict[str, Any]] = []
+    for entry in discussions:
+        title = entry.get("title", "")
+        heading = entry.get("heading", "")
+        body = entry.get("body", "")
+        document = f"{title}\n{heading}\n{body}".strip()
+        records.append(
+            {
+                "id": f"discussion-{entry.get('discussion_id', '')}",
+                "document": document,
+                "metadata": {
+                    "discussion_id": entry.get("discussion_id", ""),
+                    "date": entry.get("date", ""),
+                    "title": title,
+                    "status": entry.get("status", ""),
+                    "topics": ",".join(entry.get("topics", [])),
+                    "related_specs": ",".join(entry.get("related_specs", [])),
+                    "related_works": ",".join(entry.get("related_works", [])),
+                    "promoted_to": ",".join(entry.get("promoted_to", [])),
+                    "heading": heading,
+                    "chunk_idx": int(entry.get("chunk_idx", 0)),
+                    "total_chunks": int(entry.get("total_chunks", 1)),
+                },
+            }
+        )
+    return records
+
+
+def action_index_discussions_v2(
+    project_root: str,
+    repo_hash: str,
+    worktree_hash: Optional[str],
+    mode: str = "full",
+    db_root: Optional[Path] = None,
+) -> dict:
+    """Index ``tasks/discussions.md`` into the repo-scoped discussions store."""
+    del worktree_hash
+    db_path = resolve_db_path(repo_hash, None, "discussions", db_root=db_root)
+    discussions, new_entries = _load_discussion_documents(project_root)
+
+    emit_progress(
+        {
+            "phase": "indexing",
+            "scope": "discussions",
+            "mode": mode,
+            "done": 0,
+            "total": len(discussions),
+        }
+    )
+
+    indexed = 0
+    with acquire_lock(db_path, exclusive=True):
+        if mode != "incremental":
+            _reset_chroma_store(db_path)
+        make_collection = (
+            _make_chroma_collection
+            if mode == "incremental"
+            else _make_chroma_collection_repairing
+        )
+        client, collection = make_collection(db_path, V2_DISCUSSIONS_COLLECTION)
+        try:
+            old_entries = read_manifest(db_path, scope="discussions")
+            diff = compute_manifest_diff(old_entries, new_entries)
+            file_changed = bool(diff["added"] or diff["changed"] or diff["removed"])
+
+            if mode != "incremental" or file_changed:
+                try:
+                    existing = collection.get()
+                    if existing.get("ids"):
+                        collection.delete(ids=existing["ids"])
+                except Exception:
+                    pass
+                records = _build_discussion_records(discussions)
+            else:
+                records = []
+
+            emit_progress(
+                {
+                    "phase": "diff",
+                    "scope": "discussions",
+                    "added": len(diff["added"]),
+                    "changed": len(diff["changed"]),
+                    "removed": len(diff["removed"]),
+                }
+            )
+
+            if records:
+                ids = [r["id"] for r in records]
+                documents = [r["document"] for r in records]
+                metadatas = [r["metadata"] for r in records]
+                batch = 100
+                for i in range(0, len(ids), batch):
+                    collection.upsert(
+                        ids=ids[i : i + batch],
+                        documents=documents[i : i + batch],
+                        metadatas=metadatas[i : i + batch],
+                    )
+                indexed = len(records)
+
+            write_manifest(db_path, scope="discussions", entries=new_entries)
+            _write_scope_meta(
+                repo_hash=repo_hash,
+                worktree_hash=None,
+                scope="discussions",
+                db_root=db_root,
+                updates={
+                    "last_repair_at": _now_utc().isoformat(),
+                    "document_count": indexed,
+                },
+            )
+        finally:
+            _close_chroma_client(client)
+
+    emit_progress(
+        {
+            "phase": "complete",
+            "scope": "discussions",
+            "mode": mode,
+            "indexed": indexed,
+            "total": indexed,
+        }
+    )
+    return {"ok": True, "scope": "discussions", "indexed": indexed}
+
+
 def _gwt_home() -> Path:
     return Path(os.environ.get("HOME") or os.environ.get("USERPROFILE") or Path.home()) / ".gwt"
 
@@ -2480,6 +2716,40 @@ def _format_memory_results(
     return formatted
 
 
+def _format_discussion_results(
+    items: List[Dict[str, Any]], n_results: int = 10
+) -> List[Dict[str, Any]]:
+    """Collapse chunked discussion results so each dated title appears once."""
+    formatted: List[Dict[str, Any]] = []
+    seen: set = set()
+    for it in items:
+        meta = it.get("metadata") or {}
+        date = meta.get("date", "")
+        title = meta.get("title", "")
+        key = (date, title)
+        if key in seen:
+            continue
+        seen.add(key)
+        formatted.append(
+            {
+                "discussion_id": meta.get("discussion_id", it.get("id", "")),
+                "date": date,
+                "title": title,
+                "status": meta.get("status", ""),
+                "topics": _split_csv_meta(meta.get("topics", "")),
+                "related_specs": _split_csv_meta(meta.get("related_specs", "")),
+                "related_works": _split_csv_meta(meta.get("related_works", "")),
+                "promoted_to": _split_csv_meta(meta.get("promoted_to", "")),
+                "heading": meta.get("heading", ""),
+                "chunk_idx": int(meta.get("chunk_idx", 0)),
+                "distance": it.get("distance"),
+            }
+        )
+        if len(formatted) >= n_results:
+            break
+    return formatted
+
+
 def _build_spec_records(specs: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
     records: List[Dict[str, Any]] = []
     for spec in specs:
@@ -2551,6 +2821,8 @@ def _scope_meta_path(
         return resolve_db_path(repo_hash, None, "specs", db_root=db_root) / META_FILENAME
     if scope == "memory":
         return resolve_db_path(repo_hash, None, "memory", db_root=db_root) / META_FILENAME
+    if scope == "discussions":
+        return resolve_db_path(repo_hash, None, "discussions", db_root=db_root) / META_FILENAME
     if scope == "board":
         return resolve_db_path(repo_hash, None, "board", db_root=db_root) / META_FILENAME
     if scope in WORKTREE_SCOPED:
@@ -2623,6 +2895,7 @@ def _scope_collection_name(scope: str) -> str:
         "specs": V2_SPECS_COLLECTION,
         "issues": V2_ISSUES_COLLECTION,
         "memory": V2_MEMORY_COLLECTION,
+        "discussions": V2_DISCUSSIONS_COLLECTION,
         "board": V2_BOARD_COLLECTION,
     }[scope]
 
@@ -2695,11 +2968,11 @@ def _scope_status_v2(
         reason = "empty_collection"
         healthy = False
         repair_required = True
-    elif scope in ("specs", "memory", "board") and document_count < manifest_count:
+    elif scope in ("specs", "memory", "discussions", "board") and document_count < manifest_count:
         reason = "count_mismatch"
         healthy = False
         repair_required = True
-    elif scope not in ("specs", "memory", "board") and document_count != manifest_count:
+    elif scope not in ("specs", "memory", "discussions", "board") and document_count != manifest_count:
         reason = "empty_collection" if document_count == 0 and manifest_count > 0 else "count_mismatch"
         healthy = False
         repair_required = True
@@ -3003,6 +3276,7 @@ def action_search_v2(
         "search-specs": "specs",
         "search-issues": "issues",
         "search-memory": "memory",
+        "search-discussions": "discussions",
         "search-board": "board",
     }
     if action not in scope_for_action:
@@ -3061,6 +3335,14 @@ def action_search_v2(
                 mode="full",
                 db_root=db_root,
             )
+        elif scope == "discussions":
+            build = action_index_discussions_v2(
+                project_root=project_root,
+                repo_hash=repo_hash,
+                worktree_hash=None,
+                mode="full",
+                db_root=db_root,
+            )
         elif scope == "board":
             build = action_index_board_v2(
                 repo_hash=repo_hash,
@@ -3086,7 +3368,7 @@ def action_search_v2(
         try:
             # SPECs / Memory are chunked, so a single owner can span many
             # Chroma records. Over-fetch by 5x then collapse in the formatter.
-            fetch_n = n_results * 5 if scope in ("specs", "memory") else n_results
+            fetch_n = n_results * 5 if scope in ("specs", "memory", "discussions") else n_results
             items = _search_collection_v2(collection, query, fetch_n)
         finally:
             _close_chroma_client(client)
@@ -3097,6 +3379,8 @@ def action_search_v2(
         return {"ok": True, "specResults": _format_spec_results(items)[:n_results]}
     if scope == "memory":
         return {"ok": True, "memoryResults": _format_memory_results(items, n_results)}
+    if scope == "discussions":
+        return {"ok": True, "discussionResults": _format_discussion_results(items, n_results)}
     if scope == "board":
         return {"ok": True, "boardResults": _format_board_results(items)[:n_results]}
     return {"ok": True, "issueResults": _format_issue_results(items)}
@@ -3121,6 +3405,7 @@ def action_search_multi_v2(
         "issues": "search-issues",
         "specs": "search-specs",
         "memory": "search-memory",
+        "discussions": "search-discussions",
         "board": "search-board",
         "files": "search-files",
         "files-docs": "search-files-docs",
@@ -3181,6 +3466,7 @@ def action_status_v2(
         "issues": _issue_status_v2(repo_hash, db_root=db_root),
         "specs": _scope_status_v2(repo_hash, None, "specs", db_root=db_root),
         "memory": _scope_status_v2(repo_hash, None, "memory", db_root=db_root),
+        "discussions": _scope_status_v2(repo_hash, None, "discussions", db_root=db_root),
         "board": _scope_status_v2(repo_hash, None, "board", db_root=db_root),
     }
     if worktree_hash:
@@ -3215,6 +3501,8 @@ def parse_args() -> argparse.Namespace:
             "search-specs",
             "index-memory",
             "search-memory",
+            "index-discussions",
+            "search-discussions",
             "index-board",
             "search-board",
             "search-multi",
@@ -3230,7 +3518,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--scope",
         default="",
-        choices=["", "issues", "specs", "files", "files-docs", "memory", "board"],
+        choices=["", "issues", "specs", "files", "files-docs", "memory", "discussions", "board"],
     )
     parser.add_argument("--scopes", default="")
     parser.add_argument("--mode", default="full", choices=["full", "incremental"])
@@ -3306,6 +3594,20 @@ def _dispatch_v2(action: str, args: argparse.Namespace) -> int:
             )
             return 0
 
+        if action == "index-discussions":
+            if not args.project_root:
+                emit({"ok": False, "error_code": "BAD_ARGS", "error": "--project-root is required"})
+                return 2
+            emit(
+                action_index_discussions_v2(
+                    project_root=args.project_root,
+                    repo_hash=repo_hash,
+                    worktree_hash=None,
+                    mode=args.mode,
+                )
+            )
+            return 0
+
         if action == "index-board":
             emit(
                 action_index_board_v2(
@@ -3339,6 +3641,7 @@ def _dispatch_v2(action: str, args: argparse.Namespace) -> int:
             "search-specs",
             "search-issues",
             "search-memory",
+            "search-discussions",
             "search-board",
         ):
             if not args.query:

--- a/crates/gwt-core/runtime/index_path_policy.json
+++ b/crates/gwt-core/runtime/index_path_policy.json
@@ -2,7 +2,8 @@
   "schema_version": 1,
   "max_file_size": 1048576,
   "allow_paths": [
-    "tasks/memory.md"
+    "tasks/memory.md",
+    "tasks/discussions.md"
   ],
   "deny_root_prefixes": [
     ".git",

--- a/crates/gwt-core/runtime/tests/test_discussion_indexer.py
+++ b/crates/gwt-core/runtime/tests/test_discussion_indexer.py
@@ -1,0 +1,181 @@
+"""Tests for the discussions semantic index scope.
+
+Discussion entries live in `tasks/discussions.md` as H2 sections with the
+canonical shape:
+
+    ## YYYY-MM-DD — title
+    Status: active
+    Topics: workspace, work
+    Related SPECs: #2359
+
+    Summary:
+    ...
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import chroma_index_runner as runner
+
+
+SAMPLE_DISCUSSIONS = """# Discussions
+
+## 2026-05-22 — Workspace terminology
+
+Status: active
+Topics: workspace, work, discussion
+Related SPECs: #2359
+Related Works:
+Promoted To:
+
+Summary:
+Workspace is being split into Project State, Work, Agent, Discussion, and Branch.
+
+Decisions:
+- Discussion is not Work.
+- Work is durable.
+
+Open Questions:
+- Topic Stack persistence.
+
+Next:
+Define Project State migration.
+
+## 2026-05-21 — Agent title labels
+
+Status: completed
+Topics: agent, title
+Related SPECs: #2359
+
+Summary:
+Agent role badges should show Codex or Claude Code.
+"""
+
+
+class LoadDiscussionDocumentsTests(unittest.TestCase):
+    def _write_discussions_file(self, contents: str) -> Path:
+        root = Path(tempfile.mkdtemp())
+        tasks = root / "tasks"
+        tasks.mkdir(parents=True, exist_ok=True)
+        (tasks / "discussions.md").write_text(contents, encoding="utf-8")
+        return root
+
+    def test_returns_chunks_for_each_h2_section(self):
+        root = self._write_discussions_file(SAMPLE_DISCUSSIONS)
+        discussions, manifest = runner._load_discussion_documents(str(root))
+
+        self.assertEqual(len(discussions), 2)
+        self.assertEqual(len(manifest), 1)
+        self.assertEqual(manifest[0]["path"], "tasks/discussions.md")
+
+    def test_extracts_status_topics_and_related_specs(self):
+        root = self._write_discussions_file(SAMPLE_DISCUSSIONS)
+        discussions, _manifest = runner._load_discussion_documents(str(root))
+        first = discussions[0]
+
+        self.assertEqual(first["date"], "2026-05-22")
+        self.assertEqual(first["title"], "Workspace terminology")
+        self.assertEqual(first["status"], "active")
+        self.assertEqual(first["topics"], ["workspace", "work", "discussion"])
+        self.assertEqual(first["related_specs"], ["2359"])
+
+
+class BuildDiscussionRecordsTests(unittest.TestCase):
+    def test_returns_chroma_records_with_metadata(self):
+        discussions = [
+            {
+                "discussion_id": "abc123def456",
+                "date": "2026-05-22",
+                "title": "Workspace terminology",
+                "status": "active",
+                "topics": ["workspace", "work"],
+                "related_specs": ["2359"],
+                "heading": "## 2026-05-22 — Workspace terminology",
+                "body": "Summary:\nWorkspace is being split.",
+                "chunk_idx": 0,
+                "total_chunks": 1,
+            }
+        ]
+
+        records = runner._build_discussion_records(discussions)
+
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["id"], "discussion-abc123def456")
+        self.assertIn("Workspace terminology", records[0]["document"])
+        meta = records[0]["metadata"]
+        self.assertEqual(meta["status"], "active")
+        self.assertEqual(meta["topics"], "workspace,work")
+        self.assertEqual(meta["related_specs"], "2359")
+
+
+class ActionIndexDiscussionsTests(unittest.TestCase):
+    def test_full_mode_writes_manifest_and_chunks(self):
+        with tempfile.TemporaryDirectory() as wt, tempfile.TemporaryDirectory() as db_root_dir:
+            root = Path(wt)
+            tasks = root / "tasks"
+            tasks.mkdir(parents=True, exist_ok=True)
+            (tasks / "discussions.md").write_text(SAMPLE_DISCUSSIONS, encoding="utf-8")
+            collection = _FakeCollection()
+
+            with mock.patch.object(
+                runner,
+                "_make_chroma_collection_repairing",
+                return_value=(_FakeClient(), collection),
+            ), mock.patch.object(runner, "_close_chroma_client"):
+                result = runner.action_index_discussions_v2(
+                    project_root=str(root),
+                    repo_hash="abc1234567890def",
+                    worktree_hash=None,
+                    mode="full",
+                    db_root=Path(db_root_dir),
+                )
+
+            self.assertTrue(result.get("ok"), result)
+            self.assertEqual(result["scope"], "discussions")
+            self.assertGreaterEqual(result["indexed"], 2)
+            self.assertEqual(len(collection.upserts), 1)
+
+            db_path = runner.resolve_db_path(
+                "abc1234567890def", None, "discussions", db_root=Path(db_root_dir)
+            )
+            manifest_file = runner._manifest_path(db_path, "discussions")
+            self.assertTrue(manifest_file.is_file(), f"missing manifest at {manifest_file}")
+            manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+            entries = manifest.get("entries") if isinstance(manifest, dict) else manifest
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0]["path"], "tasks/discussions.md")
+
+
+class _FakeClient:
+    pass
+
+
+class _FakeCollection:
+    def __init__(self) -> None:
+        self.ids = []
+        self.upserts = []
+
+    def get(self):
+        return {"ids": list(self.ids)}
+
+    def delete(self, ids):
+        self.ids = [existing for existing in self.ids if existing not in ids]
+
+    def upsert(self, ids, documents, metadatas):
+        self.ids.extend(ids)
+        self.upserts.append(
+            {
+                "ids": ids,
+                "documents": documents,
+                "metadatas": metadatas,
+            }
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/crates/gwt-core/runtime/tests/test_discussion_indexer.py
+++ b/crates/gwt-core/runtime/tests/test_discussion_indexer.py
@@ -83,6 +83,8 @@ class LoadDiscussionDocumentsTests(unittest.TestCase):
         self.assertEqual(first["status"], "active")
         self.assertEqual(first["topics"], ["workspace", "work", "discussion"])
         self.assertEqual(first["related_specs"], ["2359"])
+        self.assertEqual(first["related_works"], [])
+        self.assertEqual(first["promoted_to"], [])
 
 
 class BuildDiscussionRecordsTests(unittest.TestCase):

--- a/crates/gwt-core/runtime/tests/test_search_match_mode.py
+++ b/crates/gwt-core/runtime/tests/test_search_match_mode.py
@@ -1,0 +1,77 @@
+"""SPEC-1939 Phase 17: Index search match modes."""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+import chroma_index_runner as runner
+
+
+class SearchMatchModeTests(unittest.TestCase):
+    def test_parse_required_terms_preserves_quoted_phrases_and_no_space_japanese(self):
+        self.assertEqual(
+            runner._parse_required_terms('Workspace "Project State" 移行'),
+            ["Workspace", "Project State", "移行"],
+        )
+        self.assertEqual(
+            runner._parse_required_terms("Workspace置き換え"),
+            ["Workspace置き換え"],
+        )
+
+    def test_all_terms_split_keeps_strict_results_separate_from_suggestions(self):
+        items = [
+            {
+                "id": "strict",
+                "document": "Workspace terminology replacement keeps 置き換え history.",
+                "metadata": {"title": "Workspace 置き換え"},
+                "distance": 0.1,
+            },
+            {
+                "id": "suggestion",
+                "document": "Workspace terminology only.",
+                "metadata": {"title": "Workspace"},
+                "distance": 0.2,
+            },
+        ]
+
+        strict, suggestions = runner._apply_match_mode(
+            items,
+            query="Workspace 置き換え",
+            match_mode="all_terms",
+        )
+
+        self.assertEqual([item["id"] for item in strict], ["strict"])
+        self.assertEqual([item["id"] for item in suggestions], ["suggestion"])
+        self.assertEqual(strict[0]["matched_terms"], ["Workspace", "置き換え"])
+        self.assertEqual(strict[0]["missing_terms"], [])
+        self.assertEqual(suggestions[0]["matched_terms"], ["Workspace"])
+        self.assertEqual(suggestions[0]["missing_terms"], ["置き換え"])
+
+    def test_search_multi_returns_suggestions_by_scope(self):
+        with mock.patch.object(
+            runner,
+            "action_search_v2",
+            return_value={
+                "ok": True,
+                "issueResults": [],
+                "suggestions": [{"number": 1, "title": "Workspace only"}],
+            },
+        ) as action:
+            result = runner.action_search_multi_v2(
+                repo_hash="repo",
+                worktree_hash=None,
+                project_root="/repo",
+                query="Workspace 置き換え",
+                n_results=10,
+                scopes=["issues"],
+                match_mode="all_terms",
+            )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["suggestions"]["issues"][0]["title"], "Workspace only")
+        self.assertEqual(action.call_args.kwargs["match_mode"], "all_terms")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/crates/gwt-core/src/index/paths.rs
+++ b/crates/gwt-core/src/index/paths.rs
@@ -17,6 +17,10 @@
 //!     chroma.sqlite3
 //!     .lock
 //!     manifest.json
+//!   discussions/
+//!     chroma.sqlite3
+//!     .lock
+//!     manifest.json
 //!   worktrees/
 //!     <wt-hash>/
 //!       meta.json
@@ -44,6 +48,8 @@ pub enum Scope {
     Specs,
     /// Repo-scoped: post-mortem fix knowledge sourced from `tasks/memory.md`.
     Memory,
+    /// Repo-scoped: discussion knowledge sourced from `tasks/discussions.md`.
+    Discussions,
     /// Worktree-scoped: project source code files.
     FilesCode,
     /// Worktree-scoped: project documentation files.
@@ -61,6 +67,7 @@ impl Scope {
             Scope::Issues => "issues",
             Scope::Specs => "specs",
             Scope::Memory => "memory",
+            Scope::Discussions => "discussions",
             Scope::FilesCode => "files",
             Scope::FilesDocs => "files-docs",
         }
@@ -94,7 +101,10 @@ pub fn gwt_index_db_path(
     worktree: Option<&WorktreeHash>,
     scope: Scope,
 ) -> Result<PathBuf> {
-    if matches!(scope, Scope::Issues | Scope::Specs | Scope::Memory) {
+    if matches!(
+        scope,
+        Scope::Issues | Scope::Specs | Scope::Memory | Scope::Discussions
+    ) {
         return Ok(gwt_index_repo_dir(repo).join(scope.subdir()));
     }
     let wt = worktree.ok_or_else(|| {
@@ -170,5 +180,17 @@ mod tests {
         assert!(!with_wt
             .components()
             .any(|component| component.as_os_str() == "worktrees"));
+    }
+
+    #[test]
+    fn discussions_scope_is_repo_scoped() {
+        let repo = compute_repo_hash("https://github.com/akiojin/gwt.git");
+        let tmp = tempfile::tempdir().unwrap();
+        let wt = compute_worktree_hash(tmp.path()).unwrap();
+        let with_wt = gwt_index_db_path(&repo, Some(&wt), Scope::Discussions).unwrap();
+        let without_wt = gwt_index_db_path(&repo, None, Scope::Discussions).unwrap();
+        assert_eq!(with_wt, without_wt);
+        assert!(with_wt.ends_with(format!("{}/discussions", repo.as_str())));
+        assert!(!Scope::Discussions.requires_worktree());
     }
 }

--- a/crates/gwt-core/src/paths.rs
+++ b/crates/gwt-core/src/paths.rs
@@ -72,24 +72,52 @@ pub fn gwt_project_dir_for_repo_path(repo_path: &Path) -> PathBuf {
     gwt_project_dir(&repo_hash)
 }
 
+/// Return the Project State current projection path for a repository hash.
+pub fn gwt_project_state_projection_path(repo_hash: &RepoHash) -> PathBuf {
+    gwt_project_dir(repo_hash).join("project-state/current.json")
+}
+
+/// Return the Project State summary journal path for a repository hash.
+pub fn gwt_project_state_journal_path(repo_hash: &RepoHash) -> PathBuf {
+    gwt_project_dir(repo_hash).join("project-state/journal.jsonl")
+}
+
+/// Return the Project State Work hot projection path for a repository hash.
+pub fn gwt_project_state_works_path(repo_hash: &RepoHash) -> PathBuf {
+    gwt_project_dir(repo_hash).join("project-state/works.json")
+}
+
+/// Return the Project State Work event log path for a repository hash.
+pub fn gwt_project_state_work_events_path(repo_hash: &RepoHash) -> PathBuf {
+    gwt_project_dir(repo_hash).join("project-state/work-events.jsonl")
+}
+
 /// Return the Workspace current projection path for a repository hash.
+///
+/// This compatibility function now points at the Project State storage root.
 pub fn gwt_workspace_projection_path(repo_hash: &RepoHash) -> PathBuf {
-    gwt_project_dir(repo_hash).join("workspace/current.json")
+    gwt_project_state_projection_path(repo_hash)
 }
 
 /// Return the Workspace summary journal path for a repository hash.
+///
+/// This compatibility function now points at the Project State storage root.
 pub fn gwt_workspace_journal_path(repo_hash: &RepoHash) -> PathBuf {
-    gwt_project_dir(repo_hash).join("workspace/journal.jsonl")
+    gwt_project_state_journal_path(repo_hash)
 }
 
 /// Return the Workspace WorkItem hot projection path for a repository hash.
+///
+/// This compatibility function now points at `project-state/works.json`.
 pub fn gwt_workspace_work_items_path(repo_hash: &RepoHash) -> PathBuf {
-    gwt_project_dir(repo_hash).join("workspace/work_items.json")
+    gwt_project_state_works_path(repo_hash)
 }
 
 /// Return the Workspace WorkItem event log path for a repository hash.
+///
+/// This compatibility function now points at `project-state/work-events.jsonl`.
 pub fn gwt_workspace_work_events_path(repo_hash: &RepoHash) -> PathBuf {
-    gwt_project_dir(repo_hash).join("workspace/work_events.jsonl")
+    gwt_project_state_work_events_path(repo_hash)
 }
 
 /// Return the Workspace current projection path for a repository path.

--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -12,8 +12,9 @@ use crate::{
     coordination::{BoardEntry, BoardEntryKind},
     error::{GwtError, Result},
     paths::{
-        gwt_workspace_journal_path_for_repo_path, gwt_workspace_projection_path_for_repo_path,
-        gwt_workspace_work_events_path_for_repo_path, gwt_workspace_work_items_path_for_repo_path,
+        gwt_project_dir_for_repo_path, gwt_workspace_journal_path_for_repo_path,
+        gwt_workspace_projection_path_for_repo_path, gwt_workspace_work_events_path_for_repo_path,
+        gwt_workspace_work_items_path_for_repo_path,
     },
 };
 
@@ -964,8 +965,76 @@ fn coordination_scope_for_entry(entry: &BoardEntry) -> Option<String> {
     }
 }
 
+fn legacy_workspace_projection_path_for_repo_path(repo_path: &Path) -> PathBuf {
+    gwt_project_dir_for_repo_path(repo_path).join("workspace/current.json")
+}
+
+fn legacy_workspace_journal_path_for_repo_path(repo_path: &Path) -> PathBuf {
+    gwt_project_dir_for_repo_path(repo_path).join("workspace/journal.jsonl")
+}
+
+fn legacy_workspace_work_items_path_for_repo_path(repo_path: &Path) -> PathBuf {
+    gwt_project_dir_for_repo_path(repo_path).join("workspace/work_items.json")
+}
+
+fn legacy_workspace_work_events_path_for_repo_path(repo_path: &Path) -> PathBuf {
+    gwt_project_dir_for_repo_path(repo_path).join("workspace/work_events.jsonl")
+}
+
+fn copy_legacy_workspace_file_if_needed(legacy_path: &Path, canonical_path: &Path) -> Result<()> {
+    if canonical_path.exists() || legacy_path == canonical_path || !legacy_path.is_file() {
+        return Ok(());
+    }
+    if let Some(parent) = canonical_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::copy(legacy_path, canonical_path)?;
+    Ok(())
+}
+
+fn migrate_legacy_workspace_projection(
+    repo_path: &Path,
+    canonical_path: &Path,
+) -> Result<Option<WorkspaceProjection>> {
+    if canonical_path.exists() {
+        return load_workspace_projection_from_path(canonical_path);
+    }
+
+    let legacy_path = legacy_workspace_projection_path_for_repo_path(repo_path);
+    if legacy_path == canonical_path {
+        return load_workspace_projection_from_path(canonical_path);
+    }
+    let Some(projection) = load_workspace_projection_from_path(&legacy_path)? else {
+        return Ok(None);
+    };
+    save_workspace_projection_to_path(canonical_path, &projection)?;
+    Ok(Some(projection))
+}
+
+fn migrate_legacy_workspace_work_items(
+    repo_path: &Path,
+    canonical_path: &Path,
+) -> Result<Option<WorkspaceWorkItemsProjection>> {
+    if let Some(projection) = load_workspace_work_items_from_path(canonical_path)? {
+        return Ok(Some(projection));
+    }
+    let legacy_path = legacy_workspace_work_items_path_for_repo_path(repo_path);
+    if legacy_path == canonical_path {
+        return load_workspace_work_items_from_path(canonical_path);
+    }
+    let Some(projection) = load_workspace_work_items_from_path(&legacy_path)? else {
+        return Ok(None);
+    };
+    save_workspace_work_items_projection_to_path(canonical_path, &projection)?;
+    Ok(Some(projection))
+}
+
 pub fn load_workspace_projection(repo_path: &Path) -> Result<Option<WorkspaceProjection>> {
-    load_workspace_projection_from_path(&gwt_workspace_projection_path_for_repo_path(repo_path))
+    let path = gwt_workspace_projection_path_for_repo_path(repo_path);
+    if let Some(projection) = load_workspace_projection_from_path(&path)? {
+        return Ok(Some(projection));
+    }
+    migrate_legacy_workspace_projection(repo_path, &path)
 }
 
 /// SPEC-2359 FR-094 / FR-097 / FR-098 / FR-099: resolve the currently
@@ -1013,10 +1082,8 @@ pub fn resolve_workspace_id_for_mention(
 }
 
 pub fn load_or_default_workspace_projection(repo_path: &Path) -> Result<WorkspaceProjection> {
-    load_or_default_workspace_projection_from_path(
-        &gwt_workspace_projection_path_for_repo_path(repo_path),
-        repo_path,
-    )
+    Ok(load_workspace_projection(repo_path)?
+        .unwrap_or_else(|| WorkspaceProjection::default_for_project(repo_path)))
 }
 
 pub fn save_workspace_projection(repo_path: &Path, projection: &WorkspaceProjection) -> Result<()> {
@@ -1030,9 +1097,16 @@ pub fn update_workspace_projection_with_journal(
     repo_path: &Path,
     update: WorkspaceProjectionUpdate,
 ) -> Result<WorkspaceJournalEntry> {
+    let current_path = gwt_workspace_projection_path_for_repo_path(repo_path);
+    let journal_path = gwt_workspace_journal_path_for_repo_path(repo_path);
+    let _ = migrate_legacy_workspace_projection(repo_path, &current_path)?;
+    copy_legacy_workspace_file_if_needed(
+        &legacy_workspace_journal_path_for_repo_path(repo_path),
+        &journal_path,
+    )?;
     let entry = update_workspace_projection_with_journal_paths(
-        &gwt_workspace_projection_path_for_repo_path(repo_path),
-        &gwt_workspace_journal_path_for_repo_path(repo_path),
+        &current_path,
+        &journal_path,
         repo_path,
         update,
     )?;
@@ -1048,13 +1122,9 @@ pub fn mark_workspace_agent_stopped(
     session_id: &str,
     window_id: Option<&str>,
 ) -> Result<bool> {
-    mark_workspace_agent_stopped_at(
-        &gwt_workspace_projection_path_for_repo_path(repo_path),
-        repo_path,
-        session_id,
-        window_id,
-        Utc::now(),
-    )
+    let current_path = gwt_workspace_projection_path_for_repo_path(repo_path);
+    let _ = migrate_legacy_workspace_projection(repo_path, &current_path)?;
+    mark_workspace_agent_stopped_at(&current_path, repo_path, session_id, window_id, Utc::now())
 }
 
 pub fn load_workspace_projection_from_path(path: &Path) -> Result<Option<WorkspaceProjection>> {
@@ -1068,7 +1138,10 @@ pub fn load_workspace_projection_from_path(path: &Path) -> Result<Option<Workspa
 }
 
 pub fn load_workspace_work_items(repo_path: &Path) -> Result<Option<WorkspaceWorkItemsProjection>> {
-    load_workspace_work_items_from_path(&gwt_workspace_work_items_path_for_repo_path(repo_path))
+    migrate_legacy_workspace_work_items(
+        repo_path,
+        &gwt_workspace_work_items_path_for_repo_path(repo_path),
+    )
 }
 
 pub fn load_workspace_work_items_from_path(
@@ -1086,10 +1159,19 @@ pub fn load_workspace_work_items_from_path(
 pub fn load_or_synthesize_workspace_work_items(
     repo_path: &Path,
 ) -> Result<WorkspaceWorkItemsProjection> {
+    let current_path = gwt_workspace_projection_path_for_repo_path(repo_path);
+    let journal_path = gwt_workspace_journal_path_for_repo_path(repo_path);
+    let work_items_path = gwt_workspace_work_items_path_for_repo_path(repo_path);
+    let _ = migrate_legacy_workspace_projection(repo_path, &current_path)?;
+    copy_legacy_workspace_file_if_needed(
+        &legacy_workspace_journal_path_for_repo_path(repo_path),
+        &journal_path,
+    )?;
+    let _ = migrate_legacy_workspace_work_items(repo_path, &work_items_path)?;
     load_or_synthesize_workspace_work_items_from_paths(
-        &gwt_workspace_work_items_path_for_repo_path(repo_path),
-        &gwt_workspace_projection_path_for_repo_path(repo_path),
-        &gwt_workspace_journal_path_for_repo_path(repo_path),
+        &work_items_path,
+        &current_path,
+        &journal_path,
         repo_path,
     )
 }
@@ -1116,11 +1198,14 @@ pub fn save_workspace_work_items_projection_to_path(
 }
 
 pub fn record_workspace_work_event(repo_path: &Path, event: WorkspaceWorkEvent) -> Result<()> {
-    record_workspace_work_event_paths(
-        &gwt_workspace_work_items_path_for_repo_path(repo_path),
-        &gwt_workspace_work_events_path_for_repo_path(repo_path),
-        event,
-    )
+    let work_items_path = gwt_workspace_work_items_path_for_repo_path(repo_path);
+    let events_path = gwt_workspace_work_events_path_for_repo_path(repo_path);
+    let _ = migrate_legacy_workspace_work_items(repo_path, &work_items_path)?;
+    copy_legacy_workspace_file_if_needed(
+        &legacy_workspace_work_events_path_for_repo_path(repo_path),
+        &events_path,
+    )?;
+    record_workspace_work_event_paths(&work_items_path, &events_path, event)
 }
 
 pub fn record_workspace_work_event_paths(
@@ -1330,6 +1415,11 @@ pub fn rebuild_work_items_from_events_for_repo(
 ) -> Result<WorkspaceWorkItemsRebuildOutcome> {
     let work_items_path = gwt_workspace_work_items_path_for_repo_path(repo_path);
     let events_path = gwt_workspace_work_events_path_for_repo_path(repo_path);
+    let _ = migrate_legacy_workspace_work_items(repo_path, &work_items_path)?;
+    copy_legacy_workspace_file_if_needed(
+        &legacy_workspace_work_events_path_for_repo_path(repo_path),
+        &events_path,
+    )?;
     let marker_path = work_items_path
         .parent()
         .map(|dir| dir.join("work_items.migration.json"))
@@ -1366,12 +1456,16 @@ fn write_rebuild_marker(path: &Path) -> Result<()> {
 /// current, work_items, and work_events paths from `repo_path` and invoking
 /// [`retroactive_auto_done_scan_paths`].
 pub fn retroactive_auto_done_scan(repo_path: &Path, now: DateTime<Utc>) -> Result<usize> {
-    retroactive_auto_done_scan_paths(
-        &gwt_workspace_projection_path_for_repo_path(repo_path),
-        &gwt_workspace_work_items_path_for_repo_path(repo_path),
-        &gwt_workspace_work_events_path_for_repo_path(repo_path),
-        now,
-    )
+    let current_path = gwt_workspace_projection_path_for_repo_path(repo_path);
+    let work_items_path = gwt_workspace_work_items_path_for_repo_path(repo_path);
+    let events_path = gwt_workspace_work_events_path_for_repo_path(repo_path);
+    let _ = migrate_legacy_workspace_projection(repo_path, &current_path)?;
+    let _ = migrate_legacy_workspace_work_items(repo_path, &work_items_path)?;
+    copy_legacy_workspace_file_if_needed(
+        &legacy_workspace_work_events_path_for_repo_path(repo_path),
+        &events_path,
+    )?;
+    retroactive_auto_done_scan_paths(&current_path, &work_items_path, &events_path, now)
 }
 
 fn work_item_is_eligible_for_auto_done(item: &WorkspaceWorkItem) -> bool {
@@ -2088,11 +2182,16 @@ where
         if !project_dir.is_dir() {
             continue;
         }
-        let workspace_dir = project_dir.join("workspace");
-        let current_json = workspace_dir.join("current.json");
-        if !current_json.is_file() {
+        let state_dir = project_dir.join("project-state");
+        let legacy_dir = project_dir.join("workspace");
+        let workspace_dir = if state_dir.join("current.json").is_file() {
+            state_dir
+        } else if legacy_dir.join("current.json").is_file() {
+            legacy_dir
+        } else {
             continue;
-        }
+        };
+        let current_json = workspace_dir.join("current.json");
         let projection = match load_workspace_projection_from_path(&current_json) {
             Ok(Some(p)) => p,
             _ => continue,

--- a/crates/gwt-core/tests/index_path_policy.rs
+++ b/crates/gwt-core/tests/index_path_policy.rs
@@ -59,7 +59,7 @@ fn index_path_policy_ignores_global_gitignore_files() {
 }
 
 #[test]
-fn index_path_policy_allowlists_memory_only_under_tasks() {
+fn index_path_policy_allowlists_shared_knowledge_files_only_under_tasks() {
     let dir = tempdir().expect("tempdir");
     let tasks = dir.path().join("tasks");
     fs::create_dir_all(&tasks).expect("create tasks");
@@ -68,6 +68,7 @@ fn index_path_policy_allowlists_memory_only_under_tasks() {
     let matcher = build_project_ignore_matcher(dir.path());
 
     assert!(policy.is_indexable_path(&matcher, dir.path(), &tasks.join("memory.md")));
+    assert!(policy.is_indexable_path(&matcher, dir.path(), &tasks.join("discussions.md")));
     assert!(!policy.is_indexable_path(&matcher, dir.path(), &tasks.join("todo.md")));
     assert!(!policy.is_indexable_path(&matcher, dir.path(), &tasks.join("spec-1939/notes.md")));
 }

--- a/crates/gwt-core/tests/workspace_projection.rs
+++ b/crates/gwt-core/tests/workspace_projection.rs
@@ -2,7 +2,10 @@ use std::path::{Path, PathBuf};
 
 use chrono::{TimeZone, Utc};
 use gwt_core::{
-    paths::gwt_workspace_projection_path,
+    paths::{
+        gwt_project_state_projection_path, gwt_workspace_projection_path,
+        gwt_workspace_projection_path_for_repo_path,
+    },
     repo_hash::compute_repo_hash,
     workspace_projection::{
         load_or_default_workspace_projection_from_path, load_workspace_projection_from_path,
@@ -10,6 +13,13 @@ use gwt_core::{
         WorkspaceAgentSummary, WorkspaceProjection, WorkspaceStatusCategory,
     },
 };
+
+fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+        .lock()
+        .expect("env lock")
+}
 
 fn projection(project_root: &Path) -> WorkspaceProjection {
     WorkspaceProjection {
@@ -381,7 +391,50 @@ fn workspace_projection_path_is_project_scoped() {
 
     let path = gwt_workspace_projection_path(&repo_hash);
 
-    assert!(path.ends_with(PathBuf::from(repo_hash.as_str()).join("workspace/current.json")));
+    assert!(path.ends_with(PathBuf::from(repo_hash.as_str()).join("project-state/current.json")));
+    assert_eq!(path, gwt_project_state_projection_path(&repo_hash));
+}
+
+#[test]
+fn workspace_projection_repo_path_migrates_legacy_workspace_current_json() {
+    let temp_home = tempfile::tempdir().expect("home");
+    let repo = tempfile::tempdir().expect("repo");
+    let _guard = env_lock();
+    let original_home = std::env::var_os("HOME");
+    std::env::set_var("HOME", temp_home.path());
+
+    let legacy_path =
+        gwt_core::paths::gwt_project_dir_for_repo_path(repo.path()).join("workspace/current.json");
+    save_workspace_projection_to_path(&legacy_path, &projection(repo.path()))
+        .expect("save legacy projection");
+    let new_path = gwt_workspace_projection_path_for_repo_path(repo.path());
+    assert!(
+        new_path.ends_with("project-state/current.json"),
+        "new canonical path must be project-state/current.json"
+    );
+    assert!(
+        !new_path.exists(),
+        "test precondition: canonical project-state file should not exist"
+    );
+
+    let loaded = gwt_core::workspace_projection::load_workspace_projection(repo.path())
+        .expect("migrate")
+        .expect("migrated projection");
+
+    assert_eq!(loaded.title, "Start payment cleanup");
+    assert!(
+        new_path.is_file(),
+        "load must materialize migrated project-state file"
+    );
+    assert!(
+        legacy_path.is_file(),
+        "legacy workspace/current.json remains for non-destructive migration"
+    );
+
+    match original_home {
+        Some(value) => std::env::set_var("HOME", value),
+        None => std::env::remove_var("HOME"),
+    }
 }
 
 #[test]

--- a/crates/gwt/playwright/tests/index-status.spec.ts
+++ b/crates/gwt/playwright/tests/index-status.spec.ts
@@ -372,6 +372,97 @@ test.describe("Project Index status surface", () => {
     await expect(animatedDot).toHaveCSS("animation-name", /index-search-loading/);
   });
 
+  test("Index window Search all-terms mode separates strict results and suggestions", async ({
+    page,
+  }) => {
+    await installEmbeddedRoutes(page);
+    await installIndexStatusBackend(page, {
+      state: "ready",
+      scopes: {
+        specs: { healthy: true, repair_required: false, document_count: 774 },
+        discussions: { healthy: true, repair_required: false, document_count: 91 },
+      },
+      worktrees: {},
+    });
+
+    await page.goto(APP_URL);
+    const { root } = await openIndexSearchPanel(page);
+    await root.locator("[data-match-mode='all_terms']").click();
+    await root.locator(".index-search-input").fill("Workspace volatile");
+    await root.locator(".index-run-button").click();
+
+    const request = await page.waitForFunction(() => {
+      const sends = (window.__gwtFixtureWebSocket && window.__gwtFixtureWebSocket.recordedSends) || [];
+      return sends
+        .map((raw) => {
+          try {
+            return JSON.parse(raw);
+          } catch (e) {
+            return null;
+          }
+        })
+        .filter((m) => m && m.kind === "search_project_index")
+        .pop();
+    });
+    const requestPayload = await request.jsonValue();
+    expect(requestPayload).toMatchObject({
+      kind: "search_project_index",
+      match_mode: "all_terms",
+      query: "Workspace volatile",
+    });
+
+    await page.evaluate((payload) => {
+      window.__gwtFixtureWebSocket.emit(payload);
+    }, {
+      kind: "project_index_search_results",
+      project_root: "/fixture",
+      id: requestPayload.id,
+      request_id: requestPayload.request_id,
+      query: requestPayload.query,
+      scope: "all",
+      results: [
+        {
+          scope: "specs",
+          title: "Workspace volatility decision",
+          subtitle: "SPEC #1939",
+          preview: "Workspace is current state; Work is durable.",
+          distance: 0.08,
+          match_mode: "all_terms",
+          matched_terms: ["Workspace", "volatile"],
+          missing_terms: [],
+        },
+      ],
+      suggestions: [
+        {
+          scope: "discussions",
+          title: "Workspace naming discussion",
+          subtitle: "discussion",
+          preview: "Workspace was confusing and Work may be a better durable unit.",
+          distance: 0.18,
+          match_mode: "all_terms",
+          matched_terms: ["Workspace"],
+          missing_terms: ["volatile"],
+        },
+      ],
+    });
+
+    await expect(root.locator(".index-search-status")).toContainText(
+      "1 strict results · 1 semantic suggestions",
+    );
+    await expect(root.locator(".index-result-group-label").first()).toContainText("Strict results");
+    await expect(root.locator(".index-result-row").first()).toContainText(
+      "Workspace volatility decision",
+    );
+    await expect(root.locator(".index-result-row.is-suggestion")).toContainText(
+      "Workspace naming discussion",
+    );
+    await expect(root.locator(".index-result-row.is-suggestion")).toContainText(
+      "Matched: Workspace",
+    );
+    await root.locator(".index-result-row.is-suggestion").click();
+    await expect(root.locator(".index-detail-meta", { hasText: "Missing: volatile" })).toBeVisible();
+  });
+
   test("Index window Health per-cell Rebuild dispatches rebuild_index_cell IPC (T-IDX-102/T-IDX-110)", async ({
     page,
   }) => {

--- a/crates/gwt/playwright/tests/index-status.spec.ts
+++ b/crates/gwt/playwright/tests/index-status.spec.ts
@@ -387,7 +387,15 @@ test.describe("Project Index status surface", () => {
 
     await page.goto(APP_URL);
     const { root } = await openIndexSearchPanel(page);
+    await expect(root.locator(".index-search-input")).toHaveAttribute(
+      "placeholder",
+      "Search by meaning, e.g. workspace lifecycle",
+    );
     await root.locator("[data-match-mode='all_terms']").click();
+    await expect(root.locator(".index-search-input")).toHaveAttribute(
+      "placeholder",
+      "All terms required, e.g. Workspace discussion",
+    );
     await root.locator(".index-search-input").fill("Workspace volatile");
     await root.locator(".index-run-button").click();
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -92,6 +92,7 @@ pub struct ProjectIndexSearchRequest<'a> {
     pub(crate) request_id: u64,
     pub(crate) scopes: Vec<gwt::IndexSearchScope>,
     pub(crate) worktree_hash: Option<String>,
+    pub(crate) match_mode: gwt::IndexSearchMatchMode,
 }
 
 struct KnowledgeRefreshTask {
@@ -122,6 +123,7 @@ struct ProjectIndexSearchTask {
     request_id: u64,
     scopes: Vec<gwt::IndexSearchScope>,
     worktree_hash: Option<String>,
+    match_mode: gwt::IndexSearchMatchMode,
 }
 
 pub struct WindowRuntime {
@@ -3145,6 +3147,7 @@ impl AppRuntime {
                 request_id,
                 scopes,
                 worktree_hash,
+                match_mode,
             } => self.search_project_index_events(
                 &client_id,
                 ProjectIndexSearchRequest {
@@ -3153,6 +3156,7 @@ impl AppRuntime {
                     request_id,
                     scopes,
                     worktree_hash,
+                    match_mode,
                 },
             ),
             FrontendEvent::SelectKnowledgeBridgeEntry {
@@ -5556,6 +5560,7 @@ impl AppRuntime {
             request_id: request.request_id,
             scopes: request.scopes,
             worktree_hash: request.worktree_hash,
+            match_mode: request.match_mode,
         });
         Vec::new()
     }
@@ -5569,6 +5574,7 @@ impl AppRuntime {
             request_id,
             scopes,
             worktree_hash,
+            match_mode,
         } = task;
         let proxy = self.proxy.clone();
         self.blocking_tasks.spawn(move || {
@@ -5577,12 +5583,14 @@ impl AppRuntime {
                 &query,
                 &scopes,
                 worktree_hash.as_deref(),
+                match_mode,
             ) {
-                Ok(results) => BackendEvent::ProjectIndexSearchResults {
+                Ok(outcome) => BackendEvent::ProjectIndexSearchResults {
                     id: id.clone(),
                     query: query.clone(),
                     request_id,
-                    results,
+                    results: outcome.results,
+                    suggestions: outcome.suggestions,
                 },
                 Err(error) => BackendEvent::ProjectIndexSearchError {
                     id: id.clone(),
@@ -14596,6 +14604,7 @@ exit 1
                 gwt::IndexSearchScope::FilesDocs,
             ],
             worktree_hash: Some("worktree-hash".to_string()),
+            match_mode: gwt::IndexSearchMatchMode::AllTerms,
         })
         .expect("project index search user action log");
 

--- a/crates/gwt/src/bin/gwtd.rs
+++ b/crates/gwt/src/bin/gwtd.rs
@@ -67,6 +67,7 @@ fn print_help() {
     println!("  memory      Append reusable project memory");
     println!("  lessons     Legacy alias for memory add");
     println!("  discuss     gwt-discussion exit CLI (SPEC-1935)");
+    println!("  discussion  Persist/update Git-managed discussion notes");
     println!("  plan        gwt-plan-spec exit CLI (SPEC-1935)");
     println!("  build       gwt-build-spec exit CLI (SPEC-1935)");
     println!("  register    gwt-register-spec exit CLI (SPEC-2784)");
@@ -88,6 +89,7 @@ fn family_help(family: &str) -> Option<String> {
         "index" => Some(format_index_help()),
         "memory" | "lessons" => Some(format_memory_help()),
         "discuss" => Some(format_discuss_help()),
+        "discussion" => Some(format_discussion_help()),
         "plan" => Some(format_plan_help()),
         "build" => Some(format_build_help()),
         "register" => Some(format_register_help()),
@@ -268,7 +270,7 @@ fn format_index_help() -> String {
         "",
         "Subcommands:",
         "  status                                  Show index runtime + asset status",
-        "  rebuild [--scope all|issues|specs|memory|board|files|files-docs]",
+        "  rebuild [--scope all|issues|specs|memory|discussions|board|files|files-docs]",
         "                                          Rebuild a specific scope",
         "",
     ]
@@ -290,6 +292,30 @@ fn format_memory_help() -> String {
         "  --context <text>                        What happened or what was observed",
         "  --learning <text>                       Reusable learning",
         "  --future-action <text>                  What future agents should do",
+        "",
+    ]
+    .join("\n")
+}
+
+fn format_discussion_help() -> String {
+    [
+        "gwtd discussion — Persist/update Git-managed discussion notes.",
+        "",
+        "Usage: gwtd discussion update [fields]",
+        "",
+        "Fields:",
+        "  --date <yyyy-mm-dd>                     Entry date (defaults to today)",
+        "  --title <text>                          Discussion title",
+        "  --status <active|suspended|completed|promoted>",
+        "                                          Discussion lifecycle status",
+        "  --topic <text>                          Repeatable topic tag",
+        "  --related-spec <n>                      Repeatable related SPEC number",
+        "  --related-work <id>                     Repeatable related Work id",
+        "  --promoted-to <target>                  Repeatable target if promoted",
+        "  --summary <text>                        Current discussion summary",
+        "  --decision <text>                       Repeatable decision",
+        "  --open-question <text>                  Repeatable open question",
+        "  --next <text>                           Next discussion step",
         "",
     ]
     .join("\n")

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -10,6 +10,7 @@ mod board;
 mod build;
 pub mod daemon;
 mod discuss;
+mod discussion;
 mod env;
 pub mod gwtd_resolver;
 pub mod hook;
@@ -31,6 +32,7 @@ mod workspace;
 use std::io::{self};
 
 pub use board::{BoardCommand, BoardPostCommand};
+pub use discussion::DiscussionCommand;
 pub(crate) use env::ClientRef;
 pub use env::{dispatch, CliEnv, DefaultCliEnv, TestEnv};
 use gwt_github::{ApiError, SpecOpsError};
@@ -123,35 +125,21 @@ pub struct PrEditCall {
 /// variants and dispatch becomes a nested match.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CliCommand {
-    /// `gwtd issue ...` — issue + spec management.
     Issue(IssueCommand),
-    /// `gwtd pr ...` — pull request management.
     Pr(PrCommand),
-    /// `gwtd actions ...` — GitHub Actions log access.
     Actions(ActionsCommand),
-    /// `gwtd board ...` — coordination Board read/post.
     Board(BoardCommand),
-    /// `gwtd hook ...` and `gwtd __internal daemon-hook ...`.
     Hook(HookCommand),
-    /// `gwtd index ...` — local search index.
     Index(IndexCommand),
-    /// `gwtd memory ...` / `gwtd lessons ...` — append reusable project memory.
     Memory(MemoryCommand),
-    /// `gwtd discuss ...` — gwt-discussion exit CLI.
     Discuss(DiscussCommand),
-    /// `gwtd plan ...` — gwt-plan-spec exit CLI.
+    Discussion(DiscussionCommand),
     Plan(PlanCommand),
-    /// `gwtd build ...` — gwt-build-spec exit CLI.
     Build(BuildCommand),
-    /// `gwtd register ...` — gwt-register-spec exit CLI (SPEC-2784).
     Register(RegisterCommand),
-    /// `gwtd update [...]` and `gwtd __internal {apply-update,run-installer} ...`.
     Update(UpdateCommand),
-    /// `gwtd daemon ...` — long-running runtime daemon (SPEC-2077).
     Daemon(DaemonCommand),
-    /// `gwtd workspace ...` — Workspace projection and summary updates.
     Workspace(WorkspaceCommand),
-    /// `gwtd pane ...` — inspect and control live agent panes.
     Pane(PaneCommand),
 }
 
@@ -386,6 +374,7 @@ pub enum IndexScope {
     Issues,
     Specs,
     Memory,
+    Discussions,
     Board,
     Files,
     FilesDocs,
@@ -427,7 +416,7 @@ impl std::fmt::Display for CliParseError {
         match self {
             CliParseError::Usage => write!(
                 f,
-                "usage: gwtd issue spec <n> [--section <name>|--rename <title>|--edit <name> (-f <file>|--json [-f <file>] [--replace])] | gwtd issue spec list [--phase <p>] [--state open|closed] | gwtd issue spec create (--title <t> -f <file> | --json --title <t> [-f <file>] | --help) [--label <l>]* | gwtd issue view|comments|linked-prs <n> [--refresh] | gwtd issue create --title <t> -f <file> [--label <l>]* | gwtd issue comment <n> -f <file> | gwtd pr current|create --base <b> [--head <h>] --title <t> -f <file> [--label <l>]* [--draft]|edit <n> [--title <t>] [-f <file>] [--add-label <l>]*|view <n>|comment <n> -f <file>|reviews <n>|review-threads <n>|review-threads reply-and-resolve <n> -f <file>|checks <n> | gwtd actions logs --run <id> | gwtd actions job-logs --job <id> | gwtd board show [--json] [--workspace <id>|--all] | gwtd board post --kind <kind> (--body <text> | -f <file>) [--title-summary <text>] [--parent <id>] [--topic <t>]* [--owner <n>]* [--target <id>]* [--mention <kind:id>]* [--broadcast] | gwtd memory add [--date <yyyy-mm-dd>] [--type lesson|decision|workflow|failure-pattern] --title <text> --context <text> --learning <text> --future-action <text> | gwtd lessons add ... | gwtd workspace update [--title-summary <text>] [fields] | gwtd workspace candidates --agent-session <id> | gwtd workspace join --agent-session <id> --workspace <id> | gwtd workspace create --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--split-from <id>] [--boundary <text>] | gwtd workspace ensure --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--topic <t>] [--boundary <text>] | gwtd pane list|read <id> [--lines <n>]|close <id> | gwtd index status|rebuild [--scope all|issues|specs|memory|board|files|files-docs]"
+                "usage: gwtd issue spec <n> [--section <name>|--rename <title>|--edit <name> (-f <file>|--json [-f <file>] [--replace])] | gwtd issue spec list [--phase <p>] [--state open|closed] | gwtd issue spec create (--title <t> -f <file> | --json --title <t> [-f <file>] | --help) [--label <l>]* | gwtd issue view|comments|linked-prs <n> [--refresh] | gwtd issue create --title <t> -f <file> [--label <l>]* | gwtd issue comment <n> -f <file> | gwtd pr current|create --base <b> [--head <h>] --title <t> -f <file> [--label <l>]* [--draft]|edit <n> [--title <t>] [-f <file>] [--add-label <l>]*|view <n>|comment <n> -f <file>|reviews <n>|review-threads <n>|review-threads reply-and-resolve <n> -f <file>|checks <n> | gwtd actions logs --run <id> | gwtd actions job-logs --job <id> | gwtd board show [--json] [--workspace <id>|--all] | gwtd board post --kind <kind> (--body <text> | -f <file>) [--title-summary <text>] [--parent <id>] [--topic <t>]* [--owner <n>]* [--target <id>]* [--mention <kind:id>]* [--broadcast] | gwtd memory add [--date <yyyy-mm-dd>] [--type lesson|decision|workflow|failure-pattern] --title <text> --context <text> --learning <text> --future-action <text> | gwtd discussion update [fields] | gwtd lessons add ... | gwtd workspace update [--title-summary <text>] [fields] | gwtd workspace candidates --agent-session <id> | gwtd workspace join --agent-session <id> --workspace <id> | gwtd workspace create --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--split-from <id>] [--boundary <text>] | gwtd workspace ensure --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--topic <t>] [--boundary <text>] | gwtd pane list|read <id> [--lines <n>]|close <id> | gwtd index status|rebuild [--scope all|issues|specs|memory|discussions|board|files|files-docs]"
             ),
             CliParseError::InvalidNumber(s) => write!(f, "invalid issue number: {s}"),
             CliParseError::MissingFlag(flag) => write!(f, "missing required flag: {flag}"),
@@ -550,6 +539,7 @@ pub fn should_dispatch_cli(args: &[String]) -> bool {
                     | "memory"
                     | "lessons"
                     | "discuss"
+                    | "discussion"
                     | "plan"
                     | "build"
                     | "register"
@@ -591,6 +581,11 @@ pub fn parse_index_args(args: &[String]) -> Result<CliCommand, CliParseError> {
 /// Parse an argv slice into a `gwtd memory ...` / `gwtd lessons ...` [`CliCommand`].
 pub fn parse_memory_args(args: &[String]) -> Result<CliCommand, CliParseError> {
     memory::parse(args).map(CliCommand::Memory)
+}
+
+/// Parse an argv slice into a `gwtd discussion ...` [`CliCommand`].
+pub fn parse_discussion_args(args: &[String]) -> Result<CliCommand, CliParseError> {
+    discussion::parse(args).map(CliCommand::Discussion)
 }
 
 /// Parse an argv slice into a `gwtd daemon ...` [`CliCommand`] (SPEC-2077).
@@ -748,6 +743,7 @@ pub fn run<E: CliEnv>(env: &mut E, cmd: CliCommand) -> Result<i32, SpecOpsError>
         CliCommand::Index(inner) => index::run(env, inner, &mut out)?,
         CliCommand::Memory(inner) => memory::run(env, inner, &mut out)?,
         CliCommand::Discuss(action) => discuss::run(env, action, &mut out)?,
+        CliCommand::Discussion(inner) => discussion::run(env, inner, &mut out)?,
         CliCommand::Plan(action) => plan::run(env, action, &mut out)?,
         CliCommand::Build(action) => build::run(env, action, &mut out)?,
         CliCommand::Register(action) => register::run(env, action, &mut out)?,

--- a/crates/gwt/src/cli/discussion.rs
+++ b/crates/gwt/src/cli/discussion.rs
@@ -1,0 +1,263 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use chrono::{Local, NaiveDate};
+use gwt_github::{client::ApiError, SpecOpsError};
+
+use super::{CliEnv, CliParseError};
+
+const DEFAULT_DISCUSSIONS_HEADER: &str = "# Discussions\n\nThis file is the canonical gwt discussion log. Entries are updated in place while active and indexed by the `discussions` semantic scope.\n";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiscussionCommand {
+    Update(DiscussionUpdateCommand),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscussionUpdateCommand {
+    pub date: Option<String>,
+    pub title: String,
+    pub status: String,
+    pub topics: Vec<String>,
+    pub related_specs: Vec<u64>,
+    pub related_works: Vec<String>,
+    pub promoted_to: Vec<String>,
+    pub summary: String,
+    pub decisions: Vec<String>,
+    pub open_questions: Vec<String>,
+    pub next: String,
+}
+
+pub fn parse(args: &[String]) -> Result<DiscussionCommand, CliParseError> {
+    let (head, rest) = args.split_first().ok_or(CliParseError::Usage)?;
+    match head.as_str() {
+        "update" => parse_update(rest).map(DiscussionCommand::Update),
+        other => Err(CliParseError::UnknownSubcommand(other.to_string())),
+    }
+}
+
+fn parse_update(args: &[String]) -> Result<DiscussionUpdateCommand, CliParseError> {
+    let mut date = None;
+    let mut title = None;
+    let mut status = Some("active".to_string());
+    let mut topics = Vec::new();
+    let mut related_specs = Vec::new();
+    let mut related_works = Vec::new();
+    let mut promoted_to = Vec::new();
+    let mut summary = None;
+    let mut decisions = Vec::new();
+    let mut open_questions = Vec::new();
+    let mut next = None;
+    let mut i = 0;
+
+    while i < args.len() {
+        let flag = args[i].as_str();
+        let value = args
+            .get(i + 1)
+            .ok_or(CliParseError::MissingFlag(flag_name(flag)?))?;
+        match flag {
+            "--date" => date = Some(valid_date(value)?),
+            "--title" => title = Some(non_empty("--title", value)?),
+            "--status" => status = Some(valid_status(value)?),
+            "--topic" => topics.push(non_empty("--topic", value)?),
+            "--related-spec" => related_specs.push(parse_spec(value)?),
+            "--related-work" => related_works.push(non_empty("--related-work", value)?),
+            "--promoted-to" => promoted_to.push(non_empty("--promoted-to", value)?),
+            "--summary" => summary = Some(non_empty("--summary", value)?),
+            "--decision" => decisions.push(non_empty("--decision", value)?),
+            "--open-question" => open_questions.push(non_empty("--open-question", value)?),
+            "--next" => next = Some(non_empty("--next", value)?),
+            other => return Err(CliParseError::UnknownSubcommand(other.to_string())),
+        }
+        i += 2;
+    }
+
+    Ok(DiscussionUpdateCommand {
+        date,
+        title: title.ok_or(CliParseError::MissingFlag("--title"))?,
+        status: status.unwrap_or_else(|| "active".to_string()),
+        topics,
+        related_specs,
+        related_works,
+        promoted_to,
+        summary: summary.ok_or(CliParseError::MissingFlag("--summary"))?,
+        decisions,
+        open_questions,
+        next: next.ok_or(CliParseError::MissingFlag("--next"))?,
+    })
+}
+
+fn flag_name(flag: &str) -> Result<&'static str, CliParseError> {
+    match flag {
+        "--date" => Ok("--date"),
+        "--title" => Ok("--title"),
+        "--status" => Ok("--status"),
+        "--topic" => Ok("--topic"),
+        "--related-spec" => Ok("--related-spec"),
+        "--related-work" => Ok("--related-work"),
+        "--promoted-to" => Ok("--promoted-to"),
+        "--summary" => Ok("--summary"),
+        "--decision" => Ok("--decision"),
+        "--open-question" => Ok("--open-question"),
+        "--next" => Ok("--next"),
+        other => Err(CliParseError::UnknownSubcommand(other.to_string())),
+    }
+}
+
+fn non_empty(flag: &'static str, value: &str) -> Result<String, CliParseError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(CliParseError::InvalidValue {
+            flag,
+            reason: "must not be empty",
+        });
+    }
+    Ok(trimmed.to_string())
+}
+
+fn valid_date(value: &str) -> Result<String, CliParseError> {
+    let value = non_empty("--date", value)?;
+    NaiveDate::parse_from_str(&value, "%Y-%m-%d")
+        .map(|_| value)
+        .map_err(|_| CliParseError::InvalidValue {
+            flag: "--date",
+            reason: "must be YYYY-MM-DD",
+        })
+}
+
+fn valid_status(value: &str) -> Result<String, CliParseError> {
+    let value = non_empty("--status", value)?;
+    match value.as_str() {
+        "active" | "suspended" | "completed" | "promoted" => Ok(value),
+        _ => Err(CliParseError::InvalidValue {
+            flag: "--status",
+            reason: "must be active, suspended, completed, or promoted",
+        }),
+    }
+}
+
+fn parse_spec(value: &str) -> Result<u64, CliParseError> {
+    let value = non_empty("--related-spec", value)?;
+    value
+        .trim_start_matches('#')
+        .trim_start_matches("SPEC-")
+        .trim_start_matches("spec-")
+        .parse::<u64>()
+        .map_err(|_| CliParseError::InvalidNumber(value))
+}
+
+pub fn run<E: CliEnv>(
+    env: &mut E,
+    command: DiscussionCommand,
+    out: &mut String,
+) -> Result<i32, SpecOpsError> {
+    match command {
+        DiscussionCommand::Update(update) => {
+            let path =
+                update_discussion_entry(env.repo_path(), &update).map_err(io_as_spec_error)?;
+            out.push_str(&format!("discussion updated: {}\n", path.display()));
+            Ok(0)
+        }
+    }
+}
+
+fn update_discussion_entry(
+    repo_root: &Path,
+    update: &DiscussionUpdateCommand,
+) -> std::io::Result<PathBuf> {
+    let tasks_dir = repo_root.join("tasks");
+    fs::create_dir_all(&tasks_dir)?;
+    let path = tasks_dir.join("discussions.md");
+    ensure_discussions_file(&path)?;
+
+    let mut content = fs::read_to_string(&path)?;
+    let date = update
+        .date
+        .clone()
+        .unwrap_or_else(|| Local::now().format("%Y-%m-%d").to_string());
+    let heading = format!("## {date} — {}", update.title);
+    let entry = format_discussion_entry(&date, update);
+    content = replace_or_append_section(&content, &heading, &entry);
+    fs::write(&path, content)?;
+    Ok(path)
+}
+
+fn ensure_discussions_file(path: &Path) -> std::io::Result<()> {
+    if path.exists() {
+        return Ok(());
+    }
+    fs::write(path, DEFAULT_DISCUSSIONS_HEADER)
+}
+
+fn format_discussion_entry(date: &str, update: &DiscussionUpdateCommand) -> String {
+    let related_specs = if update.related_specs.is_empty() {
+        String::new()
+    } else {
+        update
+            .related_specs
+            .iter()
+            .map(|number| format!("#{number}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    format!(
+        "## {date} — {title}\n\nStatus: {status}\nTopics: {topics}\nRelated SPECs: {related_specs}\nRelated Works: {related_works}\nPromoted To: {promoted_to}\n\nSummary:\n{summary}\n\nDecisions:\n{decisions}\n\nOpen Questions:\n{open_questions}\n\nNext:\n{next}\n",
+        title = update.title,
+        status = update.status,
+        topics = update.topics.join(", "),
+        related_specs = related_specs,
+        related_works = update.related_works.join(", "),
+        promoted_to = update.promoted_to.join(", "),
+        summary = update.summary,
+        decisions = format_bullets(&update.decisions),
+        open_questions = format_bullets(&update.open_questions),
+        next = update.next,
+    )
+}
+
+fn format_bullets(items: &[String]) -> String {
+    if items.is_empty() {
+        return String::new();
+    }
+    items
+        .iter()
+        .map(|item| format!("- {item}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn replace_or_append_section(content: &str, heading: &str, entry: &str) -> String {
+    let mut ranges = Vec::new();
+    let mut offset = 0;
+    for line in content.split_inclusive('\n') {
+        if line.trim_end() == heading {
+            ranges.push(offset);
+        }
+        offset += line.len();
+    }
+    let Some(start) = ranges.first().copied() else {
+        let mut output = content.trim_end().to_string();
+        output.push_str("\n\n");
+        output.push_str(entry.trim_end());
+        output.push('\n');
+        return output;
+    };
+    let tail = &content[start + heading.len()..];
+    let next = tail
+        .find("\n## ")
+        .map(|index| start + heading.len() + index + 1)
+        .unwrap_or(content.len());
+    let mut output = String::new();
+    output.push_str(content[..start].trim_end());
+    output.push_str("\n\n");
+    output.push_str(entry.trim_end());
+    output.push('\n');
+    output.push_str(content[next..].trim_start_matches('\n'));
+    output
+}
+
+fn io_as_spec_error(err: std::io::Error) -> SpecOpsError {
+    SpecOpsError::from(ApiError::Network(err.to_string()))
+}

--- a/crates/gwt/src/cli/env/mod.rs
+++ b/crates/gwt/src/cli/env/mod.rs
@@ -28,9 +28,9 @@ use gwt_git::PrStatus;
 use gwt_github::{client::IssueClient, IssueNumber, SpecListFilter};
 
 use super::{
-    parse_actions_args, parse_board_args, parse_hook_args, parse_issue_args, parse_memory_args,
-    parse_pane_args, parse_pr_args, run, CliParseError, LinkedPrSummary, PrChecksSummary, PrReview,
-    PrReviewThread,
+    parse_actions_args, parse_board_args, parse_discussion_args, parse_hook_args, parse_issue_args,
+    parse_memory_args, parse_pane_args, parse_pr_args, run, CliParseError, LinkedPrSummary,
+    PrChecksSummary, PrReview, PrReviewThread,
 };
 
 /// High-level runtime environment for the CLI. Kept as a trait so tests can
@@ -183,6 +183,7 @@ pub fn dispatch<E: CliEnv>(env: &mut E, args: &[String]) -> i32 {
         "board" => parse_board_args(&rest),
         "index" => super::parse_index_args(&rest),
         "memory" | "lessons" => parse_memory_args(&rest),
+        "discussion" => parse_discussion_args(&rest),
         "hook" => parse_hook_args(&rest),
         "discuss" => super::parse_discuss_args(&rest),
         "plan" => super::parse_plan_args(&rest),

--- a/crates/gwt/src/cli/index/mod.rs
+++ b/crates/gwt/src/cli/index/mod.rs
@@ -53,6 +53,7 @@ fn parse_rebuild_scope(args: &[String]) -> Result<IndexScope, CliParseError> {
         "issues" => Ok(IndexScope::Issues),
         "specs" => Ok(IndexScope::Specs),
         "memory" => Ok(IndexScope::Memory),
+        "discussions" => Ok(IndexScope::Discussions),
         "board" => Ok(IndexScope::Board),
         "files" => Ok(IndexScope::Files),
         "files-docs" => Ok(IndexScope::FilesDocs),
@@ -169,6 +170,16 @@ mod tests {
             parse(&s(&["rebuild", "--scope", "memory"])).unwrap(),
             IndexCommand::Rebuild {
                 scope: IndexScope::Memory
+            }
+        );
+    }
+
+    #[test]
+    fn parses_index_rebuild_discussions_scope() {
+        assert_eq!(
+            parse(&s(&["rebuild", "--scope", "discussions"])).unwrap(),
+            IndexCommand::Rebuild {
+                scope: IndexScope::Discussions
             }
         );
     }

--- a/crates/gwt/src/cli/index/mod.rs
+++ b/crates/gwt/src/cli/index/mod.rs
@@ -138,13 +138,55 @@ fn runtime_error(err: gwt_core::GwtError) -> SpecOpsError {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     use super::runtime::IndexContext;
     use super::*;
 
     fn s(items: &[&str]) -> Vec<String> {
         items.iter().map(|item| (*item).to_string()).collect()
+    }
+
+    fn run_git_at(path: &Path, args: &[&str]) {
+        let output = gwt_core::process::hidden_command("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .unwrap_or_else(|err| panic!("git {args:?}: {err}"));
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn make_bare_workspace_with_worktree(home: &Path) -> PathBuf {
+        let bare = home.join("gwt.git");
+        let bootstrap = home.join(".bootstrap");
+        let develop = home.join("develop");
+        std::fs::create_dir_all(home).expect("workspace home");
+        run_git_at(home, &["init", "--bare", bare.to_str().unwrap()]);
+        run_git_at(
+            &bare,
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/example/gwt.git",
+            ],
+        );
+        run_git_at(home, &["clone", bare.to_str().unwrap(), ".bootstrap"]);
+        run_git_at(&bootstrap, &["config", "user.email", "test@example.com"]);
+        run_git_at(&bootstrap, &["config", "user.name", "Test User"]);
+        run_git_at(&bootstrap, &["checkout", "-b", "develop"]);
+        run_git_at(&bootstrap, &["commit", "--allow-empty", "-m", "init"]);
+        run_git_at(&bootstrap, &["push", "origin", "develop"]);
+        run_git_at(
+            &bare,
+            &["worktree", "add", develop.to_str().unwrap(), "develop"],
+        );
+        std::fs::remove_dir_all(&bootstrap).expect("remove bootstrap");
+        develop
     }
 
     #[test]
@@ -191,6 +233,29 @@ mod tests {
             IndexCommand::Rebuild {
                 scope: IndexScope::Board
             }
+        );
+    }
+
+    #[test]
+    fn index_context_uses_active_worktree_for_workspace_home() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let develop = make_bare_workspace_with_worktree(temp.path());
+
+        let context = super::runtime::resolve_index_context(temp.path()).expect("index context");
+
+        assert_eq!(
+            dunce::canonicalize(&context.project_root).expect("context root"),
+            dunce::canonicalize(&develop).expect("develop root")
+        );
+        assert_eq!(
+            context.repo_hash.as_str(),
+            gwt_core::repo_hash::compute_repo_hash("https://github.com/example/gwt.git").as_str()
+        );
+        assert_eq!(
+            context.worktree_hash,
+            gwt_core::worktree_hash::compute_worktree_hash(&develop)
+                .expect("develop hash")
+                .to_string()
         );
     }
 

--- a/crates/gwt/src/cli/index/runtime.rs
+++ b/crates/gwt/src/cli/index/runtime.rs
@@ -24,14 +24,19 @@ pub(crate) struct IndexContext {
 }
 
 pub(crate) fn resolve_index_context(repo_path: &Path) -> Result<IndexContext, SpecOpsError> {
-    let project_root = repo_path
-        .canonicalize()
-        .unwrap_or_else(|_| repo_path.to_path_buf());
-    let repo_hash = crate::index_worker::detect_repo_hash(&project_root).ok_or_else(|| {
-        SpecOpsError::from(ApiError::Unexpected(
-            "could not resolve project index repo hash from git origin".to_string(),
-        ))
-    })?;
+    let project_root = crate::index_worker::default_project_index_worktree_root(repo_path)
+        .unwrap_or_else(|| {
+            repo_path
+                .canonicalize()
+                .unwrap_or_else(|_| repo_path.to_path_buf())
+        });
+    let repo_hash = crate::index_worker::detect_repo_hash(repo_path)
+        .or_else(|| crate::index_worker::detect_repo_hash(&project_root))
+        .ok_or_else(|| {
+            SpecOpsError::from(ApiError::Unexpected(
+                "could not resolve project index repo hash from git origin".to_string(),
+            ))
+        })?;
     let worktree_hash = compute_worktree_hash(&project_root)
         .map_err(|err| SpecOpsError::from(ApiError::Unexpected(err.to_string())))?
         .to_string();

--- a/crates/gwt/src/cli/index/runtime.rs
+++ b/crates/gwt/src/cli/index/runtime.rs
@@ -93,6 +93,12 @@ pub(crate) fn rebuild_actions(scope: IndexScope) -> Vec<RebuildAction> {
             needs_worktree_hash: false,
         },
         RebuildAction {
+            label: "discussions",
+            action: "index-discussions",
+            scope: None,
+            needs_worktree_hash: false,
+        },
+        RebuildAction {
             label: "board",
             action: "index-board",
             scope: None,
@@ -116,6 +122,10 @@ pub(crate) fn rebuild_actions(scope: IndexScope) -> Vec<RebuildAction> {
         IndexScope::Issues => all.into_iter().filter(|a| a.label == "issues").collect(),
         IndexScope::Specs => all.into_iter().filter(|a| a.label == "specs").collect(),
         IndexScope::Memory => all.into_iter().filter(|a| a.label == "memory").collect(),
+        IndexScope::Discussions => all
+            .into_iter()
+            .filter(|a| a.label == "discussions")
+            .collect(),
         IndexScope::Board => all.into_iter().filter(|a| a.label == "board").collect(),
         IndexScope::Files => all.into_iter().filter(|a| a.label == "files").collect(),
         IndexScope::FilesDocs => all
@@ -192,7 +202,15 @@ pub fn render_index_status(
         report.dependencies_installed
     ));
     if let Some(status) = payload.get("status").and_then(Value::as_object) {
-        for scope in ["issues", "specs", "memory", "board", "files", "files-docs"] {
+        for scope in [
+            "issues",
+            "specs",
+            "memory",
+            "discussions",
+            "board",
+            "files",
+            "files-docs",
+        ] {
             if let Some(scope_status) = status.get(scope) {
                 let healthy = scope_status
                     .get("healthy")

--- a/crates/gwt/src/index_search.rs
+++ b/crates/gwt/src/index_search.rs
@@ -175,6 +175,7 @@ fn default_index_search_scopes() -> Vec<IndexSearchScope> {
         IndexSearchScope::Issues,
         IndexSearchScope::Specs,
         IndexSearchScope::Memory,
+        IndexSearchScope::Discussions,
         IndexSearchScope::Board,
         IndexSearchScope::Files,
         IndexSearchScope::FilesDocs,
@@ -339,6 +340,7 @@ fn search_action(scope: IndexSearchScope) -> &'static str {
         IndexSearchScope::Issues => "search-issues",
         IndexSearchScope::Specs => "search-specs",
         IndexSearchScope::Memory => "search-memory",
+        IndexSearchScope::Discussions => "search-discussions",
         IndexSearchScope::Board => "search-board",
         IndexSearchScope::Files => "search-files",
         IndexSearchScope::FilesDocs => "search-files-docs",
@@ -355,6 +357,7 @@ fn append_scope_results(
         IndexSearchScope::Issues => "issueResults",
         IndexSearchScope::Specs => "specResults",
         IndexSearchScope::Memory => "memoryResults",
+        IndexSearchScope::Discussions => "discussionResults",
         IndexSearchScope::Board => "boardResults",
         IndexSearchScope::Files | IndexSearchScope::FilesDocs => "results",
     };
@@ -366,6 +369,7 @@ fn append_scope_results(
             IndexSearchScope::Issues => issue_result(item),
             IndexSearchScope::Specs => spec_result(item),
             IndexSearchScope::Memory => memory_result(item),
+            IndexSearchScope::Discussions => discussion_result(item),
             IndexSearchScope::Board => board_result(item, board_scope),
             IndexSearchScope::Files | IndexSearchScope::FilesDocs => file_result(scope, item),
         };
@@ -418,6 +422,25 @@ fn memory_result(item: &Value) -> Option<IndexSearchResult> {
         preview: heading.clone(),
         distance: item.get("distance").and_then(Value::as_f64),
         target: IndexSearchTarget::Memory { heading, date },
+    })
+}
+
+fn discussion_result(item: &Value) -> Option<IndexSearchResult> {
+    let heading = value_str(item.get("heading"))?;
+    let title = value_str(item.get("title")).unwrap_or_else(|| heading.clone());
+    let date = value_str(item.get("date")).unwrap_or_default();
+    let status = value_str(item.get("status")).unwrap_or_else(|| "discussion".to_string());
+    Some(IndexSearchResult {
+        scope: IndexSearchScope::Discussions,
+        title,
+        subtitle: if date.is_empty() {
+            status
+        } else {
+            format!("{status} · {date}")
+        },
+        preview: heading.clone(),
+        distance: item.get("distance").and_then(Value::as_f64),
+        target: IndexSearchTarget::Discussion { heading, date },
     })
 }
 
@@ -585,6 +608,7 @@ mod tests {
                 IndexSearchScope::Issues,
                 IndexSearchScope::Specs,
                 IndexSearchScope::Memory,
+                IndexSearchScope::Discussions,
                 IndexSearchScope::Board,
                 IndexSearchScope::Files,
                 IndexSearchScope::FilesDocs,
@@ -593,7 +617,7 @@ mod tests {
     }
 
     #[test]
-    fn append_scope_results_formats_issue_spec_memory_and_file_targets() {
+    fn append_scope_results_formats_issue_spec_memory_discussion_and_file_targets() {
         let mut results = Vec::new();
         let board_scope = BoardAudienceScope::All;
 
@@ -640,6 +664,20 @@ mod tests {
         );
         append_scope_results(
             &mut results,
+            IndexSearchScope::Discussions,
+            &json!({
+                "discussionResults": [{
+                    "heading": "## 2026-05-22 — Workspace terminology",
+                    "title": "Workspace terminology",
+                    "date": "2026-05-22",
+                    "status": "active",
+                    "distance": 0.25
+                }]
+            }),
+            &board_scope,
+        );
+        append_scope_results(
+            &mut results,
             IndexSearchScope::FilesDocs,
             &json!({
                 "results": [{
@@ -652,7 +690,7 @@ mod tests {
             &board_scope,
         );
 
-        assert_eq!(results.len(), 4);
+        assert_eq!(results.len(), 5);
         assert_eq!(results[0].title, "#42 Search index");
         assert_eq!(results[0].preview, "enhancement, index");
         assert!(matches!(
@@ -670,9 +708,14 @@ mod tests {
             results[2].target,
             IndexSearchTarget::Memory { .. }
         ));
-        assert_eq!(results[3].title, "README.md");
-        assert_eq!(results[3].subtitle, "Markdown");
-        assert!(matches!(results[3].target, IndexSearchTarget::File { .. }));
+        assert_eq!(results[3].subtitle, "active · 2026-05-22");
+        assert!(matches!(
+            results[3].target,
+            IndexSearchTarget::Discussion { .. }
+        ));
+        assert_eq!(results[4].title, "README.md");
+        assert_eq!(results[4].subtitle, "Markdown");
+        assert!(matches!(results[4].target, IndexSearchTarget::File { .. }));
     }
 
     #[test]
@@ -804,6 +847,7 @@ mod tests {
                 IndexSearchScope::Issues,
                 IndexSearchScope::Specs,
                 IndexSearchScope::Board,
+                IndexSearchScope::Discussions,
                 IndexSearchScope::Memory,
             ],
             "Git",
@@ -813,7 +857,8 @@ mod tests {
         assert!(args.iter().any(|arg| arg == "search-multi"));
         assert!(
             args.windows(2)
-                .any(|pair| pair[0] == "--scopes" && pair[1] == "issues,specs,board,memory"),
+                .any(|pair| pair[0] == "--scopes"
+                    && pair[1] == "issues,specs,board,discussions,memory"),
             "repo-scoped searches should share one runner process"
         );
         assert!(args.iter().any(|arg| arg == "--no-auto-build"));
@@ -851,6 +896,11 @@ mod tests {
             ScopeSearchJob {
                 search_root: PathBuf::from("/repo"),
                 worktree_hash: None,
+                scope: IndexSearchScope::Discussions,
+            },
+            ScopeSearchJob {
+                search_root: PathBuf::from("/repo"),
+                worktree_hash: None,
                 scope: IndexSearchScope::Memory,
             },
         ];
@@ -864,6 +914,7 @@ mod tests {
                 IndexSearchScope::Issues => "issueResults",
                 IndexSearchScope::Specs => "specResults",
                 IndexSearchScope::Board => "boardResults",
+                IndexSearchScope::Discussions => "discussionResults",
                 IndexSearchScope::Memory => "memoryResults",
                 IndexSearchScope::Files | IndexSearchScope::FilesDocs => "results",
             };
@@ -874,7 +925,7 @@ mod tests {
         })
         .expect("parallel scope search should succeed");
 
-        assert_eq!(results.len(), 4);
+        assert_eq!(results.len(), 5);
         assert!(
             peak.load(Ordering::SeqCst) > 1,
             "expected selected scope searches to overlap"

--- a/crates/gwt/src/index_search.rs
+++ b/crates/gwt/src/index_search.rs
@@ -23,8 +23,12 @@ pub fn search_project_index(
     if query.is_empty() {
         return Ok(Vec::new());
     }
-    let repo_hash = crate::index_worker::detect_repo_hash(project_root)
+    let index_repo_root = crate::index_worker::resolve_project_index_repo_root(project_root)
         .ok_or_else(|| "project index search requires a git origin remote".to_string())?;
+    let repo_hash = crate::index_worker::detect_repo_hash(&index_repo_root)
+        .ok_or_else(|| "project index search requires a git origin remote".to_string())?;
+    let repo_search_root = crate::index_worker::default_project_index_worktree_root(project_root)
+        .unwrap_or_else(|| index_repo_root.clone());
     gwt_core::runtime::ensure_project_index_runtime().map_err(|error| error.to_string())?;
 
     let effective_scopes = if scopes.is_empty() {
@@ -66,7 +70,7 @@ pub fn search_project_index(
     }
     if !repo_scopes.is_empty() {
         let payload = run_repo_scope_search(
-            project_root,
+            &repo_search_root,
             repo_hash.as_str(),
             &repo_scopes,
             query,
@@ -191,26 +195,51 @@ fn resolve_file_search_worktree(
     project_root: &Path,
     selected_worktree_hash: Option<&str>,
 ) -> Result<FileSearchWorktree, String> {
+    let index_repo_root = crate::index_worker::resolve_project_index_repo_root(project_root)
+        .unwrap_or_else(|| project_root.to_path_buf());
     if let Some(hash) = selected_worktree_hash
         .map(str::trim)
         .filter(|hash| !hash.is_empty())
     {
-        let entries = worktree_inventory::enumerate_worktrees(project_root, Some(project_root))
-            .map_err(|error| error.to_string())?;
+        let active_root = crate::index_worker::default_project_index_worktree_root(project_root);
+        let entries =
+            worktree_inventory::enumerate_worktrees(&index_repo_root, active_root.as_deref())
+                .map_err(|error| error.to_string())?;
         let entry = entries
             .into_iter()
             .find(|entry| entry.id == hash)
             .ok_or_else(|| format!("worktree with hash {hash} not found"))?;
+        if matches!(entry.kind, worktree_inventory::WorktreeEntryKind::BareMain) {
+            return Err("file search requires a non-bare worktree".to_string());
+        }
         return Ok(FileSearchWorktree {
             path: entry.path,
             hash: hash.to_string(),
         });
     }
-    let hash = gwt_core::worktree_hash::compute_worktree_hash(project_root)
+    let worktree_root = crate::index_worker::default_project_index_worktree_root(project_root)
+        .ok_or_else(|| "file search requires a git worktree".to_string())?;
+    if worktree_root == index_repo_root {
+        let entries = worktree_inventory::enumerate_worktrees(&index_repo_root, None)
+            .map_err(|error| error.to_string())?;
+        if let Some(entry) = entries
+            .into_iter()
+            .find(|entry| matches!(entry.kind, worktree_inventory::WorktreeEntryKind::Workspace))
+        {
+            let hash = gwt_core::worktree_hash::compute_worktree_hash(&entry.path)
+                .map_err(|error| error.to_string())?
+                .to_string();
+            return Ok(FileSearchWorktree {
+                path: entry.path,
+                hash,
+            });
+        }
+    }
+    let hash = gwt_core::worktree_hash::compute_worktree_hash(&worktree_root)
         .map_err(|error| error.to_string())?
         .to_string();
     Ok(FileSearchWorktree {
-        path: project_root.to_path_buf(),
+        path: worktree_root,
         hash,
     })
 }
@@ -592,6 +621,52 @@ mod tests {
     use gwt_core::coordination::BoardAudienceScope;
     use serde_json::json;
 
+    fn run_git_at(path: &Path, args: &[&str]) {
+        let output = gwt_core::process::hidden_command("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .unwrap_or_else(|err| panic!("git {args:?}: {err}"));
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn make_bare_workspace_with_worktree(home: &Path) -> PathBuf {
+        let bare = home.join("gwt.git");
+        let bootstrap = home.join(".bootstrap");
+        let develop = home.join("develop");
+        std::fs::create_dir_all(home).expect("workspace home");
+        run_git_at(home, &["init", "--bare", bare.to_str().unwrap()]);
+        run_git_at(
+            &bare,
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/example/gwt.git",
+            ],
+        );
+        run_git_at(home, &["clone", bare.to_str().unwrap(), ".bootstrap"]);
+        run_git_at(&bootstrap, &["config", "user.email", "test@example.com"]);
+        run_git_at(&bootstrap, &["config", "user.name", "Test User"]);
+        run_git_at(&bootstrap, &["checkout", "-b", "develop"]);
+        run_git_at(&bootstrap, &["commit", "--allow-empty", "-m", "init"]);
+        run_git_at(&bootstrap, &["push", "origin", "develop"]);
+        run_git_at(
+            &bare,
+            &["worktree", "add", develop.to_str().unwrap(), "develop"],
+        );
+        std::fs::remove_dir_all(&bootstrap).expect("remove bootstrap");
+        develop
+    }
+
+    fn canonical(path: &Path) -> PathBuf {
+        dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+    }
+
     #[test]
     fn empty_index_search_query_returns_no_results_without_runtime() {
         let results = search_project_index(Path::new("/definitely/not/a/repo"), "   ", &[], None)
@@ -800,6 +875,23 @@ mod tests {
             &workspace,
             &BoardAudienceScope::Workspace("workspace-b".to_string())
         ));
+    }
+
+    #[test]
+    fn file_search_default_worktree_uses_workspace_entry_for_workspace_home() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let develop = make_bare_workspace_with_worktree(temp.path());
+
+        let resolved =
+            resolve_file_search_worktree(temp.path(), None).expect("file search worktree");
+
+        assert_eq!(canonical(&resolved.path), canonical(&develop));
+        assert_eq!(
+            resolved.hash,
+            gwt_core::worktree_hash::compute_worktree_hash(&develop)
+                .expect("worktree hash")
+                .to_string()
+        );
     }
 
     #[test]

--- a/crates/gwt/src/index_search.rs
+++ b/crates/gwt/src/index_search.rs
@@ -7,21 +7,28 @@ use std::{
 use serde_json::Value;
 
 use crate::{
-    protocol::{IndexSearchResult, IndexSearchScope, IndexSearchTarget},
+    protocol::{IndexSearchMatchMode, IndexSearchResult, IndexSearchScope, IndexSearchTarget},
     worktree_inventory,
 };
 
 const INDEX_SEARCH_LIMIT: usize = 50;
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct ProjectIndexSearchOutcome {
+    pub results: Vec<IndexSearchResult>,
+    pub suggestions: Vec<IndexSearchResult>,
+}
 
 pub fn search_project_index(
     project_root: &Path,
     query: &str,
     scopes: &[IndexSearchScope],
     selected_worktree_hash: Option<&str>,
-) -> Result<Vec<IndexSearchResult>, String> {
+    match_mode: IndexSearchMatchMode,
+) -> Result<ProjectIndexSearchOutcome, String> {
     let query = query.trim();
     if query.is_empty() {
-        return Ok(Vec::new());
+        return Ok(ProjectIndexSearchOutcome::default());
     }
     let index_repo_root = crate::index_worker::resolve_project_index_repo_root(project_root)
         .ok_or_else(|| "project index search requires a git origin remote".to_string())?;
@@ -51,6 +58,7 @@ pub fn search_project_index(
     };
 
     let mut results = Vec::new();
+    let mut suggestions = Vec::new();
     let per_scope_limit = per_scope_limit(effective_scopes.len());
     let mut file_jobs = Vec::new();
     let mut repo_scopes = Vec::new();
@@ -75,9 +83,11 @@ pub fn search_project_index(
             &repo_scopes,
             query,
             per_scope_limit,
+            match_mode,
         )?;
         for scope in repo_scopes {
             append_scope_results(&mut results, scope, &payload, &board_scope);
+            append_scope_suggestions(&mut suggestions, scope, &payload, &board_scope);
         }
     }
     for outcome in run_scope_search_jobs(
@@ -85,14 +95,26 @@ pub fn search_project_index(
         repo_hash.as_str(),
         query,
         per_scope_limit,
+        match_mode,
         run_scope_search,
     )? {
         append_scope_results(&mut results, outcome.scope, &outcome.payload, &board_scope);
+        append_scope_suggestions(
+            &mut suggestions,
+            outcome.scope,
+            &outcome.payload,
+            &board_scope,
+        );
     }
 
     results.sort_by(|left, right| distance_key(left).total_cmp(&distance_key(right)));
+    suggestions.sort_by(|left, right| distance_key(left).total_cmp(&distance_key(right)));
     results.truncate(INDEX_SEARCH_LIMIT);
-    Ok(results)
+    suggestions.truncate(INDEX_SEARCH_LIMIT);
+    Ok(ProjectIndexSearchOutcome {
+        results,
+        suggestions,
+    })
 }
 
 fn is_file_scope(scope: IndexSearchScope) -> bool {
@@ -123,10 +145,20 @@ fn run_scope_search_jobs<F>(
     repo_hash: &str,
     query: &str,
     limit: usize,
+    match_mode: IndexSearchMatchMode,
     runner: F,
 ) -> Result<Vec<ScopeSearchOutcome>, String>
 where
-    F: Fn(&Path, &str, Option<&str>, IndexSearchScope, &str, usize) -> Result<Value, String> + Sync,
+    F: Fn(
+            &Path,
+            &str,
+            Option<&str>,
+            IndexSearchScope,
+            &str,
+            usize,
+            IndexSearchMatchMode,
+        ) -> Result<Value, String>
+        + Sync,
 {
     thread::scope(|scope| {
         let mut handles = Vec::with_capacity(jobs.len());
@@ -140,6 +172,7 @@ where
                     job.scope,
                     query,
                     limit,
+                    match_mode,
                 )
                 .map(|payload| ScopeSearchOutcome {
                     scope: job.scope,
@@ -251,6 +284,7 @@ fn run_scope_search(
     scope: IndexSearchScope,
     query: &str,
     limit: usize,
+    match_mode: IndexSearchMatchMode,
 ) -> Result<Value, String> {
     let output =
         gwt_core::process::hidden_command(crate::index_worker::project_index_python_path())
@@ -261,6 +295,7 @@ fn run_scope_search(
                 scope,
                 query,
                 limit,
+                match_mode,
             ))
             .current_dir(project_root)
             .output()
@@ -281,6 +316,7 @@ fn run_repo_scope_search(
     scopes: &[IndexSearchScope],
     query: &str,
     limit: usize,
+    match_mode: IndexSearchMatchMode,
 ) -> Result<Value, String> {
     let output =
         gwt_core::process::hidden_command(crate::index_worker::project_index_python_path())
@@ -290,6 +326,7 @@ fn run_repo_scope_search(
                 scopes,
                 query,
                 limit,
+                match_mode,
             ))
             .current_dir(project_root)
             .output()
@@ -311,6 +348,7 @@ fn scope_search_command_args(
     scope: IndexSearchScope,
     query: &str,
     limit: usize,
+    match_mode: IndexSearchMatchMode,
 ) -> Vec<OsString> {
     let mut args = vec![
         gwt_core::runtime::project_index_runner_path().into_os_string(),
@@ -324,6 +362,8 @@ fn scope_search_command_args(
         OsString::from(query),
         OsString::from("--n-results"),
         OsString::from(limit.to_string()),
+        OsString::from("--match-mode"),
+        OsString::from(match_mode.as_str()),
         OsString::from("--no-auto-build"),
     ];
     if let Some(hash) = worktree_hash {
@@ -339,6 +379,7 @@ fn repo_scope_search_command_args(
     scopes: &[IndexSearchScope],
     query: &str,
     limit: usize,
+    match_mode: IndexSearchMatchMode,
 ) -> Vec<OsString> {
     vec![
         gwt_core::runtime::project_index_runner_path().into_os_string(),
@@ -352,6 +393,8 @@ fn repo_scope_search_command_args(
         OsString::from(query),
         OsString::from("--n-results"),
         OsString::from(limit.to_string()),
+        OsString::from("--match-mode"),
+        OsString::from(match_mode.as_str()),
         OsString::from("--scopes"),
         OsString::from(
             scopes
@@ -408,6 +451,37 @@ fn append_scope_results(
     }
 }
 
+fn append_scope_suggestions(
+    out: &mut Vec<IndexSearchResult>,
+    scope: IndexSearchScope,
+    payload: &Value,
+    board_scope: &gwt_core::coordination::BoardAudienceScope,
+) {
+    let Some(suggestions) = payload.get("suggestions") else {
+        return;
+    };
+    let items = suggestions
+        .get(scope.as_str())
+        .or_else(|| suggestions.as_array().map(|_| suggestions))
+        .and_then(Value::as_array);
+    let Some(items) = items else {
+        return;
+    };
+    for item in items {
+        let result = match scope {
+            IndexSearchScope::Issues => issue_result(item),
+            IndexSearchScope::Specs => spec_result(item),
+            IndexSearchScope::Memory => memory_result(item),
+            IndexSearchScope::Discussions => discussion_result(item),
+            IndexSearchScope::Board => board_result(item, board_scope),
+            IndexSearchScope::Files | IndexSearchScope::FilesDocs => file_result(scope, item),
+        };
+        if let Some(result) = result {
+            out.push(result);
+        }
+    }
+}
+
 fn issue_result(item: &Value) -> Option<IndexSearchResult> {
     let number = value_u64(item.get("number")?)?;
     let title = value_str(item.get("title")).unwrap_or_default();
@@ -417,6 +491,9 @@ fn issue_result(item: &Value) -> Option<IndexSearchResult> {
         subtitle: value_str(item.get("state")).unwrap_or_else(|| "issue".to_string()),
         preview: labels_preview(item),
         distance: item.get("distance").and_then(Value::as_f64),
+        match_mode: item_match_mode(item),
+        matched_terms: value_string_array(item.get("matched_terms")),
+        missing_terms: value_string_array(item.get("missing_terms")),
         target: IndexSearchTarget::Issue { number },
     })
 }
@@ -432,6 +509,9 @@ fn spec_result(item: &Value) -> Option<IndexSearchResult> {
             .unwrap_or_else(|| "spec".to_string()),
         preview: value_str(item.get("matched_section")).unwrap_or_default(),
         distance: item.get("distance").and_then(Value::as_f64),
+        match_mode: item_match_mode(item),
+        matched_terms: value_string_array(item.get("matched_terms")),
+        missing_terms: value_string_array(item.get("missing_terms")),
         target: IndexSearchTarget::Spec { spec_id },
     })
 }
@@ -450,6 +530,9 @@ fn memory_result(item: &Value) -> Option<IndexSearchResult> {
         },
         preview: heading.clone(),
         distance: item.get("distance").and_then(Value::as_f64),
+        match_mode: item_match_mode(item),
+        matched_terms: value_string_array(item.get("matched_terms")),
+        missing_terms: value_string_array(item.get("missing_terms")),
         target: IndexSearchTarget::Memory { heading, date },
     })
 }
@@ -469,6 +552,9 @@ fn discussion_result(item: &Value) -> Option<IndexSearchResult> {
         },
         preview: heading.clone(),
         distance: item.get("distance").and_then(Value::as_f64),
+        match_mode: item_match_mode(item),
+        matched_terms: value_string_array(item.get("matched_terms")),
+        missing_terms: value_string_array(item.get("missing_terms")),
         target: IndexSearchTarget::Discussion { heading, date },
     })
 }
@@ -497,6 +583,9 @@ fn board_result(
         },
         preview: value_str(item.get("body_preview")).unwrap_or_default(),
         distance: item.get("distance").and_then(Value::as_f64),
+        match_mode: item_match_mode(item),
+        matched_terms: value_string_array(item.get("matched_terms")),
+        missing_terms: value_string_array(item.get("missing_terms")),
         target: IndexSearchTarget::Board { entry_id },
     })
 }
@@ -515,8 +604,31 @@ fn file_result(scope: IndexSearchScope, item: &Value) -> Option<IndexSearchResul
         },
         preview: description,
         distance: item.get("distance").and_then(Value::as_f64),
+        match_mode: item_match_mode(item),
+        matched_terms: value_string_array(item.get("matched_terms")),
+        missing_terms: value_string_array(item.get("missing_terms")),
         target: IndexSearchTarget::File { path },
     })
+}
+
+fn item_match_mode(item: &Value) -> Option<IndexSearchMatchMode> {
+    match item.get("match_mode").and_then(Value::as_str) {
+        Some("all_terms") => Some(IndexSearchMatchMode::AllTerms),
+        Some("semantic") => Some(IndexSearchMatchMode::Semantic),
+        _ => None,
+    }
+}
+
+fn value_string_array(value: Option<&Value>) -> Vec<String> {
+    value
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value_str(Some(value)))
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn board_item_visible_for_scope(
@@ -669,10 +781,17 @@ mod tests {
 
     #[test]
     fn empty_index_search_query_returns_no_results_without_runtime() {
-        let results = search_project_index(Path::new("/definitely/not/a/repo"), "   ", &[], None)
-            .expect("empty query should short-circuit");
+        let outcome = search_project_index(
+            Path::new("/definitely/not/a/repo"),
+            "   ",
+            &[],
+            None,
+            IndexSearchMatchMode::Semantic,
+        )
+        .expect("empty query should short-circuit");
 
-        assert!(results.is_empty());
+        assert!(outcome.results.is_empty());
+        assert!(outcome.suggestions.is_empty());
     }
 
     #[test]
@@ -847,6 +966,41 @@ mod tests {
     }
 
     #[test]
+    fn append_scope_suggestions_preserves_match_evidence() {
+        let mut suggestions = Vec::new();
+        let board_scope = BoardAudienceScope::All;
+
+        append_scope_suggestions(
+            &mut suggestions,
+            IndexSearchScope::Issues,
+            &json!({
+                "suggestions": {
+                    "issues": [{
+                        "number": 77,
+                        "title": "Workspace only",
+                        "state": "open",
+                        "labels": ["index"],
+                        "distance": 0.35,
+                        "match_mode": "all_terms",
+                        "matched_terms": ["Workspace"],
+                        "missing_terms": ["置き換え"]
+                    }]
+                }
+            }),
+            &board_scope,
+        );
+
+        assert_eq!(suggestions.len(), 1);
+        assert_eq!(suggestions[0].title, "#77 Workspace only");
+        assert_eq!(
+            suggestions[0].match_mode,
+            Some(IndexSearchMatchMode::AllTerms)
+        );
+        assert_eq!(suggestions[0].matched_terms, vec!["Workspace"]);
+        assert_eq!(suggestions[0].missing_terms, vec!["置き換え"]);
+    }
+
+    #[test]
     fn board_visibility_supports_all_broadcast_and_workspace_modes() {
         let broadcast = json!({ "audience": [] });
         let workspace = json!({ "audience": ["workspace-a"] });
@@ -922,11 +1076,17 @@ mod tests {
             IndexSearchScope::Issues,
             "Git",
             50,
+            crate::protocol::IndexSearchMatchMode::AllTerms,
         );
 
         assert!(
             args.iter().any(|arg| arg == "--no-auto-build"),
             "interactive Index search must not block on auto-index rebuilds"
+        );
+        assert!(
+            args.windows(2)
+                .any(|pair| pair[0] == "--match-mode" && pair[1] == "all_terms"),
+            "runner args should carry the requested match mode"
         );
     }
 
@@ -944,6 +1104,7 @@ mod tests {
             ],
             "Git",
             12,
+            crate::protocol::IndexSearchMatchMode::AllTerms,
         );
 
         assert!(args.iter().any(|arg| arg == "search-multi"));
@@ -954,6 +1115,11 @@ mod tests {
             "repo-scoped searches should share one runner process"
         );
         assert!(args.iter().any(|arg| arg == "--no-auto-build"));
+        assert!(
+            args.windows(2)
+                .any(|pair| pair[0] == "--match-mode" && pair[1] == "all_terms"),
+            "repo-scoped searches should forward match mode to search-multi"
+        );
     }
 
     #[test]
@@ -997,24 +1163,31 @@ mod tests {
             },
         ];
 
-        let results = run_scope_search_jobs(jobs, "repo", "Git", 3, |_, _, _, scope, _, _| {
-            let active_now = active.fetch_add(1, Ordering::SeqCst) + 1;
-            peak.fetch_max(active_now, Ordering::SeqCst);
-            thread::sleep(Duration::from_millis(120));
-            active.fetch_sub(1, Ordering::SeqCst);
-            let key = match scope {
-                IndexSearchScope::Issues => "issueResults",
-                IndexSearchScope::Specs => "specResults",
-                IndexSearchScope::Board => "boardResults",
-                IndexSearchScope::Discussions => "discussionResults",
-                IndexSearchScope::Memory => "memoryResults",
-                IndexSearchScope::Files | IndexSearchScope::FilesDocs => "results",
-            };
-            let mut payload = serde_json::Map::new();
-            payload.insert("ok".to_string(), Value::Bool(true));
-            payload.insert(key.to_string(), Value::Array(Vec::new()));
-            Ok(Value::Object(payload))
-        })
+        let results = run_scope_search_jobs(
+            jobs,
+            "repo",
+            "Git",
+            3,
+            IndexSearchMatchMode::Semantic,
+            |_, _, _, scope, _, _, _| {
+                let active_now = active.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(active_now, Ordering::SeqCst);
+                thread::sleep(Duration::from_millis(120));
+                active.fetch_sub(1, Ordering::SeqCst);
+                let key = match scope {
+                    IndexSearchScope::Issues => "issueResults",
+                    IndexSearchScope::Specs => "specResults",
+                    IndexSearchScope::Board => "boardResults",
+                    IndexSearchScope::Discussions => "discussionResults",
+                    IndexSearchScope::Memory => "memoryResults",
+                    IndexSearchScope::Files | IndexSearchScope::FilesDocs => "results",
+                };
+                let mut payload = serde_json::Map::new();
+                payload.insert("ok".to_string(), Value::Bool(true));
+                payload.insert(key.to_string(), Value::Array(Vec::new()));
+                Ok(Value::Object(payload))
+            },
+        )
         .expect("parallel scope search should succeed");
 
         assert_eq!(results.len(), 5);

--- a/crates/gwt/src/index_worker.rs
+++ b/crates/gwt/src/index_worker.rs
@@ -22,7 +22,45 @@ use serde::Serialize;
 /// Determine `RepoHash` for the given repository root by shelling out to
 /// `git remote get-url origin`. Returns `None` if no origin is configured.
 pub fn detect_repo_hash(repo_root: &Path) -> Option<RepoHash> {
-    gwt_core::repo_hash::detect_repo_hash(repo_root)
+    gwt_core::repo_hash::detect_repo_hash(repo_root).or_else(|| {
+        let index_root = resolve_project_index_repo_root(repo_root)?;
+        gwt_core::repo_hash::detect_repo_hash(&index_root)
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectIndexGitContext {
+    pub repo_root: PathBuf,
+    pub current_worktree_root: Option<PathBuf>,
+}
+
+pub fn project_index_git_context(project_root: &Path) -> Option<ProjectIndexGitContext> {
+    if !project_root.exists() {
+        return None;
+    }
+    let current_worktree_root = resolve_current_git_worktree_root(project_root);
+    let repo_root = gwt_git::worktree::main_worktree_root(project_root)
+        .ok()
+        .map(canonicalize_path)
+        .or_else(|| current_worktree_root.clone())?;
+    Some(ProjectIndexGitContext {
+        repo_root,
+        current_worktree_root,
+    })
+}
+
+pub fn resolve_project_index_repo_root(project_root: &Path) -> Option<PathBuf> {
+    project_index_git_context(project_root).map(|context| context.repo_root)
+}
+
+pub fn default_project_index_worktree_root(project_root: &Path) -> Option<PathBuf> {
+    let context = project_index_git_context(project_root)?;
+    if context.current_worktree_root.is_some() {
+        return context.current_worktree_root;
+    }
+    process_cwd_worktree_root_for_repo(&context.repo_root)
+        .or_else(|| first_active_worktree_path(&context.repo_root))
+        .or(Some(context.repo_root))
 }
 
 pub fn bootstrap_project_index_for_path(project_root: &Path) -> Result<(), String> {
@@ -519,12 +557,13 @@ fn aggregate_project_index_status_for_path_inner(
     project_root: &Path,
     probe_scope: StatusProbeScope,
 ) -> Result<ProjectIndexStatusView, String> {
-    let Some(repo_root) = resolve_git_worktree_root(project_root) else {
+    let Some(context) = project_index_git_context(project_root) else {
         return Ok(ProjectIndexStatusView::new(
             ProjectIndexStatusState::Skipped,
             "No git worktree detected",
         ));
     };
+    let repo_root = context.repo_root;
     let Some(repo_hash) = detect_repo_hash(&repo_root) else {
         return Ok(ProjectIndexStatusView::new(
             ProjectIndexStatusState::Skipped,
@@ -545,7 +584,11 @@ fn aggregate_project_index_status_for_path_inner(
         StatusProbeScope::AllWorktrees => list_worktree_probe_inputs(&repo_root)?,
         StatusProbeScope::CurrentWorktree => {
             let inputs = list_worktree_probe_inputs(&repo_root)?;
-            collect_current_worktree_probe_inputs(inputs, &repo_root)
+            if let Some(current_worktree_root) = context.current_worktree_root.as_deref() {
+                collect_current_worktree_probe_inputs(inputs, current_worktree_root)
+            } else {
+                inputs
+            }
         }
     };
     let mut probes: Vec<WorktreeProbeOutcome> = Vec::with_capacity(inputs.len());
@@ -1068,20 +1111,25 @@ where
 fn project_index_status_for_path_inner(
     project_root: &Path,
 ) -> Result<ProjectIndexStatusView, String> {
-    let Some(repo_root) = resolve_git_worktree_root(project_root) else {
+    let Some(context) = project_index_git_context(project_root) else {
         return Ok(ProjectIndexStatusView::new(
             ProjectIndexStatusState::Skipped,
             "No git worktree detected",
         ));
     };
+    let repo_root = context.repo_root;
     let Some(repo_hash) = detect_repo_hash(&repo_root) else {
         return Ok(ProjectIndexStatusView::new(
             ProjectIndexStatusState::Skipped,
             "No origin remote configured",
         ));
     };
-    let worktree_hash =
-        compute_worktree_hash(&repo_root).map_err(|err| format!("compute worktree hash: {err}"))?;
+    let worktree_root = context
+        .current_worktree_root
+        .or_else(|| first_active_worktree_path(&repo_root))
+        .unwrap_or_else(|| repo_root.clone());
+    let worktree_hash = compute_worktree_hash(&worktree_root)
+        .map_err(|err| format!("compute worktree hash: {err}"))?;
     let runtime_started = Instant::now();
     let report =
         gwt_core::runtime::ensure_project_index_runtime().map_err(|err| err.to_string())?;
@@ -1163,9 +1211,12 @@ pub fn bootstrap_project_index_for_path_with<S: RunnerSpawner + ?Sized>(
         return Ok(());
     }
     let bootstrap_started = Instant::now();
-    let Some(repo_root) = resolve_git_worktree_root(project_root) else {
+    let Some(context) = project_index_git_context(project_root) else {
         return Ok(());
     };
+    let repo_root = context.repo_root;
+    let refresh_project_root =
+        default_project_index_worktree_root(project_root).unwrap_or_else(|| repo_root.clone());
     let Some(repo_hash) = detect_repo_hash(&repo_root) else {
         return Ok(());
     };
@@ -1198,7 +1249,7 @@ pub fn bootstrap_project_index_for_path_with<S: RunnerSpawner + ?Sized>(
     let refresh = RefreshIssuesOptions {
         index_root: index_root.to_path_buf(),
         repo_hash,
-        project_root: repo_root.clone(),
+        project_root: refresh_project_root,
         ttl: Duration::from_secs(15 * 60),
     };
     let runtime = tokio::runtime::Builder::new_current_thread()
@@ -1228,7 +1279,7 @@ pub fn bootstrap_project_index_for_path_with<S: RunnerSpawner + ?Sized>(
     Ok(())
 }
 
-fn resolve_git_worktree_root(path: &Path) -> Option<PathBuf> {
+fn resolve_current_git_worktree_root(path: &Path) -> Option<PathBuf> {
     if !path.exists() {
         return None;
     }
@@ -1245,6 +1296,27 @@ fn resolve_git_worktree_root(path: &Path) -> Option<PathBuf> {
         return None;
     }
     Some(canonicalize_path(PathBuf::from(root)))
+}
+
+fn first_active_worktree_path(repo_root: &Path) -> Option<PathBuf> {
+    list_worktree_probe_inputs(repo_root)
+        .ok()?
+        .into_iter()
+        .next()
+        .map(|input| input.path)
+}
+
+fn process_cwd_worktree_root_for_repo(repo_root: &Path) -> Option<PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    let cwd_worktree = resolve_current_git_worktree_root(&cwd)?;
+    let cwd_repo_root = gwt_git::worktree::main_worktree_root(&cwd_worktree)
+        .ok()
+        .map(canonicalize_path)?;
+    if canonicalize_path(cwd_repo_root) == canonicalize_path(repo_root.to_path_buf()) {
+        Some(cwd_worktree)
+    } else {
+        None
+    }
 }
 
 fn list_git_worktree_paths(project_root: &Path) -> Result<Vec<PathBuf>, String> {
@@ -1404,6 +1476,107 @@ detached
             .output()
             .expect("git remote add origin");
         assert!(remote.status.success(), "git remote add origin failed");
+    }
+
+    fn run_git_at(path: &Path, args: &[&str]) {
+        let output = gwt_core::process::hidden_command("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .unwrap_or_else(|err| panic!("git {args:?}: {err}"));
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn make_bare_workspace_with_origin(home: &Path) -> (PathBuf, PathBuf) {
+        let bare = home.join("gwt.git");
+        let bootstrap = home.join(".bootstrap");
+        let develop = home.join("develop");
+        std::fs::create_dir_all(home).expect("workspace home");
+        run_git_at(home, &["init", "--bare", bare.to_str().unwrap()]);
+        run_git_at(
+            &bare,
+            &[
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/example/gwt.git",
+            ],
+        );
+        run_git_at(home, &["clone", bare.to_str().unwrap(), ".bootstrap"]);
+        run_git_at(&bootstrap, &["config", "user.email", "test@example.com"]);
+        run_git_at(&bootstrap, &["config", "user.name", "Test User"]);
+        run_git_at(&bootstrap, &["checkout", "-b", "develop"]);
+        run_git_at(&bootstrap, &["commit", "--allow-empty", "-m", "init"]);
+        run_git_at(&bootstrap, &["push", "origin", "develop"]);
+        run_git_at(
+            &bare,
+            &["worktree", "add", develop.to_str().unwrap(), "develop"],
+        );
+        std::fs::remove_dir_all(&bootstrap).expect("remove bootstrap");
+        (bare, develop)
+    }
+
+    struct CurrentDirGuard {
+        previous: PathBuf,
+    }
+
+    impl CurrentDirGuard {
+        fn set(path: &Path) -> Self {
+            let previous = std::env::current_dir().expect("current dir");
+            std::env::set_current_dir(path).expect("set current dir");
+            Self { previous }
+        }
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            let _ = std::env::set_current_dir(&self.previous);
+        }
+    }
+
+    #[test]
+    fn detect_repo_hash_reads_origin_from_workspace_home_child_bare_repo() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        make_bare_workspace_with_origin(temp.path());
+
+        let hash = detect_repo_hash(temp.path()).expect("repo hash from workspace home");
+
+        assert_eq!(
+            hash.as_str(),
+            gwt_core::repo_hash::compute_repo_hash("https://github.com/example/gwt.git").as_str()
+        );
+    }
+
+    #[test]
+    fn default_project_index_worktree_root_prefers_process_cwd_worktree_for_workspace_home() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (bare, _develop) = make_bare_workspace_with_origin(temp.path());
+        let active = temp.path().join("work").join("active");
+        std::fs::create_dir_all(active.parent().expect("active parent")).expect("active parent");
+        run_git_at(
+            &bare,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "work/active",
+                active.to_str().unwrap(),
+                "develop",
+            ],
+        );
+        let _cwd = CurrentDirGuard::set(&active);
+
+        let root = default_project_index_worktree_root(temp.path()).expect("default worktree root");
+
+        assert_eq!(
+            canonicalize_path(root),
+            canonicalize_path(active),
+            "workspace home should use the already-running worktree before the first listed worktree"
+        );
     }
 
     #[test]

--- a/crates/gwt/src/index_worker.rs
+++ b/crates/gwt/src/index_worker.rs
@@ -57,6 +57,7 @@ pub enum IndexRebuildScope {
     Issues,
     Specs,
     Memory,
+    Discussions,
     Board,
     Files,
     #[serde(rename = "files-docs")]
@@ -69,6 +70,7 @@ impl IndexRebuildScope {
             Self::Issues => "issues",
             Self::Specs => "specs",
             Self::Memory => "memory",
+            Self::Discussions => "discussions",
             Self::Board => "board",
             Self::Files => "files",
             Self::FilesDocs => "files-docs",
@@ -164,6 +166,8 @@ pub struct ProjectIndexScopes {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memory: Option<ScopeHealthView>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub discussions: Option<ScopeHealthView>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub board: Option<ScopeHealthView>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     pub files: BTreeMap<String, ScopeHealthView>,
@@ -180,6 +184,7 @@ impl ProjectIndexScopes {
         self.issues.is_none()
             && self.specs.is_none()
             && self.memory.is_none()
+            && self.discussions.is_none()
             && self.board.is_none()
             && self.files.is_empty()
             && self.files_docs.is_empty()
@@ -348,6 +353,11 @@ pub fn build_aggregated_status_view(
                 scopes.memory = Some(view);
             }
         }
+        if scopes.discussions.is_none() {
+            if let Some(view) = status_obj.get("discussions").and_then(parse_scope_health) {
+                scopes.discussions = Some(view);
+            }
+        }
         if scopes.board.is_none() {
             if let Some(view) = status_obj.get("board").and_then(parse_scope_health) {
                 scopes.board = Some(view);
@@ -402,6 +412,9 @@ fn count_unhealthy_scopes(scopes: &ProjectIndexScopes) -> usize {
         count += 1;
     }
     if matches!(&scopes.memory, Some(view) if !view.healthy) {
+        count += 1;
+    }
+    if matches!(&scopes.discussions, Some(view) if !view.healthy) {
         count += 1;
     }
     if matches!(&scopes.board, Some(view) if !view.healthy) {
@@ -821,6 +834,12 @@ pub fn default_rebuild_runner(
             scope: None,
             needs_worktree_hash: false,
         },
+        IndexRebuildScope::Discussions => RebuildAction {
+            label: "discussions",
+            action: "index-discussions",
+            scope: None,
+            needs_worktree_hash: false,
+        },
         IndexRebuildScope::Board => RebuildAction {
             label: "board",
             action: "index-board",
@@ -859,6 +878,9 @@ pub fn collect_unhealthy_rebuild_targets(scopes: &ProjectIndexScopes) -> Vec<Reb
     }
     if matches!(&scopes.memory, Some(view) if !view.healthy) {
         targets.push((IndexRebuildScope::Memory, None));
+    }
+    if matches!(&scopes.discussions, Some(view) if !view.healthy) {
+        targets.push((IndexRebuildScope::Discussions, None));
     }
     if matches!(&scopes.board, Some(view) if !view.healthy) {
         targets.push((IndexRebuildScope::Board, None));
@@ -906,6 +928,9 @@ fn collect_unhealthy_rebuild_targets_for_worktree_hash(
     }
     if matches!(&scopes.memory, Some(view) if !view.healthy) {
         targets.push((IndexRebuildScope::Memory, None));
+    }
+    if matches!(&scopes.discussions, Some(view) if !view.healthy) {
+        targets.push((IndexRebuildScope::Discussions, None));
     }
     if matches!(&scopes.board, Some(view) if !view.healthy) {
         targets.push((IndexRebuildScope::Board, None));

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -126,11 +126,11 @@ pub use protocol::{
     ActiveWorkAgentView, ActiveWorkCleanupCandidateView, ActiveWorkProjectionView, AppStateView,
     ArrangeMode, BackendEvent, BranchEntriesPhase, CustomAgentErrorCode, FileContentErrorKind,
     FileContentMode, FileContentSaveErrorKind, FocusCycleDirection, FrontendEvent,
-    GitHubRepositorySearchResultView, IndexSearchResult, IndexSearchScope, IndexSearchTarget,
-    ProfileEntryView, ProfileEnvEntryView, ProfileSnapshotView, ProjectTabView, RecentProjectView,
-    RunningAgentSummary, UiTraceEntry, UiTracePayload, WorkspaceExecutionContainerView,
-    WorkspaceHistoryAgentView, WorkspaceHistoryEventView, WorkspaceHistoryView,
-    WorkspaceJournalEntryView, WorkspaceResumeSource, WorkspaceView, WorkspaceWorkAgentView,
-    WorkspaceWorkEventView, WorkspaceWorkItemView,
+    GitHubRepositorySearchResultView, IndexSearchMatchMode, IndexSearchResult, IndexSearchScope,
+    IndexSearchTarget, ProfileEntryView, ProfileEnvEntryView, ProfileSnapshotView, ProjectTabView,
+    RecentProjectView, RunningAgentSummary, UiTraceEntry, UiTracePayload,
+    WorkspaceExecutionContainerView, WorkspaceHistoryAgentView, WorkspaceHistoryEventView,
+    WorkspaceHistoryView, WorkspaceJournalEntryView, WorkspaceResumeSource, WorkspaceView,
+    WorkspaceWorkAgentView, WorkspaceWorkEventView, WorkspaceWorkItemView,
 };
 pub use workspace::WorkspaceState;

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -52,6 +52,23 @@ pub enum IndexSearchScope {
     FilesDocs,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum IndexSearchMatchMode {
+    #[default]
+    Semantic,
+    AllTerms,
+}
+
+impl IndexSearchMatchMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Semantic => "semantic",
+            Self::AllTerms => "all_terms",
+        }
+    }
+}
+
 impl IndexSearchScope {
     pub fn as_str(self) -> &'static str {
         match self {
@@ -85,6 +102,12 @@ pub struct IndexSearchResult {
     pub preview: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub distance: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub match_mode: Option<IndexSearchMatchMode>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub matched_terms: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub missing_terms: Vec<String>,
     pub target: IndexSearchTarget,
 }
 
@@ -315,6 +338,8 @@ pub enum FrontendEvent {
         scopes: Vec<IndexSearchScope>,
         #[serde(default)]
         worktree_hash: Option<String>,
+        #[serde(default)]
+        match_mode: IndexSearchMatchMode,
     },
     SelectKnowledgeBridgeEntry {
         id: String,
@@ -1068,6 +1093,8 @@ pub enum BackendEvent {
         query: String,
         request_id: u64,
         results: Vec<IndexSearchResult>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        suggestions: Vec<IndexSearchResult>,
     },
     ProjectIndexSearchError {
         id: String,
@@ -1977,9 +2004,9 @@ mod tests {
 
     use super::{
         backend_event_policy, BackendEvent, BackendEventBackpressurePolicy,
-        BackendEventDeliveryClass, BranchEntriesPhase, FrontendEvent, IndexSearchResult,
-        IndexSearchScope, IndexSearchTarget, ProfileEntryView, ProfileEnvEntryView,
-        ProfileSnapshotView, UiTracePayload, BACKEND_EVENT_POLICIES,
+        BackendEventDeliveryClass, BranchEntriesPhase, FrontendEvent, IndexSearchMatchMode,
+        IndexSearchResult, IndexSearchScope, IndexSearchTarget, ProfileEntryView,
+        ProfileEnvEntryView, ProfileSnapshotView, UiTracePayload, BACKEND_EVENT_POLICIES,
     };
 
     #[test]
@@ -2464,7 +2491,8 @@ mod tests {
             "query": "Board semantic search",
             "request_id": 42,
             "scopes": ["issues", "specs", "board", "files", "files-docs", "memory", "discussions"],
-            "worktree_hash": "wt-a"
+            "worktree_hash": "wt-a",
+            "match_mode": "all_terms"
         }))
         .expect("deserialize search_project_index");
 
@@ -2475,13 +2503,35 @@ mod tests {
                 query,
                 request_id: 42,
                 scopes,
-                worktree_hash
+                worktree_hash,
+                match_mode
             } if id == "tab-1:index-1"
                 && query == "Board semantic search"
                 && scopes.contains(&IndexSearchScope::Board)
                 && scopes.contains(&IndexSearchScope::Discussions)
                 && scopes.contains(&IndexSearchScope::FilesDocs)
                 && worktree_hash.as_deref() == Some("wt-a")
+                && match_mode == IndexSearchMatchMode::AllTerms
+        ));
+    }
+
+    #[test]
+    fn index_search_request_defaults_to_semantic_match_mode() {
+        let event: FrontendEvent = serde_json::from_value(serde_json::json!({
+            "kind": "search_project_index",
+            "id": "tab-1:index-1",
+            "query": "Board semantic search",
+            "request_id": 42,
+            "scopes": ["board"]
+        }))
+        .expect("deserialize search_project_index");
+
+        assert!(matches!(
+            event,
+            FrontendEvent::SearchProjectIndex {
+                match_mode: IndexSearchMatchMode::Semantic,
+                ..
+            }
         ));
     }
 
@@ -2497,8 +2547,24 @@ mod tests {
                 subtitle: "status · Codex".to_string(),
                 preview: "Board discussion history".to_string(),
                 distance: Some(0.1234),
+                match_mode: Some(IndexSearchMatchMode::AllTerms),
+                matched_terms: vec!["Board".to_string(), "search".to_string()],
+                missing_terms: Vec::new(),
                 target: IndexSearchTarget::Board {
                     entry_id: "board-1".to_string(),
+                },
+            }],
+            suggestions: vec![IndexSearchResult {
+                scope: IndexSearchScope::Board,
+                title: "Board suggestion".to_string(),
+                subtitle: "status · Codex".to_string(),
+                preview: "Board history".to_string(),
+                distance: Some(0.2234),
+                match_mode: Some(IndexSearchMatchMode::AllTerms),
+                matched_terms: vec!["Board".to_string()],
+                missing_terms: vec!["search".to_string()],
+                target: IndexSearchTarget::Board {
+                    entry_id: "board-2".to_string(),
                 },
             }],
         };
@@ -2506,8 +2572,11 @@ mod tests {
         let value = serde_json::to_value(&event).expect("serialize event");
         assert_eq!(value["kind"], "project_index_search_results");
         assert_eq!(value["results"][0]["scope"], "board");
+        assert_eq!(value["results"][0]["match_mode"], "all_terms");
+        assert_eq!(value["results"][0]["matched_terms"][0], "Board");
         assert_eq!(value["results"][0]["target"]["kind"], "board");
         assert_eq!(value["results"][0]["target"]["entry_id"], "board-1");
+        assert_eq!(value["suggestions"][0]["missing_terms"][0], "search");
     }
 
     #[test]

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -45,6 +45,7 @@ pub enum IndexSearchScope {
     Issues,
     Specs,
     Memory,
+    Discussions,
     Board,
     Files,
     #[serde(rename = "files-docs")]
@@ -57,6 +58,7 @@ impl IndexSearchScope {
             Self::Issues => "issues",
             Self::Specs => "specs",
             Self::Memory => "memory",
+            Self::Discussions => "discussions",
             Self::Board => "board",
             Self::Files => "files",
             Self::FilesDocs => "files-docs",
@@ -70,6 +72,7 @@ pub enum IndexSearchTarget {
     Issue { number: u64 },
     Spec { spec_id: u64 },
     Memory { heading: String, date: String },
+    Discussion { heading: String, date: String },
     Board { entry_id: String },
     File { path: String },
 }
@@ -2397,7 +2400,7 @@ mod tests {
             "id": "tab-1:index-1",
             "query": "Board semantic search",
             "request_id": 42,
-            "scopes": ["issues", "specs", "board", "files", "files-docs", "memory"],
+            "scopes": ["issues", "specs", "board", "files", "files-docs", "memory", "discussions"],
             "worktree_hash": "wt-a"
         }))
         .expect("deserialize search_project_index");
@@ -2413,6 +2416,7 @@ mod tests {
             } if id == "tab-1:index-1"
                 && query == "Board semantic search"
                 && scopes.contains(&IndexSearchScope::Board)
+                && scopes.contains(&IndexSearchScope::Discussions)
                 && scopes.contains(&IndexSearchScope::FilesDocs)
                 && worktree_hash.as_deref() == Some("wt-a")
         ));

--- a/crates/gwt/tests/discussion_cli_test.rs
+++ b/crates/gwt/tests/discussion_cli_test.rs
@@ -1,0 +1,114 @@
+use std::{
+    fs,
+    process::{Command, Stdio},
+};
+
+fn run_gwtd_in(root: &std::path::Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_gwtd"))
+        .current_dir(root)
+        .args(args)
+        .stdin(Stdio::null())
+        .output()
+        .expect("run gwtd")
+}
+
+#[test]
+fn discussion_update_creates_single_canonical_discussions_file() {
+    let repo = tempfile::tempdir().expect("repo");
+
+    let output = run_gwtd_in(
+        repo.path(),
+        &[
+            "discussion",
+            "update",
+            "--date",
+            "2026-05-22",
+            "--title",
+            "Workspace / Work / Discussion terminology",
+            "--status",
+            "active",
+            "--topic",
+            "workspace",
+            "--topic",
+            "work",
+            "--related-spec",
+            "2359",
+            "--summary",
+            "Workspace is being split into Project State, Work, Agent, Discussion, and Branch.",
+            "--decision",
+            "Discussion is not Work.",
+            "--decision",
+            "Discussions are saved in tasks/discussions.md.",
+            "--open-question",
+            "How should Topic Stack resume across sessions?",
+            "--next",
+            "Define Project State migration.",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "discussion update should succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("tasks/discussions.md"),
+        "stdout should name updated path, got: {stdout}"
+    );
+    let content =
+        fs::read_to_string(repo.path().join("tasks/discussions.md")).expect("read discussions");
+    assert!(content.contains("# Discussions"));
+    assert!(content.contains("## 2026-05-22 — Workspace / Work / Discussion terminology"));
+    assert!(content.contains("Status: active"));
+    assert!(content.contains("Topics: workspace, work"));
+    assert!(content.contains("Related SPECs: #2359"));
+    assert!(content.contains("- Discussion is not Work."));
+    assert!(content.contains("- Discussions are saved in tasks/discussions.md."));
+    assert!(content.contains("- How should Topic Stack resume across sessions?"));
+    assert!(content.contains("Define Project State migration."));
+}
+
+#[test]
+fn discussion_update_rewrites_existing_section_instead_of_appending_duplicate() {
+    let repo = tempfile::tempdir().expect("repo");
+
+    for summary in ["First summary", "Updated summary"] {
+        let output = run_gwtd_in(
+            repo.path(),
+            &[
+                "discussion",
+                "update",
+                "--date",
+                "2026-05-22",
+                "--title",
+                "Workspace terminology",
+                "--status",
+                "active",
+                "--summary",
+                summary,
+                "--decision",
+                summary,
+                "--next",
+                "Continue",
+            ],
+        );
+        assert!(
+            output.status.success(),
+            "discussion update should succeed, stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let content =
+        fs::read_to_string(repo.path().join("tasks/discussions.md")).expect("read discussions");
+    assert_eq!(
+        content
+            .matches("## 2026-05-22 — Workspace terminology")
+            .count(),
+        1,
+        "active discussion should keep one canonical section"
+    );
+    assert!(!content.contains("First summary"));
+    assert!(content.contains("Updated summary"));
+}

--- a/crates/gwt/tests/gwtd_cli_test.rs
+++ b/crates/gwt/tests/gwtd_cli_test.rs
@@ -53,7 +53,7 @@ fn gwtd_index_help_lists_every_rebuild_scope() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("all|issues|specs|memory|board|files|files-docs"),
+        stdout.contains("all|issues|specs|memory|discussions|board|files|files-docs"),
         "index help must list every accepted rebuild scope, got: {stdout}"
     );
 }

--- a/crates/gwt/tests/index_rebuild_cell_protocol_test.rs
+++ b/crates/gwt/tests/index_rebuild_cell_protocol_test.rs
@@ -82,6 +82,28 @@ fn frontend_event_rebuild_index_cell_deserializes_with_all_scopes() {
         }
         other => panic!("unexpected event: {other:?}"),
     }
+
+    let discussions = serde_json::from_value::<FrontendEvent>(json!({
+        "kind": "rebuild_index_cell",
+        "project_root": "/abs/repo",
+        "scope": "discussions"
+    }))
+    .expect("rebuild_index_cell scope=discussions should deserialize");
+    match discussions {
+        FrontendEvent::RebuildIndexCell {
+            project_root,
+            scope,
+            worktree_hash,
+        } => {
+            assert_eq!(project_root, "/abs/repo");
+            assert_eq!(scope, IndexRebuildScope::Discussions);
+            assert_eq!(
+                worktree_hash, None,
+                "discussions is repo-scoped, worktree_hash must not be required"
+            );
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
 }
 
 #[test]
@@ -91,5 +113,12 @@ fn index_rebuild_scope_memory_metadata_matches_repo_scoped_contract() {
     assert!(
         !scope.requires_worktree_hash(),
         "memory is repo-scoped — rebuild cell must not require worktree_hash"
+    );
+
+    let scope = IndexRebuildScope::Discussions;
+    assert_eq!(scope.label(), "discussions");
+    assert!(
+        !scope.requires_worktree_hash(),
+        "discussions is repo-scoped — rebuild cell must not require worktree_hash"
     );
 }

--- a/crates/gwt/web/__tests__/index-settings-panel.test.mjs
+++ b/crates/gwt/web/__tests__/index-settings-panel.test.mjs
@@ -48,6 +48,12 @@ test("renderIndexSettingsPanel renders one row per scope and one column per work
           document_count: 5,
           reason: "count_mismatch",
         },
+        discussions: {
+          healthy: true,
+          document_count: 8,
+          repair_required: false,
+          reason: "ready",
+        },
         board: { healthy: true, document_count: 21, repair_required: false, reason: "ready" },
         files: {
           wtAhash: { healthy: true, document_count: 310, repair_required: false, reason: "ready" },
@@ -83,7 +89,15 @@ test("renderIndexSettingsPanel renders one row per scope and one column per work
 
   const scopeRows = Array.from(table.querySelectorAll("tbody tr"));
   const scopes = scopeRows.map((tr) => tr.dataset.scope);
-  assert.deepEqual(scopes, ["issues", "specs", "memory", "board", "files", "files-docs"]);
+  assert.deepEqual(scopes, [
+    "issues",
+    "specs",
+    "memory",
+    "discussions",
+    "board",
+    "files",
+    "files-docs",
+  ]);
 
   // Repo-shared issues row spans all worktree columns and reports ready.
   const issuesCell = scopeRows[0].querySelector(".settings-index-cell");
@@ -99,20 +113,25 @@ test("renderIndexSettingsPanel renders one row per scope and one column per work
   const memoryCell = scopeRows[2].querySelector(".settings-index-cell");
   assert.equal(memoryCell.colSpan, 2);
 
+  // discussions row is repo-shared and reports the Discussion semantic index.
+  const discussionsCell = scopeRows[3].querySelector(".settings-index-cell");
+  assert.equal(discussionsCell.colSpan, 2);
+  assert.match(discussionsCell.textContent, /8 docs/);
+
   // board row is repo-shared and reports the Board semantic index.
-  const boardCell = scopeRows[3].querySelector(".settings-index-cell");
+  const boardCell = scopeRows[4].querySelector(".settings-index-cell");
   assert.equal(boardCell.colSpan, 2);
   assert.match(boardCell.textContent, /21 docs/);
 
   // files row has one cell per worktree, in worktree-hash sort order.
-  const filesCells = scopeRows[4].querySelectorAll(".settings-index-cell");
+  const filesCells = scopeRows[5].querySelectorAll(".settings-index-cell");
   assert.equal(filesCells.length, 2);
   assert.equal(filesCells[0].dataset.worktreeHash, "wtAhash");
   assert.equal(filesCells[1].dataset.worktreeHash, "wtBhash");
   assert.ok(filesCells[1].classList.contains("unhealthy"));
 
   // files-docs only seeded wtAhash — wtB renders an empty placeholder.
-  const docsCells = scopeRows[5].querySelectorAll(".settings-index-cell");
+  const docsCells = scopeRows[6].querySelectorAll(".settings-index-cell");
   assert.equal(docsCells.length, 2);
   assert.ok(docsCells[1].classList.contains("settings-index-cell-empty"));
 });

--- a/crates/gwt/web/__tests__/index-status-controller.test.mjs
+++ b/crates/gwt/web/__tests__/index-status-controller.test.mjs
@@ -212,6 +212,28 @@ test("Index search UI exposes explicit search controls and readable result scori
   );
 });
 
+test("Index search UI exposes semantic and all-terms match modes", () => {
+  assert.ok(
+    appSource.includes("index-match-mode-list") &&
+      appSource.includes('data-match-mode="semantic"') &&
+      appSource.includes('data-match-mode="all_terms"'),
+    "Index search should expose a Semantic / All terms segmented control",
+  );
+  assert.ok(
+    appSource.includes("match_mode: state.matchMode") &&
+      appSource.includes("matchMode") &&
+      appSource.includes("searchSignature = JSON.stringify({ query, scopes, worktreeHash, matchMode"),
+    "match mode should be sent to the backend and included in the request signature",
+  );
+  assert.ok(
+    appSource.includes("state.suggestions") &&
+      appSource.includes("Semantic suggestions") &&
+      appSource.includes("Matched:") &&
+      appSource.includes("Searching all terms"),
+    "All terms mode should render suggestions separately, show concise matched-term evidence, and use matching loading copy",
+  );
+});
+
 test("Index search clears invalidate any in-flight request immediately", () => {
   assert.ok(
     appSource.includes("function clearProjectIndexSearchState(state)") &&

--- a/crates/gwt/web/__tests__/index-status-controller.test.mjs
+++ b/crates/gwt/web/__tests__/index-status-controller.test.mjs
@@ -232,6 +232,13 @@ test("Index search UI exposes semantic and all-terms match modes", () => {
       appSource.includes("Searching all terms"),
     "All terms mode should render suggestions separately, show concise matched-term evidence, and use matching loading copy",
   );
+  assert.ok(
+    appSource.includes("function indexSearchPlaceholder(state)") &&
+      appSource.includes("Search by meaning, e.g. workspace lifecycle") &&
+      appSource.includes("All terms required, e.g. Workspace discussion") &&
+      appSource.includes("input.placeholder = indexSearchPlaceholder(state);"),
+    "Index search placeholder should explain the active Semantic / All terms mode",
+  );
 });
 
 test("Index search clears invalidate any in-flight request immediately", () => {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -572,12 +572,12 @@
         "discussions",
         "memory",
       ]);
-
       function ensureIndexSearchState(windowId) {
         if (!indexSearchStateMap.has(windowId)) {
           indexSearchStateMap.set(windowId, {
             activeTab: "search",
             query: "",
+            matchMode: "semantic",
             selectedScopes: new Set(INDEX_SEARCH_DEFAULT_SCOPES),
             selectedWorktreeHash: "",
             searchTimer: 0,
@@ -586,6 +586,7 @@
             inFlightSignature: "",
             searching: false,
             results: [],
+            suggestions: [],
             selectedResultIndex: -1,
             error: "",
           });
@@ -606,6 +607,7 @@
         }
         invalidateProjectIndexSearchRequest(state);
         state.results = [];
+        state.suggestions = [];
         state.selectedResultIndex = -1;
         state.searching = false;
         state.error = "";
@@ -667,6 +669,35 @@
         return `${Math.round(score * 100)}% match`;
       }
 
+      function indexSearchVisibleResults(state) {
+        return [
+          ...state.results.map((result) => ({ result, suggestion: false })),
+          ...state.suggestions.map((result) => ({ result, suggestion: true })),
+        ];
+      }
+
+      function selectedIndexSearchItem(state) {
+        const visible = indexSearchVisibleResults(state);
+        return visible[state.selectedResultIndex] || visible[0] || null;
+      }
+
+      function formatIndexSearchEvidence(result, includeMissing = false) {
+        const matched = Array.isArray(result?.matched_terms) ? result.matched_terms : [];
+        const missing = Array.isArray(result?.missing_terms) ? result.missing_terms : [];
+        const parts = [];
+        if (matched.length > 0) {
+          parts.push(`Matched: ${matched.join(", ")}`);
+        }
+        if (includeMissing && missing.length > 0) {
+          parts.push(`Missing: ${missing.join(", ")}`);
+        }
+        return parts.join(" · ");
+      }
+
+      function indexSearchLoadingLabel(state) {
+        return state.matchMode === "all_terms" ? "Searching all terms" : "Searching semantic index";
+      }
+
       function scheduleProjectIndexSearch(windowId) {
         const state = ensureIndexSearchState(windowId);
         if (state.searchTimer) {
@@ -699,7 +730,8 @@
         const worktreeHash = indexFileScopesSelected(state)
           ? selectedIndexWorktreeHash(state, status)
           : "";
-        const searchSignature = JSON.stringify({ query, scopes, worktreeHash });
+        const matchMode = state.matchMode || "semantic";
+        const searchSignature = JSON.stringify({ query, scopes, worktreeHash, matchMode });
         if (state.searching && state.inFlightSignature === searchSignature) {
           renderProjectIndexSearch(windowId);
           return;
@@ -715,6 +747,7 @@
           query,
           request_id: requestId,
           scopes,
+          match_mode: state.matchMode,
           worktree_hash: worktreeHash || null,
         });
         renderProjectIndexSearch(windowId);
@@ -771,6 +804,12 @@
             scopes.appendChild(button);
           }
         }
+        const matchModes = root.querySelectorAll("[data-match-mode]");
+        matchModes.forEach((button) => {
+          const active = button.dataset.matchMode === state.matchMode;
+          button.classList.toggle("active", active);
+          button.setAttribute("aria-pressed", String(active));
+        });
         const runButton = root.querySelector(".index-run-button");
         if (runButton) {
           runButton.disabled = !state.query.trim() || state.searching;
@@ -806,11 +845,13 @@
           if (state.searching) {
             statusNode.textContent = state.results.length > 0
               ? `Updating results · ${scopeSummary}`
-              : `Searching semantic index · ${scopeSummary}`;
+              : `${indexSearchLoadingLabel(state)} · ${scopeSummary}`;
           } else if (state.error) {
             statusNode.textContent = state.error;
-          } else if (state.query.trim() && state.results.length > 0) {
-            statusNode.textContent = `${state.results.length} results · ${scopeSummary}`;
+          } else if (state.query.trim() && indexSearchVisibleResults(state).length > 0) {
+            statusNode.textContent = state.matchMode === "all_terms"
+              ? `${state.results.length} strict results · ${state.suggestions.length} semantic suggestions · ${scopeSummary}`
+              : `${state.results.length} results · ${scopeSummary}`;
           } else if (state.query.trim()) {
             statusNode.textContent = "No indexed results";
           } else {
@@ -825,54 +866,78 @@
         const list = root.querySelector(".index-result-list");
         const detail = root.querySelector(".index-result-detail");
         if (!list || !detail) return;
+        const visibleResults = indexSearchVisibleResults(state);
         clearChildren(list);
         clearChildren(detail);
-        layout?.classList.toggle("is-empty", state.results.length === 0);
+        layout?.classList.toggle("is-empty", visibleResults.length === 0);
         if (layout) {
           layout.setAttribute("aria-busy", String(Boolean(state.searching)));
         }
         if (!state.query.trim()) {
           list.appendChild(makeEl("div", { className: "workspace-empty-state", text: "Search indexed content." }));
         } else if (state.searching && state.results.length === 0) {
-          list.appendChild(makeIndexSearchLoadingState());
+          list.appendChild(makeIndexSearchLoadingState(indexSearchLoadingLabel(state)));
         } else if (state.error) {
           list.appendChild(makeEl("div", { className: "workspace-empty-state", text: state.error }));
-        } else if (state.results.length === 0) {
+        } else if (visibleResults.length === 0) {
           list.appendChild(makeEl("div", { className: "workspace-empty-state", text: "No indexed results" }));
         } else {
           if (state.searching) {
             list.appendChild(makeIndexSearchLoadingState("Updating results"));
           }
-          state.results.forEach((result, index) => {
-            const row = makeEl("button", {
-              className: "index-result-row",
-              attrs: {
-                type: "button",
-                "aria-selected": String(index === state.selectedResultIndex),
-              },
-              dataset: { resultIndex: String(index) },
+          let rowIndex = 0;
+          const appendResultGroup = (label, items, suggestion) => {
+            if (items.length === 0) return;
+            if (state.matchMode === "all_terms") {
+              list.appendChild(makeEl("div", { className: "index-result-group-label", text: label }));
+            }
+            items.forEach((result) => {
+              const index = rowIndex;
+              rowIndex += 1;
+              const row = makeEl("button", {
+                className: `index-result-row${suggestion ? " is-suggestion" : ""}`,
+                attrs: {
+                  type: "button",
+                  "aria-selected": String(index === state.selectedResultIndex),
+                },
+                dataset: { resultIndex: String(index) },
+              });
+              row.appendChild(makeEl("span", { className: "index-result-scope", text: result.scope || "" }));
+              row.appendChild(makeEl("strong", { text: result.title || "Untitled" }));
+              row.appendChild(makeEl("span", {
+                className: "index-result-subtitle",
+                text: [result.subtitle || "", formatIndexSearchMatch(result.distance)].filter(Boolean).join(" · "),
+              }));
+              const evidence = formatIndexSearchEvidence(result);
+              if (evidence) {
+                row.appendChild(makeEl("span", { className: "index-result-evidence", text: evidence }));
+              }
+              list.appendChild(row);
             });
-            row.appendChild(makeEl("span", { className: "index-result-scope", text: result.scope || "" }));
-            row.appendChild(makeEl("strong", { text: result.title || "Untitled" }));
-            row.appendChild(makeEl("span", {
-              className: "index-result-subtitle",
-              text: [result.subtitle || "", formatIndexSearchMatch(result.distance)].filter(Boolean).join(" · "),
-            }));
-            list.appendChild(row);
-          });
+          };
+          appendResultGroup("Strict results", state.results, false);
+          appendResultGroup("Semantic suggestions", state.suggestions, true);
         }
 
-        const selected = state.results[state.selectedResultIndex] || state.results[0] || null;
-        if (!selected) {
+        const selectedItem = selectedIndexSearchItem(state);
+        if (!selectedItem) {
           detail.appendChild(makeEl("div", { className: "workspace-empty-state", text: "Select a result" }));
           return;
         }
-        state.selectedResultIndex = Math.max(0, state.results.indexOf(selected));
+        const selected = selectedItem.result;
+        state.selectedResultIndex = Math.max(
+          0,
+          Math.min(visibleResults.length - 1, state.selectedResultIndex),
+        );
         detail.appendChild(makeEl("h3", { className: "index-detail-title", text: selected.title || "Untitled" }));
         detail.appendChild(makeEl("div", { className: "index-detail-subtitle", text: selected.subtitle || selected.scope || "" }));
         const match = formatIndexSearchMatch(selected.distance);
         if (match) {
           detail.appendChild(makeEl("div", { className: "index-detail-meta", text: match }));
+        }
+        const evidence = formatIndexSearchEvidence(selected, true);
+        if (evidence) {
+          detail.appendChild(makeEl("div", { className: "index-detail-meta", text: evidence }));
         }
         detail.appendChild(makeEl("p", { className: "index-detail-preview", text: selected.preview || "No preview available" }));
         detail.appendChild(makeEl("button", {
@@ -910,7 +975,8 @@
         state.inFlightSignature = "";
         state.error = "";
         state.results = Array.isArray(event.results) ? event.results : [];
-        state.selectedResultIndex = state.results.length > 0 ? 0 : -1;
+        state.suggestions = Array.isArray(event.suggestions) ? event.suggestions : [];
+        state.selectedResultIndex = indexSearchVisibleResults(state).length > 0 ? 0 : -1;
         renderProjectIndexSearch(event.id);
       }
 
@@ -934,9 +1000,10 @@
 
       function moveIndexResultSelection(windowId, delta) {
         const state = ensureIndexSearchState(windowId);
-        if (state.results.length === 0) return;
+        const visibleResults = indexSearchVisibleResults(state);
+        if (visibleResults.length === 0) return;
         const current = Math.max(0, state.selectedResultIndex);
-        state.selectedResultIndex = Math.max(0, Math.min(state.results.length - 1, current + delta));
+        state.selectedResultIndex = Math.max(0, Math.min(visibleResults.length - 1, current + delta));
         renderProjectIndexSearch(windowId);
         document
           .querySelector(`[data-id='${CSS.escape(windowId)}'] [data-result-index='${state.selectedResultIndex}']`)
@@ -9576,6 +9643,10 @@
                     <button class="index-run-button" type="submit">Search</button>
                   </form>
                   <div class="index-filter-bar">
+                    <div class="index-match-mode-list" role="group" aria-label="Search mode">
+                      <button class="index-match-mode-button active" type="button" aria-pressed="true" data-match-mode="semantic">Semantic</button>
+                      <button class="index-match-mode-button" type="button" aria-pressed="false" data-match-mode="all_terms">All terms</button>
+                    </div>
                     <div class="index-scope-list" role="group" aria-label="Search scopes"></div>
                     <label class="index-worktree-field">
                       <span>File worktree</span>
@@ -9642,6 +9713,16 @@
             renderProjectIndexSearch(windowData.id);
             scheduleProjectIndexSearch(windowData.id);
           });
+          body.querySelector(".index-match-mode-list").addEventListener("click", (event) => {
+            const button = event.target.closest("[data-match-mode]");
+            if (!button) return;
+            state.matchMode = button.dataset.matchMode || "semantic";
+            if (state.query.trim()) {
+              markProjectIndexSearchPending(state);
+            }
+            renderProjectIndexSearch(windowData.id);
+            scheduleProjectIndexSearch(windowData.id);
+          });
           body.querySelector(".index-worktree-select").addEventListener("change", (event) => {
             state.selectedWorktreeHash = event.target.value || "";
             if (state.query.trim()) {
@@ -9675,7 +9756,7 @@
             const row = event.target.closest("[data-result-index]");
             if (!row) return;
             state.selectedResultIndex = Number(row.dataset.resultIndex || 0);
-            const result = state.results[state.selectedResultIndex] || state.results[0];
+            const result = selectedIndexSearchItem(state)?.result;
             openIndexResultTarget(result);
           });
           body.querySelector(".index-result-list").addEventListener("keydown", (event) => {
@@ -9687,13 +9768,13 @@
               moveIndexResultSelection(windowData.id, -1);
             } else if (event.key === "Enter") {
               event.preventDefault();
-              const result = state.results[state.selectedResultIndex] || state.results[0];
+              const result = selectedIndexSearchItem(state)?.result;
               openIndexResultTarget(result);
             }
           });
           body.querySelector(".index-result-detail").addEventListener("click", (event) => {
             if (!event.target.closest("[data-action='open-index-result']")) return;
-            const result = state.results[state.selectedResultIndex] || state.results[0];
+            const result = selectedIndexSearchItem(state)?.result;
             openIndexResultTarget(result);
           });
           renderProjectIndexSearch(windowData.id);

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -559,6 +559,7 @@
         { id: "issues", label: "Issues" },
         { id: "specs", label: "SPECs" },
         { id: "board", label: "Board" },
+        { id: "discussions", label: "Discussions" },
         { id: "files", label: "Files" },
         { id: "files-docs", label: "Docs" },
         { id: "memory", label: "Memory" },
@@ -567,6 +568,7 @@
         "issues",
         "specs",
         "board",
+        "discussions",
         "memory",
       ]);
 
@@ -956,6 +958,7 @@
             focusOrSpawnPreset("file_tree");
             return;
           case "memory":
+          case "discussion":
             focusOrSpawnPreset("index");
             return;
           default:

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -698,6 +698,12 @@
         return state.matchMode === "all_terms" ? "Searching all terms" : "Searching semantic index";
       }
 
+      function indexSearchPlaceholder(state) {
+        return state.matchMode === "all_terms"
+          ? "All terms required, e.g. Workspace discussion"
+          : "Search by meaning, e.g. workspace lifecycle";
+      }
+
       function scheduleProjectIndexSearch(windowId) {
         const state = ensureIndexSearchState(windowId);
         if (state.searchTimer) {
@@ -814,6 +820,10 @@
         if (runButton) {
           runButton.disabled = !state.query.trim() || state.searching;
           runButton.textContent = state.searching ? "Searching" : "Search";
+        }
+        const input = root.querySelector(".index-search-input");
+        if (input) {
+          input.placeholder = indexSearchPlaceholder(state);
         }
         const fileWorktreeField = root.querySelector(".index-worktree-field");
         if (fileWorktreeField) {
@@ -9639,7 +9649,7 @@
               <section class="index-search-panel" data-index-panel="search">
                 <div class="index-search-toolbar">
                   <form class="index-search-box" role="search">
-                    <input class="index-search-input" type="search" placeholder="Search indexed content" aria-label="Search indexed content" />
+                    <input class="index-search-input" type="search" placeholder="Search by meaning, e.g. workspace lifecycle" aria-label="Search indexed content" />
                     <button class="index-run-button" type="submit">Search</button>
                   </form>
                   <div class="index-filter-bar">

--- a/crates/gwt/web/index-settings-panel.js
+++ b/crates/gwt/web/index-settings-panel.js
@@ -6,7 +6,7 @@
 // and a per-cell Rebuild button that emits `rebuild_index_cell` with
 // `(project_root, scope, worktree_hash?)`.
 
-const REPO_SHARED_SCOPES = ["issues", "specs", "memory", "board"];
+const REPO_SHARED_SCOPES = ["issues", "specs", "memory", "discussions", "board"];
 const PER_WORKTREE_SCOPES = ["files", "files-docs"];
 const ALL_SCOPES = [...REPO_SHARED_SCOPES, ...PER_WORKTREE_SCOPES];
 
@@ -111,6 +111,7 @@ export function renderIndexSettingsPanel(options) {
     && !scopes.issues
     && !scopes.specs
     && !scopes.memory
+    && !scopes.discussions
     && !scopes.board
     && (!scopes.files || Object.keys(scopes.files).length === 0)
     && (!scopes["files-docs"] || Object.keys(scopes["files-docs"]).length === 0)

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -1158,6 +1158,34 @@ body {
   gap: 6px;
 }
 
+.index-match-mode-list {
+  display: inline-flex;
+  flex: 0 0 auto;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+}
+
+.index-match-mode-button {
+  min-width: 82px;
+  border: 0;
+  border-right: 1px solid var(--color-border);
+  padding: 5px 9px;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: var(--type-xs);
+  cursor: pointer;
+}
+
+.index-match-mode-button:last-child {
+  border-right: 0;
+}
+
+.index-match-mode-button[aria-pressed="true"] {
+  background: color-mix(in oklab, var(--color-state-active) 18%, var(--color-surface-elevated));
+  color: var(--color-text-strong);
+}
+
 .index-scope-button {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
@@ -1300,6 +1328,16 @@ body {
   }
 }
 
+.index-result-group-label {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-surface-elevated);
+  color: var(--color-text-muted);
+  font-size: var(--type-xs);
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
 .index-result-row {
   width: 100%;
   display: grid;
@@ -1319,6 +1357,10 @@ body {
   background: color-mix(in oklab, var(--color-state-active) 12%, transparent);
 }
 
+.index-result-row.is-suggestion {
+  background: color-mix(in oklab, var(--color-surface-elevated) 72%, var(--color-surface));
+}
+
 .index-result-scope {
   grid-row: span 2;
   align-self: start;
@@ -1329,10 +1371,15 @@ body {
 }
 
 .index-result-subtitle,
+.index-result-evidence,
 .index-detail-subtitle,
 .index-detail-meta {
   color: var(--color-text-muted);
   font-size: var(--type-xs);
+}
+
+.index-result-evidence {
+  grid-column: 2;
 }
 
 .index-result-detail {

--- a/tasks/discussions.md
+++ b/tasks/discussions.md
@@ -1,0 +1,26 @@
+# Discussions
+
+This file is the canonical gwt discussion log. Entries are updated in place while active and indexed by the `discussions` semantic scope.
+
+## 2026-05-23 — Workspace terminology and durable discussions
+
+Status: active
+Topics: workspace, work, discussion, semantic-search
+Related SPECs: #2359
+Related Works:
+Promoted To:
+
+Summary:
+Workspace の意味が分かりにくい。Branch は作業空間、SPEC は仕様、Work は永続する作業単位として整理する。議論フェーズは Work ではなく Discussion として扱い、memory と同じくファイルへ保存し、セマンティック検索できるようにする。
+
+Decisions:
+- Discussion is not Work.
+- Work remains durable until completion and can be persisted with completed status.
+- A Work can cover multiple SPECs, and concrete tasks may be undecided at creation time.
+- Past Work and Discussion records should be semantically searchable and can surface similar candidates during conversation.
+
+Open Questions:
+- Workspace という語を UI 上で Project State / Work / Discussion / Branch とどう分けると直感的か。
+
+Next:
+実データとして discussion log を保存し、discussions semantic index で検索できることを確認する。

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6032,3 +6032,10 @@ Type: lesson
 Context: Issue #2867 の Recent Projects pollution 修正で headless 確認を行う際、私が独断で「production GWT.app (PID 9569) を終了してください」と要求した。ユーザーから skill にそのような手順は無いと指摘され、誤って kill されると困るとの再発防止依頼を受けた。
 Learning: headless-browser-check skill は 'gwt serve を別プロセスとして起動する' という前提で、ユーザーの常用 gwt / GWT.app を停止する手順は含まない。session.json や app-instance.lock の競合懸念があっても、エージェントが自動で停止判断をしてはならない。
 Future Action: headless 起動時に共有 state (session.json / app-instance.lock / port) の懸念がある場合は、懸念点を明示してユーザーに判断を委ねる。production gwt を停止する選択肢は提示してよいが、エージェント側で前提化したり、依頼したりしない。skill の guardrail にも明文化済み (.claude/.codex の SKILL.md 両方)。
+
+## 2026-05-23 — Index search must resolve workspace-home project roots
+
+Type: lesson
+Context: Index window search can run with the active tab project_root set to the gwt workspace home rather than a concrete git worktree. The workspace home itself has no git origin, while its child bare repo and launched worktree do.
+Learning: Project-index callers must separate repository identity from the searchable/default worktree. Resolve repo hash through the workspace-home child bare repo and prefer the running process cwd worktree for repo-scoped and file searches.
+Future Action: When changing index search or status paths, test both direct worktree roots and workspace-home roots created by gwt-managed layouts before relying on git rev-parse or origin detection.

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6046,3 +6046,10 @@ Type: lesson
 Context: Index window search can run with the active tab project_root set to the gwt workspace home rather than a concrete git worktree. The workspace home itself has no git origin, while its child bare repo and launched worktree do.
 Learning: Project-index callers must separate repository identity from the searchable/default worktree. Resolve repo hash through the workspace-home child bare repo and prefer the running process cwd worktree for repo-scoped and file searches.
 Future Action: When changing index search or status paths, test both direct worktree roots and workspace-home roots created by gwt-managed layouts before relying on git rev-parse or origin detection.
+
+## 2026-05-23 — Do not assume Workspace update is the current coordination path after Project State migration
+
+Type: lesson
+Context: After implementing durable discussions and Project State storage paths, I still followed stale generated gwt-coordination guidance and ran gwtd workspace update. The user pointed out from Board that Workspace is gone for the current discussion/coordination framing and told me to merge origin/develop to see the current state.
+Learning: Generated local skill text can lag the branch's product terminology. For this work, current-state reporting should be checked against Board and the latest develop/SPEC context; do not treat gwtd workspace update as the default user-facing path when Project State / Work / Discussion / Branch separation is being discussed.
+Future Action: Before posting coordination updates in SPEC-2359 terminology work, merge or inspect origin/develop, read recent Board entries, and prefer Board-only reporting unless the active instructions explicitly require the compatibility gwtd workspace path.


### PR DESCRIPTION
## Summary

- Adds durable discussion indexing and project-state path support so prior discussion context can be searched alongside SPECs, Issues, Board, Memory, and files.
- Adds Index search `All terms` mode so users and agents can narrow FAQ-style searches to strict all-term matches while still seeing semantic suggestions separately.
- Clarifies the Index search input placeholder for Semantic versus All terms so the active search behavior is discoverable before typing.

## Changes

- `crates/gwt-core/runtime/chroma_index_runner.py`: indexes discussions, supports `--match-mode semantic|all_terms`, performs bounded overfetch, and separates strict results from semantic suggestions.
- `crates/gwt/src/index_search.rs` / `crates/gwt/src/protocol.rs` / `crates/gwt/src/app_runtime/mod.rs`: carry match mode, matched/missing term evidence, and suggestions through the Rust search contract and backend events.
- `crates/gwt/web/app.js` / `crates/gwt/web/styles/app.css`: add the Semantic / All terms controls, strict/suggestion grouping, match evidence display, loading copy, and mode-specific placeholders.
- `crates/gwt/src/cli/discussion.rs` and related CLI/runtime paths: add discussion persistence/indexing support and discussion CLI coverage.
- `.claude/commands/gwt-search.md`, `.claude/skills/gwt-search/SKILL.md`, `.codex/skills/gwt-search/SKILL.md`: document `--match-mode all_terms` for high-precision searches.
- `tasks/discussions.md` / `tasks/memory.md`: record the Workspace terminology discussion and workflow correction notes used by this implementation.

## Testing

- [x] `PYTHONPATH=crates/gwt-core/runtime GWT_INDEX_FAKE_EMBEDDING=1 ~/.gwt/runtime/chroma-venv/bin/python3 -m unittest discover -s crates/gwt-core/runtime/tests` — PASS (88 tests).
- [x] `cargo test -p gwt index_search -- --nocapture` — PASS.
- [x] `cargo test -p gwt-core -p gwt --all-features -- --test-threads=1` — PASS.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — PASS.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — PASS.
- [x] `cargo build -p gwt --bin gwt` — PASS after the placeholder follow-up.
- [x] `cargo fmt -- --check` and `git diff --check` — PASS.
- [x] `node --check crates/gwt/web/app.js` — PASS.
- [x] `node --test crates/gwt/web/__tests__/*.test.mjs` with temporary `linkedom` — PASS (583 tests).
- [x] `bash scripts/run-visual-tests.sh --headed --project=chromium-dark --grep "all-terms mode" crates/gwt/playwright/tests/index-status.spec.ts` — PASS.
- [x] `bash scripts/run-visual-tests.sh crates/gwt/playwright/tests/index-status.spec.ts` — PASS (18 tests).
- [x] Live `gwt serve` smoke at `http://127.0.0.1:54463/` — PASS; browser confirmed Semantic placeholder `Search by meaning, e.g. workspace lifecycle` and All terms placeholder `All terms required, e.g. Workspace discussion`.
- [x] User visual verification — confirmed on 2026-05-23 (`OKです。進めて`).

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — this is a complete Index search/discussion indexing increment with tests, docs, and UI verification.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- #1939
- #2359

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `node --check`)
- [x] Documentation updated (gwt-search skill and command usage)
- [x] Migration/backfill plan included (not applicable; index layout remains compatible and runner auto-build handles missing indexes)
- [x] CHANGELOG impact considered (minor feature plus patch-level UX clarification; no breaking change)

## Context

- This PR follows the Workspace terminology discussion where `Work`, `SPEC`, `Discussion`, and durable searchable history needed clearer boundaries.
- The Index window previously only offered broad semantic search, which made multi-term narrowing hard for both users and agents.

## Risk / Impact

- **Affected areas**: Project Index runtime, Index window search UI, discussion persistence/indexing, generated gwt search guidance.
- **Rollback plan**: revert this PR; existing semantic search remains the default mode and index data can be rebuilt from source files/caches.

## Screenshots

| Before | After |
|--------|-------|
| Semantic-only search input with generic placeholder | Local headed/live smoke inspected: `/var/folders/p8/3j934ld94g5drz6_x1zy39m80000gn/T/gwt-live-index-all-terms.png`; live placeholder check passed at `http://127.0.0.1:54463/` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added discussions feature for managing project discussion logs via `gwtd discussion update` command
  * Introduced search match modes to Index search: semantic (default) and all-terms for precision matching
  * Enhanced Index search UI to display matched/missing terms and semantic suggestions alongside strict results
  * Added discussions scope to Index search and rebuild operations

* **Documentation**
  * Updated search documentation to describe new match modes and all-terms matching behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2873?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->