### PR TITLE
fix(ui): keep canvas windows opaque

### DIFF
--- a/crates/gwt/playwright/playwright.config.ts
+++ b/crates/gwt/playwright/playwright.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const chromiumChannel = process.env.GWT_PLAYWRIGHT_CHROMIUM_CHANNEL;
+const desktopChrome = chromiumChannel
+  ? { ...devices["Desktop Chrome"], channel: chromiumChannel }
+  : devices["Desktop Chrome"];
+
 // SPEC-2356 Operator Design System — Visual regression baseline.
 // Tests render the embedded gwt frontend and snapshot per surface × theme.
 export default defineConfig({
@@ -26,11 +31,11 @@ export default defineConfig({
   projects: [
     {
       name: "chromium-dark",
-      use: { ...devices["Desktop Chrome"], colorScheme: "dark" },
+      use: { ...desktopChrome, colorScheme: "dark" },
     },
     {
       name: "chromium-light",
-      use: { ...devices["Desktop Chrome"], colorScheme: "light" },
+      use: { ...desktopChrome, colorScheme: "light" },
     },
   ],
 });

--- a/crates/gwt/playwright/tests/text-first-ui-live.spec.ts
+++ b/crates/gwt/playwright/tests/text-first-ui-live.spec.ts
@@ -1,0 +1,105 @@
+/* SPEC-2356 Phase 11 — Text-first live opacity guard.
+ *
+ * Drives a real `gwt serve` instance because parent opacity regressions are
+ * only obvious once the Canvas grid, window chrome, and terminal renderer are
+ * composited by a headed browser.
+ */
+import { expect, test } from "@playwright/test";
+import { gotoLiveGwt } from "./_helpers/live-gwt";
+
+const BASE = process.env.GWT_PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:0/";
+
+test.describe("Text-first UI live readability", () => {
+  test.skip(!process.env.GWT_PLAYWRIGHT_BASE_URL, "no GWT_PLAYWRIGHT_BASE_URL set");
+
+  test("workspace windows remain fully opaque across Light/Dark themes", async ({
+    page,
+  }, testInfo) => {
+    await gotoLiveGwt(page, BASE, { enableTestBridge: true });
+
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("__gwt_test_inject", {
+          detail: {
+            kind: "workspace_state",
+            workspace: {
+              app_version: "playwright",
+              tabs: [
+                {
+                  id: "text-first-tab",
+                  title: "Text First Fixture",
+                  project_root: "/fixture/text-first",
+                  kind: "git",
+                  workspace: {
+                    viewport: { x: 0, y: 0, zoom: 1 },
+                    windows: [
+                      {
+                        id: "text-first-idle-agent",
+                        title: "Claude Code",
+                        preset: "agent",
+                        geometry: { x: 80, y: 80, width: 760, height: 420 },
+                        z_index: 11,
+                        status: "idle",
+                        minimized: false,
+                        maximized: false,
+                        pre_maximize_geometry: null,
+                        persist: true,
+                        purpose_title: null,
+                        dynamic_title: "Claude Code",
+                        dynamic_title_detail: "Readable idle transcript",
+                        agent_id: "agent-idle",
+                        agent_color: "yellow",
+                        tab_group_id: null,
+                        tab_group_active: false,
+                      },
+                      {
+                        id: "text-first-not-started-agent",
+                        title: "Codex",
+                        preset: "codex",
+                        geometry: { x: 880, y: 120, width: 520, height: 360 },
+                        z_index: 12,
+                        status: "not_started",
+                        minimized: false,
+                        maximized: false,
+                        pre_maximize_geometry: null,
+                        persist: true,
+                        purpose_title: null,
+                        dynamic_title: "Codex",
+                        dynamic_title_detail: "Readable not-started transcript",
+                        agent_id: "agent-not-started",
+                        agent_color: "cyan",
+                        tab_group_id: null,
+                        tab_group_active: false,
+                      },
+                    ],
+                  },
+                },
+              ],
+              active_tab_id: "text-first-tab",
+              recent_projects: [],
+            },
+          },
+        }),
+      );
+    });
+
+    const theme = testInfo.project.name.includes("light") ? "light" : "dark";
+    await page.locator(`#op-theme-toggle [data-theme-value="${theme}"]`).click();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", theme);
+
+    for (const id of ["text-first-idle-agent", "text-first-not-started-agent"]) {
+      const workspaceWindow = page.locator(`.workspace-window[data-id="${id}"]`);
+      await expect(workspaceWindow).toBeVisible();
+      await expect(workspaceWindow).toHaveCSS("opacity", "1");
+      await expect(workspaceWindow.locator(".window-body")).not.toHaveCSS(
+        "background-color",
+        "rgba(0, 0, 0, 0)",
+      );
+    }
+
+    await page.screenshot({
+      path: testInfo.outputPath(`text-first-${theme}-window.png`),
+      fullPage: true,
+    });
+  });
+});

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -2373,18 +2373,147 @@ test("terminal root does not combine full inset with padding overflow (SPEC-2008
   );
 });
 
