### PR TITLE
fix(gui): bound file drop attachment memory

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -4687,7 +4687,7 @@ impl AppRuntime {
         let runtime_target = session.runtime_target;
         let limits = ContentLimits::default();
 
-        let mut prepared_files = Vec::with_capacity(files.len());
+        let mut agent_paths = Vec::with_capacity(files.len());
         for (index, file) in files.iter().enumerate() {
             let token = format!("{}-{index}", image_paste_unique_token());
             let prepared = match prepare_file_attachment(
@@ -4708,23 +4708,16 @@ impl AppRuntime {
                     return Vec::new();
                 }
             };
-            prepared_files.push(prepared);
-        }
-
-        for file in &prepared_files {
-            if let Err(error) = save_file_attachment(file) {
+            if let Err(error) = save_file_attachment(&prepared) {
                 return self.handle_runtime_status(
                     id.to_string(),
                     WindowProcessStatus::Error,
                     Some(error.to_string()),
                 );
             }
+            agent_paths.push(prepared.agent_path);
         }
 
-        let agent_paths = prepared_files
-            .iter()
-            .map(|file| file.agent_path.clone())
-            .collect::<Vec<_>>();
         let prompt = format_file_attachment_prompt(&agent_paths);
         if prompt.is_empty() {
             return Vec::new();
@@ -9474,6 +9467,82 @@ exit 1
         assert_eq!(
             fs::read(files[0].path()).expect("read saved file"),
             b"text-bytes"
+        );
+    }
+
+    #[test]
+    fn file_attachment_event_saves_prepared_files_incrementally() {
+        let temp = tempdir().expect("tempdir");
+        let worktree = temp.path().join("repo");
+        fs::create_dir_all(&worktree).expect("create worktree");
+        let tab_id = "tab-1";
+        let raw_window_id = "agent-1";
+        let window_id = combined_window_id(tab_id, raw_window_id);
+        let tab = sample_project_tab_with_window_at(
+            tab_id,
+            raw_window_id,
+            worktree.clone(),
+            WindowPreset::Agent,
+            WindowProcessStatus::Running,
+        );
+        let (mut runtime, _events) =
+            sample_runtime_with_events(temp.path(), vec![tab], Some(tab_id));
+        runtime.active_agent_sessions.insert(
+            window_id.clone(),
+            ActiveAgentSession {
+                window_id: window_id.clone(),
+                session_id: "session-1".to_string(),
+                agent_id: "codex".to_string(),
+                branch_name: "feature/file-drop".to_string(),
+                display_name: "Codex".to_string(),
+                worktree_path: worktree.clone(),
+                agent_project_root: worktree.display().to_string(),
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                tab_id: tab_id.to_string(),
+            },
+        );
+        let valid_payload = base64::engine::general_purpose::STANDARD.encode(b"saved-first");
+        let event: FrontendEvent = serde_json::from_value(serde_json::json!({
+            "kind": "attach_files",
+            "id": window_id,
+            "files": [
+                {
+                    "source": "inline",
+                    "filename": "first.txt",
+                    "mime_type": "text/plain",
+                    "size": 11,
+                    "data_base64": valid_payload
+                },
+                {
+                    "source": "inline",
+                    "filename": "invalid.txt",
+                    "mime_type": "text/plain",
+                    "size": 4,
+                    "data_base64": "not base64"
+                }
+            ]
+        }))
+        .expect("deserialize attach files event");
+
+        let events = runtime.handle_frontend_event("client-1".to_string(), event);
+
+        assert!(
+            events.is_empty(),
+            "invalid later attachment must not inject a partial prompt",
+        );
+        let drop_dir = worktree.join(".gwt").join("drop-files");
+        let files = fs::read_dir(&drop_dir)
+            .expect("read drop dir")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("collect drop files");
+        assert_eq!(
+            files.len(),
+            1,
+            "first attachment should be saved before a later file fails",
+        );
+        assert_eq!(
+            fs::read(files[0].path()).expect("read saved file"),
+            b"saved-first"
         );
     }
 

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -756,6 +756,15 @@ mod tests {
             "generic file drops must not inherit the clipboard image MIME allow-list",
         );
         assert!(
+            html.contains("MAX_TOTAL_FILE_DROP_BYTES")
+                && drop_source.contains("droppedFilesWithinTotalSizeLimit"),
+            "browser file drops must enforce a total payload guard",
+        );
+        assert!(
+            !drop_source.contains("Promise.all("),
+            "browser file drops must not read every dropped file concurrently",
+        );
+        assert!(
             html.contains("terminal.focus();"),
             "expected file drop paths to restore terminal focus after sending",
         );

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -3697,6 +3697,8 @@
         "image/webp",
       ]);
       const MAX_FILE_DROP_BYTES = 10 * 1024 * 1024;
