### PR TITLE
chore(release): v9.45.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [9.45.1] - 2026-05-25
+
+### Bug Fixes
+
+- Focus cycleで最大化中の切替元を復元する
+
 ## [9.45.0] - 2026-05-25
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.45.0"
+version = "9.45.1"
 dependencies = [
  "ammonia",
  "axum",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.45.0"
+version = "9.45.1"
 dependencies = [
  "chrono",
  "dunce",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.45.0"
+version = "9.45.1"
 dependencies = [
  "reqwest",
  "serde",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.45.0"
+version = "9.45.1"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.45.0"
+version = "9.45.1"
 dependencies = [
  "dirs",
  "serde",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.45.0"
+version = "9.45.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.45.0"
+version = "9.45.1"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.45.0"
+version = "9.45.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.45.0"
+version = "9.45.1"
 dependencies = [
  "gwt-core",
  "regex",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.45.0"
+version = "9.45.1"
 dependencies = [
  "chrono",
  "fs2",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.45.0"
+version = "9.45.1"
 dependencies = [
  "libc",
  "nix 0.31.3",
@@ -1542,7 +1542,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.45.0"
+version = "9.45.1"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.45.0"
+version = "9.45.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -8488,10 +8488,10 @@ mod tests {
     use chrono::{TimeZone, Utc};
     use gwt::{
         empty_workspace_state, load_restored_workspace_state, load_session_state, BackendEvent,
-        BranchCleanupInfo, BranchListEntry, BranchScope, ContentLimits, FrontendEvent,
-        LaunchWizardAction, LaunchWizardContext, LaunchWizardState, ProfileEnvEntryView,
-        ProjectKind, UiTracePayload, WindowGeometry, WindowPreset, WindowProcessStatus,
-        WorkspaceState,
+        BranchCleanupInfo, BranchListEntry, BranchScope, ContentLimits, FocusCycleDirection,
+        FrontendEvent, LaunchWizardAction, LaunchWizardContext, LaunchWizardState,
+        ProfileEnvEntryView, ProjectKind, UiTracePayload, WindowGeometry, WindowPreset,
+        WindowProcessStatus, WorkspaceState,
     };
     use gwt_config::{Profile, Settings};
     use gwt_core::{
@@ -10340,6 +10340,90 @@ exit 1
                 .expect("pane");
             assert_eq!(pane.screen().size(), (expected_rows, expected_cols));
         }
+    }
+
+    #[test]
+    fn app_runtime_cycle_focus_resizes_restored_source_runtime() {
+        let temp = tempdir().expect("tempdir");
+        let bounds = canvas_bounds();
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            temp.path().to_path_buf(),
+            ProjectKind::Git,
+            &[WindowPreset::Shell, WindowPreset::Claude],
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let shell_id = combined_window_id("tab-1", "shell-1");
+        let claude_id = combined_window_id("tab-1", "claude-1");
+        for window_id in [&shell_id, &claude_id] {
+            let pane = Pane::new(
+                window_id.clone(),
+                if cfg!(windows) { "cmd" } else { "/bin/sh" }.to_string(),
+                if cfg!(windows) {
+                    vec![
+                        "/d".to_string(),
+                        "/s".to_string(),
+                        "/c".to_string(),
+                        "exit /b 0".to_string(),
+                    ]
+                } else {
+                    vec!["-lc".to_string(), "exit 0".to_string()]
+                },
+                80,
+                24,
+                HashMap::new(),
+                None,
+            )
+            .expect("pane");
+            runtime.runtimes.insert(
+                window_id.clone(),
+                WindowRuntime {
+                    pane: Arc::new(Mutex::new(pane)),
+                    output_thread: None,
+                    status_thread: None,
+                },
+            );
+        }
+        let original_claude_geometry = runtime
+            .tab("tab-1")
+            .expect("tab")
+            .workspace
+            .window("claude-1")
+            .expect("claude")
+            .geometry
+            .clone();
+        let (expected_cols, expected_rows) = geometry_to_pty_size(&original_claude_geometry);
+
+        assert_eq!(
+            runtime
+                .maximize_window_events(&claude_id, bounds.clone())
+                .len(),
+            1
+        );
+        assert_eq!(
+            runtime
+                .cycle_focus_events(FocusCycleDirection::Forward, bounds)
+                .len(),
+            1
+        );
+
+        let claude_window = runtime
+            .tab("tab-1")
+            .expect("tab")
+            .workspace
+            .window("claude-1")
+            .expect("claude");
+        assert_eq!(claude_window.geometry, original_claude_geometry);
+        assert!(!claude_window.maximized);
+        let pane = runtime
+            .runtimes
+            .get(&claude_id)
+            .expect("runtime")
+            .pane
+            .lock()
+            .expect("pane");
+        assert_eq!(pane.screen().size(), (expected_rows, expected_cols));
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/window.rs
+++ b/crates/gwt/src/app_runtime/window.rs
@@ -108,11 +108,22 @@ impl AppRuntime {
         direction: FocusCycleDirection,
         bounds: WindowGeometry,
     ) -> Vec<OutboundEvent> {
-        let Some(tab) = self.active_tab_mut() else {
+        let Some(tab_id) = self.active_tab_id.clone() else {
             return Vec::new();
         };
-        if tab.workspace.cycle_focus(direction, bounds).is_none() {
+        let focused = {
+            let Some(tab) = self.tab_mut(&tab_id) else {
+                return Vec::new();
+            };
+            tab.workspace.cycle_focus(direction, bounds)
+        };
+        if focused.is_none() {
             return Vec::new();
+        }
+        if let Some(tab) = self.tab(&tab_id) {
+            for window in &tab.workspace.persisted().windows {
+                self.resize_runtime_to_window(&combined_window_id(&tab_id, &window.id));
+            }
         }
         let _ = self.persist();
         vec![self.workspace_state_broadcast()]

--- a/crates/gwt/src/workspace.rs
+++ b/crates/gwt/src/workspace.rs
@@ -222,7 +222,16 @@ impl WorkspaceState {
             FocusCycleDirection::Forward => (pos + 1) % eligible.len(),
             FocusCycleDirection::Backward => (pos + eligible.len() - 1) % eligible.len(),
         };
+        let current_id = self.persisted.windows[current_idx].id.clone();
         let next_id = self.persisted.windows[eligible[next_pos]].id.clone();
+        if self
+            .persisted
+            .windows
+            .get(current_idx)
+            .is_some_and(|window| window.maximized)
+        {
+            let _ = self.restore_window(&current_id);
+        }
         let _ = self.activate_window_tab(&next_id);
         self.center_window(&next_id, bounds);
         Some(next_id)
@@ -1370,6 +1379,83 @@ mod tests {
                 .expect("claude")
                 .tab_group_active
         );
+    }
+
+    #[test]
+    fn cycling_focus_restores_maximized_source_before_activating_next_window() {
+        let mut workspace = WorkspaceState::from_persisted(default_workspace_state());
+        let bounds = WindowGeometry {
+            x: 0.0,
+            y: 0.0,
+            width: 1200.0,
+            height: 800.0,
+        };
+        let codex_original = workspace.window("codex-1").expect("codex").geometry.clone();
+        let claude = workspace
+            .window("claude-1")
+            .expect("claude")
+            .geometry
+            .clone();
+
+        assert!(workspace.maximize_window("codex-1", bounds.clone()));
+        let focused = workspace
+            .cycle_focus(FocusCycleDirection::Forward, bounds.clone())
+            .expect("focused window");
+
+        assert_eq!(focused, "claude-1");
+        let codex = workspace.window("codex-1").expect("codex");
+        assert_eq!(codex.geometry, codex_original);
+        assert!(!codex.maximized);
+        assert_eq!(codex.pre_maximize_geometry, None);
+        assert!(
+            workspace.window("claude-1").expect("claude").z_index > codex.z_index,
+            "next window must end as topmost after source restore"
+        );
+        assert_eq!(
+            workspace.persisted().viewport.x,
+            bounds.width / 2.0 - (claude.x + claude.width / 2.0)
+        );
+        assert_eq!(
+            workspace.persisted().viewport.y,
+            bounds.height / 2.0 - (claude.y + claude.height / 2.0)
+        );
+    }
+
+    #[test]
+    fn cycling_focus_restores_maximized_group_before_activating_hidden_tab() {
+        let mut workspace = WorkspaceState::from_persisted(default_workspace_state());
+        assert!(workspace.dock_window_tab("codex-1", "claude-1"));
+        let bounds = arrange_bounds();
+        let original = workspace.window("codex-1").expect("codex").geometry.clone();
+
+        assert!(workspace.maximize_window("codex-1", bounds.clone()));
+        let focused = workspace
+            .cycle_focus(FocusCycleDirection::Forward, bounds)
+            .expect("focused window");
+
+        assert_eq!(focused, "claude-1");
+        let codex = workspace.window("codex-1").expect("codex");
+        let claude = workspace.window("claude-1").expect("claude");
+        assert_eq!(codex.geometry, original);
+        assert_eq!(claude.geometry, original);
+        assert!(!codex.maximized);
+        assert!(!claude.maximized);
+        assert!(claude.tab_group_active);
+        assert!(!codex.tab_group_active);
+    }
+
+    #[test]
+    fn cycling_focus_keeps_single_maximized_window_maximized() {
+        let mut workspace = WorkspaceState::from_persisted(empty_workspace_state());
+        let window = workspace.add_window(WindowPreset::Shell, arrange_bounds());
+        assert!(workspace.maximize_window(&window.id, arrange_bounds()));
+
+        let focused = workspace
+            .cycle_focus(FocusCycleDirection::Forward, arrange_bounds())
+            .expect("focused window");
+
+        assert_eq!(focused, window.id);
+        assert!(workspace.window(&window.id).expect("window").maximized);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Patch release v9.45.1 with 1 bug fix: focus cycle now restores maximized source window before switching.

## Changes

- **fix:** Focus cycleで最大化中の切替元を復元する (Shift+Cmd+Arrow で最大化中のウィンドウから切り替える際、切替元を自動的に復元)

## Version

v9.45.1

## Closing Issues

None

## Related Issues / Links

- #2008


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed focus cycling behavior when maximized windows are involved. Previously, when cycling focus between windows, a maximized window would remain in maximized state after focus switched to another window. Now the source window is properly restored to its normal state before focus transitions to the next active window.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2892?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->