### PR TITLE
fix(index): refresh issue index from cache changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,6 +1363,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tao",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/gwt-core/runtime/chroma_index_runner.py
+++ b/crates/gwt-core/runtime/chroma_index_runner.py
@@ -1956,6 +1956,50 @@ def _load_cached_issue_documents(repo_hash: str) -> List[Dict[str, Any]]:
     return issues
 
 
+def _issue_cache_refresh_meta(repo_hash: str) -> Dict[str, Any]:
+    meta_path = _issue_cache_root(repo_hash) / "refresh-meta.json"
+    if not meta_path.is_file():
+        return {}
+    try:
+        return json.loads(meta_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+        return {}
+
+
+def _issue_source_fingerprint(issues: Sequence[Dict[str, Any]]) -> str:
+    payload: List[Dict[str, Any]] = []
+    for issue in sorted(issues, key=lambda item: int(item.get("number", 0) or 0)):
+        labels = issue.get("labels", [])
+        if isinstance(labels, str):
+            labels = [labels]
+        payload.append(
+            {
+                "number": int(issue.get("number", 0) or 0),
+                "title": str(issue.get("title", "") or ""),
+                "body": str(issue.get("body", "") or ""),
+                "state": str(issue.get("state", "") or ""),
+                "labels": sorted(label for label in labels if isinstance(label, str)),
+            }
+        )
+    raw = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def _issue_cache_source_snapshot(repo_hash: str) -> Dict[str, Any]:
+    issues = _load_cached_issue_documents(repo_hash)
+    refresh_meta = _issue_cache_refresh_meta(repo_hash)
+    return {
+        "fingerprint": _issue_source_fingerprint(issues),
+        "document_count": len(issues),
+        "cache_refresh_at": refresh_meta.get("last_full_refresh"),
+    }
+
+
 def _load_cached_spec_documents(
     repo_hash: str,
 ) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
@@ -3000,6 +3044,7 @@ def _issue_status_v2(
 ) -> Dict[str, Any]:
     db_path = resolve_db_path(repo_hash, None, "issues", db_root=db_root)
     meta = _read_issue_meta(db_path) or {}
+    source = _issue_cache_source_snapshot(repo_hash)
     exists = (db_path / "chroma.sqlite3").exists() or (db_path / META_FILENAME).is_file()
     count_ok, document_count = _scope_document_count(db_path, "issues")
 
@@ -3015,6 +3060,13 @@ def _issue_status_v2(
         reason = "metadata_missing"
         healthy = False
         repair_required = True
+    else:
+        indexed_fingerprint = meta.get("source_cache_fingerprint")
+        current_fingerprint = source.get("fingerprint")
+        if current_fingerprint and indexed_fingerprint != current_fingerprint:
+            reason = "source_cache_changed"
+            healthy = False
+            repair_required = True
 
     status: Dict[str, Any] = {
         "exists": exists,
@@ -3032,6 +3084,15 @@ def _issue_status_v2(
                 "ttl_minutes": meta.get("ttl_minutes", ISSUE_TTL_MINUTES_DEFAULT),
             }
         )
+        if meta.get("source_cache_fingerprint"):
+            status["source_cache_fingerprint"] = meta.get("source_cache_fingerprint")
+        if "source_document_count" in meta:
+            status["source_document_count"] = meta.get("source_document_count")
+        if meta.get("source_cache_refresh_at"):
+            status["source_cache_refresh_at"] = meta.get("source_cache_refresh_at")
+        if reason == "source_cache_changed":
+            status["current_source_cache_fingerprint"] = source.get("fingerprint")
+            status["current_source_document_count"] = source.get("document_count")
         last = _parse_iso(meta.get("last_full_refresh", "")) if meta.get("last_full_refresh") else None
         if last is not None:
             age = (_now_utc() - last).total_seconds()
@@ -3084,6 +3145,7 @@ def action_index_issues_v2(
     with acquire_lock(db_path, exclusive=True):
         _reset_chroma_store(db_path)
         issues = _load_cached_issue_documents(repo_hash)
+        source = _issue_cache_source_snapshot(repo_hash)
 
         client, collection = _make_chroma_collection_repairing(db_path, V2_ISSUES_COLLECTION)
         try:
@@ -3130,6 +3192,9 @@ def action_index_issues_v2(
                     "last_full_refresh": _now_utc().isoformat(),
                     "ttl_minutes": ttl_minutes,
                     "document_count": len(issues),
+                    "source_cache_fingerprint": source["fingerprint"],
+                    "source_document_count": source["document_count"],
+                    "source_cache_refresh_at": source.get("cache_refresh_at"),
                 },
             )
         finally:

--- a/crates/gwt-core/runtime/tests/test_issue_ttl.py
+++ b/crates/gwt-core/runtime/tests/test_issue_ttl.py
@@ -58,6 +58,76 @@ class IssueTtlTests(unittest.TestCase):
             meta = json.loads(meta_path.read_text())
             self.assertIn("last_full_refresh", meta)
             self.assertEqual(meta.get("ttl_minutes"), 15)
+            self.assertRegex(meta.get("source_cache_fingerprint", ""), r"^[0-9a-f]{64}$")
+            self.assertEqual(meta.get("source_document_count"), 1)
+
+    def test_status_reports_source_cache_changed_when_cached_issue_state_changes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_root = Path(tmp) / "index_root"
+            cache_root = Path(tmp) / ".gwt" / "cache" / "issues" / "abc1234567890def"
+            self._write_cached_issue(cache_root, 2867, "Recent Projects", "cache body", ["bug"])
+
+            with mock.patch.dict(os.environ, {"HOME": tmp}, clear=False):
+                result = runner.action_index_issues_v2(
+                    repo_hash="abc1234567890def",
+                    project_root=tmp,
+                    db_root=db_root,
+                    respect_ttl=False,
+                )
+            self.assertTrue(result["ok"], result)
+
+            meta_path = cache_root / "2867" / "meta.json"
+            meta = json.loads(meta_path.read_text())
+            meta["state"] = "closed"
+            meta_path.write_text(json.dumps(meta))
+
+            with mock.patch.dict(os.environ, {"HOME": tmp}, clear=False):
+                status = runner.action_status_v2(
+                    repo_hash="abc1234567890def",
+                    worktree_hash=None,
+                    db_root=db_root,
+                )
+
+            issues = status["status"]["issues"]
+            self.assertFalse(issues["healthy"], issues)
+            self.assertTrue(issues["repair_required"], issues)
+            self.assertEqual(issues["reason"], "source_cache_changed")
+
+    def test_search_issues_rebuilds_after_cached_issue_state_changes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db_root = Path(tmp) / "index_root"
+            cache_root = Path(tmp) / ".gwt" / "cache" / "issues" / "abc1234567890def"
+            self._write_cached_issue(cache_root, 2867, "Recent Projects", "cache body", ["bug"])
+
+            with mock.patch.dict(os.environ, {"HOME": tmp}, clear=False):
+                result = runner.action_index_issues_v2(
+                    repo_hash="abc1234567890def",
+                    project_root=tmp,
+                    db_root=db_root,
+                    respect_ttl=False,
+                )
+            self.assertTrue(result["ok"], result)
+
+            meta_path = cache_root / "2867" / "meta.json"
+            meta = json.loads(meta_path.read_text())
+            meta["state"] = "closed"
+            meta_path.write_text(json.dumps(meta))
+
+            with mock.patch.dict(os.environ, {"HOME": tmp}, clear=False):
+                search = runner.action_search_v2(
+                    action="search-issues",
+                    repo_hash="abc1234567890def",
+                    worktree_hash=None,
+                    project_root=tmp,
+                    query="Recent Projects",
+                    n_results=5,
+                    no_auto_build=False,
+                    db_root=db_root,
+                )
+
+            self.assertTrue(search["ok"], search)
+            self.assertEqual(search["issueResults"][0]["number"], 2867)
+            self.assertEqual(search["issueResults"][0]["state"], "closed")
 
     def test_status_v2_returns_ttl_remaining_seconds(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/crates/gwt/Cargo.toml
+++ b/crates/gwt/Cargo.toml
@@ -49,6 +49,7 @@ base64.workspace = true
 regex.workspace = true
 rfd = "0.17"
 reqwest.workspace = true
+sha2.workspace = true
 notify.workspace = true
 notify-debouncer-mini.workspace = true
 chardetng.workspace = true

--- a/crates/gwt/src/cli/issue.rs
+++ b/crates/gwt/src/cli/issue.rs
@@ -239,16 +239,47 @@ pub(super) fn refresh_issue_cache<E: CliEnv>(
     env: &mut E,
     number: IssueNumber,
 ) -> Result<gwt_github::CacheEntry, SpecOpsError> {
+    refresh_issue_cache_with_index_rebuild(env, number, |repo_path| {
+        if crate::index_worker::detect_repo_hash(repo_path).is_none() {
+            return Ok(());
+        }
+        crate::index_worker::default_rebuild_runner(
+            repo_path,
+            crate::index_worker::IndexRebuildScope::Issues,
+            None,
+        )
+    })
+}
+
+pub(super) fn refresh_issue_cache_with_index_rebuild<E, F>(
+    env: &mut E,
+    number: IssueNumber,
+    mut rebuild_issue_index: F,
+) -> Result<gwt_github::CacheEntry, SpecOpsError>
+where
+    E: CliEnv,
+    F: FnMut(&std::path::Path) -> Result<(), String>,
+{
+    let cache_root = env.cache_root();
+    let before = crate::issue_cache::issue_cache_source_fingerprint(&cache_root)
+        .map_err(|err| SpecOpsError::from(ApiError::Network(err)))?;
     let snapshot = match env.client().fetch(number, None)? {
         gwt_github::FetchResult::Updated(snapshot) => snapshot,
         gwt_github::FetchResult::NotModified => {
-            return Cache::new(env.cache_root())
+            return Cache::new(cache_root)
                 .load_entry(number)
                 .ok_or_else(|| SpecOpsError::SectionNotFound(format!("issue {}", number.0)));
         }
     };
-    let cache = Cache::new(env.cache_root());
+    let cache = Cache::new(cache_root.clone());
     cache.write_snapshot(&snapshot)?;
+    let after = crate::issue_cache::issue_cache_source_fingerprint(&cache_root)
+        .map_err(|err| SpecOpsError::from(ApiError::Network(err)))?;
+    if crate::issue_cache::issue_cache_source_changed(&before, &after) {
+        rebuild_issue_index(env.repo_path()).map_err(|err| {
+            SpecOpsError::from(ApiError::Network(format!("rebuild issue index: {err}")))
+        })?;
+    }
     cache
         .load_entry(number)
         .ok_or_else(|| SpecOpsError::SectionNotFound(format!("issue {}", number.0)))
@@ -542,5 +573,30 @@ mod tests {
         std::fs::create_dir_all(cache_path.parent().expect("cache dir")).expect("create cache dir");
         std::fs::write(&cache_path, "{not-json").expect("write invalid json");
         assert!(read_linked_prs_cache(temp.path(), snapshot.number).is_err());
+    }
+
+    #[test]
+    fn explicit_issue_refresh_rebuilds_issue_index_when_cache_source_changes() {
+        let temp = TempDir::new().expect("tempdir");
+        let mut env = crate::cli::TestEnv::new(temp.path().to_path_buf());
+        let mut old = sample_issue_snapshot();
+        old.state = IssueState::Open;
+        gwt_github::Cache::new(env.cache_root())
+            .write_snapshot(&old)
+            .expect("write old cache");
+
+        let mut updated = old.clone();
+        updated.state = IssueState::Closed;
+        env.client.seed(updated.clone());
+
+        let mut rebuild_calls = Vec::new();
+        let entry = refresh_issue_cache_with_index_rebuild(&mut env, updated.number, |repo_path| {
+            rebuild_calls.push(repo_path.to_path_buf());
+            Ok(())
+        })
+        .expect("refresh with rebuild");
+
+        assert_eq!(entry.snapshot.state, IssueState::Closed);
+        assert_eq!(rebuild_calls, vec![env.repo_path().to_path_buf()]);
     }
 }

--- a/crates/gwt/src/index_worker.rs
+++ b/crates/gwt/src/index_worker.rs
@@ -9,10 +9,7 @@ use std::{
 use gwt_core::{
     index::{
         paths::gwt_index_root,
-        runtime::{
-            reconcile_repo, refresh_issues_if_stale, PythonRunnerSpawner, ReconcileOptions,
-            RefreshIssuesOptions, RunnerSpawner,
-        },
+        runtime::{reconcile_repo, PythonRunnerSpawner, ReconcileOptions, RunnerSpawner},
     },
     repo_hash::RepoHash,
     worktree_hash::compute_worktree_hash,
@@ -1197,6 +1194,76 @@ fn project_index_status_for_path_inner(
     }
 }
 
+fn read_issue_index_source_fingerprint(index_root: &Path, repo_hash: &RepoHash) -> Option<String> {
+    let meta_path = index_root
+        .join(repo_hash.as_str())
+        .join("issues")
+        .join("meta.json");
+    let bytes = std::fs::read(meta_path).ok()?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    value
+        .get("source_cache_fingerprint")
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+fn issue_index_needs_rebuild_for_cache(
+    index_root: &Path,
+    repo_hash: &RepoHash,
+    cache_root: &Path,
+) -> Result<bool, String> {
+    let Some(source) = crate::issue_cache::issue_cache_source_fingerprint(cache_root)? else {
+        return Ok(false);
+    };
+    if source.document_count == 0 {
+        return Ok(false);
+    }
+    Ok(
+        read_issue_index_source_fingerprint(index_root, repo_hash).as_deref()
+            != Some(source.fingerprint.as_str()),
+    )
+}
+
+fn refresh_issue_cache_and_index_for_startup<S: RunnerSpawner + ?Sized>(
+    repo_root: &Path,
+    refresh_project_root: &Path,
+    index_root: &Path,
+    repo_hash: &RepoHash,
+    spawner: &S,
+) -> Result<(), String> {
+    let cache_root = crate::issue_cache::issue_cache_root_for_repo_hash(repo_hash);
+    match crate::issue_cache::sync_issue_cache_from_remote_if_stale_with_fingerprint(
+        refresh_project_root,
+        &cache_root,
+        crate::issue_cache::ISSUE_CACHE_TTL,
+    ) {
+        Ok(outcome) => {
+            tracing::info!(
+                target: "gwt::index",
+                project_root = %repo_root.display(),
+                cache_refreshed = outcome.refreshed,
+                source_changed = outcome.source_changed,
+                "project index issue cache refresh checked"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                target: "gwt::index",
+                project_root = %repo_root.display(),
+                error = %error,
+                "project index issue cache refresh failed; continuing with local cache/index"
+            );
+        }
+    }
+
+    if issue_index_needs_rebuild_for_cache(index_root, repo_hash, &cache_root)? {
+        spawner
+            .spawn_index_issues(repo_hash.as_str(), refresh_project_root, false)
+            .map_err(|err| format!("spawn issue index: {err}"))?;
+    }
+    Ok(())
+}
+
 pub fn bootstrap_project_index_for_path_with<S: RunnerSpawner + ?Sized>(
     project_root: &Path,
     index_root: &Path,
@@ -1246,29 +1313,20 @@ pub fn bootstrap_project_index_for_path_with<S: RunnerSpawner + ?Sized>(
         "project index repository reconciled"
     );
 
-    let refresh = RefreshIssuesOptions {
-        index_root: index_root.to_path_buf(),
-        repo_hash,
-        project_root: refresh_project_root,
-        ttl: Duration::from_secs(15 * 60),
-    };
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|err| err.to_string())?;
     let refresh_started = Instant::now();
-    runtime
-        .block_on(refresh_issues_if_stale(&refresh, spawner))
-        .map(|decision| {
-            tracing::info!(
-                target: "gwt::index",
-                project_root = %repo_root.display(),
-                elapsed_ms = refresh_started.elapsed().as_millis() as u64,
-                decision = ?decision,
-                "project index issue refresh checked"
-            );
-        })
-        .map_err(|err| err.to_string())?;
+    refresh_issue_cache_and_index_for_startup(
+        &repo_root,
+        &refresh_project_root,
+        index_root,
+        &repo_hash,
+        spawner,
+    )?;
+    tracing::info!(
+        target: "gwt::index",
+        project_root = %repo_root.display(),
+        elapsed_ms = refresh_started.elapsed().as_millis() as u64,
+        "project index issue source refresh checked"
+    );
     tracing::info!(
         target: "gwt::index",
         project_root = %repo_root.display(),
@@ -2241,6 +2299,48 @@ detached
         assert_eq!(events[0].state, ProjectIndexStatusState::Repairing);
         assert_eq!(events[1].state, ProjectIndexStatusState::Error);
         assert!(events[1].detail.contains("synthetic failure"));
+    }
+
+    #[test]
+    fn issue_index_source_mismatch_requires_startup_rebuild() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo_hash =
+            gwt_core::repo_hash::compute_repo_hash("https://github.com/example/gwt.git");
+        let cache_root = temp.path().join("issue-cache");
+        let snapshot = gwt_github::IssueSnapshot {
+            number: gwt_github::IssueNumber(2867),
+            title: "Recent Projects".to_string(),
+            body: "workspace home".to_string(),
+            labels: vec!["bug".to_string()],
+            state: gwt_github::IssueState::Closed,
+            updated_at: gwt_github::UpdatedAt::new("2026-05-23T00:00:00Z"),
+            comments: vec![],
+        };
+        gwt_github::Cache::new(cache_root.clone())
+            .write_snapshot(&snapshot)
+            .expect("write cache");
+
+        let index_root = temp.path().join("index");
+        let issues_dir = index_root.join(repo_hash.as_str()).join("issues");
+        std::fs::create_dir_all(&issues_dir).expect("issues dir");
+        std::fs::write(
+            issues_dir.join("meta.json"),
+            serde_json::json!({
+                "schema_version": 1,
+                "last_full_refresh": chrono::Utc::now().to_rfc3339(),
+                "ttl_minutes": 15,
+                "source_cache_fingerprint": "stale",
+                "source_document_count": 1,
+            })
+            .to_string(),
+        )
+        .expect("write meta");
+
+        assert!(
+            issue_index_needs_rebuild_for_cache(&index_root, &repo_hash, &cache_root)
+                .expect("rebuild decision"),
+            "startup must rebuild issues when source cache fingerprint differs from index meta",
+        );
     }
 
     #[test]

--- a/crates/gwt/src/issue_cache.rs
+++ b/crates/gwt/src/issue_cache.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use std::{
+    collections::BTreeMap,
     fs,
     path::{Path, PathBuf},
     time::Duration,
@@ -18,6 +19,7 @@ use gwt_github::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 
 const DETACHED_REPO_CACHE_DIR: &str = "__detached__";
 const SPEC_LABEL: &str = "gwt-spec";
@@ -34,6 +36,30 @@ pub const ISSUE_CACHE_TTL: Duration = Duration::from_secs(15 * 60);
 struct IssueCacheRefreshMeta {
     last_full_refresh: String,
     ttl_minutes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssueCacheSourceFingerprint {
+    pub fingerprint: String,
+    pub document_count: usize,
+    pub cache_refresh_at: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IssueCacheSyncOutcome {
+    pub refreshed: bool,
+    pub source_changed: bool,
+    pub before: Option<IssueCacheSourceFingerprint>,
+    pub after: Option<IssueCacheSourceFingerprint>,
+}
+
+#[derive(Debug)]
+struct IssueCacheSourceDocument {
+    number: u64,
+    title: String,
+    body: String,
+    state: String,
+    labels: Vec<String>,
 }
 
 pub fn issue_cache_base_root() -> PathBuf {
@@ -60,6 +86,107 @@ pub fn issue_cache_root_for_repo_path(repo_path: &Path) -> Option<PathBuf> {
 
 pub fn issue_cache_root_for_repo_path_or_detached(repo_path: &Path) -> PathBuf {
     issue_cache_root_for_repo_path(repo_path).unwrap_or_else(detached_issue_cache_root)
+}
+
+pub fn issue_cache_source_fingerprint(
+    cache_root: &Path,
+) -> Result<Option<IssueCacheSourceFingerprint>, String> {
+    if !cache_root.is_dir() {
+        return Ok(None);
+    }
+
+    let mut docs = Vec::new();
+    let entries = fs::read_dir(cache_root).map_err(|err| err.to_string())?;
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let Some(name) = entry.file_name().to_str().map(ToOwned::to_owned) else {
+            continue;
+        };
+        let Ok(number) = name.parse::<u64>() else {
+            continue;
+        };
+        let issue_dir = entry.path();
+        let meta_path = issue_dir.join("meta.json");
+        if !meta_path.is_file() {
+            continue;
+        }
+        let meta_bytes = match fs::read(&meta_path) {
+            Ok(bytes) => bytes,
+            Err(_) => continue,
+        };
+        let meta: Value = match serde_json::from_slice(&meta_bytes) {
+            Ok(value) => value,
+            Err(_) => continue,
+        };
+        let body = fs::read_to_string(issue_dir.join("body.md")).unwrap_or_default();
+        let mut labels = match meta.get("labels") {
+            Some(Value::String(label)) => vec![label.clone()],
+            Some(Value::Array(values)) => values
+                .iter()
+                .filter_map(|value| value.as_str().map(ToOwned::to_owned))
+                .collect::<Vec<_>>(),
+            _ => Vec::new(),
+        };
+        labels.sort();
+        docs.push(IssueCacheSourceDocument {
+            number,
+            title: meta
+                .get("title")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            body: body.chars().take(2000).collect(),
+            state: meta
+                .get("state")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            labels,
+        });
+    }
+
+    docs.sort_by_key(|doc| doc.number);
+    let document_count = docs.len();
+    let canonical = docs
+        .into_iter()
+        .map(|doc| {
+            let mut map = BTreeMap::new();
+            map.insert("body", Value::String(doc.body));
+            map.insert(
+                "labels",
+                Value::Array(doc.labels.into_iter().map(Value::String).collect()),
+            );
+            map.insert("number", Value::Number(doc.number.into()));
+            map.insert("state", Value::String(doc.state));
+            map.insert("title", Value::String(doc.title));
+            map
+        })
+        .collect::<Vec<_>>();
+    let bytes = serde_json::to_vec(&canonical).map_err(|err| err.to_string())?;
+    let digest = Sha256::digest(&bytes);
+    let fingerprint = digest
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    Ok(Some(IssueCacheSourceFingerprint {
+        fingerprint,
+        document_count,
+        cache_refresh_at: read_issue_cache_refresh_meta(cache_root)
+            .map(|meta| meta.last_full_refresh),
+    }))
+}
+
+pub fn issue_cache_source_changed(
+    before: &Option<IssueCacheSourceFingerprint>,
+    after: &Option<IssueCacheSourceFingerprint>,
+) -> bool {
+    before.as_ref().map(|value| &value.fingerprint)
+        != after.as_ref().map(|value| &value.fingerprint)
 }
 
 pub fn sync_issue_cache_from_remote_if_missing(
@@ -89,6 +216,37 @@ pub fn sync_issue_cache_from_remote_if_stale(
     }
     sync_issue_cache_from_remote(repo_path, cache_root)?;
     Ok(true)
+}
+
+pub fn sync_issue_cache_from_remote_if_stale_with_fingerprint(
+    repo_path: &Path,
+    cache_root: &Path,
+    ttl: Duration,
+) -> Result<IssueCacheSyncOutcome, String> {
+    let before = issue_cache_source_fingerprint(cache_root)?;
+    let refreshed = sync_issue_cache_from_remote_if_stale(repo_path, cache_root, ttl)?;
+    let after = issue_cache_source_fingerprint(cache_root)?;
+    Ok(IssueCacheSyncOutcome {
+        refreshed,
+        source_changed: refreshed && issue_cache_source_changed(&before, &after),
+        before,
+        after,
+    })
+}
+
+pub fn sync_issue_cache_from_remote_with_fingerprint(
+    repo_path: &Path,
+    cache_root: &Path,
+) -> Result<IssueCacheSyncOutcome, String> {
+    let before = issue_cache_source_fingerprint(cache_root)?;
+    sync_issue_cache_from_remote(repo_path, cache_root)?;
+    let after = issue_cache_source_fingerprint(cache_root)?;
+    Ok(IssueCacheSyncOutcome {
+        refreshed: true,
+        source_changed: issue_cache_source_changed(&before, &after),
+        before,
+        after,
+    })
 }
 
 pub fn sync_issue_cache_from_remote(repo_path: &Path, cache_root: &Path) -> Result<(), String> {
@@ -729,6 +887,55 @@ exit 1\n",
         assert!(
             issue_cache_refresh_is_stale(&cache_root, ISSUE_CACHE_TTL),
             "expired refresh metadata should mark cache stale",
+        );
+    }
+
+    #[test]
+    fn issue_cache_source_fingerprint_tracks_indexed_issue_fields_only() {
+        let temp = tempdir().expect("tempdir");
+        let cache_root = temp.path().join("cache");
+        let snapshot = IssueSnapshot {
+            number: IssueNumber(7),
+            title: "Cache freshness".to_string(),
+            body: "body".to_string(),
+            labels: vec!["bug".to_string()],
+            state: IssueState::Open,
+            updated_at: UpdatedAt::new("2026-05-23T00:00:00Z"),
+            comments: vec![],
+        };
+        Cache::new(cache_root.clone())
+            .write_snapshot(&snapshot)
+            .expect("write snapshot");
+
+        let initial = issue_cache_source_fingerprint(&cache_root)
+            .expect("initial fingerprint")
+            .expect("source snapshot");
+        assert_eq!(initial.document_count, 1);
+        assert_eq!(
+            initial.fingerprint, "0c31a39b484318da3ec39b51fc5e073334bb3d64bba3886fb0ecff50b400d915",
+            "Rust source fingerprint must match the Python runner metadata algorithm",
+        );
+
+        fs::write(cache_root.join("7").join("linked_prs.json"), "[]").expect("linked prs");
+        let linked_prs = issue_cache_source_fingerprint(&cache_root)
+            .expect("linked prs fingerprint")
+            .expect("source snapshot");
+        assert_eq!(
+            linked_prs.fingerprint, initial.fingerprint,
+            "linked PR cache is not part of the Issue search source",
+        );
+
+        let mut changed = snapshot.clone();
+        changed.state = IssueState::Closed;
+        Cache::new(cache_root.clone())
+            .write_snapshot(&changed)
+            .expect("write changed snapshot");
+        let after_state = issue_cache_source_fingerprint(&cache_root)
+            .expect("changed fingerprint")
+            .expect("source snapshot");
+        assert_ne!(
+            after_state.fingerprint, initial.fingerprint,
+            "indexed Issue state changes must invalidate the Issue search index",
         );
     }
 }

--- a/crates/gwt/src/knowledge_bridge.rs
+++ b/crates/gwt/src/knowledge_bridge.rs
@@ -11,7 +11,8 @@ use serde_json::Value;
 
 use crate::issue_cache::{
     issue_cache_root_for_repo_path, issue_cache_root_for_repo_path_or_detached,
-    sync_issue_cache_from_remote, sync_issue_cache_from_remote_if_stale, ISSUE_CACHE_TTL,
+    sync_issue_cache_from_remote_if_stale_with_fingerprint,
+    sync_issue_cache_from_remote_with_fingerprint, ISSUE_CACHE_TTL,
 };
 
 const SPEC_LABEL: &str = "gwt-spec";
@@ -273,12 +274,30 @@ pub fn refresh_knowledge_bridge_cache(repo_path: &Path, force: bool) -> Result<b
         return Ok(false);
     }
     let cache_root = issue_cache_root_for_repo_path_or_detached(repo_path);
-    if force {
-        sync_issue_cache_from_remote(repo_path, &cache_root)?;
-        Ok(true)
+    let outcome = if force {
+        sync_issue_cache_from_remote_with_fingerprint(repo_path, &cache_root)?
     } else {
-        sync_issue_cache_from_remote_if_stale(repo_path, &cache_root, ISSUE_CACHE_TTL)
+        sync_issue_cache_from_remote_if_stale_with_fingerprint(
+            repo_path,
+            &cache_root,
+            ISSUE_CACHE_TTL,
+        )?
+    };
+    if outcome.source_changed && crate::index_worker::detect_repo_hash(repo_path).is_some() {
+        if let Err(error) = crate::index_worker::default_rebuild_runner(
+            repo_path,
+            crate::index_worker::IndexRebuildScope::Issues,
+            None,
+        ) {
+            tracing::warn!(
+                target: "gwt::knowledge_bridge",
+                project_root = %repo_path.display(),
+                error = %error,
+                "issue cache refresh succeeded but issue index rebuild failed"
+            );
+        }
     }
+    Ok(outcome.refreshed)
 }
 
 pub fn search_knowledge_bridge(

--- a/crates/gwt/tests/index_bootstrap_test.rs
+++ b/crates/gwt/tests/index_bootstrap_test.rs
@@ -1,12 +1,13 @@
 use std::{
+    ffi::OsString,
     fs,
     path::{Path, PathBuf},
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, OnceLock},
 };
 
 use gwt::index_worker::bootstrap_project_index_for_path_with;
 use gwt_core::{
-    index::runtime::RunnerSpawner, repo_hash::detect_repo_hash,
+    index::runtime::RunnerSpawner, paths::gwt_cache_dir, repo_hash::detect_repo_hash,
     worktree_hash::compute_worktree_hash,
 };
 
@@ -35,9 +36,45 @@ impl RunnerSpawner for RecordingSpawner {
     }
 }
 
+struct ScopedEnvVar {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl ScopedEnvVar {
+    fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        if let Some(previous) = self.previous.as_ref() {
+            std::env::set_var(self.key, previous);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
+}
+
+fn env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
 #[test]
 fn bootstrap_helper_reconciles_index_layout_and_kicks_issue_refresh() {
+    let _env_lock = env_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     let tmp = tempfile::tempdir().expect("tempdir");
+    let home = tmp.path().join("home");
+    fs::create_dir_all(&home).expect("create home");
+    let _home = ScopedEnvVar::set("HOME", &home);
+    let _userprofile = ScopedEnvVar::set("USERPROFILE", &home);
+
     let repo = tmp.path().join("repo");
     let wt = tmp.path().join("wt-feature");
     init_git_repo(&repo);
@@ -79,10 +116,24 @@ fn bootstrap_helper_reconciles_index_layout_and_kicks_issue_refresh() {
             "schema_version": 1,
             "last_full_refresh": stale.to_rfc3339(),
             "ttl_minutes": 15,
+            "source_cache_fingerprint": "stale",
+            "source_document_count": 1,
         })
         .to_string(),
     )
     .expect("write issues meta");
+    let cache_root = gwt_cache_dir().join("issues").join(repo_hash.as_str());
+    gwt_github::Cache::new(cache_root)
+        .write_snapshot(&gwt_github::IssueSnapshot {
+            number: gwt_github::IssueNumber(2867),
+            title: "Recent Projects cache freshness".to_string(),
+            body: "Closed state should reach Issue search at startup.".to_string(),
+            labels: vec!["bug".to_string()],
+            state: gwt_github::IssueState::Closed,
+            updated_at: gwt_github::UpdatedAt::new("2026-05-23T00:00:00Z"),
+            comments: vec![],
+        })
+        .expect("write issue cache snapshot");
 
     let spawner = RecordingSpawner::default();
     bootstrap_project_index_for_path_with(&wt, &index_root, &spawner).expect("bootstrap index");
@@ -115,22 +166,30 @@ fn bootstrap_helper_reconciles_index_layout_and_kicks_issue_refresh() {
     assert_eq!(
         calls.len(),
         1,
-        "stale issue metadata should kick one refresh"
+        "source cache fingerprint mismatch should kick one issue rebuild"
     );
     assert!(
         calls[0].contains(repo_hash.as_str()),
-        "refresh must target the resolved repo hash, got {:?}",
+        "rebuild must target the resolved repo hash, got {:?}",
         *calls
     );
     assert!(
         call_project_root_matches(&calls[0], &wt),
-        "refresh should use the requested worktree path, got {:?}",
+        "rebuild should use the requested worktree path, got {:?}",
+        *calls
+    );
+    assert!(
+        calls[0].ends_with("|false"),
+        "startup rebuild should bypass index TTL after cache source mismatch, got {:?}",
         *calls
     );
 }
 
 #[test]
 fn bootstrap_preserves_repo_scoped_memory_index_directory() {
+    let _env_lock = env_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
     // SPEC-2805: memory is repo-scoped at ~/.gwt/index/<repo>/memory/. Bootstrap
     // must not treat it as an orphan worktree dir or as legacy worktree-scoped
     // state, regardless of whether a current worktree exists.


### PR DESCRIPTION
## Summary

- Refreshes the GitHub Issue cache during startup and rebuilds the Issue search index when cached issue content changes.
- Stores a source cache fingerprint in the Python issue index metadata so stale search results are detected by status/search health checks.
- Wires explicit issue refresh and Knowledge Bridge refresh paths to rebuild or mark the issue index stale without blocking cached issue views.

## Changes

- `crates/gwt/src/issue_cache.rs`: added source fingerprint calculation over indexed issue fields and refresh outcomes that report source changes.
- `crates/gwt/src/index_worker.rs`: replaced startup issue-index TTL coupling with cache-refresh plus source-fingerprint rebuild decisions.
- `crates/gwt-core/runtime/chroma_index_runner.py`: writes `source_cache_fingerprint` / source document metadata and reports `source_cache_changed`.
- `crates/gwt/src/cli/issue.rs`: triggers an immediate issue-index rebuild when explicit issue refresh changes indexed fields.
- `crates/gwt/src/knowledge_bridge.rs`: refreshes with source-change detection and logs index rebuild failures without failing the cached view.
- `crates/gwt-core/runtime/tests/test_issue_ttl.py` and `crates/gwt/tests/index_bootstrap_test.rs`: cover the #2867 stale open/closed issue search regression and startup rebuild contract.

## Testing

- [x] `PYTHONPATH=crates/gwt-core/runtime GWT_INDEX_FAKE_EMBEDDING=1 ~/.gwt/runtime/chroma-venv/bin/python3 -m unittest crates/gwt-core/runtime/tests/test_issue_ttl.py` — PASS (7 tests).
- [x] `cargo test -p gwt -j1 issue_cache_source_fingerprint -- --nocapture` — PASS.
- [x] `cargo test -p gwt -j1 explicit_issue_refresh_rebuilds_issue_index -- --nocapture` — PASS.
- [x] `cargo test -p gwt -j1 issue_index_source_mismatch -- --nocapture` — PASS.
- [x] `cargo test -p gwt -j1 knowledge_bridge -- --nocapture` — PASS.
- [x] `cargo test -p gwt-core -j1 --test issue_refresh -- --nocapture` — PASS.
- [x] `PYTHONPATH=crates/gwt-core/runtime GWT_INDEX_FAKE_EMBEDDING=1 ~/.gwt/runtime/chroma-venv/bin/python3 -m unittest discover -s crates/gwt-core/runtime/tests` — PASS (90 tests).
- [x] `cargo test -p gwt-core -p gwt --all-features -j1` — PASS.
- [x] `cargo clippy --all-targets --all-features -j1 -- -D warnings` — PASS.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — PASS.
- [x] `cargo fmt -- --check` — PASS.
- [x] `git diff --check` — PASS.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — PASS.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — cache refresh and index rebuild behavior is fully gated by source fingerprint metadata and existing fail-open paths.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- Closes #2867

## Related Issues / Links

- #1939

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (if user-facing change) — N/A, behavior is backend cache/index freshness.
- [x] Migration/backfill plan included (if schema/data change) — N/A, new metadata is written on next issue index rebuild.
- [x] CHANGELOG impact considered (breaking change flagged in commit)

## Context

- Issue #2867 showed that a recently closed Issue could remain searchable as open because issue index TTL freshness was coupled only to index metadata, not to the GitHub Issue cache content.
- SPEC #1939 Phase 18 defines startup cache refresh and source-fingerprint coupling so cache changes invalidate stale Issue search results.

## Risk / Impact

- **Affected areas**: Issue cache refresh, Issue semantic search/status health, startup index bootstrap, explicit `gwtd issue --refresh`, and Knowledge Bridge refresh.
- **Rollback plan**: Revert this PR; existing cache/index files are compatible because the new source metadata is additive.
