### PR TITLE
chore(skill): use root path for headless gwt launch

### DIFF
--- a/.claude/skills/headless-browser-check/SKILL.md
+++ b/.claude/skills/headless-browser-check/SKILL.md
@@ -15,23 +15,25 @@ not use it for CI-only Playwright runs or generic web app servers.
 
 ## Workflow
 
-1. Capture the launch directory:
+1. Capture the launch checkout root:
    - Treat the current working directory at skill start as the launch directory.
    - Resolve the repository root for that same checkout and note the current
      branch.
+   - Run the remaining workflow from that repository root, or use absolute
+     paths prefixed by that repository root.
    - Do not switch to another worktree, reuse another checkout, or use a
      production install for this check.
 2. Resolve the gwt binary:
-   - Use only this launch checkout's `target/debug/gwt`.
-   - Otherwise run `cargo build -p gwt --bin gwt` from this checkout, then use
-     its `target/debug/gwt`.
+   - Use only this launch checkout's `<repo-root>/target/debug/gwt`.
+   - Otherwise run `cargo build -p gwt --bin gwt` from `<repo-root>`, then use
+     `<repo-root>/target/debug/gwt`.
    - If the user explicitly asks to test freshly edited code, build first even
-     when `target/debug/gwt` exists.
+     when `<repo-root>/target/debug/gwt` exists.
    - Never fall back to `/Applications/GWT.app`, `command -v gwt`, another
      worktree's binary, or any installed production gwt binary.
 3. Start headless mode in a long-running exec session:
    - Create a temp URL handoff file and log path under `${TMPDIR:-/tmp}`.
-   - Run `GWT_BROWSER_URL_FILE=<url-file> target/debug/gwt serve 2>&1 | tee <log-file>`.
+   - Run `GWT_BROWSER_URL_FILE=<url-file> <repo-root>/target/debug/gwt serve 2>&1 | tee <log-file>`.
    - Always start a fresh `gwt serve` process for this check, using the binary
      resolved above.
    - Treat this tee log as the startup/stdout log only; ordinary browser UI

--- a/.codex/skills/headless-browser-check/SKILL.md
+++ b/.codex/skills/headless-browser-check/SKILL.md
@@ -15,23 +15,25 @@ not use it for CI-only Playwright runs or generic web app servers.
 
 ## Workflow
 
-1. Capture the launch directory:
+1. Capture the launch checkout root:
    - Treat the current working directory at skill start as the launch directory.
    - Resolve the repository root for that same checkout and note the current
      branch.
+   - Run the remaining workflow from that repository root, or use absolute
+     paths prefixed by that repository root.
    - Do not switch to another worktree, reuse another checkout, or use a
      production install for this check.
 2. Resolve the gwt binary:
-   - Use only this launch checkout's `target/debug/gwt`.
-   - Otherwise run `cargo build -p gwt --bin gwt` from this checkout, then use
-     its `target/debug/gwt`.
+   - Use only this launch checkout's `<repo-root>/target/debug/gwt`.
+   - Otherwise run `cargo build -p gwt --bin gwt` from `<repo-root>`, then use
+     `<repo-root>/target/debug/gwt`.
    - If the user explicitly asks to test freshly edited code, build first even
-     when `target/debug/gwt` exists.
+     when `<repo-root>/target/debug/gwt` exists.
    - Never fall back to `/Applications/GWT.app`, `command -v gwt`, another
      worktree's binary, or any installed production gwt binary.
 3. Start headless mode in a long-running exec session:
    - Create a temp URL handoff file and log path under `${TMPDIR:-/tmp}`.