+test("terminal transcript host paints every xterm layer as an opaque dark body (SPEC-2356 FR-035)", () => {
+  const expectedSelectors = [
+    ".surface-terminal .terminal-root",
+    ".surface-terminal .terminal-root .xterm",
+    ".surface-terminal .terminal-root .xterm-viewport",
+    ".surface-terminal .terminal-root .xterm-screen",
+    ".surface-terminal .terminal-root .xterm-helper-textarea",
+  ];
+
+  for (const selector of expectedSelectors) {
+    const block = cssBlockContaining(inlineStyle, selector);
+    assert.match(
+      block,
+      /background:\s*(?:#0a0d12|var\(\s*--color-canvas-dark\s*\))/i,
+      `${selector} must explicitly paint the Dark Operator terminal background`,
+    );
+    assert.doesNotMatch(
+      block,
+      /transparent|backdrop-filter|opacity:\s*0\.[0-9]/i,
+      `${selector} must not let the Canvas or sibling windows show through text`,
+    );
+  }
+});
+
+test("terminal overlay surfaces are opaque and copyable, not translucent glass (SPEC-2356 FR-033)", () => {
+  for (const selector of [".terminal-overlay", ".terminal-overlay.visible"]) {
+    const block = cssBlockContaining(inlineStyle, selector);
+    assert.doesNotMatch(
+      block,
+      /transparent|backdrop-filter|opacity:\s*0\.[0-9]/i,
+      `${selector} must not use translucent readable backgrounds`,
+    );
+    assert.match(
+      block,
+      /background:\s*(?:#0a0d12|var\(\s*--color-canvas-dark\s*\)|var\(\s*--color-surface(?:-elevated)?\s*\)|color-mix\([^;]+var\(\s*--color-canvas-dark\s*\)[^;]+\))/i,
+      `${selector} must use an opaque terminal/text surface background`,
+    );
+  }
+});
+
+test("agent-state telemetry never makes readable workspace windows translucent (SPEC-2356 FR-033)", () => {
+  const css = readFileSync(resolve(here, "../styles/components.css"), "utf8");
+  for (const state of ["idle", "not_started"]) {
+    const selector = `.workspace-window[data-agent-state="${state}"]`;
+    const block = cssBlockContaining(css, selector);
+    assert.match(
+      block,
+      /opacity:\s*1\s*;/,
+      `${selector} must keep the entire window fully opaque; state dimming belongs on non-window telemetry affordances only`,
+    );
+  }
+
+  for (const state of ["idle", "not_started"]) {
+    const block = cssBlockContaining(css, `[data-agent-state="${state}"]`);
+    assert.doesNotMatch(
+      block,
+      /opacity:\s*0\.[0-9]/,
+      `[data-agent-state="${state}"] must not dim every descendant surface by applying opacity to the parent window`,
+    );
+  }
+});
+
 test("non-terminal surface bodies still follow the overall theme (FR-013 boundary)", () => {
   // The Dark fix is scoped to .surface-terminal.  Other surfaces (Board /
-  // Logs / File Tree / Branches / Knowledge / Mock / Profile) must
+  // Logs / File Tree / Branches / Knowledge / Workspace / Console / Mock / Profile) must
   // keep tracking the active theme via --color-surface so tabbed windows
   // still flip body color when a non-terminal tab is selected.
   const otherSurfaceRule =
-    /(?:\.surface-(?:file-tree|branches|board|logs|knowledge|mock|profile)\s+\.window-body,?\s*)+\{[^}]*background:\s*var\(\s*--color-surface\s*\)/;
+    /(?:\.surface-(?:file-tree|branches|board|logs|knowledge|index|workspace|console|mock|profile)\s+\.window-body,?\s*)+\{[^}]*background:\s*var\(\s*--color-surface\s*\)/;
   assert.match(
     inlineStyle,
     otherSurfaceRule,
     "non-terminal surface bodies must continue to use var(--color-surface)",
   );
+});
+
+test("mountWindowBody clears every known surface class before applying the active surface", () => {
+  const mountBody = appSource.match(
+    /function\s+mountWindowBody\(windowData,\s*element\)\s*\{[\s\S]*?if\s*\(surface\s*===\s*"terminal"\)/,
+  );
+  assert.ok(mountBody, "expected mountWindowBody implementation");
+  for (const surfaceClass of [
+    "surface-terminal",
+    "surface-file-tree",
+    "surface-branches",
+    "surface-board",
+    "surface-logs",
+    "surface-knowledge",
+    "surface-index",
+    "surface-workspace",
+    "surface-profile",
+    "surface-console",
+    "surface-mock",
+  ]) {
+    assert.match(
+      mountBody[0],
+      new RegExp(`"${surfaceClass}"`),
+      `mountWindowBody must remove stale ${surfaceClass} classes before adding the active surface`,
+    );
+  }
+});
+
+test("every readable non-terminal surface participates in the opaque window chrome grammar", () => {
+  for (const surface of [
+    "file-tree",
+    "branches",
+    "board",
+    "logs",
+    "knowledge",
+    "index",
+    "workspace",
+    "profile",
+    "console",
+    "mock",
+  ]) {
+    assert.match(
+      inlineStyle,
+      new RegExp(`\\.workspace-window\\.surface-${surface}\\b`),
+      `${surface} window shell must opt into the shared opaque surface background`,
+    );
+    assert.match(
+      inlineStyle,
+      new RegExp(`\\.surface-${surface}\\s+\\.titlebar\\b`),
+      `${surface} titlebar must use the shared opaque titlebar rule`,
+    );
+    assert.match(
+      inlineStyle,
+      new RegExp(`\\.surface-${surface}\\s+\\.window-body\\b`),
+      `${surface} body must use the shared opaque body rule`,
+    );
+    assert.match(
+      inlineStyle,
+      new RegExp(`\\.surface-${surface}\\s+\\.status-chip\\b`),
+      `${surface} status chip text must use the shared readable chrome rule`,
+    );
+    assert.match(
+      inlineStyle,
+      new RegExp(`\\.surface-${surface}\\s+\\.icon-button\\b`),
+      `${surface} icon button text must use the shared readable chrome rule`,
+    );
+  }
 });
 
 test("Sidebar Layer buttons reset UA chrome so Windows WebView2 stops drawing default border (FR-030)", () => {
@@ -2412,3 +2541,11 @@ test("Sidebar Layer buttons reset UA chrome so Windows WebView2 stops drawing de
     ".op-layer must clear background so the sidebar surface shows through",
   );
 });
+
+function cssBlockContaining(css, selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`(?:^|\\n)([^{}]*${escaped}[^{}]*)\\{([^}]*)\\}`, "m");
+  const match = css.match(regex);
+  assert.ok(match, `missing CSS rule containing selector: ${selector}`);
+  return match[2];
+}

--- a/crates/gwt/web/__tests__/quiet-work-ui-contract.test.mjs
+++ b/crates/gwt/web/__tests__/quiet-work-ui-contract.test.mjs
@@ -59,11 +59,73 @@ test("Release Notes uses shared global window chrome instead of a custom fixed o
   );
 });
 
