### PR TITLE
fix(gui): resolve Issue Bridge cwd for workspace home

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -8239,6 +8239,42 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
+    fn init_workspace_home_with_child_bare(workspace_home: &Path) -> PathBuf {
+        fs::create_dir_all(workspace_home).expect("create workspace home");
+        let bare_repo = workspace_home.join("repo.git");
+        let remote = format!(
+            "https://github.com/example/repo-{:x}.git",
+            remote_suffix(workspace_home)
+        );
+        let init = gwt_core::process::hidden_command("git")
+            .args(["init", "--bare", bare_repo.to_str().unwrap()])
+            .output()
+            .expect("git init bare");
+        assert!(
+            init.status.success(),
+            "git init bare failed: {}",
+            String::from_utf8_lossy(&init.stderr)
+        );
+        let remote_add = gwt_core::process::hidden_command("git")
+            .args([
+                "-C",
+                bare_repo.to_str().unwrap(),
+                "remote",
+                "add",
+                "origin",
+                remote.as_str(),
+            ])
+            .output()
+            .expect("git remote add");
+        assert!(
+            remote_add.status.success(),
+            "git remote add failed: {}",
+            String::from_utf8_lossy(&remote_add.stderr)
+        );
+        bare_repo
+    }
+
     fn remote_suffix(repo_path: &Path) -> u64 {
         use std::hash::{Hash, Hasher};
 
@@ -8336,12 +8372,16 @@ exit /b 0\r\n",
             fs::write(
                 &fake_gh,
                 r#"#!/bin/sh
-if [ -n "$GWT_FAKE_GH_MARKER" ]; then
-  touch "$GWT_FAKE_GH_MARKER"
-fi
-if [ "$GWT_FAKE_GH_MODE" = "fail" ]; then
-  printf '%s\n' 'gh refresh failed' >&2
-  exit 1
+	if [ -n "$GWT_FAKE_GH_MARKER" ]; then
+	  touch "$GWT_FAKE_GH_MARKER"
+	fi
+	if [ -n "$GWT_FAKE_GH_EXPECT_CWD" ] && [ "$(pwd)" != "$GWT_FAKE_GH_EXPECT_CWD" ]; then
+	  printf '%s\n' "wrong cwd: $(pwd)" >&2
+	  exit 1
+	fi
+	if [ "$GWT_FAKE_GH_MODE" = "fail" ]; then
+	  printf '%s\n' 'gh refresh failed' >&2
+	  exit 1
 fi
 printf '%s\n' '[{"number":43,"title":"Refreshed issue","body":"Fresh body","labels":[{"name":"bug"}],"state":"OPEN","url":"https://example.test/issues/43","updatedAt":"2026-04-20T00:00:00Z"}]'
 exit 0
@@ -14250,6 +14290,85 @@ exit 1
                 )
             })
         });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn app_runtime_manual_knowledge_refresh_uses_child_bare_repo_for_workspace_home() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _gh_lock = fake_gh_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let fake_gh = write_fake_gh_issue_list(temp.path());
+        let _path = prepend_fake_gh_to_path(&fake_gh);
+        let _gh = ScopedEnvVar::set("GWT_TEST_GH", &fake_gh);
+        let _mode = ScopedEnvVar::set("GWT_FAKE_GH_MODE", "ok");
+
+        let workspace_home = temp.path().join("workspace");
+        let bare_repo = init_workspace_home_with_child_bare(&workspace_home);
+        let expected_cwd = dunce::canonicalize(&bare_repo).expect("canonical bare repo");
+        let _expected = ScopedEnvVar::set("GWT_FAKE_GH_EXPECT_CWD", &expected_cwd);
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "issue-1",
+            workspace_home,
+            WindowPreset::Issue,
+            WindowProcessStatus::Ready,
+        );
+        let (mut runtime, events) =
+            sample_runtime_with_events(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "issue-1");
+
+        let immediate_events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::LoadKnowledgeBridge {
+                id: window_id.clone(),
+                knowledge_kind: gwt::KnowledgeKind::Issue,
+                request_id: Some(35),
+                selected_number: Some(43),
+                refresh: true,
+            },
+        );
+
+        assert!(
+            immediate_events.is_empty(),
+            "manual refresh must stay asynchronous for workspace homes"
+        );
+        wait_for_recorded_event(
+            "workspace home knowledge refresh dispatch",
+            &events,
+            |events| {
+                events.iter().any(|event| {
+                    matches!(
+                        event,
+                        UserEvent::Dispatch(dispatched)
+                            if dispatched.iter().any(|outbound| {
+                                matches!(
+                                    &outbound.event,
+                                    BackendEvent::KnowledgeEntries {
+                                        id,
+                                        knowledge_kind,
+                                        request_id,
+                                        entries,
+                                        selected_number,
+                                        ..
+                                    } if id == &window_id
+                                        && *knowledge_kind == gwt::KnowledgeKind::Issue
+                                        && *request_id == Some(35)
+                                        && *selected_number == Some(43)
+                                        && entries.len() == 1
+                                        && entries[0].number == 43
+                                )
+                            })
+                    )
+                })
+            },
+        );
     }
 
     #[test]

