### PR TITLE
fix(launch-wizard): enable start with last settings launch

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -2580,6 +2580,12 @@ pub struct LaunchWizardSession {
 }
 
 #[derive(Debug, Clone)]
+pub struct LaunchFeedbackContext {
+    pub(crate) client_id: ClientId,
+    pub(crate) title: String,
+}
+
+#[derive(Debug, Clone)]
 pub struct IssueLaunchWizardPrepared {
     pub(crate) client_id: ClientId,
     pub(crate) id: String,
@@ -2618,6 +2624,7 @@ pub struct AppRuntime {
     pub(crate) launch_wizard_cache: LaunchWizardMemoryCache,
     pub(crate) launch_wizard: Option<LaunchWizardSession>,
     pub(crate) pending_workspace_resume_contexts: HashMap<String, WorkspaceResumeContext>,
+    pub(crate) pending_launch_feedback_contexts: HashMap<String, LaunchFeedbackContext>,
     pub(crate) pending_auto_resume_sources: HashMap<String, String>,
     pub(crate) pending_startup_auto_resume_sessions: Vec<PendingStartupAutoResumeSession>,
     pub(crate) active_agent_sessions: HashMap<String, ActiveAgentSession>,
@@ -2715,6 +2722,7 @@ impl AppRuntime {
             launch_wizard_cache,
             launch_wizard: None,
             pending_workspace_resume_contexts: HashMap::new(),
+            pending_launch_feedback_contexts: HashMap::new(),
             pending_auto_resume_sources: HashMap::new(),
             pending_startup_auto_resume_sessions: Vec::new(),
             active_agent_sessions: HashMap::new(),
@@ -3301,7 +3309,7 @@ impl AppRuntime {
                 linked_issue_number,
             } => self.open_active_work_launch_wizard(&client_id, &branch_name, linked_issue_number),
             FrontendEvent::LaunchWizardAction { action, bounds } => {
-                self.handle_launch_wizard_action(action, bounds)
+                self.handle_launch_wizard_action_for_client(Some(&client_id), action, bounds)
             }
             FrontendEvent::ApplyUpdate => self.apply_pending_update_events(&client_id),
             FrontendEvent::ApplyUpdateStart => self.apply_update_start_events(&client_id),
@@ -6137,6 +6145,7 @@ impl AppRuntime {
         result: AgentLaunchResult,
     ) -> Vec<OutboundEvent> {
         let workspace_resume_context = self.pending_workspace_resume_contexts.remove(&window_id);
+        let launch_feedback_context = self.pending_launch_feedback_contexts.remove(&window_id);
         let auto_resume_source_session_id = self.pending_auto_resume_sources.remove(&window_id);
         match result {
             Ok((
@@ -6152,14 +6161,25 @@ impl AppRuntime {
                 agent_project_root,
             )) => {
                 let Some(address) = self.window_lookup.get(&window_id).cloned() else {
-                    return self.launch_error_events(window_id, "Window not found".to_string());
+                    return self.launch_error_events(
+                        window_id,
+                        "Window not found".to_string(),
+                        launch_feedback_context.clone(),
+                    );
                 };
                 let Some(tab) = self.tab(&address.tab_id) else {
-                    return self
-                        .launch_error_events(window_id, "Project tab not found".to_string());
+                    return self.launch_error_events(
+                        window_id,
+                        "Project tab not found".to_string(),
+                        launch_feedback_context.clone(),
+                    );
                 };
                 let Some(window) = tab.workspace.window(&address.raw_id) else {
-                    return self.launch_error_events(window_id, "Window not found".to_string());
+                    return self.launch_error_events(
+                        window_id,
+                        "Window not found".to_string(),
+                        launch_feedback_context.clone(),
+                    );
                 };
                 let tab_id = address.tab_id.clone();
                 let project_root = tab.project_root.clone();
@@ -6306,10 +6326,12 @@ impl AppRuntime {
                         events.extend(Self::status_events(window_id, composed_status, None));
                         events
                     }
-                    Err(error) => self.launch_error_events(window_id, error),
+                    Err(error) => {
+                        self.launch_error_events(window_id, error, launch_feedback_context)
+                    }
                 }
             }
-            Err(error) => self.launch_error_events(window_id, error),
+            Err(error) => self.launch_error_events(window_id, error, launch_feedback_context),
         }
     }
 
@@ -6321,14 +6343,25 @@ impl AppRuntime {
         match result {
             Ok(process_launch) => {
                 let Some(address) = self.window_lookup.get(&window_id).cloned() else {
-                    return self.launch_error_events(window_id, "Window not found".to_string());
+                    return self.launch_error_events(
+                        window_id,
+                        "Window not found".to_string(),
+                        None,
+                    );
                 };
                 let Some(tab) = self.tab(&address.tab_id) else {
-                    return self
-                        .launch_error_events(window_id, "Project tab not found".to_string());
+                    return self.launch_error_events(
+                        window_id,
+                        "Project tab not found".to_string(),
+                        None,
+                    );
                 };
                 let Some(window) = tab.workspace.window(&address.raw_id) else {
-                    return self.launch_error_events(window_id, "Window not found".to_string());
+                    return self.launch_error_events(
+                        window_id,
+                        "Window not found".to_string(),
+                        None,
+                    );
                 };
                 let geometry = window.geometry.clone();
 
@@ -6365,11 +6398,11 @@ impl AppRuntime {
                     }
                     Err(error) => {
                         emit_agent_launch_stage(stage_id, "error", &error);
-                        self.launch_error_events(window_id, error)
+                        self.launch_error_events(window_id, error, None)
                     }
                 }
             }
-            Err(error) => self.launch_error_events(window_id, error),
+            Err(error) => self.launch_error_events(window_id, error, None),
         }
     }
 
@@ -6561,6 +6594,24 @@ impl AppRuntime {
             config,
             AgentWindowPlacement::Centered(bounds),
             workspace_resume_context,
+            None,
+        )
+    }
+
+    pub(crate) fn spawn_agent_window_with_feedback(
+        &mut self,
+        tab_id: &str,
+        config: gwt_agent::LaunchConfig,
+        bounds: WindowGeometry,
+        workspace_resume_context: Option<WorkspaceResumeContext>,
+        launch_feedback_context: LaunchFeedbackContext,
+    ) -> Result<Vec<OutboundEvent>, String> {
+        self.spawn_agent_window_with_placement(
+            tab_id,
+            config,
+            AgentWindowPlacement::Centered(bounds),
+            workspace_resume_context,
+            Some(launch_feedback_context),
         )
     }
 
@@ -6576,6 +6627,7 @@ impl AppRuntime {
             config,
             AgentWindowPlacement::Exact(geometry),
             workspace_resume_context,
+            None,
         )
     }
 