+      const MAX_TOTAL_FILE_DROP_BYTES = 50 * 1024 * 1024;
+      const MAX_FILE_DROP_COUNT = 16;
 
       function findClipboardImagePasteItem(items) {
         for (const item of Array.from(items || [])) {
@@ -3756,6 +3758,35 @@
 
       function droppedFilesWithinSizeLimit(files) {
         return files.every((file) => file.size <= MAX_FILE_DROP_BYTES);
+      }
+
+      function droppedFilesWithinTotalSizeLimit(files) {
+        let totalBytes = 0;
+        for (const file of files) {
+          totalBytes += file.size || 0;
+          if (totalBytes > MAX_TOTAL_FILE_DROP_BYTES) {
+            return false;
+          }
+        }
+        return true;
+      }
+
+      function droppedFilesWithinCountLimit(files) {
+        return files.length <= MAX_FILE_DROP_COUNT;
+      }
+
+      async function readDroppedFilesAsAttachments(files) {
+        const attachments = [];
+        for (const file of files) {
+          attachments.push({
+            source: "inline",
+            filename: file.name || "file",
+            mime_type: file.type || null,
+            size: file.size,
+            data_base64: await readDroppedFileAsBase64(file),
+          });
+        }
+        return attachments;
       }
 
       async function readNavigatorClipboardItems() {
@@ -3983,20 +4014,16 @@
           }
           event.preventDefault();
           event.stopPropagation();
-          if (!droppedFilesWithinSizeLimit(files)) {
+          if (
+            !droppedFilesWithinCountLimit(files) ||
+            !droppedFilesWithinSizeLimit(files) ||
+            !droppedFilesWithinTotalSizeLimit(files)
+          ) {
             terminal.focus();
             return;
           }
 
-          void Promise.all(
-            files.map(async (file) => ({
-              source: "inline",
-              filename: file.name || "file",
-              mime_type: file.type || null,
-              size: file.size,
-              data_base64: await readDroppedFileAsBase64(file),
-            })),
-          )
+          void readDroppedFilesAsAttachments(files)
             .then((attachments) => {
               send({
                 kind: "attach_files",


### PR DESCRIPTION
## Summary

Fixes the file drop attachment memory follow-up from PR #2887 by bounding browser-side bulk drops and avoiding backend buffering of every attachment before saving.

## Changes

- Read dropped browser files sequentially instead of using `Promise.all` over every `FileReader`.
- Add browser-side file count and total payload guards in addition to the existing per-file size guard.
- Save prepared backend attachments immediately and keep only agent-visible paths for prompt construction.
- Add regression coverage for sequential browser drop handling and incremental backend saving.

## Testing

- `cargo test -p gwt file_attachment_event_saves_prepared_files_incrementally --all-features` — PASS
- `cargo test -p gwt embedded_web_terminal_file_drop_sends_attach_files_event --all-features` — PASS
- `node --check crates/gwt/web/app.js` — PASS
- `cargo fmt --check` — PASS
- `bash scripts/run-frontend-unit-tests.sh` — PASS (565 tests)
- `cargo test -p gwt-core -p gwt --all-features` — PASS
- `cargo clippy --all-targets --all-features -- -D warnings` — PASS
- `cargo build -p gwt --bin gwt --bin gwtd` — PASS
- `bunx commitlint --from origin/develop --to HEAD` — PASS

## PR Readiness

State: Ready

Known blockers: None

Remaining acceptance: None

Rollback / follow-up boundary: This PR only changes attachment drop resource handling. Reverting it would restore PR #2887 behavior without changing the file attachment protocol.

User Verification Result: n/a — no visible layout or visual behavior changed; this is a resource-limit and backend persistence-order fix. The base D&D behavior was visually confirmed before PR #2887.

## Closing Issues

None

## Related Issues

- Related: #2012
- Follow-up to PR #2887 review comments

## Checklist

- [x] SPEC / tasks updated, or N/A with reason
- [x] Automated tests passed
- [x] User verification complete or N/A with reason
- [x] No known blockers remain

## Risk/Impact

Bulk browser drops above 16 files or 50 MiB total are ignored instead of being read into memory. Normal file drop behavior remains unchanged.

## Screenshots

N/A — no visual change.