+test("Text-first UI primitives define shared readable content formatting", () => {
+  const primitives = [
+    [".text-first-content", /font-family:\s*var\(--font-body\)/, /line-height:\s*1\.[5-9]/],
+    [".text-first-message", /background:\s*var\(--color-surface(?:-elevated)?\)/, /border:\s*1px solid var\(--color-border\)/],
+    [".text-first-meta", /font-family:\s*var\(--font-mono\)/, /color:\s*var\(--color-text-muted\)/],
+    [".text-first-code", /font-family:\s*var\(--font-mono\)/, /background:\s*var\(--color-surface(?:-elevated)?\)/],
+    [".text-first-state", /background:\s*var\(--color-surface(?:-elevated)?\)/, /border:\s*1px solid var\(--color-border\)/],
+    [".text-first-scroll", /overflow:\s*auto/, /min-height:\s*0/],
+  ];
+
+  for (const [selector, first, second] of primitives) {
+    const block = ruleFor(componentsCss, selector);
+    assert.match(block, first, `${selector} is missing the primary text-first contract`);
+    assert.match(block, second, `${selector} is missing the secondary text-first contract`);
+    assert.doesNotMatch(
+      block,
+      /font-family:\s*var\(--font-display\)|font-stretch:\s*75%|backdrop-filter|transparent|opacity:\s*0\.[0-9]/,
+      `${selector} must stay body/mono, opaque, and non-decorative`,
+    );
+  }
+});
+
+test("Core readable surfaces opt into the text-first app-wide format bridge", () => {
+  const combinedCss = `${appCss}\n${componentsCss}`;
+  const bridge = blockContaining(combinedCss, ".release-notes-content", ".workspace-overview-detail-pane");
+
+  for (const selector of [
+    ".release-notes-content",
+    ".workspace-overview-detail-pane",
+    ".workspace-overview-row",
+    ".workspace-detail-agent",
+    ".workspace-detail-event",
+    ".terminal-overlay",
+    ".file-tree-viewer-body",
+    ".board-panel",
+    ".logs-panel",
+    ".knowledge-panel",
+  ]) {
+    assert.match(bridge, selectorRegex(selector), `text-first bridge must include ${selector}`);
+  }
+  assert.match(bridge, /font-family:\s*var\(--font-body\)/);
+  assert.match(bridge, /line-height:\s*1\.[5-9]/);
+  assert.doesNotMatch(
+    bridge,
+    /font-family:\s*var\(--font-display\)|font-stretch:\s*75%|backdrop-filter|transparent|opacity:\s*0\.[0-9]/,
+    "text-first bridge must not use display typography or translucent readable backgrounds",
+  );
+});
+
 function ruleFor(css, selector) {
   const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const match = css.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`));
   assert.ok(match, `missing CSS rule: ${selector}`);
   return match[1];
+}
+
+function selectorRegex(selector) {
+  return new RegExp(selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+}
+
+function blockContaining(css, ...selectors) {
+  const blocks = blocksFor(css, /[^{]+\{/);
+  const match = blocks
+    .split("\n/* block */\n")
+    .find((block) => selectors.every((selector) => selectorRegex(selector).test(block)));
+  assert.ok(match, `missing CSS bridge block containing selectors: ${selectors.join(", ")}`);
+  return match;
 }
 
 function blocksFor(css, selectorRegex) {
@@ -83,5 +145,5 @@ function blocksFor(css, selectorRegex) {
     }
     blocks.push(css.slice(start, i));
   }
-  return blocks.join("\n");
+  return blocks.join("\n/* block */\n");
 }

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -9236,6 +9236,8 @@
           "surface-knowledge",
           "surface-index",
           "surface-workspace",
+          "surface-profile",
+          "surface-console",
           "surface-mock",
         );
         element.classList.add(`surface-${surface}`);

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -263,10 +263,9 @@ body {
   letter-spacing: var(--tracking-mono);
   padding: 8px 12px;
   border-radius: var(--radius-md);
-  background: color-mix(in oklab, var(--color-surface) 85%, transparent);
+  background: var(--color-surface);
   border: 1px solid var(--color-border);
   color: var(--color-text-muted);
-  backdrop-filter: blur(12px);
 }
 
 .connection-dot {
@@ -572,6 +571,8 @@ body {
   min-height: 260px;
   border-radius: var(--radius-md);
   overflow: hidden;
+  background: var(--color-surface);
+  color: var(--color-text);
   border: 1px solid var(--color-border-strong);
   box-shadow: var(--shadow-2);
 }
@@ -601,7 +602,7 @@ body {
 .workspace-window.surface-terminal {
   /* Terminal chrome follows the app theme; xterm content stays on the
      Dark Operator palette for terminal readability. */
-  background: var(--color-canvas);
+  background: var(--color-surface);
 }
 
 .workspace-window.surface-file-tree,
@@ -611,6 +612,7 @@ body {
 .workspace-window.surface-mock,
 .workspace-window.surface-workspace,
 .workspace-window.surface-knowledge,
+.workspace-window.surface-index,
 .workspace-window.surface-profile,
 .workspace-window.surface-console {
   background: var(--color-surface);
@@ -640,6 +642,8 @@ body {
 .surface-logs .titlebar,
 .surface-mock .titlebar,
 .surface-knowledge .titlebar,
+.surface-index .titlebar,
+.surface-workspace .titlebar,
 .surface-profile .titlebar,
 .surface-console .titlebar {
   background: var(--color-surface-elevated);
@@ -682,7 +686,7 @@ body {
   padding: 2px 7px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-pill);
-  background: color-mix(in oklab, var(--color-surface-elevated) 86%, transparent);
+  background: var(--color-surface-elevated);
   color: var(--color-text-muted);
   font-family: var(--font-mono);
   font-size: var(--type-xs);
@@ -705,8 +709,9 @@ body {
   flex-shrink: 0;
   gap: 6px;
   padding: 4px 8px;
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-pill);
-  background: color-mix(in oklab, var(--color-text-muted) 16%, transparent);
+  background: var(--color-surface-elevated);
   font-family: var(--font-mono);
   font-size: var(--type-xs);
   letter-spacing: var(--tracking-mono);
@@ -725,6 +730,10 @@ body {
 .surface-board .status-chip,
 .surface-logs .status-chip,
 .surface-knowledge .status-chip,
+.surface-index .status-chip,
+.surface-workspace .status-chip,
+.surface-profile .status-chip,
+.surface-console .status-chip,
 .surface-mock .status-chip {
   color: var(--color-text);
 }
@@ -772,7 +781,7 @@ body {
   height: 24px;
   border: none;
   border-radius: var(--radius-sm);
-  background: color-mix(in oklab, var(--color-text-muted) 16%, transparent);
+  background: var(--color-surface-elevated);
   color: var(--color-text);
   cursor: pointer;
 }
@@ -786,12 +795,16 @@ body {
 .surface-board .icon-button,
 .surface-logs .icon-button,
 .surface-knowledge .icon-button,
+.surface-index .icon-button,
+.surface-workspace .icon-button,
+.surface-profile .icon-button,
+.surface-console .icon-button,
 .surface-mock .icon-button {
   color: var(--color-text);
 }
 
 .icon-button:hover {
-  background: color-mix(in oklab, var(--color-text-muted) 28%, transparent);
+  background: color-mix(in oklab, var(--color-text-muted) 28%, var(--color-surface-elevated));
 }
 
 .window-body {
@@ -817,7 +830,7 @@ body {
   outline: 2px solid var(--color-state-active);
   outline-offset: 3px;
   box-shadow:
-    0 0 0 5px color-mix(in oklab, var(--color-state-active) 20%, transparent),
+    0 0 0 5px color-mix(in oklab, var(--color-state-active) 20%, var(--color-surface)),
     var(--shadow-window);
 }
 
@@ -834,7 +847,7 @@ body {
   height: 3px;
   border-radius: 999px;
   background: var(--color-state-active);
-  box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-state-active) 20%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-state-active) 20%, var(--color-surface));
 }
 
 .window-tab-strip {
@@ -878,9 +891,9 @@ body {
   max-width: 180px;
   height: 24px;
   padding: 0 9px;
-  border: 1px solid transparent;
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: transparent;
+  background: var(--color-surface);
   color: var(--color-text-muted);
   font-size: var(--type-xs);
   white-space: nowrap;
@@ -893,9 +906,9 @@ body {
   width: 22px;
   height: 24px;
   margin-left: -2px;
-  border: 1px solid transparent;
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: transparent;
+  background: var(--color-surface);
   color: var(--color-text-muted);
   cursor: pointer;
 }
@@ -911,7 +924,7 @@ body {
 }
 
 .window-tab-close:hover {
-  background: color-mix(in oklab, var(--color-text-muted) 18%, transparent);
+  background: color-mix(in oklab, var(--color-text-muted) 18%, var(--color-surface-elevated));
   color: var(--color-text);
 }
 
@@ -929,6 +942,7 @@ body {
    overall theme; this override is scoped to the body only. */
 .surface-terminal .window-body {
   background: #0a0d12;
+  color: #e8eaed;
 }
 
 .surface-file-tree .window-body,
@@ -937,6 +951,8 @@ body {
 .surface-logs .window-body,
 .surface-knowledge .window-body,
 .surface-index .window-body,
+.surface-workspace .window-body,
+.surface-console .window-body,
 .surface-mock .window-body,
 .surface-profile .window-body {
   background: var(--color-surface);
@@ -947,6 +963,17 @@ body {
   inset: 8px 10px 10px;
   padding: 0;
   overflow: hidden;
+  background: #0a0d12;
+  color: #e8eaed;
+}
+
+.surface-terminal .terminal-root,
+.surface-terminal .terminal-root .xterm,
+.surface-terminal .terminal-root .xterm-viewport,
+.surface-terminal .terminal-root .xterm-screen,
+.surface-terminal .terminal-root .xterm-helper-textarea {
+  background: #0a0d12;
+  color: #e8eaed;
 }
 
 .terminal-overlay {
@@ -954,8 +981,8 @@ body {
   inset: 12px;
   padding: 10px 12px;
   border-radius: var(--radius-md);
-  background: color-mix(in oklab, var(--color-canvas) 82%, transparent);
-  color: var(--color-text);
+  background: #0a0d12;
+  color: #e8eaed;
   font-family: var(--font-mono);
   font-size: var(--type-xs);
   letter-spacing: var(--tracking-mono);
@@ -971,7 +998,7 @@ body {
   align-items: stretch;
   justify-content: flex-start;
   gap: 8px;
-  background: color-mix(in oklab, var(--color-canvas) 95%, transparent);
+  background: #0a0d12;
   pointer-events: auto;
   user-select: text;
 }
@@ -1006,7 +1033,7 @@ body {
   height: 26px;
   border: 1px solid var(--color-border-strong);
   border-radius: var(--radius-sm);
-  background: color-mix(in oklab, var(--color-state-active) 18%, transparent);
+  background: color-mix(in oklab, var(--color-state-active) 18%, #0a0d12);
   color: var(--color-text-strong);
   cursor: pointer;
   font-family: var(--font-mono);
@@ -1017,7 +1044,7 @@ body {
 }
 
 .overlay-copy-button:hover:not(:disabled) {
-  background: color-mix(in oklab, var(--color-state-active) 28%, transparent);
+  background: color-mix(in oklab, var(--color-state-active) 28%, #0a0d12);
 }
 
 .overlay-copy-button:disabled {
@@ -3182,7 +3209,6 @@ body {
   align-items: center;
   justify-content: center;
   background: var(--color-overlay);
-  backdrop-filter: blur(2px);
   z-index: 1000;
 }
 
@@ -3932,7 +3958,6 @@ body {
   justify-content: center;
   padding: 24px;
   background: var(--color-overlay);
-  backdrop-filter: blur(2px);
   z-index: 1200;
 }
 

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -27,6 +27,103 @@ body {
   position: relative;
 }
 
+/* ============================================================
+   SPEC-2356 Phase 11 — Text-first readable surface primitives.
+
+   gwt is primarily a long-form coding conversation workspace. These
+   primitives define the shared, opaque grammar for readable content
+   blocks while leaving decorative Canvas/backdrop layers outside of the
+   text contract.
+   ============================================================ */
+
+.text-first-content {
+  min-width: 0;
+  color: var(--color-text);
+  background: var(--color-surface);
+  font-family: var(--font-body);
+  font-size: var(--type-sm);
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+
+.text-first-message {
+  min-width: 0;
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-elevated);
+  color: var(--color-text);
+  font-family: var(--font-body);
+  line-height: 1.6;
+}
+
+.text-first-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  min-width: 0;
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  line-height: 1.45;
+  letter-spacing: var(--tracking-mono);
+}
+
+.text-first-code {
+  min-width: 0;
+  padding: var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-elevated);
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  line-height: 1.55;
+  white-space: pre-wrap;
+  overflow: auto;
+}
+
+.text-first-state {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-elevated);
+  color: var(--color-text);
+  font-family: var(--font-body);
+  font-size: var(--type-sm);
+  line-height: 1.5;
+}
+
+.text-first-scroll {
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
+:root[data-theme] .release-notes-content,
+:root[data-theme] .workspace-overview-detail-pane,
+:root[data-theme] .workspace-overview-row,
+:root[data-theme] .workspace-detail-agent,
+:root[data-theme] .workspace-detail-event,
+:root[data-theme] .terminal-overlay,
+:root[data-theme] .file-tree-viewer-body,
+:root[data-theme] .board-panel,
+:root[data-theme] .logs-panel,
+:root[data-theme] .knowledge-panel {
+  min-width: 0;
+  color: var(--color-text);
+  background-color: var(--color-surface);
+  font-family: var(--font-body);
+  font-size: var(--type-sm);
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+
 /* Scan-grid backdrop (subtle, behind everything else) */
 body::before {
   content: "";
@@ -156,7 +253,6 @@ body::after {
   border: 1px solid var(--color-focus-ring);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-2);
-  backdrop-filter: blur(8px);
   font-family: var(--font-mono);
   font-size: var(--type-sm);
   letter-spacing: var(--tracking-mono);
@@ -1048,13 +1144,16 @@ body::after {
      static rim remains. */
   --agent-color: color-mix(in oklab, var(--current-agent, var(--color-state-idle)) 55%, var(--color-state-idle));
   box-shadow: 0 0 0 1px var(--agent-color);
-  opacity: 0.82;
 }
 
 [data-agent-state="not_started"] {
   --agent-color: color-mix(in oklab, var(--current-agent, var(--color-state-idle)) 35%, var(--color-border));
   box-shadow: 0 0 0 1px var(--agent-color);
-  opacity: 0.72;
+}
+
+.workspace-window[data-agent-state="idle"],
+.workspace-window[data-agent-state="not_started"] {
+  opacity: 1;
 }
 
 [data-agent-state="blocked"] {
@@ -1136,7 +1235,6 @@ body::after {
   position: fixed;
   inset: 0;
   background: var(--color-overlay);
-  backdrop-filter: blur(2px);
   z-index: 30;
   opacity: 0;
   pointer-events: none;
@@ -1235,7 +1333,6 @@ body::after {
   position: fixed;
   inset: 0;
   background: var(--color-scrim);
-  backdrop-filter: blur(4px);
   z-index: 40;
   opacity: 0;
   pointer-events: none;
@@ -1328,7 +1425,6 @@ body::after {
   position: fixed;
   inset: 0;
   background: var(--color-scrim);
-  backdrop-filter: blur(4px);
   z-index: 50;
   opacity: 0;
   pointer-events: none;
@@ -2083,7 +2179,6 @@ kbd.op-kbd {
 :root[data-theme] .project-picker,
 :root[data-theme] .project-onboarding {
   background: var(--color-overlay);
-  backdrop-filter: blur(2px);
 }
 :root[data-theme] .project-picker-card,
 :root[data-theme] .project-onboarding-card {
@@ -2150,7 +2245,6 @@ kbd.op-kbd {
   align-items: stretch;
   justify-content: flex-end;
   background: var(--color-overlay);
-  backdrop-filter: blur(2px);
 }
 .modal-backdrop.is-drawer.open {
   display: flex;

--- a/scripts/run-frontend-unit-tests.sh
+++ b/scripts/run-frontend-unit-tests.sh
@@ -14,6 +14,7 @@ bash scripts/run-node-tests-with-linkedom.sh \
   crates/gwt/web/__tests__/board-surface.test.mjs \
   crates/gwt/web/__tests__/focus-trap.test.mjs \
   crates/gwt/web/__tests__/kanban-structure.test.mjs \
+  crates/gwt/web/__tests__/quiet-work-ui-contract.test.mjs \
   crates/gwt/web/__tests__/kanban-dnd.test.mjs \
   crates/gwt/web/__tests__/kanban-drawer.test.mjs \
   crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs \


### PR DESCRIPTION
## Summary

- Keep Canvas floating windows and text-bearing surfaces opaque so natural-language agent output stays readable in Light and Dark themes.
- Add shared text-first CSS primitives and contract tests so Board, Logs, Knowledge, Workspace detail, terminal overlays, and floating-window bodies use a consistent readable format.
- Add live headed Playwright coverage for the reported translucency/readability regression.

## Changes

- `crates/gwt/web/styles/app.css`: hardens Canvas window shell, titlebar, body, terminal root/xterm layers, terminal overlays, status chips, and icon buttons to use opaque readable backgrounds.
- `crates/gwt/web/styles/components.css`: adds shared `.text-first-*` primitives and bridges core readable surfaces into the same text-first formatting grammar.
- `crates/gwt/web/app.js`: clears all known surface classes during body remounts so stale surface styling cannot leak between window types.
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: adds contract coverage for opaque window chrome, terminal continuity, overlay opacity, surface cleanup, and readable surface coverage.
- `crates/gwt/web/__tests__/quiet-work-ui-contract.test.mjs`: adds text-first primitive and bridge coverage.
- `crates/gwt/playwright/tests/text-first-ui-live.spec.ts`: adds headed/browser coverage for Canvas opacity and Light/Dark readability.
- `crates/gwt/playwright/playwright.config.ts`: supports the focused text-first live UI test path.
- `scripts/run-frontend-unit-tests.sh`: includes the quiet-work UI contract suite in the full frontend unit runner.

## Testing

- [x] `bash scripts/run-node-tests-with-linkedom.sh crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — 108 tests GREEN.
- [x] `bash scripts/run-node-tests-with-linkedom.sh crates/gwt/web/__tests__/quiet-work-ui-contract.test.mjs` — GREEN.
- [x] `GWT_PLAYWRIGHT_CHROMIUM_CHANNEL=chrome GWT_PLAYWRIGHT_BASE_URL=http://127.0.0.1:62780/ bash scripts/run-visual-tests.sh --headed crates/gwt/playwright/tests/text-first-ui-live.spec.ts` — 2 tests GREEN.
- [x] `bash scripts/run-frontend-unit-tests.sh` — 565 tests GREEN.
- [x] `bash scripts/check-frontend-bundle.sh` — GREEN.
- [x] `cargo test -p gwt embedded_web --all-features` — GREEN.
- [x] `cargo test -p gwt-core -p gwt --all-features` — GREEN.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — GREEN.
- [x] `cargo fmt --all -- --check` — GREEN.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — GREEN.
- [x] `git diff --check` — GREEN.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — GREEN.
- [x] Manual user verification — `target/debug/gwt serve --no-open` served `http://127.0.0.1:49540/` with HTTP 200; user confirmed Light/Dark Canvas readability with “OKです。” on 2026-05-24.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — the patch is scoped to UI readability and test coverage, with no incomplete user-facing flow exposed.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

None

## Related Issues / Links

- #2356

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, frontend bundle check)
- [x] Documentation updated (SPEC-2356 spec/plan/tasks updated; README change not required for this scoped fix)
- [x] Migration/backfill plan included (N/A: no schema or data migration)
- [x] CHANGELOG impact considered (patch-level `fix:` commit, no breaking change)

## Context

- This fixes the reported Canvas readability issue where translucent window surfaces made `$gwt-discussion` and similar LLM text output difficult to read, including Night/Dark mode.
- The implementation treats the report as app-wide UI/UX hardening, not as a one-off opacity tweak.

## Risk / Impact

- **Affected areas**: Canvas floating windows, terminal window chrome, terminal overlays, readable utility panels, frontend design-system CSS, and UI contract tests.
- **Rollback plan**: revert this PR; no migration or persisted data change is involved.

## Screenshots / Visual Verification

| Before | After |
|--------|-------|
| Reported issue: translucent Canvas window content was difficult to read in Light and Night/Dark modes. | User manually verified `http://127.0.0.1:49540/` and confirmed the updated Light/Dark Canvas readability with “OKです。” on 2026-05-24. |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed surface class cleanup when switching between Profile and Console windows
  * Improved window opacity consistency for agent state display

* **Style**
  * Standardized surface colors and theme behavior across UI panels using token-based styling
  * Removed backdrop blur effects from overlay and modal components
  * Strengthened terminal theme with consistent dark backgrounds and light text

* **Tests**
  * Added UI test for text-first live readability scenario
  * Expanded CSS contract coverage for operator window opacity and styling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2879?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->