### PR TITLE
chore(skill): harden headless browser check launch rules

### DIFF
--- a/.claude/skills/headless-browser-check/SKILL.md
+++ b/.claude/skills/headless-browser-check/SKILL.md
@@ -15,15 +15,25 @@ not use it for CI-only Playwright runs or generic web app servers.
 
 ## Workflow
 
-1. Start from the repository root and note the current branch.
+1. Capture the launch directory:
+   - Treat the current working directory at skill start as the launch directory.
+   - Resolve the repository root for that same checkout and note the current
+     branch.
+   - Do not switch to another worktree, reuse another checkout, or use a
+     production install for this check.
 2. Resolve the gwt binary:
-   - Prefer `target/debug/gwt` when it exists.
-   - Otherwise run `cargo build -p gwt --bin gwt`, then use `target/debug/gwt`.
+   - Use only this launch checkout's `target/debug/gwt`.
+   - Otherwise run `cargo build -p gwt --bin gwt` from this checkout, then use
+     its `target/debug/gwt`.
    - If the user explicitly asks to test freshly edited code, build first even
      when `target/debug/gwt` exists.
+   - Never fall back to `/Applications/GWT.app`, `command -v gwt`, another
+     worktree's binary, or any installed production gwt binary.
 3. Start headless mode in a long-running exec session:
    - Create a temp URL handoff file and log path under `${TMPDIR:-/tmp}`.
    - Run `GWT_BROWSER_URL_FILE=<url-file> target/debug/gwt serve 2>&1 | tee <log-file>`.
+   - Always start a fresh `gwt serve` process for this check, using the binary
+     resolved above.
    - Treat this tee log as the startup/stdout log only; ordinary browser UI
      actions may not appear there.
    - Use default auto-open behavior unless the user asks not to open a browser.
@@ -31,6 +41,7 @@ not use it for CI-only Playwright runs or generic web app servers.
 4. Wait for readiness:
    - Read the URL from `GWT_BROWSER_URL_FILE` first.
    - Fall back to the log line `gwt browser URL: <url>`.
+   - Accept only the URL produced by the fresh process launched in step 3.
    - Verify the URL with `curl -fsS -I <url>` or an equivalent HTTP 200 check.
 5. Do not manually open the URL after a normal startup. `gwt serve` opens the
    browser by default, and running an additional platform opener will create a
@@ -68,6 +79,10 @@ not use it for CI-only Playwright runs or generic web app servers.
   the user required that exact port.
 - Keep user-facing status messages concise and in Japanese. Keep command names
   and log identifiers as-is.