@@ -6585,6 +6637,7 @@ impl AppRuntime {
         config: gwt_agent::LaunchConfig,
         placement: AgentWindowPlacement,
         workspace_resume_context: Option<WorkspaceResumeContext>,
+        launch_feedback_context: Option<LaunchFeedbackContext>,
     ) -> Result<Vec<OutboundEvent>, String> {
         let issue_link_cache_dir = self.issue_link_cache_dir.clone();
         let tab = self
@@ -6644,6 +6697,10 @@ impl AppRuntime {
         let profile_config_path = self.profile_config_path()?;
         if let Some(context) = workspace_resume_context {
             self.pending_workspace_resume_contexts
+                .insert(window_id.clone(), context);
+        }
+        if let Some(context) = launch_feedback_context {
+            self.pending_launch_feedback_contexts
                 .insert(window_id.clone(), context);
         }
 
@@ -7616,12 +7673,28 @@ impl AppRuntime {
         tokens.join(" ")
     }
 
-    fn launch_error_events(&mut self, window_id: String, detail: String) -> Vec<OutboundEvent> {
+    fn launch_error_events(
+        &mut self,
+        window_id: String,
+        detail: String,
+        launch_feedback_context: Option<LaunchFeedbackContext>,
+    ) -> Vec<OutboundEvent> {
         self.log_window_launch_error("launch_complete", &window_id, &detail);
         if self.tracked_window_exists(&window_id) {
             return self.handle_runtime_status(window_id, WindowProcessStatus::Error, Some(detail));
         }
-        Self::status_events(window_id, WindowProcessStatus::Error, Some(detail))
+        let mut events =
+            Self::status_events(window_id, WindowProcessStatus::Error, Some(detail.clone()));
+        if let Some(context) = launch_feedback_context {
+            events.push(OutboundEvent::reply(
+                context.client_id,
+                BackendEvent::LaunchWizardOpenError {
+                    title: context.title,
+                    message: detail,
+                },
+            ));
+        }
+        events
     }
 
     fn status_events(
@@ -8827,6 +8900,7 @@ exit 1
             launch_wizard_cache,
             launch_wizard: None,
             pending_workspace_resume_contexts: HashMap::new(),
+            pending_launch_feedback_contexts: HashMap::new(),
             pending_auto_resume_sources: HashMap::new(),
             pending_startup_auto_resume_sessions: Vec::new(),
             active_agent_sessions: HashMap::<String, ActiveAgentSession>::new(),
@@ -9134,6 +9208,43 @@ exit 1
                     linked_issue_kind: None,
                 },
                 Vec::new(),
+                Vec::new(),
+            ),
+            workspace_resume_context: None,
+        }
+    }
+
+    fn sample_ready_agent_launch_wizard_session(
+        tab_id: &str,
+        project_root: &Path,
+    ) -> LaunchWizardSession {
+        LaunchWizardSession {
+            tab_id: tab_id.to_string(),
+            wizard_id: "wizard-ready-agent".to_string(),
+            wizard: LaunchWizardState::open_with(
+                LaunchWizardContext {
+                    selected_branch: BranchListEntry {
+                        name: "feature/demo".to_string(),
+                        scope: BranchScope::Local,
+                        is_head: false,
+                        upstream: None,
+                        ahead: 0,
+                        behind: 0,
+                        last_commit_date: None,
+                        cleanup_ready: true,
+                        cleanup: BranchCleanupInfo::default(),
+                        resume: gwt::BranchResumeInfo::unavailable(),
+                    },
+                    normalized_branch_name: "feature/demo".to_string(),
+                    worktree_path: Some(project_root.to_path_buf()),
+                    quick_start_root: project_root.to_path_buf(),
+                    live_sessions: Vec::new(),
+                    docker_context: None,
+                    docker_service_status: gwt_docker::ComposeServiceStatus::NotFound,
+                    linked_issue_number: Some(42),
+                    linked_issue_kind: None,
+                },
+                sample_agent_options(),
                 Vec::new(),
             ),
             workspace_resume_context: None,
@@ -10717,6 +10828,126 @@ exit 1
             event.fields.get("error").map(String::as_str),
             Some("launch failed before process spawn")
         );
+    }
+
+    #[test]
+    fn app_runtime_launch_wizard_submit_emits_agent_window_launching_status() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        init_repo(&repo);
+        let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        runtime.launch_wizard = Some(sample_ready_agent_launch_wizard_session("tab-1", &repo));
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::LaunchWizardAction {
+                action: LaunchWizardAction::Submit,
+                bounds: Some(canvas_bounds()),
+            },
+        );
+
+        let workspace = events
+            .iter()
+            .find_map(|event| match &event.event {
+                BackendEvent::WorkspaceState { workspace } => Some(workspace),
+                _ => None,
+            })
+            .expect("workspace state after wizard submit");
+        let agent_window = workspace
+            .tabs
+            .iter()
+            .find(|tab| tab.id == "tab-1")
+            .and_then(|tab| {
+                tab.workspace
+                    .windows
+                    .iter()
+                    .find(|window| window.preset == WindowPreset::Agent)
+            })
+            .expect("agent placeholder window");
+        assert_eq!(agent_window.title, "Codex");
+        assert_eq!(agent_window.agent_id.as_deref(), Some("codex"));
+
+        let launch_status = events
+            .iter()
+            .find_map(|event| match &event.event {
+                BackendEvent::TerminalStatus { id, detail, .. }
+                    if detail.as_deref() == Some("Launching...") =>
+                {
+                    Some(id)
+                }
+                _ => None,
+            })
+            .expect("launching terminal status");
+        assert!(launch_status.ends_with("::agent-1"));
+        assert!(events.iter().any(|event| {
+            matches!(
+                event.event,
+                BackendEvent::LaunchWizardState { wizard: None }
+            )
+        }));
+    }
+
+    #[test]
+    fn app_runtime_launch_complete_missing_wizard_window_surfaces_open_error() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        init_repo(&repo);
+        let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        runtime.launch_wizard = Some(sample_ready_agent_launch_wizard_session("tab-1", &repo));
+
+        let submit_events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::LaunchWizardAction {
+                action: LaunchWizardAction::Submit,
+                bounds: Some(canvas_bounds()),
+            },
+        );
+        let window_id = submit_events
+            .iter()
+            .find_map(|event| match &event.event {
+                BackendEvent::TerminalStatus { id, detail, .. }
+                    if detail.as_deref() == Some("Launching...") =>
+                {
+                    Some(id.clone())
+                }
+                _ => None,
+            })
+            .expect("wizard launch window id");
+        let address = runtime
+            .window_lookup
+            .remove(&window_id)
+            .expect("registered agent window");
+        let tab = runtime.tab_mut(&address.tab_id).expect("tab");
+        assert!(tab.workspace.close_window(&address.raw_id));
+
+        let completion_events =
+            runtime.handle_launch_complete(window_id, Err("Window not found".to_string()));
+
+        assert!(completion_events.iter().any(|event| {
+            matches!(
+                (&event.target, &event.event),
+                (
+                    DispatchTarget::Client(client_id),
+                    BackendEvent::LaunchWizardOpenError { title, message }
+                ) if client_id == "client-1"
+                    && title == "Launch Agent"
+                    && message == "Window not found"
+            )
+        }));
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -68,8 +68,9 @@ use super::{
     workspace_resume_branch_exists, workspace_resume_branch_from_journal_project_root,
     workspace_resume_context_from_journal, workspace_resume_context_from_projection,
     workspace_resume_owner_issue_number, AppEventProxy, AppRuntime, BackendEvent,
-    IssueLaunchWizardPrepared, LaunchWizardMemoryCache, LaunchWizardSession, OutboundEvent,
-    WindowPreset, WindowProcessStatus, WorkspaceResumeContext, WORKSPACE_OVERVIEW_JOURNAL_LIMIT,
+    IssueLaunchWizardPrepared, LaunchFeedbackContext, LaunchWizardMemoryCache, LaunchWizardSession,
+    OutboundEvent, WindowPreset, WindowProcessStatus, WorkspaceResumeContext,
+    WORKSPACE_OVERVIEW_JOURNAL_LIMIT,
 };
 use crate::usable_worktree_path_for_branch;
 
