### PR TITLE
feat(gui): support file drag and drop attachments

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -847,7 +847,8 @@ fn frontend_user_action_log(event: &FrontendEvent) -> Option<FrontendUserActionL
         | FrontendEvent::UpdateViewport { .. }
         | FrontendEvent::UpdateWindowGeometry { .. }
         | FrontendEvent::TerminalInput { .. }
-        | FrontendEvent::PasteImage { .. } => return None,
+        | FrontendEvent::PasteImage { .. }
+        | FrontendEvent::AttachFiles { .. } => return None,
     };
     Some(log)
 }
@@ -952,7 +953,49 @@ impl std::fmt::Display for ImagePasteError {
 
 const IMAGE_PASTE_RELATIVE_DIR: &str = ".gwt/paste-images";
 const IMAGE_PASTE_PROMPT_PREFIX: &str = "Image file: ";
+const FILE_ATTACHMENT_RELATIVE_DIR: &str = ".gwt/drop-files";
 static IMAGE_PASTE_SEQUENCE: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PreparedFileAttachment {
+    pub(crate) bytes: Option<Vec<u8>>,
+    pub(crate) storage_path: Option<PathBuf>,
+    pub(crate) agent_path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum FileAttachmentError {
+    EmptyPath,
+    InvalidBase64(String),
+    SizeMismatch { declared: u64, actual: u64 },
+    TooLarge { size: u64, limit: u64 },
+    NotAFile(String),
+    ReadFailed(String),
+    WriteFailed(String),
+}
+
+impl std::fmt::Display for FileAttachmentError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyPath => formatter.write_str("file attachment path is empty"),
+            Self::InvalidBase64(error) => {
+                write!(formatter, "invalid file attachment payload: {error}")
+            }
+            Self::SizeMismatch { declared, actual } => write!(
+                formatter,
+                "file attachment size mismatch: declared {declared}, decoded {actual}"
+            ),
+            Self::TooLarge { size, limit } => {
+                write!(formatter, "file attachment is too large: {size} > {limit}")
+            }
+            Self::NotAFile(path) => write!(formatter, "file attachment is not a file: {path}"),
+            Self::ReadFailed(error) => write!(formatter, "failed to read file attachment: {error}"),
+            Self::WriteFailed(error) => {
+                write!(formatter, "failed to save file attachment: {error}")
+            }
+        }
+    }
+}
 
 fn image_extension_for_mime(mime_type: &str) -> Option<&'static str> {
     match mime_type.trim().to_ascii_lowercase().as_str() {
@@ -987,6 +1030,32 @@ fn sanitize_image_paste_stem(filename: Option<&str>) -> String {
     }
 }
 