+- **Never reuse an already-running gwt address** from an existing browser tab,
+  previous log, GUI status bar, `~/.gwt/session.json`, structured logs, or a
+  reachable old server. A successful HTTP check only proves the server is
+  reachable; it does not prove the URL belongs to the checkout under test.
 - **Never stop, kill, or ask the user to quit the user's production gwt /
   `GWT.app` instance** (`/Applications/GWT.app`, any locally installed gwt
   GUI, or any long-running `gwt` process the user did not launch in this

--- a/.codex/skills/headless-browser-check/SKILL.md
+++ b/.codex/skills/headless-browser-check/SKILL.md
@@ -15,15 +15,25 @@ not use it for CI-only Playwright runs or generic web app servers.
 
 ## Workflow
 
-1. Start from the repository root and note the current branch.
+1. Capture the launch directory:
+   - Treat the current working directory at skill start as the launch directory.
+   - Resolve the repository root for that same checkout and note the current
+     branch.
+   - Do not switch to another worktree, reuse another checkout, or use a
+     production install for this check.
 2. Resolve the gwt binary:
-   - Prefer `target/debug/gwt` when it exists.
-   - Otherwise run `cargo build -p gwt --bin gwt`, then use `target/debug/gwt`.
+   - Use only this launch checkout's `target/debug/gwt`.
+   - Otherwise run `cargo build -p gwt --bin gwt` from this checkout, then use
+     its `target/debug/gwt`.
    - If the user explicitly asks to test freshly edited code, build first even
      when `target/debug/gwt` exists.
+   - Never fall back to `/Applications/GWT.app`, `command -v gwt`, another
+     worktree's binary, or any installed production gwt binary.
 3. Start headless mode in a long-running exec session:
    - Create a temp URL handoff file and log path under `${TMPDIR:-/tmp}`.
    - Run `GWT_BROWSER_URL_FILE=<url-file> target/debug/gwt serve 2>&1 | tee <log-file>`.
+   - Always start a fresh `gwt serve` process for this check, using the binary
+     resolved above.
    - Treat this tee log as the startup/stdout log only; ordinary browser UI
      actions may not appear there.
    - Use default auto-open behavior unless the user asks not to open a browser.
@@ -31,6 +41,7 @@ not use it for CI-only Playwright runs or generic web app servers.
 4. Wait for readiness:
    - Read the URL from `GWT_BROWSER_URL_FILE` first.
    - Fall back to the log line `gwt browser URL: <url>`.
+   - Accept only the URL produced by the fresh process launched in step 3.
    - Verify the URL with `curl -fsS -I <url>` or an equivalent HTTP 200 check.
 5. Do not manually open the URL after a normal startup. `gwt serve` opens the
    browser by default, and running an additional platform opener will create a
@@ -68,6 +79,10 @@ not use it for CI-only Playwright runs or generic web app servers.
   the user required that exact port.
 - Keep user-facing status messages concise and in Japanese. Keep command names
   and log identifiers as-is.
+- **Never reuse an already-running gwt address** from an existing browser tab,
+  previous log, GUI status bar, `~/.gwt/session.json`, structured logs, or a
+  reachable old server. A successful HTTP check only proves the server is
+  reachable; it does not prove the URL belongs to the checkout under test.
 - **Never stop, kill, or ask the user to quit the user's production gwt /
   `GWT.app` instance** (`/Applications/GWT.app`, any locally installed gwt
   GUI, or any long-running `gwt` process the user did not launch in this

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6088,3 +6088,10 @@ Type: lesson
 Context: SPEC-1935 investigation and implementation found that Codex hook discovery path differs by CLI version in gwt-managed worktrees.
 Learning: Codex versions older than 0.131.0-alpha.21 discover <worktree>/.codex/hooks.json; 0.131.0-alpha.21 and newer discover the workspace-home/CODEX_HOME hooks path. Unknown installed versions should use a both-path fallback.
 Future Action: When changing Codex managed hook materialization or trust registration, route path selection through CodexHookDiscoveryMode and verify old, new, and unknown-version cases.
+
+## 2026-05-25 — headless-browser-check must launch fresh serve from the current checkout
+
+Type: lesson
+Context: User clarified that headless-browser-check must not stop production gwt, must not reuse an already-running gwt address, and must server-launch the gwt binary from the launch/current checkout.
+Learning: Manual browser verification can be falsely performed against a stale or production server if an agent reuses a reachable URL or an installed gwt binary. The skill must start a fresh gwt serve process from the current checkout's target/debug/gwt and accept only that process's URL handoff/log.
+Future Action: Before sharing a headless-browser-check URL, capture the launch directory, resolve that same checkout's repository root and target/debug/gwt, start a new gwt serve with a fresh GWT_BROWSER_URL_FILE, verify that fresh URL, and stop only the process launched by the skill when the user is done.


### PR DESCRIPTION
## Summary

- Hardened the headless-browser-check skill so manual browser checks always use a fresh `gwt serve` launched from the current checkout.
- Preserved the production `GWT.app` safety rule while making stale URL and installed-binary reuse explicitly forbidden.

## Changes

- `.claude/skills/headless-browser-check/SKILL.md`: Captures the launch directory, restricts binary resolution to that checkout's `target/debug/gwt`, and accepts only the URL emitted by the fresh process.
- `.codex/skills/headless-browser-check/SKILL.md`: Mirrors the Claude skill update byte-for-byte for Codex agents.
- `tasks/memory.md`: Records the workflow lesson so future headless checks do not reuse stale URLs or production binaries.

## Testing

- [x] `diff -u .claude/skills/headless-browser-check/SKILL.md .codex/skills/headless-browser-check/SKILL.md` — no output; the two skill copies are identical.
- [x] `bash scripts/validate-skill-frontmatter.sh` — validated 37 SKILL.md frontmatter blocks.
- [x] `npx --yes markdownlint-cli2 .claude/skills/headless-browser-check/SKILL.md .codex/skills/headless-browser-check/SKILL.md tasks/memory.md` — 0 errors.
- [x] `git diff --check` — no whitespace errors.
- [x] `cargo test -p gwt-skills` — 193 passed.
- [x] `cargo test -p gwt --test managed_assets_test` — 6 passed.
- [x] `bunx commitlint --from origin/develop --to HEAD` — passed.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes; this is a contained skill-guidance update plus memory entry and does not expose partial runtime behavior.
- Known blockers: None
- Remaining acceptance: None
- User Verification Result: n/a; skill/docs-only change with no GUI or visual surface to inspect.

## Closing Issues

- None

## Related Issues / Links

- #1942
- #2785

## Checklist

- [x] Tests added/updated (N/A: no new production code; existing skill asset and managed asset tests cover the changed surface.)
- [x] Lint/format passed (`bash scripts/validate-skill-frontmatter.sh`, `markdownlint-cli2`, `git diff --check`.)
- [x] Documentation updated (the skill instructions are the user-facing artifact for agents.)
- [x] Migration/backfill plan included (N/A: no schema or data migration.)
- [x] CHANGELOG impact considered (no runtime feature or released user behavior change.)

## Context

- The user clarified that headless-browser-check must not stop production gwt, must not reuse an already-running gwt address, and must launch the gwt server from the startup/current checkout.

## Risk / Impact

- **Affected areas**: Agent skill guidance for manual browser checks only.
- **Rollback plan**: Revert this PR to restore the previous skill wording.