@@ -976,8 +977,18 @@ impl AppRuntime {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn handle_launch_wizard_action(
         &mut self,
+        action: gwt::LaunchWizardAction,
+        bounds: Option<WindowGeometry>,
+    ) -> Vec<OutboundEvent> {
+        self.handle_launch_wizard_action_for_client(None, action, bounds)
+    }
+
+    pub(crate) fn handle_launch_wizard_action_for_client(
+        &mut self,
+        client_id: Option<&str>,
         action: gwt::LaunchWizardAction,
         bounds: Option<WindowGeometry>,
     ) -> Vec<OutboundEvent> {
@@ -1108,12 +1119,35 @@ impl AppRuntime {
                 match *config {
                     LaunchWizardLaunchRequest::Agent(config) => {
                         let workspace_resume_context = session.workspace_resume_context.clone();
-                        match self.spawn_agent_window(
-                            &session.tab_id,
-                            *config,
-                            bounds,
-                            workspace_resume_context,
-                        ) {
+                        let launch_feedback_context =
+                            client_id.map(|client_id| LaunchFeedbackContext {
+                                client_id: client_id.to_string(),
+                                title: if session.wizard.wizard_mode
+                                    == gwt::LaunchWizardMode::StartWork
+                                {
+                                    "Start Work".to_string()
+                                } else {
+                                    "Launch Agent".to_string()
+                                },
+                            });
+                        let spawn_result =
+                            if let Some(launch_feedback_context) = launch_feedback_context {
+                                self.spawn_agent_window_with_feedback(
+                                    &session.tab_id,
+                                    *config,
+                                    bounds,
+                                    workspace_resume_context,
+                                    launch_feedback_context,
+                                )
+                            } else {
+                                self.spawn_agent_window(
+                                    &session.tab_id,
+                                    *config,
+                                    bounds,
+                                    workspace_resume_context,
+                                )
+                            };
+                        match spawn_result {
                             Ok(mut events) => {
                                 events.push(self.launch_wizard_state_broadcast(None));
                                 events

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -2711,7 +2711,27 @@ mod tests {
         )
         .expect("valid regex");
         let submit_button = regex::Regex::new(
-            r#"wizardSubmitButton\.addEventListener\("click",\s*\(\)\s*=>\s*\{\s*if\s*\(\s*launchWizardOpenError\s*\)\s*\{\s*return;\s*\}\s*(?:flushWizardBranchDraft|frontendUnits\.launchWizardSurface\.flushBranchDraft)\(\);\s*(?:sendWizardAction|frontendUnits\.launchWizardSurface\.sendAction)\(\{\s*kind:\s*"submit"\s*\}\);\s*\}\);"#,
+            r#"function\s+handleLaunchWizardSubmitFromChrome\(\)\s*\{[\s\S]*?releaseWizardInteractionGuardForChromeAction\(\)[\s\S]*?launchWizardOpenError[\s\S]*?(?:flushWizardBranchDraft|frontendUnits\.launchWizardSurface\.flushBranchDraft)\(\);[\s\S]*?(?:sendWizardAction|frontendUnits\.launchWizardSurface\.sendAction)\(\{\s*kind:\s*"submit"\s*\}\);\s*\}"#,
+        )
+        .expect("valid regex");
+        let chrome_guard_release = regex::Regex::new(
+            r#"function\s+releaseWizardInteractionGuardForChromeAction\(\)\s*\{[\s\S]*?wizardInteractionGuard\.isActive\(\)[\s\S]*?wizardInteractionGuard\.release\(\)[\s\S]*?return\s+Boolean\(launchWizard\s*\|\|\s*launchWizardOpenError\);"#,
+        )
+        .expect("valid regex");
+        let guarded_submit_button = regex::Regex::new(
+            r#"function\s+handleLaunchWizardSubmitFromChrome\(\)[\s\S]*?releaseWizardInteractionGuardForChromeAction\(\)[\s\S]*?(?:flushWizardBranchDraft|frontendUnits\.launchWizardSurface\.flushBranchDraft)\(\);[\s\S]*?(?:sendWizardAction|frontendUnits\.launchWizardSurface\.sendAction)\(\{\s*kind:\s*"submit"\s*\}\);"#,
+        )
+        .expect("valid regex");
+        let guarded_start_method_button = regex::Regex::new(
+            r#"const\s+handleStartMethodLaunchAction\s*=\s*\(\)\s*=>\s*\{[\s\S]*?releaseWizardInteractionGuardForChromeAction\(\)[\s\S]*?setLaunchWizardPendingAction\(\{[\s\S]*?kind:\s*"use_start_method"[\s\S]*?(?:sendWizardAction|frontendUnits\.launchWizardSurface\.sendAction)\(\{[\s\S]*?kind:\s*"use_start_method""#,
+        )
+        .expect("valid regex");
+        let submit_pointer_fallback = regex::Regex::new(
+            r#"wizardSubmitButton\.addEventListener\("pointerup"[\s\S]*?handleLaunchWizardSubmitFromChrome\(\)"#,
+        )
+        .expect("valid regex");
+        let start_method_pointer_fallback = regex::Regex::new(
+            r#"button\.addEventListener\("pointerup"[\s\S]*?handleStartMethodLaunchAction\(\)"#,
         )
         .expect("valid regex");
 
@@ -2752,6 +2772,21 @@ mod tests {
         assert!(
             submit_button.is_match(html),
             "expected submit control to ignore error-only state and flush branch draft before dispatching submit",
+        );
+        assert!(
+            chrome_guard_release.is_match(html)
+                && html.contains("if (!releaseWizardInteractionGuardForChromeAction())")
+                && guarded_submit_button.is_match(html),
+            "expected Launch Wizard chrome actions to release pending interaction guard state before dispatch",
+        );
+        assert!(
+            html.contains("launchWizardPendingAction")
+                && html.contains("is-launch-pending")
+                && html.contains("Creating agent window...")
+                && guarded_start_method_button.is_match(html)
+                && submit_pointer_fallback.is_match(html)
+                && start_method_pointer_fallback.is_match(html),
+            "expected Launch Wizard launch actions to expose local pending feedback and pointer-safe Start method dispatch",
         );
         assert!(
             !html.contains("event.target === wizardModal")

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -1836,7 +1836,7 @@ impl LaunchWizardState {
                     return;
                 }
                 self.apply_latest_start_settings();
-                self.launch_path = LaunchWizardLaunchPath::QuickStart;
+                self.launch_path = LaunchWizardLaunchPath::ManualSetup;
                 self.start_method_selected = true;
                 self.finish_launch_request();
             }
@@ -4935,6 +4935,78 @@ mod tests {
             },
             other => panic!("expected start method launch completion, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn start_with_last_settings_runtime_confirmation_stays_enabled_without_quick_start_entry() {
+        let previous = LaunchWizardPreviousProfile {
+            agent_id: "claude".to_string(),
+            model: Some("Default (Opus 4.7)".to_string()),
+            reasoning: Some("max".to_string()),
+            version: Some("latest".to_string()),
+            session_mode: gwt_agent::SessionMode::Normal,
+            skip_permissions: true,
+            codex_fast_mode: false,
+            runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+            docker_service: None,
+            docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::Connect,
+            windows_shell: None,
+        };
+        let mut state = LaunchWizardState::open_start_work_with_previous_profile(
+            context(branch("origin/develop"), "work/20260523-1406"),
+            "origin/develop".to_string(),
+            sample_agent_options(),
+            Vec::new(),
+            Some(previous.clone()),
+        );
+        state.mark_runtime_context_unresolved();
+
+        let initial = state.view();
+        assert!(initial.show_start_methods);
+        assert!(initial
+            .start_methods
+            .iter()
+            .any(|method| method.kind == "start_with_last_settings" && method.enabled));
+
+        state.apply(LaunchWizardAction::UseStartMethod {
+            method: LaunchWizardStartMethodKind::StartWithLastSettings,
+        });
+        assert!(matches!(
+            state.completion.as_ref(),
+            Some(LaunchWizardCompletion::ResolveRuntime(_))
+        ));
+
+        state.completion = None;
+        state.apply_runtime_context(LaunchWizardHydration {
+            selected_branch: None,
+            normalized_branch_name: "work/20260523-1406".to_string(),
+            worktree_path: None,
+            quick_start_root: PathBuf::from("/tmp/repo"),
+            docker_context: None,
+            docker_service_status: gwt_docker::ComposeServiceStatus::NotFound,
+            agent_options: sample_agent_options(),
+            quick_start_entries: Vec::new(),
+            previous_profiles: Some(LaunchWizardPreviousProfiles::from_profile(Some(previous))),
+        });
+
+        let confirmation = state.view();
+        assert_eq!(confirmation.selected_launch_path, "manual_setup");
+        assert!(confirmation.show_runtime_confirmation);
+        assert_eq!(confirmation.primary_action_label, "Create and launch");
+        assert!(confirmation.primary_action_enabled);
+
+        state.apply(LaunchWizardAction::Submit);
+        assert!(matches!(
+            state.completion.as_ref(),
+            Some(LaunchWizardCompletion::Launch(config))
+                if matches!(
+                    config.as_ref(),
+                    LaunchWizardLaunchRequest::Agent(config)
+                        if config.branch.as_deref() == Some("work/20260523-1406")
+                            && config.base_branch.as_deref() == Some("origin/develop")
+                            && config.resume_session_id.is_none()
+                )
+        ));
     }
 
     #[test]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1946,6 +1946,7 @@ mod tests {
             sessions_dir,
             launch_wizard_cache,
             launch_wizard: None,
+            pending_launch_feedback_contexts: HashMap::new(),
             pending_workspace_resume_contexts: HashMap::new(),
             pending_auto_resume_sources: HashMap::new(),
             pending_startup_auto_resume_sessions: Vec::new(),

--- a/crates/gwt/web/__tests__/kanban-drawer.test.mjs
+++ b/crates/gwt/web/__tests__/kanban-drawer.test.mjs
@@ -67,11 +67,36 @@ test("Drawer Esc / backdrop click closes the surface", () => {
   // The handler may use either `if (event.key !== "Escape") return`
   // (early-return style, which is how the rest of the codebase
   // handles global Esc) or `if (event.key === "Escape")` directly.
-  // Both patterns are acceptable; we just need a keydown handler
-  // that wires Esc to closeKanbanDrawer.
-  assert.match(
-    appSource,
-    /(?:key !== "Escape"[\s\S]{0,2500}?closeKanbanDrawer|key === "Escape"[\s\S]{0,500}?closeKanbanDrawer|kanban-drawer[\s\S]{0,500}?Escape)/,
+  // Both patterns are acceptable; we just need the global Esc handler
+  // to route the open Drawer branch to closeKanbanDrawer.
+  const escapeHandlerIndex = appSource.indexOf(
+    'document.addEventListener("keydown", (event) => {\n        if (event.key !== "Escape") return;',
+  );
+  assert.notEqual(
+    escapeHandlerIndex,
+    -1,
+    "expected a global Escape keydown handler",
+  );
+  const kanbanBranchIndex = appSource.indexOf(
+    'if (kanbanDrawer && kanbanDrawer.dataset.open === "true")',
+    escapeHandlerIndex,
+  );
+  assert.notEqual(
+    kanbanBranchIndex,
+    -1,
+    "expected the Escape handler to inspect Kanban Drawer open state",
+  );
+  const nextBranchIndex = appSource.indexOf(
+    "if (windowListOpen)",
+    kanbanBranchIndex,
+  );
+  const closeIndex = appSource.indexOf(
+    "closeKanbanDrawer();",
+    kanbanBranchIndex,
+  );
+  assert.ok(
+    closeIndex > kanbanBranchIndex
+      && (nextBranchIndex === -1 || closeIndex < nextBranchIndex),
     "expected Esc keydown to close the Kanban Drawer",
   );
 });

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1708,7 +1708,7 @@ test("Launch wizard disables panel controls while runtime resolution is pending"
   );
   assert.match(
     appSource,
-    /panel\.classList\.toggle\("wizard-disabled",\s*isRuntimeResolutionPending\)/,
+    /panel\.classList\.toggle\(\s*"wizard-disabled"[\s\S]{0,180}?isRuntimeResolutionPending\s*\|\|\s*isLaunchActionPending/,
     "expected the launch panel to expose a disabled visual state while pending",
   );
   assert.match(
@@ -1752,6 +1752,24 @@ test("Launch wizard start methods keep disabled and hover states distinct", () =
     inlineStyle,
     /\.start-method-button:disabled/,
     "disabled start method rows should expose a disabled state",
+  );
+});
+
+test("Launch wizard pending launch feedback has stable styling hooks", () => {
+  assert.match(
+    inlineStyle,
+    /\.modal-shell\.is-wizard\.is-launch-pending[\s\S]*?cursor:\s*progress;/,
+    "expected Launch Wizard modal to expose progress cursor while a launch action is pending",
+  );
+  assert.match(
+    inlineStyle,
+    /\.start-method-button\.is-pending[\s\S]*?cursor:\s*progress;/,
+    "expected pending Start method row to expose a progress cursor",
+  );
+  assert.match(
+    inlineStyle,
+    /\.launch-pending-note[\s\S]*?color:\s*var\(--color-text-strong\)/,
+    "expected pending launch copy to be styled as visible modal feedback",
   );
 });
 

--- a/crates/gwt/web/__tests__/wizard-interaction-guard-wiring.test.mjs
+++ b/crates/gwt/web/__tests__/wizard-interaction-guard-wiring.test.mjs
@@ -61,7 +61,7 @@ test("closeLaunchWizardLocal discards pending guard state before re-render", () 
   // and active flag without invoking onFlush.
   assert.match(
     appSource,
-    /function\s+closeLaunchWizardLocal\(\)\s*\{[\s\S]{0,300}?wizardInteractionGuard\.discard\(\)[\s\S]{0,100}?renderLaunchWizard\(\)/,
+    /function\s+closeLaunchWizardLocal\(\)\s*\{[\s\S]{0,500}?wizardInteractionGuard\.discard\(\)[\s\S]{0,140}?renderLaunchWizard\(\)/,
     "expected closeLaunchWizardLocal() to discard guard before render",
   );
 });
@@ -95,5 +95,92 @@ test("wizardModal releases the guard when Escape is pressed during interaction",
     appSource,
     /wizardModal\.addEventListener\(\s*"keydown"[\s\S]{0,400}?key\s*===\s*"Escape"[\s\S]{0,200}?wizardInteractionGuard\.release\(\)/,
     "expected Escape keydown to release the guard",
+  );
+});
+
+test("wizard chrome actions release any active guard before dispatch", () => {
+  assert.match(
+    appSource,
+    /function\s+releaseWizardInteractionGuardForChromeAction\(\)\s*\{[\s\S]{0,300}?wizardInteractionGuard\.isActive\(\)[\s\S]{0,150}?wizardInteractionGuard\.release\(\)[\s\S]{0,200}?return\s+Boolean\(launchWizard\s*\|\|\s*launchWizardOpenError\)/,
+    "expected a chrome-action helper that releases the guard and reports whether wizard state remains",
+  );
+  assert.match(
+    appSource,
+    /function\s+closeLaunchWizardFromChrome\(\)\s*\{[\s\S]{0,160}?releaseWizardInteractionGuardForChromeAction\(\)/,
+    "expected Cancel/Close to release pending guard state before dispatching",
+  );
+  assert.match(
+    appSource,
+    /wizardBackButton\.addEventListener\(\s*"click"[\s\S]{0,220}?releaseWizardInteractionGuardForChromeAction\(\)[\s\S]{0,300}?kind:\s*"back"/,
+    "expected Back to release pending guard state before dispatching",
+  );
+  assert.match(
+    appSource,
+    /function\s+handleLaunchWizardSubmitFromChrome\(\)[\s\S]{0,260}?releaseWizardInteractionGuardForChromeAction\(\)[\s\S]{0,320}?kind:\s*"submit"/,
+    "expected Submit handler to release pending guard state before dispatching",
+  );
+  assert.match(
+    appSource,
+    /if\s*\(wizardModal\.classList\.contains\("open"\)\)\s*\{[\s\S]{0,260}?releaseWizardInteractionGuardForChromeAction\(\)[\s\S]{0,350}?kind:\s*"cancel"/,
+    "expected Escape-close to release pending guard state before dispatching",
+  );
+});
+
+test("wizard start method actions release guard before dispatch", () => {
+  assert.match(
+    appSource,
+    /const\s+handleStartMethodLaunchAction\s*=\s*\(\)\s*=>\s*\{[\s\S]{0,260}?releaseWizardInteractionGuardForChromeAction\(\)[\s\S]{0,360}?kind:\s*"use_start_method"/,
+    "expected Start methods direct actions to release pending guard state before dispatching",
+  );
+});
+
+test("wizard launch pointer fallback routes submit and start methods", () => {
+  assert.match(
+    appSource,
+    /function\s+handleLaunchWizardSubmitFromChrome\(\)[\s\S]{0,500}?kind:\s*"submit"/,
+    "expected Launch Wizard submit to be centralized for click and pointer fallback",
+  );
+  assert.match(
+    appSource,
+    /wizardSubmitButton\.addEventListener\(\s*"pointerup"[\s\S]{0,420}?handleLaunchWizardSubmitFromChrome\(\)/,
+    "expected Create and Launch pointerup fallback to route through submit handler",
+  );
+  assert.match(
+    appSource,
+    /button\.addEventListener\(\s*"pointerup"[\s\S]{0,420}?handleStartMethodLaunchAction\(\)/,
+    "expected Start method pointerup fallback to route through the same action handler",
+  );
+});
+
+test("wizard launch actions expose local pending feedback", () => {
+  assert.match(
+    appSource,
+    /let\s+launchWizardPendingAction\s*=\s*null/,
+    "expected Launch Wizard to track a local pending action",
+  );
+  assert.match(
+    appSource,
+    /function\s+setLaunchWizardPendingAction\(\s*action[\s\S]{0,500}?launchWizardPendingAction\s*=/,
+    "expected a helper to set Launch Wizard pending state",
+  );
+  assert.match(
+    appSource,
+    /function\s+clearLaunchWizardPendingAction\(\)[\s\S]{0,300}?launchWizardPendingAction\s*=\s*null/,
+    "expected a helper to clear Launch Wizard pending state",
+  );
+  assert.match(
+    appSource,
+    /wizardModal\.classList\.toggle\(\s*"is-launch-pending"[\s\S]{0,220}?wizardDialog\.setAttribute\(\s*"aria-busy"/,
+    "expected modal busy class and aria-busy to mirror pending launch actions",
+  );
+  assert.match(
+    appSource,
+    /wizardSubmitButton\.textContent\s*=\s*isLaunchSubmitPending[\s\S]{0,160}?"Launching\.\.\."/,
+    "expected final launch submit to show an immediate Launching label",
+  );
+  assert.match(
+    appSource,
+    /createNode\(\s*"div",\s*"launch-note launch-pending-note",\s*"Creating agent window\.\.\."/,
+    "expected pending submit to render visible progress copy in the modal",
   );
 });

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -344,6 +344,7 @@
       let wizardWasOpen = false;
       let wizardBranchDraft = "";
       let wizardBranchBackendValue = "";
+      let launchWizardPendingAction = null;
       // Issue #2698 PR 1 (B7) — defer destructive wizard re-renders
       // while the user has a native <select> dropdown open. The OS
       // dropdown overlay is anchored to the original DOM node; if
@@ -358,9 +359,11 @@
             return;
           }
           if (deferred.kind === "launch_wizard_state") {
+            clearLaunchWizardPendingAction();
             launchWizard = deferred.wizard;
             launchWizardOpenError = null;
           } else if (deferred.kind === "launch_wizard_open_error") {
+            clearLaunchWizardPendingAction();
             launchWizard = null;
             launchWizardOpenError = {
               title: deferred.title || "Launch Agent",
@@ -7210,6 +7213,7 @@
       let wizardFocusTrapRelease = null;
 
       function closeLaunchWizardLocal() {
+        clearLaunchWizardPendingAction();
         launchWizard = null;
         launchWizardOpenError = null;
         // Issue #2698 PR 1 (B7) — local close wins over any pending
@@ -7219,7 +7223,35 @@
         renderLaunchWizard();
       }
 
+      function releaseWizardInteractionGuardForChromeAction() {
+        if (wizardInteractionGuard.isActive()) {
+          wizardInteractionGuard.release();
+        }
+        return Boolean(launchWizard || launchWizardOpenError);
+      }
+
+      function setLaunchWizardPendingAction(action) {
+        launchWizardPendingAction = action || null;
+        renderLaunchWizard();
+      }
+
+      function clearLaunchWizardPendingAction() {
+        launchWizardPendingAction = null;
+      }
+
+      function syncLaunchWizardPendingChrome(isPending) {
+        wizardModal.classList.toggle("is-launch-pending", isPending);
+        if (wizardDialog) {
+          wizardDialog.classList.toggle("is-launch-pending", isPending);
+          wizardDialog.setAttribute("aria-busy", isPending ? "true" : "false");
+        }
+      }
+
       function closeLaunchWizardFromChrome() {
+        if (!releaseWizardInteractionGuardForChromeAction()) {
+          return;
+        }
+        clearLaunchWizardPendingAction();
         if (launchWizardOpenError) {
           closeLaunchWizardLocal();
           return;
@@ -7227,8 +7259,27 @@
         frontendUnits.launchWizardSurface.sendAction({ kind: "cancel" });
       }
 
+      function isPrimaryPointerActivation(event) {
+        return !event || event.button === 0 || event.button === undefined;
+      }
+
+      function handleLaunchWizardSubmitFromChrome() {
+        if (
+          !releaseWizardInteractionGuardForChromeAction()
+          || launchWizardOpenError
+          || wizardSubmitButton.disabled
+        ) {
+          return;
+        }
+        frontendUnits.launchWizardSurface.flushBranchDraft();
+        setLaunchWizardPendingAction({ kind: "submit" });
+        frontendUnits.launchWizardSurface.sendAction({ kind: "submit" });
+      }
+
       function renderLaunchWizard() {
         if (!launchWizard && !launchWizardOpenError) {
+          clearLaunchWizardPendingAction();
+          syncLaunchWizardPendingChrome(false);
           const wasOpenBeforeClose = wizardModal.classList.contains("open");
           wizardModal.classList.remove("open");
           // SPEC-2356 — keep aria-hidden in lockstep with .open so screen
@@ -7265,6 +7316,9 @@
 
         syncWizardDraftState();
         closeModal();
+        const isLaunchActionPending = Boolean(launchWizardPendingAction);
+        const isLaunchSubmitPending = launchWizardPendingAction?.kind === "submit";
+        syncLaunchWizardPendingChrome(isLaunchActionPending);
         const wasOpenWizard = wizardModal.classList.contains("open");
         if (!wasOpenWizard) {
           // Capture trigger BEFORE flipping .open so render-driven focus
@@ -7310,7 +7364,8 @@
         wizardSubmitButton.hidden = false;
         wizardBackButton.hidden = !launchWizard.show_back_button;
         wizardBackButton.disabled = Boolean(
-          launchWizard.is_hydrating
+          isLaunchActionPending
+            || launchWizard.is_hydrating
             || launchWizard.runtime_resolution_pending
             || !launchWizard.show_back_button,
         );
@@ -7321,7 +7376,9 @@
           : `Selected branch · ${
             launchWizard.selected_branch_name || launchWizard.branch_name || "Workspace"
           }`;
-        wizardSubmitButton.textContent = launchWizard.primary_action_label || (
+        wizardSubmitButton.textContent = isLaunchSubmitPending
+          ? "Launching..."
+          : launchWizard.primary_action_label || (
           launchWizard.is_hydrating
             ? "Loading..."
             : launchWizard.runtime_context_resolved === false
@@ -7331,7 +7388,8 @@
                 : "Launch"
         );
         wizardSubmitButton.disabled = Boolean(
-          launchWizard.is_hydrating
+          isLaunchActionPending
+            || launchWizard.is_hydrating
             || launchWizard.runtime_resolution_pending
             || launchWizard.primary_action_enabled === false,
         );
@@ -7365,7 +7423,10 @@
         const wizardContentPane = createNode("div", "wizard-content-pane");
         const panel = createNode("div", "launch-panel");
         const isRuntimeResolutionPending = Boolean(launchWizard.runtime_resolution_pending);
-        panel.classList.toggle("wizard-disabled", isRuntimeResolutionPending);
+        panel.classList.toggle(
+          "wizard-disabled",
+          isRuntimeResolutionPending || isLaunchActionPending,
+        );
         if (launchWizard.is_hydrating) {
           panel.appendChild(
             createNode(
@@ -7384,6 +7445,15 @@
             ),
           );
         }
+        if (isLaunchSubmitPending) {
+          panel.appendChild(
+            createNode(
+              "div",
+              "launch-note launch-pending-note",
+              "Creating agent window...",
+            ),
+          );
+        }
 
         if (showStartMethods) {
           const section = createLaunchSection(
@@ -7395,9 +7465,19 @@
           for (const method of launchWizard.start_methods || []) {
             const button = createNode("button", "start-method-button");
             button.type = "button";
-            button.disabled = method.enabled === false;
+            const isStartMethodPending =
+              launchWizardPendingAction?.kind === "use_start_method"
+                && launchWizardPendingAction.method === method.kind;
+            button.classList.toggle("is-pending", isStartMethodPending);
+            button.disabled = method.enabled === false || isLaunchActionPending;
             const head = createNode("div", "start-method-head");
-            head.appendChild(createNode("div", "start-method-title", method.label));
+            head.appendChild(
+              createNode(
+                "div",
+                "start-method-title",
+                isStartMethodPending ? "Preparing..." : method.label,
+              ),
+            );
             if (method.badge) {
               head.appendChild(createNode("div", "start-method-badge", method.badge));
             }
@@ -7411,14 +7491,32 @@
             if (detail) {
               button.appendChild(createNode("div", "start-method-detail", detail));
             }
-            button.addEventListener("click", () => {
-              if (button.disabled) {
+            const handleStartMethodLaunchAction = () => {
+              if (
+                !releaseWizardInteractionGuardForChromeAction()
+                || button.disabled
+                || launchWizardPendingAction
+              ) {
                 return;
               }
+              setLaunchWizardPendingAction({
+                kind: "use_start_method",
+                method: method.kind,
+              });
               sendWizardAction({
                 kind: "use_start_method",
                 method: method.kind,
               });
+            };
+            button.addEventListener("pointerup", (event) => {
+              if (!isPrimaryPointerActivation(event)) {
+                return;
+              }
+              event.preventDefault();
+              handleStartMethodLaunchAction();
+            });
+            button.addEventListener("click", () => {
+              handleStartMethodLaunchAction();
             });
             methodList.appendChild(button);
           }
@@ -7773,7 +7871,10 @@
           panel.appendChild(section);
         }
 
-        setLaunchWizardPendingDisabled(panel, isRuntimeResolutionPending);
+        setLaunchWizardPendingDisabled(
+          panel,
+          isRuntimeResolutionPending || isLaunchActionPending,
+        );
         wizardContentPane.appendChild(panel);
         wizardMain.appendChild(wizardContentPane);
         wizardBody.appendChild(wizardMain);
@@ -11887,6 +11988,7 @@
             ) {
               break;
             }
+            clearLaunchWizardPendingAction();
             launchWizard = null;
             launchWizardOpenError = {
               title: event.title || "Launch Agent",
@@ -11911,6 +12013,7 @@
             ) {
               break;
             }
+            clearLaunchWizardPendingAction();
             launchWizard = event.wizard;
             launchWizardOpenError = null;
             frontendUnits.launchWizardSurface.render();
@@ -12678,19 +12781,24 @@
       });
       wizardCancelButton.addEventListener("click", closeLaunchWizardFromChrome);
       wizardBackButton.addEventListener("click", () => {
-        if (launchWizardOpenError || wizardBackButton.disabled) {
+        if (
+          !releaseWizardInteractionGuardForChromeAction()
+          || launchWizardOpenError
+          || wizardBackButton.disabled
+        ) {
           return;
         }
         frontendUnits.launchWizardSurface.flushBranchDraft();
         frontendUnits.launchWizardSurface.sendAction({ kind: "back" });
       });
-      wizardSubmitButton.addEventListener("click", () => {
-        if (launchWizardOpenError) {
+      wizardSubmitButton.addEventListener("pointerup", (event) => {
+        if (!isPrimaryPointerActivation(event)) {
           return;
         }
-        frontendUnits.launchWizardSurface.flushBranchDraft();
-        frontendUnits.launchWizardSurface.sendAction({ kind: "submit" });
+        event.preventDefault();
+        handleLaunchWizardSubmitFromChrome();
       });
+      wizardSubmitButton.addEventListener("click", handleLaunchWizardSubmitFromChrome);
       // Issue #2698 PR 1 (B7) — interaction-guard wiring for native
       // <select> dropdowns inside the wizard body. We register
       // delegated listeners on `wizardBody` so they survive the
@@ -12811,6 +12919,10 @@
         if (wizardModal.classList.contains("open")) {
           // Wizard cancel is the explicit cancellation path; map Esc to
           // the same action so the modal isn't a keyboard trap.
+          if (!releaseWizardInteractionGuardForChromeAction()) {
+            event.preventDefault();
+            return;
+          }
           if (launchWizardOpenError) {
             closeLaunchWizardLocal();
           } else {

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -3492,6 +3492,10 @@ body {
   min-height: 0;
 }
 
+.modal-shell.is-wizard.is-launch-pending {
+  cursor: progress;
+}
+
 .wizard-content-pane {
   min-width: 0;
 }
@@ -3760,6 +3764,13 @@ body {
   opacity: 0.58;
 }
 
+.start-method-button.is-pending {
+  cursor: progress;
+  border-color: var(--color-focus-ring);
+  background: color-mix(in oklab, var(--color-state-active) 10%, var(--color-surface));
+  opacity: 1;
+}
+
 .start-method-head {
   min-width: 0;
   display: flex;
@@ -3802,6 +3813,10 @@ body {
   letter-spacing: var(--tracking-mono);
   color: var(--color-text-muted);
   overflow-wrap: anywhere;
+}
+
+.launch-pending-note {
+  color: var(--color-text-strong);
 }
 
 @media (max-width: 760px) {

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6060,3 +6060,10 @@ Type: lesson
 Context: User reported that Launch Agent Runtime felt slow and asked whether Runtime startup was creating a worktree. During SPEC-2014 follow-up, Runtime confirmation called resolve_launch_worktree and also scanned thousands of stale session records through legacy git root matching.
 Learning: Runtime confirmation should only inspect an existing target worktree or project root for Docker/runtime context; final Launch owns materialization. Session repo matching must cache current repo identity, treat mismatched repo_hash as authoritative, and avoid git root probes for missing session paths.
 Future Action: When changing Launch Wizard Runtime hydration or previous-profile/Quick Start matching, add tests that missing target worktrees are not created and that stale session history does not fan out per-session git probes.
+
+## 2026-05-23 — Launch Wizard click bugs require state inspection before input fallbacks
+
+Type: failure-pattern
+Context: Start Work の Create and Launch が押せない報告で、最初は pointer/click fallback と pending feedback を修正したが、headed Chrome E2E で最終ボタンが disabled=true になっている別原因を確認した。WebSocket state では Start with last settings 後に selected_launch_path=quick_start かつ quick_start_entries=[] で primary_action_enabled=false だった。
+Learning: UI action が効かない不具合は input event loss だけとは限らない。実ブラウザで disabled/aria/state を直接観測し、バックエンド state と照合してから fallback を増やすべき。
+Future Action: Launch Wizard / Start Work のボタン不具合では、headed E2E で実座標クリックを行う前に DOM disabled state と launch_wizard_state payload を保存し、disabled なら状態遷移テストを先に追加する。


### PR DESCRIPTION
## Summary

- Fix Start Work's `Start with last settings` path so the final `Create and launch` action remains enabled when there is no Quick Start entry.
- Add immediate Launch Wizard feedback for launch actions so users see pending state, progress cursor, and duplicate-submit protection after activation.
- Surface async launch failures from wizard-created Agent windows back to the originating Launch Wizard client instead of leaving the modal silent.

## Changes

- `crates/gwt/src/launch_wizard.rs`: Treat `Start with last settings` as the manual setup launch path after applying saved settings, and add regression coverage for the previously disabled final action.
- `crates/gwt/web/app.js` and `crates/gwt/web/styles/app.css`: Add Launch Wizard pending state, progress labels, cursor styling, pointerup fallback, and guarded direct Start method / submit handlers.
- `crates/gwt/src/app_runtime/*` and `crates/gwt/src/main.rs`: Track launch feedback context for wizard-launched Agent windows and route missing-window async errors back as `LaunchWizardOpenError`.
- `crates/gwt/src/embedded_web.rs` and `crates/gwt/web/__tests__/*`: Update frontend and embedded-web contract coverage for guard release, pending feedback, pointer fallback, and adjacent Escape handling.
- `tasks/memory.md`: Record the recurrence-prevention lesson to inspect Launch Wizard DOM/backend state before assuming click-event loss.

## Testing

- [x] `bash scripts/run-frontend-unit-tests.sh` — PASS, 554 tests.
- [x] `bash scripts/run-frontend-smoke-tests.sh` — PASS, 25 tests.
- [x] `bash scripts/check-frontend-bundle.sh` — PASS.
- [x] `cargo fmt -- --check` — PASS.
- [x] `git diff --check` — PASS.
- [x] `cargo test -p gwt-core -p gwt --all-features` — PASS.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — PASS.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — PASS.
- [x] `bunx --bun markdownlint-cli tasks/memory.md --config .markdownlint.json` — PASS.
- [x] Headed Chrome real-coordinate E2E — PASS: Start Work -> `Start with last settings` -> `Create and launch` was enabled, clicked, sent one final `submit`, closed the wizard, and created an Agent window.
- [x] User visual verification — confirmed on 2026-05-23 with `確認OKです`.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes; this is a contained Launch Wizard / Start Work bugfix with regression tests and manual confirmation.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- #2014

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (N/A: no README or user-guide surface changed)
- [x] Migration/backfill plan included (N/A: no schema or data migration)
- [x] CHANGELOG impact considered (patch release via `fix:` commit)

## Context

- Users could reach the Start Work runtime confirmation with `Create and launch` disabled when `Start with last settings` was selected but no Quick Start entry existed. Earlier click/pointer fixes did not address that state-model bug, so this PR fixes the root cause and keeps the launch feedback improvements.

## Risk / Impact

- **Affected areas**: Launch Wizard, Start Work, Agent window launch feedback.
- **Rollback plan**: Revert this PR; no data migration or schema changes are involved.

## Screenshots

- Static screenshots are not attached. Visual verification was performed with headed Chrome real-coordinate E2E plus user confirmation.