+fn sanitize_file_attachment_name(filename: &str) -> String {
+    let raw_name = Path::new(filename)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .unwrap_or("file");
+    let mut sanitized = String::new();
+    let mut previous_dash = false;
+    for character in raw_name.chars().flat_map(char::to_lowercase) {
+        if character.is_ascii_alphanumeric() || character == '.' || character == '_' {
+            sanitized.push(character);
+            previous_dash = false;
+        } else if !previous_dash {
+            sanitized.push('-');
+            previous_dash = true;
+        }
+    }
+    let sanitized = sanitized.trim_matches(['-', '.', '_']);
+    if sanitized.is_empty() || sanitized == "." || sanitized == ".." {
+        "file".to_string()
+    } else {
+        sanitized.to_string()
+    }
+}
+
 fn join_agent_visible_path(agent_project_root: &str, relative_path: &str) -> String {
     let root = agent_project_root.trim();
     if root.is_empty() {
@@ -1000,6 +1069,136 @@ fn join_agent_visible_path(agent_project_root: &str, relative_path: &str) -> Str
         )
     } else {
         format!("{}/{}", root.trim_end_matches('/'), relative_path)
+    }
+}
+
+fn attachment_storage_paths(
+    worktree_path: &Path,
+    agent_project_root: &str,
+    unique_token: &str,
+    filename: &str,
+) -> (PathBuf, String) {
+    let sanitized = sanitize_file_attachment_name(filename);
+    let file_name = format!("{unique_token}-{sanitized}");
+    let storage_path = worktree_path
+        .join(".gwt")
+        .join("drop-files")
+        .join(&file_name);
+    let relative_path = format!("{FILE_ATTACHMENT_RELATIVE_DIR}/{file_name}");
+    let agent_path = join_agent_visible_path(agent_project_root, &relative_path);
+    (storage_path, agent_path)
+}
+
+fn validate_file_attachment_size(size: u64, limit: u64) -> Result<(), FileAttachmentError> {
+    if size > limit {
+        return Err(FileAttachmentError::TooLarge { size, limit });
+    }
+    Ok(())
+}
+
+pub(crate) fn prepare_file_attachment(
+    worktree_path: &Path,
+    agent_project_root: &str,
+    runtime_target: gwt_agent::LaunchRuntimeTarget,
+    file: &gwt::FileAttachment,
+    unique_token: &str,
+    limits: ContentLimits,
+) -> Result<PreparedFileAttachment, FileAttachmentError> {
+    match file {
+        gwt::FileAttachment::NativePath { path } => {
+            let path = path.trim();
+            if path.is_empty() {
+                return Err(FileAttachmentError::EmptyPath);
+            }
+            let source = PathBuf::from(path);
+            let metadata = std::fs::metadata(&source)
+                .map_err(|error| FileAttachmentError::ReadFailed(error.to_string()))?;
+            if !metadata.is_file() {
+                return Err(FileAttachmentError::NotAFile(path.to_string()));
+            }
+            if runtime_target == gwt_agent::LaunchRuntimeTarget::Host {
+                return Ok(PreparedFileAttachment {
+                    bytes: None,
+                    storage_path: None,
+                    agent_path: source.display().to_string(),
+                });
+            }
+            validate_file_attachment_size(metadata.len(), limits.binary_chunk_max_bytes)?;
+            let bytes = std::fs::read(&source)
+                .map_err(|error| FileAttachmentError::ReadFailed(error.to_string()))?;
+            let filename = source
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("file");
+            let (storage_path, agent_path) =
+                attachment_storage_paths(worktree_path, agent_project_root, unique_token, filename);
+            Ok(PreparedFileAttachment {
+                bytes: Some(bytes),
+                storage_path: Some(storage_path),
+                agent_path,
+            })
+        }
+        gwt::FileAttachment::Inline {
+            filename,
+            size,
+            data_base64,
+            ..
+        } => {
+            validate_file_attachment_size(*size, limits.binary_chunk_max_bytes)?;
+            let bytes = base64::Engine::decode(
+                &base64::engine::general_purpose::STANDARD,
+                data_base64.trim(),
+            )
+            .map_err(|error| FileAttachmentError::InvalidBase64(error.to_string()))?;
+            let actual = bytes.len() as u64;
+            if actual != *size {
+                return Err(FileAttachmentError::SizeMismatch {
+                    declared: *size,
+                    actual,
+                });
+            }
+            let (storage_path, agent_path) =
+                attachment_storage_paths(worktree_path, agent_project_root, unique_token, filename);
+            Ok(PreparedFileAttachment {
+                bytes: Some(bytes),
+                storage_path: Some(storage_path),
+                agent_path,
+            })
+        }
+    }
+}
+
+fn save_file_attachment(file: &PreparedFileAttachment) -> Result<(), FileAttachmentError> {
+    let Some(storage_path) = file.storage_path.as_ref() else {
+        return Ok(());
+    };
+    let Some(bytes) = file.bytes.as_ref() else {
+        return Ok(());
+    };
+    write_attachment_bytes(storage_path, bytes).map_err(FileAttachmentError::WriteFailed)
+}
+
+fn quote_file_attachment_path(path: &str) -> String {
+    let escaped = path
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r");
+    format!("\"{escaped}\"")
+}
+
+pub(crate) fn format_file_attachment_prompt(paths: &[String]) -> String {
+    match paths {
+        [] => String::new(),
+        [path] => format!("File: {}", quote_file_attachment_path(path)),
+        _ => format!(
+            "Files: [{}]",
+            paths
+                .iter()
+                .map(|path| quote_file_attachment_path(path))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
     }
 }
 
@@ -1052,16 +1251,16 @@ fn image_paste_unique_token() -> String {
     format!("{millis}-{sequence}")
 }
 
-fn save_image_paste_file(image: &ImagePasteFile) -> Result<(), ImagePasteError> {
-    let Some(parent) = image.storage_path.parent() else {
-        return Err(ImagePasteError::WriteFailed(
-            "pasted image path has no parent directory".to_string(),
-        ));
+fn write_attachment_bytes(storage_path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let Some(parent) = storage_path.parent() else {
+        return Err("attachment path has no parent directory".to_string());
     };
-    std::fs::create_dir_all(parent)
-        .map_err(|error| ImagePasteError::WriteFailed(error.to_string()))?;
-    std::fs::write(&image.storage_path, &image.bytes)
-        .map_err(|error| ImagePasteError::WriteFailed(error.to_string()))
+    std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    std::fs::write(storage_path, bytes).map_err(|error| error.to_string())
+}
+
+fn save_image_paste_file(image: &ImagePasteFile) -> Result<(), ImagePasteError> {
+    write_attachment_bytes(&image.storage_path, &image.bytes).map_err(ImagePasteError::WriteFailed)
 }
 
 #[derive(Debug, Clone)]
@@ -3046,6 +3245,7 @@ impl AppRuntime {
                 mime_type,
                 filename,
             } => self.paste_image_events(&id, &data_base64, &mime_type, filename.as_deref()),
+            FrontendEvent::AttachFiles { id, files } => self.attach_files_events(&id, files),
             FrontendEvent::LoadFileTree { id, path } => {
                 let path = path.unwrap_or_default();
                 vec![OutboundEvent::reply(
@@ -4456,6 +4656,86 @@ impl AppRuntime {
             "saved pasted image"
         );
         self.terminal_input_events(id, &image.prompt_text)
+    }
+
+    pub(crate) fn attach_files_events(
+        &mut self,
+        id: &str,
+        files: Vec<gwt::FileAttachment>,
+    ) -> Vec<OutboundEvent> {
+        let Some(address) = self.window_lookup.get(id).cloned() else {
+            tracing::debug!(window_id = %id, "file attachment dropped: window not found");
+            return Vec::new();
+        };
+        if self.tab(&address.tab_id).is_none() {
+            tracing::debug!(window_id = %id, "file attachment dropped: project tab not found");
+            return Vec::new();
+        }
+        let Some(session) = self.active_agent_sessions.get(id) else {
+            tracing::debug!(
+                window_id = %id,
+                "file attachment dropped: active agent session not found"
+            );
+            return Vec::new();
+        };
+        if files.is_empty() {
+            tracing::debug!(window_id = %id, "file attachment dropped: empty selection");
+            return Vec::new();
+        }
+        let worktree_path = session.worktree_path.clone();
+        let agent_project_root = session.agent_project_root.clone();
+        let runtime_target = session.runtime_target;
+        let limits = ContentLimits::default();
+
+        let mut prepared_files = Vec::with_capacity(files.len());
+        for (index, file) in files.iter().enumerate() {
+            let token = format!("{}-{index}", image_paste_unique_token());
+            let prepared = match prepare_file_attachment(
+                &worktree_path,
+                &agent_project_root,
+                runtime_target,
+                file,
+                &token,
+                limits,
+            ) {
+                Ok(prepared) => prepared,
+                Err(error) => {
+                    tracing::debug!(
+                        window_id = %id,
+                        error = %error,
+                        "file attachment dropped"
+                    );
+                    return Vec::new();
+                }
+            };
+            prepared_files.push(prepared);
+        }
+
+        for file in &prepared_files {
+            if let Err(error) = save_file_attachment(file) {
+                return self.handle_runtime_status(
+                    id.to_string(),
+                    WindowProcessStatus::Error,
+                    Some(error.to_string()),
+                );
+            }
+        }
+
+        let agent_paths = prepared_files
+            .iter()
+            .map(|file| file.agent_path.clone())
+            .collect::<Vec<_>>();
+        let prompt = format_file_attachment_prompt(&agent_paths);
+        if prompt.is_empty() {
+            return Vec::new();
+        }
+        tracing::debug!(
+            window_id = %id,
+            runtime_target = ?runtime_target,
+            count = agent_paths.len(),
+            "prepared file attachments"
+        );
+        self.terminal_input_events(id, &prompt)
     }
 
     pub(crate) fn load_file_tree_event(&self, id: &str, path: &str) -> BackendEvent {
@@ -8215,9 +8495,10 @@ mod tests {
     use chrono::{TimeZone, Utc};
     use gwt::{
         empty_workspace_state, load_restored_workspace_state, load_session_state, BackendEvent,
-        BranchCleanupInfo, BranchListEntry, BranchScope, FrontendEvent, LaunchWizardAction,
-        LaunchWizardContext, LaunchWizardState, ProfileEnvEntryView, ProjectKind, UiTracePayload,
-        WindowGeometry, WindowPreset, WindowProcessStatus, WorkspaceState,
+        BranchCleanupInfo, BranchListEntry, BranchScope, ContentLimits, FrontendEvent,
+        LaunchWizardAction, LaunchWizardContext, LaunchWizardState, ProfileEnvEntryView,
+        ProjectKind, UiTracePayload, WindowGeometry, WindowPreset, WindowProcessStatus,
+        WorkspaceState,
     };
     use gwt_config::{Profile, Settings};
     use gwt_core::{
@@ -8963,6 +9244,278 @@ exit 1
         assert!(
             !worktree.join(".gwt").join("paste-images").exists(),
             "non-agent terminal paste must not create image files"
+        );
+    }
+
+    #[test]
+    fn file_attachment_prepare_uses_host_native_path_reference() {
+        let temp = tempdir().expect("tempdir");
+        let worktree = temp.path().join("repo");
+        fs::create_dir_all(&worktree).expect("create worktree");
+        let source = temp.path().join("report.pdf");
+        fs::write(&source, b"host-pdf").expect("write source file");
+
+        let prepared = super::prepare_file_attachment(
+            &worktree,
+            &worktree.display().to_string(),
+            gwt_agent::LaunchRuntimeTarget::Host,
+            &gwt::FileAttachment::NativePath {
+                path: source.display().to_string(),
+            },
+            "20260524-attach",
+            ContentLimits::default(),
+        )
+        .expect("prepare host native path attachment");
+
+        assert_eq!(prepared.bytes, None);
+        assert_eq!(prepared.storage_path, None);
+        assert_eq!(prepared.agent_path, source.display().to_string());
+        assert_eq!(
+            super::format_file_attachment_prompt(&[prepared.agent_path]),
+            format!("File: \"{}\"", source.display())
+        );
+    }
+
+    #[test]
+    fn file_attachment_prepare_copies_inline_file_under_worktree() {
+        let temp = tempdir().expect("tempdir");
+        let worktree = temp.path().join("repo");
+        fs::create_dir_all(&worktree).expect("create worktree");
+        let payload = base64::engine::general_purpose::STANDARD.encode(b"notes-bytes");
+
+        let prepared = super::prepare_file_attachment(
+            &worktree,
+            &worktree.display().to_string(),
+            gwt_agent::LaunchRuntimeTarget::Host,
+            &gwt::FileAttachment::Inline {
+                filename: "../Notes 2026.txt".to_string(),
+                mime_type: Some("application/octet-stream".to_string()),
+                size: 11,
+                data_base64: payload,
+            },
+            "20260524-inline",
+            ContentLimits::default(),
+        )
+        .expect("prepare inline file attachment");
+
+        let expected_path = worktree
+            .join(".gwt")
+            .join("drop-files")
+            .join("20260524-inline-notes-2026.txt");
+        assert_eq!(prepared.bytes.as_deref(), Some(&b"notes-bytes"[..]));
+        assert_eq!(
+            prepared.storage_path.as_deref(),
+            Some(expected_path.as_path())
+        );
+        assert_eq!(prepared.agent_path, expected_path.display().to_string());
+    }
+
+    #[test]
+    fn file_attachment_prepare_copies_native_file_for_docker_agent_path() {
+        let temp = tempdir().expect("tempdir");
+        let worktree = temp.path().join("repo");
+        fs::create_dir_all(&worktree).expect("create worktree");
+        let source = temp.path().join("Data Set.bin");
+        fs::write(&source, b"docker-bytes").expect("write source file");
+
+        let prepared = super::prepare_file_attachment(
+            &worktree,
+            "/workspace/project",
+            gwt_agent::LaunchRuntimeTarget::Docker,
+            &gwt::FileAttachment::NativePath {
+                path: source.display().to_string(),
+            },
+            "20260524-docker",
+            ContentLimits::default(),
+        )
+        .expect("prepare docker native file attachment");
+
+        assert_eq!(prepared.bytes.as_deref(), Some(&b"docker-bytes"[..]));
+        assert_eq!(
+            prepared.storage_path.as_deref(),
+            Some(
+                worktree
+                    .join(".gwt")
+                    .join("drop-files")
+                    .join("20260524-docker-data-set.bin")
+                    .as_path()
+            )
+        );
+        assert_eq!(
+            prepared.agent_path,
+            "/workspace/project/.gwt/drop-files/20260524-docker-data-set.bin"
+        );
+    }
+
+    #[test]
+    fn file_attachment_prepare_rejects_invalid_items() {
+        let temp = tempdir().expect("tempdir");
+        let worktree = temp.path().join("repo");
+        fs::create_dir_all(&worktree).expect("create worktree");
+        let payload = base64::engine::general_purpose::STANDARD.encode(b"too-large");
+        let limits = ContentLimits {
+            text_max_bytes: 16,
+            binary_chunk_max_bytes: 3,
+        };
+
+        let too_large = super::prepare_file_attachment(
+            &worktree,
+            "/workspace/project",
+            gwt_agent::LaunchRuntimeTarget::Host,
+            &gwt::FileAttachment::Inline {
+                filename: "large.dat".to_string(),
+                mime_type: None,
+                size: 9,
+                data_base64: payload,
+            },
+            "20260524-large",
+            limits,
+        );
+        assert!(matches!(
+            too_large,
+            Err(super::FileAttachmentError::TooLarge { size: 9, limit: 3 })
+        ));
+
+        let directory = super::prepare_file_attachment(
+            &worktree,
+            "/workspace/project",
+            gwt_agent::LaunchRuntimeTarget::Host,
+            &gwt::FileAttachment::NativePath {
+                path: temp.path().display().to_string(),
+            },
+            "20260524-dir",
+            ContentLimits::default(),
+        );
+        assert!(matches!(
+            directory,
+            Err(super::FileAttachmentError::NotAFile(path)) if path == temp.path().display().to_string()
+        ));
+    }
+
+    #[test]
+    fn file_attachment_prompt_formats_single_and_multiple_paths_without_newlines() {
+        let single = super::format_file_attachment_prompt(&["/tmp/a\"b\nc.txt".to_string()]);
+        assert_eq!(single, "File: \"/tmp/a\\\"b\\nc.txt\"");
+        assert!(
+            !single.contains('\n'),
+            "single-file prompt must never inject a newline"
+        );
+
+        let multiple = super::format_file_attachment_prompt(&[
+            "/tmp/a.txt".to_string(),
+            "C:\\tmp\\b\r.txt".to_string(),
+        ]);
+        assert_eq!(
+            multiple,
+            "Files: [\"/tmp/a.txt\", \"C:\\\\tmp\\\\b\\r.txt\"]"
+        );
+        assert!(
+            !multiple.contains('\r') && !multiple.contains('\n'),
+            "multi-file prompt must stay on one terminal input line"
+        );
+    }
+
+    #[test]
+    fn file_attachment_event_saves_inline_file_under_worktree() {
+        let temp = tempdir().expect("tempdir");
+        let worktree = temp.path().join("repo");
+        fs::create_dir_all(&worktree).expect("create worktree");
+        let tab_id = "tab-1";
+        let raw_window_id = "agent-1";
+        let window_id = combined_window_id(tab_id, raw_window_id);
+        let tab = sample_project_tab_with_window_at(
+            tab_id,
+            raw_window_id,
+            worktree.clone(),
+            WindowPreset::Agent,
+            WindowProcessStatus::Running,
+        );
+        let (mut runtime, _events) =
+            sample_runtime_with_events(temp.path(), vec![tab], Some(tab_id));
+        runtime.active_agent_sessions.insert(
+            window_id.clone(),
+            ActiveAgentSession {
+                window_id: window_id.clone(),
+                session_id: "session-1".to_string(),
+                agent_id: "codex".to_string(),
+                branch_name: "feature/file-drop".to_string(),
+                display_name: "Codex".to_string(),
+                worktree_path: worktree.clone(),
+                agent_project_root: worktree.display().to_string(),
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                tab_id: tab_id.to_string(),
+            },
+        );
+        let payload = base64::engine::general_purpose::STANDARD.encode(b"text-bytes");
+        let event: FrontendEvent = serde_json::from_value(serde_json::json!({
+            "kind": "attach_files",
+            "id": window_id,
+            "files": [
+                {
+                    "source": "inline",
+                    "filename": "notes.txt",
+                    "mime_type": "text/plain",
+                    "size": 10,
+                    "data_base64": payload
+                }
+            ]
+        }))
+        .expect("deserialize attach files event");
+
+        let events = runtime.handle_frontend_event("client-1".to_string(), event);
+
+        assert!(events.is_empty());
+        let drop_dir = worktree.join(".gwt").join("drop-files");
+        let files = fs::read_dir(&drop_dir)
+            .expect("read drop dir")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("collect drop files");
+        assert_eq!(files.len(), 1, "expected one saved dropped file");
+        assert_eq!(
+            fs::read(files[0].path()).expect("read saved file"),
+            b"text-bytes"
+        );
+    }
+
+    #[test]
+    fn file_attachment_event_ignores_non_agent_terminal_window() {
+        let temp = tempdir().expect("tempdir");
+        let worktree = temp.path().join("repo");
+        fs::create_dir_all(&worktree).expect("create worktree");
+        let tab_id = "tab-1";
+        let raw_window_id = "shell-1";
+        let window_id = combined_window_id(tab_id, raw_window_id);
+        let tab = sample_project_tab_with_window_at(
+            tab_id,
+            raw_window_id,
+            worktree.clone(),
+            WindowPreset::Shell,
+            WindowProcessStatus::Running,
+        );
+        let (mut runtime, _events) =
+            sample_runtime_with_events(temp.path(), vec![tab], Some(tab_id));
+        let payload = base64::engine::general_purpose::STANDARD.encode(b"ignored");
+        let event: FrontendEvent = serde_json::from_value(serde_json::json!({
+            "kind": "attach_files",
+            "id": window_id,
+            "files": [
+                {
+                    "source": "inline",
+                    "filename": "ignored.txt",
+                    "mime_type": "text/plain",
+                    "size": 7,
+                    "data_base64": payload
+                }
+            ]
+        }))
+        .expect("deserialize attach files event");
+
+        let events = runtime.handle_frontend_event("client-1".to_string(), event);
+
+        assert!(events.is_empty());
+        assert!(
+            !worktree.join(".gwt").join("drop-files").exists(),
+            "non-agent terminal file drop must not create files"
         );
     }
 

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -719,6 +719,69 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_terminal_file_drop_sends_attach_files_event() {
+        let html = frontend_bundle_source();
+
+        assert!(
+            html.contains("function installTerminalFileDropHandlers"),
+            "expected terminal file drop handler bootstrap in embedded html",
+        );
+        assert!(
+            html.contains("terminalRoot.addEventListener(\"dragover\"")
+                && html.contains("terminalRoot.addEventListener(\"drop\""),
+            "expected dragover/drop listeners to be scoped to the terminal root",
+        );
+        assert!(
+            html.contains("event.dataTransfer?.files")
+                && html.contains("readDroppedFileAsBase64")
+                && html.contains("MAX_FILE_DROP_BYTES"),
+            "expected browser file drops to read arbitrary files with a size guard",
+        );
+        assert!(
+            html.contains("kind: \"attach_files\"")
+                && html.contains("source: \"inline\"")
+                && html.contains("data_base64"),
+            "expected browser file drops to send inline attach_files payloads",
+        );
+        let drop_start = html
+            .find("function installTerminalFileDropHandlers")
+            .expect("file drop handler source");
+        let drop_end = html[drop_start..]
+            .find("function installTerminalContextMenuHandlers")
+            .expect("next terminal handler source")
+            + drop_start;
+        let drop_source = &html[drop_start..drop_end];
+        assert!(
+            !drop_source.contains("SUPPORTED_IMAGE_PASTE_MIME_TYPES"),
+            "generic file drops must not inherit the clipboard image MIME allow-list",
+        );
+        assert!(
+            html.contains("terminal.focus();"),
+            "expected file drop paths to restore terminal focus after sending",
+        );
+    }
+
+    #[test]
+    fn embedded_web_native_file_drop_maps_pointer_to_terminal() {
+        let html = frontend_bundle_source();
+
+        assert!(
+            html.contains("window.addEventListener(\"gwt:native-file-drop\""),
+            "expected native WebView file drops to be bridged through a frontend custom event",
+        );
+        assert!(
+            html.contains("document.elementFromPoint")
+                && html.contains(".terminal-root")
+                && html.contains(".workspace-window"),
+            "expected native drops to map the WebView pointer to the terminal under it",
+        );
+        assert!(
+            html.contains("source: \"native_path\"") && html.contains("kind: \"attach_files\""),
+            "expected native drops to send native_path attach_files payloads",
+        );
+    }
+
+    #[test]
     fn embedded_web_terminal_context_menu_pastes_text_and_images() {
         let html = frontend_bundle_source();
         let context_menu_source = terminal_context_menu_js();

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -125,13 +125,14 @@ pub use preset::{
 };
 pub use protocol::{
     ActiveWorkAgentView, ActiveWorkCleanupCandidateView, ActiveWorkProjectionView, AppStateView,
-    ArrangeMode, BackendEvent, BranchEntriesPhase, CustomAgentErrorCode, FileContentErrorKind,
-    FileContentMode, FileContentSaveErrorKind, FocusCycleDirection, FrontendEvent,
-    GitHubRepositorySearchResultView, IndexSearchMatchMode, IndexSearchResult, IndexSearchScope,
-    IndexSearchTarget, ProfileEntryView, ProfileEnvEntryView, ProfileSnapshotView, ProjectTabView,
-    RecentProjectView, RunningAgentSummary, UiTraceEntry, UiTracePayload,
-    WorkspaceExecutionContainerView, WorkspaceHistoryAgentView, WorkspaceHistoryEventView,
-    WorkspaceHistoryView, WorkspaceJournalEntryView, WorkspaceResumeSource, WorkspaceView,
-    WorkspaceWorkAgentView, WorkspaceWorkEventView, WorkspaceWorkItemView,
+    ArrangeMode, BackendEvent, BranchEntriesPhase, CustomAgentErrorCode, FileAttachment,
+    FileContentErrorKind, FileContentMode, FileContentSaveErrorKind, FocusCycleDirection,
+    FrontendEvent, GitHubRepositorySearchResultView, IndexSearchMatchMode, IndexSearchResult,
+    IndexSearchScope, IndexSearchTarget, ProfileEntryView, ProfileEnvEntryView,
+    ProfileSnapshotView, ProjectTabView, RecentProjectView, RunningAgentSummary, UiTraceEntry,
+    UiTracePayload, WorkspaceExecutionContainerView, WorkspaceHistoryAgentView,
+    WorkspaceHistoryEventView, WorkspaceHistoryView, WorkspaceJournalEntryView,
+    WorkspaceResumeSource, WorkspaceView, WorkspaceWorkAgentView, WorkspaceWorkEventView,
+    WorkspaceWorkItemView,
 };
 pub use workspace::WorkspaceState;

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -785,6 +785,11 @@ enum UserEvent {
         client_id: ClientId,
         event: FrontendEvent,
     },
+    NativeFileDrop {
+        paths: Vec<String>,
+        x: i32,
+        y: i32,
+    },
     LogEntry {
         entry: gwt_core::logging::LogEvent,
     },
@@ -1430,6 +1435,30 @@ mod tests {
         assert!(
             main_source.contains("if let Some((_, webview)) = webview_surface.as_ref()"),
             "ReloadWebView dispatch must destructure webview_surface as a (Window, WebView) tuple"
+        );
+    }
+
+    #[test]
+    fn native_webview_file_drop_dispatches_frontend_custom_event() {
+        let main_source = include_str!("main.rs");
+        let drag_handler = [".with_drag_drop", "_handler"].concat();
+        let wry_drop = ["wry::DragDropEvent::", "Drop"].concat();
+        let native_event = ["UserEvent::Native", "FileDrop"].concat();
+        let frontend_event = ["gwt:native", "-file-drop"].concat();
+        let custom_event = ["window.dispatchEvent(new ", "CustomEvent"].concat();
+
+        assert!(
+            main_source.contains(drag_handler.as_str()),
+            "native WebView bootstrap must install Wry file drag/drop handling",
+        );
+        assert!(
+            main_source.contains(wry_drop.as_str()) && main_source.contains(native_event.as_str()),
+            "Wry drop events must cross into the tao event loop before evaluating frontend JS",
+        );
+        assert!(
+            main_source.contains(frontend_event.as_str())
+                && main_source.contains(custom_event.as_str()),
+            "native file drops must dispatch the frontend custom event with paths and pointer coordinates",
         );
     }
 
@@ -6225,7 +6254,25 @@ fn main() -> wry::Result<()> {
         #[cfg(any(target_os = "windows", target_os = "linux"))]
         let builder = builder.with_window_icon(window_icon);
         let window = builder.build(&event_loop).expect("window");
-        let builder = WebViewBuilder::new().with_url(front_door.webview_url);
+        let native_file_drop_proxy = proxy.clone();
+        let builder = WebViewBuilder::new()
+            .with_url(front_door.webview_url)
+            .with_drag_drop_handler(move |event| {
+                if let wry::DragDropEvent::Drop { paths, position } = event {
+                    let paths = paths
+                        .into_iter()
+                        .map(|path| path.to_string_lossy().into_owned())
+                        .collect::<Vec<_>>();
+                    if !paths.is_empty() {
+                        let _ = native_file_drop_proxy.send_event(UserEvent::NativeFileDrop {
+                            paths,
+                            x: position.0,
+                            y: position.1,
+                        });
+                    }
+                }
+                true
+            });
 
         #[cfg(any(
             target_os = "windows",
@@ -6368,6 +6415,25 @@ fn main() -> wry::Result<()> {
                         proxy.clone(),
                         app.active_project_root().map(Path::to_path_buf),
                     );
+                }
+            }
+            Event::UserEvent(UserEvent::NativeFileDrop { paths, x, y }) => {
+                if let Some((_, webview)) = webview_surface.as_ref() {
+                    let detail = serde_json::json!({
+                        "paths": paths,
+                        "x": x,
+                        "y": y,
+                    });
+                    let script = format!(
+                        "window.dispatchEvent(new CustomEvent('gwt:native-file-drop', {{ detail: {} }}));",
+                        detail
+                    );
+                    if let Err(error) = webview.evaluate_script(&script) {
+                        tracing::debug!(
+                            error = %error,
+                            "failed to dispatch native file drop to frontend"
+                        );
+                    }
                 }
             }
             Event::UserEvent(UserEvent::LogEntry { entry }) => {

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -158,6 +158,20 @@ pub enum WorkspaceResumeSource {
     Journal,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(tag = "source", rename_all = "snake_case")]
+pub enum FileAttachment {
+    NativePath {
+        path: String,
+    },
+    Inline {
+        filename: String,
+        mime_type: Option<String>,
+        size: u64,
+        data_base64: String,
+    },
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum FrontendEvent {
@@ -244,6 +258,10 @@ pub enum FrontendEvent {
         data_base64: String,
         mime_type: String,
         filename: Option<String>,
+    },
+    AttachFiles {
+        id: String,
+        files: Vec<FileAttachment>,
     },
     LoadFileTree {
         id: String,
@@ -2748,6 +2766,74 @@ mod tests {
         assert!(
             matches!(event, FrontendEvent::PasteImage { filename: None, .. }),
             "clipboard images may not have a source filename"
+        );
+    }
+
+    #[test]
+    fn frontend_event_accepts_terminal_file_attachment_paths() {
+        let event: FrontendEvent = serde_json::from_value(serde_json::json!({
+            "kind": "attach_files",
+            "id": "tab-1::agent-1",
+            "files": [
+                {
+                    "source": "native_path",
+                    "path": "/Users/me/report.pdf"
+                }
+            ]
+        }))
+        .expect("deserialize file attachment event");
+
+        assert!(
+            matches!(
+                event,
+                FrontendEvent::AttachFiles { id, files }
+                    if id == "tab-1::agent-1"
+                        && matches!(
+                            files.as_slice(),
+                            [super::FileAttachment::NativePath { path }]
+                                if path == "/Users/me/report.pdf"
+                        )
+            ),
+            "native file drops must expose terminal id and host path"
+        );
+    }
+
+    #[test]
+    fn frontend_event_accepts_terminal_inline_file_attachments() {
+        let event: FrontendEvent = serde_json::from_value(serde_json::json!({
+            "kind": "attach_files",
+            "id": "tab-1::agent-1",
+            "files": [
+                {
+                    "source": "inline",
+                    "filename": "notes.txt",
+                    "mime_type": "text/plain",
+                    "size": 11,
+                    "data_base64": "aGVsbG8gd29ybGQ="
+                }
+            ]
+        }))
+        .expect("deserialize inline file attachment event");
+
+        assert!(
+            matches!(
+                event,
+                FrontendEvent::AttachFiles { id, files }
+                    if id == "tab-1::agent-1"
+                        && matches!(
+                            files.as_slice(),
+                            [super::FileAttachment::Inline {
+                                filename,
+                                mime_type: Some(mime_type),
+                                size,
+                                data_base64,
+                            }] if filename == "notes.txt"
+                                && mime_type == "text/plain"
+                                && *size == 11
+                                && data_base64 == "aGVsbG8gd29ybGQ="
+                        )
+            ),
+            "browser file drops must expose inline file metadata and bytes"
         );
     }
 

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -3696,6 +3696,7 @@
         "image/jpeg",
         "image/webp",
       ]);
+      const MAX_FILE_DROP_BYTES = 10 * 1024 * 1024;
 
       function findClipboardImagePasteItem(items) {
         for (const item of Array.from(items || [])) {
@@ -3718,7 +3719,7 @@
           return null;
         }
         const payload = dataUrl.slice(commaIndex + 1);
-        return payload || null;
+        return payload;
       }
 
       function readClipboardImageAsBase64(file) {
@@ -3732,6 +3733,29 @@
           });
           reader.readAsDataURL(file);
         });
+      }
+
+      function readDroppedFileAsBase64(file) {
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.addEventListener("load", () => {
+            const payload = dataUrlBase64Payload(reader.result);
+            resolve(payload === null ? "" : payload);
+          });
+          reader.addEventListener("error", () => {
+            reject(reader.error || new Error("Failed to read dropped file"));
+          });
+          reader.readAsDataURL(file);
+        });
+      }
+
+      function dataTransferHasFiles(dataTransfer) {
+        const types = Array.from(dataTransfer?.types || []);
+        return types.includes("Files") || Boolean(dataTransfer?.files?.length);
+      }
+
+      function droppedFilesWithinSizeLimit(files) {
+        return files.every((file) => file.size <= MAX_FILE_DROP_BYTES);
       }
 
       async function readNavigatorClipboardItems() {
@@ -3942,6 +3966,58 @@
         };
       }
 
+      function installTerminalFileDropHandlers(windowId, terminalRoot, terminal) {
+        const handleDragOver = (event) => {
+          if (!dataTransferHasFiles(event.dataTransfer)) {
+            return;
+          }
+          event.preventDefault();
+          event.stopPropagation();
+          event.dataTransfer.dropEffect = "copy";
+        };
+
+        const handleDrop = (event) => {
+          const files = Array.from(event.dataTransfer?.files || []);
+          if (files.length === 0) {
+            return;
+          }
+          event.preventDefault();
+          event.stopPropagation();
+          if (!droppedFilesWithinSizeLimit(files)) {
+            terminal.focus();
+            return;
+          }
+
+          void Promise.all(
+            files.map(async (file) => ({
+              source: "inline",
+              filename: file.name || "file",
+              mime_type: file.type || null,
+              size: file.size,
+              data_base64: await readDroppedFileAsBase64(file),
+            })),
+          )
+            .then((attachments) => {
+              send({
+                kind: "attach_files",
+                id: windowId,
+                files: attachments,
+              });
+            })
+            .catch(() => {})
+            .finally(() => {
+              terminal.focus();
+            });
+        };
+
+        terminalRoot.addEventListener("dragover", handleDragOver, true);
+        terminalRoot.addEventListener("drop", handleDrop, true);
+        return () => {
+          terminalRoot.removeEventListener("dragover", handleDragOver, true);
+          terminalRoot.removeEventListener("drop", handleDrop, true);
+        };
+      }
+
       function installTerminalContextMenuHandlers(windowId, terminalRoot, terminal) {
         const controller = createTerminalContextMenuController({
           document,
@@ -3976,6 +4052,45 @@
         return () => {
           viewportScrollDisposable.dispose();
         };
+      }
+
+      function terminalWindowIdFromPoint(x, y) {
+        if (!Number.isFinite(x) || !Number.isFinite(y)) {
+          return null;
+        }
+        const target = document.elementFromPoint(x, y);
+        const terminalRoot = target?.closest?.(".terminal-root");
+        const windowElement = terminalRoot?.closest?.(".workspace-window");
+        const windowId = windowElement?.dataset?.id || null;
+        if (!windowId || !terminalMap.has(windowId)) {
+          return null;
+        }
+        return windowId;
+      }
+
+      function installNativeFileDropBridge() {
+        window.addEventListener("gwt:native-file-drop", (event) => {
+          const detail = event.detail || {};
+          const paths = Array.isArray(detail.paths)
+            ? detail.paths.filter((path) => typeof path === "string" && path.length > 0)
+            : [];
+          if (paths.length === 0) {
+            return;
+          }
+          const windowId = terminalWindowIdFromPoint(Number(detail.x), Number(detail.y));
+          if (!windowId) {
+            return;
+          }
+          send({
+            kind: "attach_files",
+            id: windowId,
+            files: paths.map((path) => ({
+              source: "native_path",
+              path,
+            })),
+          });
+          terminalMap.get(windowId)?.terminal.focus();
+        });
       }
 
       // SPEC-2356 — xterm content stays on the Dark Operator palette even when
@@ -4027,6 +4142,11 @@
           terminalContainer,
           terminal,
         );
+        const fileDropCleanup = installTerminalFileDropHandlers(
+          windowId,
+          terminalContainer,
+          terminal,
+        );
         const contextMenuCleanup = installTerminalContextMenuHandlers(
           windowId,
           terminalContainer,
@@ -4041,6 +4161,7 @@
         const cleanup = () => {
           copyCleanup();
           imagePasteCleanup();
+          fileDropCleanup();
           contextMenuCleanup();
           wheelScrollCleanup.dispose();
           viewportRefreshCleanup();
@@ -12666,6 +12787,7 @@
       }
 
       installCanvasWheelRouting();
+      installNativeFileDropBridge();
 
       window.addEventListener(
         "keydown",


### PR DESCRIPTION
## Summary

- Adds generic terminal file drag-and-drop so agent windows can receive any dropped file, not just clipboard images.
- Supports both native WebView file paths and browser inline file payloads while preserving the existing image paste prompt behavior.
- Keeps Docker agents working by copying inaccessible host files into `.gwt/drop-files` and injecting agent-visible paths.

## Changes

- `crates/gwt/src/protocol.rs`: adds the `attach_files` frontend event with native-path and inline attachment payload variants.
- `crates/gwt/src/app_runtime/mod.rs`: prepares file attachments, copies inline/Docker files under `.gwt/drop-files`, rejects invalid items, and injects `File:` / `Files:` prompts into active agent terminals.
- `crates/gwt/web/app.js`: installs terminal-scoped drag/drop handlers for arbitrary files, size-guards browser file drops, restores terminal focus, and bridges native WebView file drops.
- `crates/gwt/src/main.rs`: forwards Wry native file drop events into the frontend as `gwt:native-file-drop` custom events.
- `crates/gwt/src/embedded_web.rs` and `crates/gwt/src/lib.rs`: add contract coverage and public re-export wiring for the new attachment protocol.

## Testing

- [x] `cargo fmt --check` — passed.
- [x] `bash scripts/run-frontend-unit-tests.sh` — passed, 565 tests.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed after merging `origin/develop`.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed.
- [x] `bunx commitlint --from origin/develop --to HEAD` — passed.
- [x] Manual headless browser verification — confirmed by user at `http://127.0.0.1:54499/`; verification server was stopped afterward.

## PR Readiness

- State: Ready for review
- Releaseable slice: Yes — the file drop path is fully wired through protocol, frontend, backend runtime, and focused regression tests.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- #2012

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, frontend unit tests)
- [x] Documentation updated (N/A: no persistent user-facing copy or documented command surface changed)
- [x] Migration/backfill plan included (N/A: no schema or persisted data migration)
- [x] CHANGELOG impact considered (feature commit, minor release impact)

## Context

- SPEC #2012 Phase 6 extends the existing frontend protocol work so terminal agents can receive generic file references through drag-and-drop, including non-image files and Docker-visible copied paths.

## Risk / Impact

- **Affected areas**: terminal frontend event handling, WebView file drop forwarding, attachment storage under `.gwt/drop-files`, and agent terminal prompt injection.
- **Rollback plan**: revert this PR; existing image paste behavior remains isolated and covered by regression tests.

## Screenshots

- N/A: this change does not introduce a persistent visual layout delta. The behavior was verified through manual headless browser D&D confirmation.