--- a/crates/gwt/src/issue_cache.rs
+++ b/crates/gwt/src/issue_cache.rs
@@ -114,6 +114,11 @@ pub fn sync_issue_cache_from_remote(repo_path: &Path, cache_root: &Path) -> Resu
     Ok(())
 }
 
+fn gh_repo_cwd(repo_path: &Path) -> PathBuf {
+    crate::index_worker::resolve_project_index_repo_root(repo_path)
+        .unwrap_or_else(|| repo_path.to_path_buf())
+}
+
 pub fn issue_cache_has_entries(cache_root: &Path) -> bool {
     let Ok(entries) = fs::read_dir(cache_root) else {
         return false;
@@ -209,7 +214,7 @@ pub(crate) fn write_issue_labels_via_gh(
         command.arg("--remove-label").arg(label);
     }
     let output = command
-        .current_dir(repo_path)
+        .current_dir(gh_repo_cwd(repo_path))
         .output()
         .map_err(|err| format!("gh issue edit #{issue_number}: {err}"))?;
     if !output.status.success() {
@@ -233,7 +238,7 @@ fn fetch_issue_list_snapshots(repo_path: &Path) -> Result<Vec<IssueSnapshot>, St
             "--json",
             "number,title,body,labels,state,url,updatedAt",
         ])
-        .current_dir(repo_path)
+        .current_dir(gh_repo_cwd(repo_path))
         .output()
         .map_err(|err| format!("gh issue list: {err}"))?;
     if !output.status.success() {
@@ -255,7 +260,7 @@ fn fetch_issue_snapshot(repo_path: &Path, number: IssueNumber) -> Result<IssueSn
             "--json",
             "number,title,body,labels,state,updatedAt,comments",
         ])
-        .current_dir(repo_path)
+        .current_dir(gh_repo_cwd(repo_path))
         .output()
         .map_err(|err| format!("gh issue view #{number}: {err}", number = number.0))?;
     if !output.status.success() {
@@ -699,6 +704,90 @@ exit 1\n",
         );
         assert_eq!(entry.snapshot.comments.len(), 1);
         assert_eq!(entry.snapshot.comments[0].id, gwt_github::CommentId(777));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sync_remote_uses_child_bare_repo_cwd_for_workspace_home() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = crate::cli::fake_gh_test_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        let temp = tempdir().expect("tempdir");
