### PR TITLE
chore: record auto-merge review lesson

### DIFF
--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6102,3 +6102,10 @@ Type: lesson
 Context: Codex review on PR #2884 pointed out that headless-browser-check resolved the repository root but still showed a relative target/debug/gwt launch command, which fails when the skill is triggered from a subdirectory such as crates/gwt.
 Learning: A skill can say 'current checkout' and still be ambiguous if command examples remain relative to the caller's cwd. For gwt serve handoff checks, the launch command must either cd to the resolved repository root or use an absolute <repo-root>/target/debug/gwt path.
 Future Action: When updating headless-browser-check or similar launch skills, make every executable path in the workflow match the resolved root/checkout contract; test the instructions mentally from a subdirectory as well as from repo root.
+
+## 2026-05-25 — Check review threads after auto-merge
+
+Type: lesson
+Context: During PR #2887, CI passed and auto-merge completed while automated review threads were posted shortly before merge.
+Learning: A PR can be merged before late automated review comments are inspected; merged state does not mean review feedback is clear.
+Future Action: After any auto-merge, run gwtd pr review-threads for the merged PR and address actionable feedback via a follow-up PR when the original PR can no longer be updated.


### PR DESCRIPTION
## Summary

Records the workflow lesson from the PR #2887 / #2888 auto-merge review timing.

## Changes

- Add a `tasks/memory.md` entry reminding agents to re-check review threads after auto-merge.
- Document the expected follow-up path when late actionable review feedback appears after the original PR has merged.

## Testing

- `bunx --bun markdownlint-cli tasks/memory.md --config .markdownlint.json` — PASS
- `git diff --check tasks/memory.md` — PASS
- `bunx commitlint --from origin/develop --to HEAD` — PASS

## PR Readiness

State: Ready

Known blockers: None

Remaining acceptance: None

Rollback / follow-up boundary: Documentation-only memory update.

User Verification Result: n/a — documentation-only workflow memory.

## Closing Issues

None

## Related Issues

- Related: #2012
- Follow-up to PR #2888 workflow handling

## Checklist

- [x] SPEC / tasks updated, or N/A with reason
- [x] Automated checks passed
- [x] User verification complete or N/A with reason
- [x] No known blockers remain

## Risk/Impact

No runtime impact.

## Screenshots

N/A — documentation-only change.