-   - Run `GWT_BROWSER_URL_FILE=<url-file> target/debug/gwt serve 2>&1 | tee <log-file>`.
+   - Run `GWT_BROWSER_URL_FILE=<url-file> <repo-root>/target/debug/gwt serve 2>&1 | tee <log-file>`.
    - Always start a fresh `gwt serve` process for this check, using the binary
      resolved above.
    - Treat this tee log as the startup/stdout log only; ordinary browser UI

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6095,3 +6095,10 @@ Type: lesson
 Context: User clarified that headless-browser-check must not stop production gwt, must not reuse an already-running gwt address, and must server-launch the gwt binary from the launch/current checkout.
 Learning: Manual browser verification can be falsely performed against a stale or production server if an agent reuses a reachable URL or an installed gwt binary. The skill must start a fresh gwt serve process from the current checkout's target/debug/gwt and accept only that process's URL handoff/log.
 Future Action: Before sharing a headless-browser-check URL, capture the launch directory, resolve that same checkout's repository root and target/debug/gwt, start a new gwt serve with a fresh GWT_BROWSER_URL_FILE, verify that fresh URL, and stop only the process launched by the skill when the user is done.
+
+## 2026-05-25 — headless-browser-check must use repo-root absolute gwt paths
+
+Type: lesson
+Context: Codex review on PR #2884 pointed out that headless-browser-check resolved the repository root but still showed a relative target/debug/gwt launch command, which fails when the skill is triggered from a subdirectory such as crates/gwt.
+Learning: A skill can say 'current checkout' and still be ambiguous if command examples remain relative to the caller's cwd. For gwt serve handoff checks, the launch command must either cd to the resolved repository root or use an absolute <repo-root>/target/debug/gwt path.
+Future Action: When updating headless-browser-check or similar launch skills, make every executable path in the workflow match the resolved root/checkout contract; test the instructions mentally from a subdirectory as well as from repo root.


### PR DESCRIPTION
## Summary

- Updated headless-browser-check to launch `gwt serve` through the resolved repository root path so the skill works from subdirectories.
- Recorded the review lesson so future launch-skill edits keep command examples aligned with their root/checkout contract.

## Changes

- `.claude/skills/headless-browser-check/SKILL.md`: Requires running from the resolved repository root or using root-prefixed absolute paths, and updates the launch command to `<repo-root>/target/debug/gwt serve`.
- `.codex/skills/headless-browser-check/SKILL.md`: Mirrors the Claude skill update byte-for-byte for Codex agents.
- `tasks/memory.md`: Adds the PR #2884 review learning about avoiding cwd-relative executable paths in launch skills.

## Testing

- [x] `diff -u .claude/skills/headless-browser-check/SKILL.md .codex/skills/headless-browser-check/SKILL.md` — no output; the two skill copies are identical.
- [x] `bash scripts/validate-skill-frontmatter.sh` — validated 37 SKILL.md frontmatter blocks.
- [x] `npx --yes markdownlint-cli2 .claude/skills/headless-browser-check/SKILL.md .codex/skills/headless-browser-check/SKILL.md tasks/memory.md` — 0 errors.
- [x] `git diff --check` — no whitespace errors.
- [x] `cargo test -p gwt-skills` — 193 passed.
- [x] `cargo test -p gwt --test managed_assets_test` — 6 passed.
- [x] `bunx commitlint --from origin/develop --to HEAD` — passed.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes; this is a contained follow-up to a merged skill-guidance PR and does not expose partial runtime behavior.
- Known blockers: None
- Remaining acceptance: None
- User Verification Result: n/a; skill/docs-only change with no GUI or visual surface to inspect.

## Closing Issues

- None

## Related Issues / Links

- #2884
- #1942
- #2785

## Checklist

- [x] Tests added/updated (N/A: no new production code; existing skill asset and managed asset tests cover the changed surface.)
- [x] Lint/format passed (`bash scripts/validate-skill-frontmatter.sh`, `markdownlint-cli2`, `git diff --check`.)
- [x] Documentation updated (the skill instructions are the user-facing artifact for agents.)
- [x] Migration/backfill plan included (N/A: no schema or data migration.)
- [x] CHANGELOG impact considered (no runtime feature or released user behavior change.)

## Context

- Codex review on PR #2884 found that the skill resolved the repository root but still showed a relative `target/debug/gwt` launch command, which fails when invoked from a subdirectory.

## Risk / Impact

- **Affected areas**: Agent skill guidance for manual browser checks only.
- **Rollback plan**: Revert this PR to restore the previous skill wording.