+        let workspace_home = temp.path().join("workspace");
+        let bare_repo = workspace_home.join("repo.git");
+        let cache_root = temp.path().join("cache");
+        fs::create_dir_all(&workspace_home).expect("create workspace home");
+        let init = gwt_core::process::hidden_command("git")
+            .args(["init", "--bare", bare_repo.to_str().unwrap()])
+            .output()
+            .expect("git init bare");
+        assert!(
+            init.status.success(),
+            "git init bare failed: {}",
+            String::from_utf8_lossy(&init.stderr)
+        );
+        let remote = gwt_core::process::hidden_command("git")
+            .args([
+                "-C",
+                bare_repo.to_str().unwrap(),
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/example/workspace-home.git",
+            ])
+            .output()
+            .expect("git remote add");
+        assert!(
+            remote.status.success(),
+            "git remote add failed: {}",
+            String::from_utf8_lossy(&remote.stderr)
+        );
+
+        let expected_cwd = dunce::canonicalize(&bare_repo).expect("canonical bare repo");
+        let cwd_log = temp.path().join("gh-cwd.log");
+        let fake_gh = temp.path().join("fake-gh");
+        fs::write(
+            &fake_gh,
+            format!(
+                "#!/bin/sh\n\
+printf '%s\\n' \"$PWD\" > '{}'\n\
+if [ \"$PWD\" != '{}' ]; then\n\
+  printf '%s\\n' \"wrong cwd: $PWD\" >&2\n\
+  exit 1\n\
+fi\n\
+if [ \"$1 $2\" = \"issue list\" ]; then\n\
+  printf '%s\\n' '[{{\"number\":43,\"title\":\"Workspace issue\",\"body\":\"Body\",\"labels\":[{{\"name\":\"bug\"}}],\"state\":\"OPEN\",\"url\":\"https://example.test/issues/43\",\"updatedAt\":\"2026-05-23T00:00:00Z\"}}]'\n\
+  exit 0\n\
+fi\n\
+printf '%s\\n' \"unexpected gh invocation $*\" >&2\n\
+exit 1\n",
+                cwd_log.display(),
+                expected_cwd.display()
+            ),
+        )
+        .expect("write fake gh");
+        fs::set_permissions(&fake_gh, fs::Permissions::from_mode(0o755)).expect("chmod fake gh");
+        let old_gh = env::var_os("GWT_TEST_GH");
+        env::set_var("GWT_TEST_GH", &fake_gh);
+
+        let result = sync_issue_cache_from_remote(&workspace_home, &cache_root);
+
+        match old_gh {
+            Some(value) => env::set_var("GWT_TEST_GH", value),
+            None => env::remove_var("GWT_TEST_GH"),
+        }
+
+        result.expect("workspace home sync should use child bare repo cwd");
+        assert_eq!(
+            fs::read_to_string(&cwd_log).expect("read cwd log").trim(),
+            expected_cwd.display().to_string()
+        );
+        let entry = Cache::new(cache_root)
+            .load_entry(IssueNumber(43))
+            .expect("cached issue entry should exist");
+        assert_eq!(entry.snapshot.title, "Workspace issue");
     }
 
     #[test]

--- a/crates/gwt/src/knowledge_bridge.rs
+++ b/crates/gwt/src/knowledge_bridge.rs
@@ -172,7 +172,9 @@ impl SemanticSearchClient for RunnerSemanticSearchClient {
             KnowledgeKind::Spec => "search-specs",
             KnowledgeKind::Pr => return Ok(Vec::new()),
         };
-        let repo_hash = crate::index_worker::detect_repo_hash(repo_path)
+        let search_root = crate::index_worker::resolve_project_index_repo_root(repo_path)
+            .unwrap_or_else(|| repo_path.to_path_buf());
+        let repo_hash = crate::index_worker::detect_repo_hash(&search_root)
             .ok_or_else(|| "semantic search requires a git origin remote".to_string())?;
         gwt_core::runtime::ensure_project_index_runtime().map_err(|error| error.to_string())?;
         let output =
@@ -183,12 +185,12 @@ impl SemanticSearchClient for RunnerSemanticSearchClient {
                 .arg("--repo-hash")
                 .arg(repo_hash.as_str())
                 .arg("--project-root")
-                .arg(repo_path)
+                .arg(&search_root)
                 .arg("--query")
                 .arg(query)
                 .arg("--n-results")
                 .arg(limit.to_string())
-                .current_dir(repo_path)
+                .current_dir(&search_root)
                 .output()
                 .map_err(|error| format!("run semantic search: {error}"))?;
         if !output.status.success() {
@@ -1007,7 +1009,7 @@ fn load_linked_branches(repo_path: &Path) -> HashMap<u64, Vec<String>> {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, ffi::OsString, fs};
+    use std::{collections::HashMap, ffi::OsString, fs, path::PathBuf};
 
     use gwt_github::{
         client::{CommentId, CommentSnapshot, IssueNumber, IssueSnapshot, IssueState, UpdatedAt},
@@ -1059,6 +1061,107 @@ mod tests {
         gwt_core::process::scrub_git_env(&mut remote_cmd);
         let remote = remote_cmd.output().expect("git remote add");
         assert!(remote.status.success(), "git remote add failed");
+    }
+
+    #[cfg(unix)]
+    fn init_workspace_home_with_child_bare(workspace_home: &Path) -> PathBuf {
+        fs::create_dir_all(workspace_home).expect("create workspace home");
+        let bare_repo = workspace_home.join("repo.git");
+        let init = gwt_core::process::hidden_command("git")
+            .args(["init", "--bare", bare_repo.to_str().unwrap()])
+            .output()
+            .expect("git init bare");
+        assert!(
+            init.status.success(),
+            "git init bare failed: {}",
+            String::from_utf8_lossy(&init.stderr)
+        );
+        let remote = gwt_core::process::hidden_command("git")
+            .args([
+                "-C",
+                bare_repo.to_str().unwrap(),
+                "remote",
+                "add",
+                "origin",
+                "https://github.com/example/workspace-home.git",
+            ])
+            .output()
+            .expect("git remote add");
+        assert!(
+            remote.status.success(),
+            "git remote add failed: {}",
+            String::from_utf8_lossy(&remote.stderr)
+        );
+        bare_repo
+    }
+
+    #[cfg(unix)]
+    fn write_fake_project_index_python_requiring_cwd(
+        expected_cwd: &Path,
+        cwd_log: &Path,
+        project_root_log: &Path,
+    ) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let legacy_python = PathBuf::from(std::env::var_os("HOME").expect("HOME"))
+            .join(".gwt")
+            .join("runtime")
+            .join("chroma-venv")
+            .join("bin")
+            .join("python3");
+        let script = format!(
+            "#!/bin/sh\n\
+for arg in \"$@\"; do\n\
+  if [ \"$arg\" = \"-c\" ]; then\n\
+    exit 0\n\
+  fi\n\
+done\n\
+case \"$*\" in\n\
+  *\"-m pip\"*) exit 0 ;;\n\
+  *\"--action probe\"*) exit 0 ;;\n\
+esac\n\
+project_root=\"\"\n\
+previous=\"\"\n\
+for arg in \"$@\"; do\n\
+  if [ \"$previous\" = \"--project-root\" ]; then\n\
+    project_root=\"$arg\"\n\
+  fi\n\
+  previous=\"$arg\"\n\
+done\n\
+printf '%s\\n' \"$PWD\" > '{}'\n\
+printf '%s\\n' \"$project_root\" > '{}'\n\
+if [ \"$PWD\" != '{}' ]; then\n\
+  printf '%s\\n' \"wrong cwd: $PWD\" >&2\n\
+  exit 1\n\
+fi\n\
+if [ \"$project_root\" != '{}' ]; then\n\
+  printf '%s\\n' \"wrong project root: $project_root\" >&2\n\
+  exit 1\n\
+fi\n\
+case \"$*\" in\n\
+  *\"--action search-issues\"*)\n\
+    printf '%s\\n' '{{\"ok\":true,\"issueResults\":[{{\"number\":43,\"distance\":0.25}}]}}'\n\
+    exit 0\n\
+    ;;\n\
+esac\n\
+printf '%s\\n' '{{\"ok\":false,\"error\":\"unexpected fake python invocation\"}}'\n\
+exit 1\n",
+            cwd_log.display(),
+            project_root_log.display(),
+            expected_cwd.display(),
+            expected_cwd.display()
+        );
+        let pythons: [PathBuf; 2] = [
+            legacy_python,
+            gwt_core::runtime::project_index_python_path(),
+        ];
+        for python in pythons {
+            fs::create_dir_all(python.parent().expect("fake python parent"))
+                .expect("create fake python dir");
+            fs::write(&python, &script).expect("write fake python");
+            fs::set_permissions(&python, fs::Permissions::from_mode(0o755))
+                .expect("chmod fake python");
+        }
     }
 
     fn issue_snapshot(
@@ -1489,6 +1592,57 @@ Extra context.
         assert!(
             !marker.exists(),
             "interactive semantic search must not invoke stale remote cache sync"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn runner_semantic_issue_search_uses_child_bare_repo_for_workspace_home() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let home = tempfile::tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", home.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
+        let workspace_home = home.path().join("workspace");
+        let bare_repo = init_workspace_home_with_child_bare(&workspace_home);
+        let expected_cwd = dunce::canonicalize(&bare_repo).expect("canonical bare repo");
+        let cwd_log = home.path().join("runner-cwd.log");
+        let project_root_log = home.path().join("runner-project-root.log");
+        write_fake_project_index_python_requiring_cwd(&expected_cwd, &cwd_log, &project_root_log);
+
+        let cache_root = crate::issue_cache::issue_cache_root_for_repo_path(&workspace_home)
+            .expect("workspace home cache root");
+        let cache = Cache::new(cache_root);
+        cache
+            .write_snapshot(&issue_snapshot(
+                43,
+                "Workspace semantic issue",
+                "Search should run from the child bare repo.",
+                &["bug"],
+                IssueState::Open,
+            ))
+            .expect("write issue");
+
+        let view = search_knowledge_bridge(
+            &workspace_home,
+            KnowledgeKind::Issue,
+            "workspace semantic",
+            None,
+        )
+        .expect("workspace home semantic search should succeed");
+
+        assert_eq!(view.entries.len(), 1);
+        assert_eq!(view.entries[0].number, 43);
+        assert_eq!(
+            fs::read_to_string(&cwd_log).expect("read cwd log").trim(),
+            expected_cwd.display().to_string()
+        );
+        assert_eq!(
+            fs::read_to_string(&project_root_log)
+                .expect("read project root log")
+                .trim(),
+            expected_cwd.display().to_string()
         );
     }
 


### PR DESCRIPTION
## Summary

- Fixes Issue Bridge refresh/search failures when the active project root is a gwt workspace home rather than a Git repository.
- Resolves `gh` and semantic search runner execution to the workspace home's child bare repo so GitHub CLI repo detection has a valid cwd.
- Adds regression coverage for Issue cache refresh, semantic search, and AppRuntime manual Issue refresh.

## Changes

- `crates/gwt/src/issue_cache.rs`: Resolve `gh issue list/view/edit` cwd through the project-index repo root helper before invoking GitHub CLI.
- `crates/gwt/src/knowledge_bridge.rs`: Use the resolved repo root for semantic search repo hash detection, `--project-root`, and process cwd.
- `crates/gwt/src/app_runtime/mod.rs`: Add a workspace-home manual Issue refresh regression test that expects `KnowledgeEntries` instead of a red `KnowledgeError`.
- SPEC #1938: Updated spec, plan, and tasks for the 2026-05-23 workspace-home follow-up.

## Testing

- [x] `cargo test -p gwt sync_remote_uses_child_bare_repo_cwd_for_workspace_home --all-features -- --nocapture` - PASS
- [x] `cargo test -p gwt app_runtime_manual_knowledge_refresh_uses_child_bare_repo_for_workspace_home --all-features -- --nocapture` - PASS
- [x] `cargo test -p gwt runner_semantic_issue_search_uses_child_bare_repo_for_workspace_home --all-features -- --nocapture` - PASS
- [x] `cargo test -p gwt workspace_home --all-features -- --nocapture` - PASS
- [x] `cargo test -p gwt knowledge_refresh --all-features -- --nocapture` - PASS
- [x] `cargo test -p gwt semantic_issue_search_reads_cache_without_stale_remote_sync --all-features -- --nocapture` - PASS
- [x] `cargo test -p gwt-core -p gwt --all-features` - PASS
- [x] `cargo fmt --check` - PASS
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - PASS
- [x] `cargo build -p gwt --bin gwt --bin gwtd` - PASS
- [x] User visual verification at `http://127.0.0.1:58822/` - confirmed on 2026-05-23

## PR Readiness

- State: Ready for review
- Releaseable slice: yes - scoped regression fix for Issue Bridge workspace-home refresh/search behavior.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- #1938
- #2867

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (N/A: user-facing docs unchanged; SPEC #1938 updated)
- [x] Migration/backfill plan included (N/A: no schema or data migration)
- [x] CHANGELOG impact considered (patch-level `fix:` commit)

## Context

- The user-reported Issue window showed `gh issue list: failed to run git: fatal: not a git repository` because the refresh path used the workspace home as cwd even though the Git repository identity lives in the child bare repo.

## Risk / Impact

- **Affected areas**: Issue Bridge refresh/search, SPEC/Issue cache refresh, semantic Issue/SPEC search invocation.
- **Rollback plan**: Revert this PR if workspace-home Issue Bridge behavior regresses; no data migration or persistent format change is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Extended test suite with Unix-specific tests for workspace home directory configurations
  * Added integration tests for issue cache synchronization and knowledge refresh operations
  * Implemented test helpers and validation utilities for repository scenarios

* **Improvements**
  * Enhanced working directory resolution for Git operations in complex repository structures
  * Improved path handling for repository-based commands across different configuration scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2875?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->