### PR TITLE
fix(paths): preserve non-utf8 cwd bytes

### DIFF
--- a/crates/gwt-core/src/paths.rs
+++ b/crates/gwt-core/src/paths.rs
@@ -44,9 +44,15 @@ fn non_empty_os(value: Option<OsString>) -> Option<OsString> {
 /// CLIs when used as cwd or `GWT_PROJECT_ROOT`. Non-prefixed paths are
 /// returned unchanged.
 pub fn normalize_windows_child_process_path(path: &Path) -> PathBuf {
-    PathBuf::from(normalize_windows_child_process_path_text(
-        &path.to_string_lossy(),
-    ))
+    let Some(value) = path.to_str() else {
+        return path.to_path_buf();
+    };
+    let normalized = normalize_windows_child_process_path_text(value);
+    if normalized == value {
+        path.to_path_buf()
+    } else {
+        PathBuf::from(normalized)
+    }
 }
 
 /// Normalize a path string with the same rules as
@@ -389,6 +395,18 @@ mod tests {
             normalize_windows_child_process_path(Path::new(r"E:\gwt\work")),
             PathBuf::from(r"E:\gwt\work")
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn normalize_windows_child_process_path_preserves_non_utf8_unix_paths() {
+        use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
+
+        let bytes = b"/tmp/gwt-\xFF-work";
+        let path = Path::new(OsStr::from_bytes(bytes));
+        let normalized = normalize_windows_child_process_path(path);
+
+        assert_eq!(normalized.as_os_str().as_bytes(), bytes);
     }
 
     #[test]

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6130,3 +6130,10 @@ Type: lesson
 Context: Windows Start Work / Launch Agent failed to start again after a previous similar launch failure. This occurrence involved PowerShell provider-qualified or verbatim cwd values such as Microsoft.PowerShell.Core\FileSystem::\\?\E:\gwt\work\... causing Claude Code to error and Codex to fall back to C:\Windows.
 Learning: Treat Windows agent launch failures as recurring regression candidates, not one-off environment issues. The cwd, GWT_PROJECT_ROOT, worktree discovery path, and PTY spawn cwd must all be inspected for Windows-specific provider/verbatim path forms before declaring the launch path healthy.
 Future Action: When a Windows Start Work / Launch Agent failure is reported, first search memory for this recurrence, then add focused RED tests for provider-qualified/verbatim cwd normalization across launch config, env, worktree parsing, and PTY spawn before fixing.
+
+## 2026-05-25 — Preserve non-UTF8 paths when normalizing Windows launch cwd
+
+Type: lesson
+Context: PR #2894 review found that normalize_windows_child_process_path used Path::to_string_lossy(), which can replace valid Unix non-UTF8 path bytes with the UTF-8 replacement sequence when the shared helper is called broadly at launch/worktree boundaries.
+Learning: Windows-specific path normalization helpers must not lossy-convert Path values. Only rewrite when Path::to_str() succeeds and a known Windows provider/verbatim prefix is present; otherwise return the original PathBuf to preserve platform path bytes.
+Future Action: Before broadening any Path normalization helper, add Unix non-UTF8 byte-preservation tests alongside the Windows prefix tests, then verify the helper returns unchanged PathBuf for non-UTF8 and no-op inputs.


### PR DESCRIPTION
## Summary

- Preserve Unix non-UTF-8 path bytes when the Windows launch cwd normalization helper receives a non-UTF-8 `Path`.
- Follow up on PR #2894 review feedback by avoiding lossy path conversion outside known Windows prefix normalization cases.

## Changes

- `crates/gwt-core/src/paths.rs`: return the original `PathBuf` when `Path::to_str()` fails, and avoid allocating a new path when text normalization is a no-op.
- `crates/gwt-core/src/paths.rs`: add Unix regression coverage that verifies non-UTF-8 bytes survive `normalize_windows_child_process_path`.
- `tasks/memory.md`: record the review lesson so future Windows cwd normalization work checks non-UTF-8 path preservation first.

## Testing

- [x] `cargo test -p gwt-core normalize_windows_child_process_path_preserves_non_utf8_unix_paths -- --nocapture` — RED before implementation because `to_string_lossy()` replaced byte `0xFF` with UTF-8 replacement bytes.
- [x] `cargo test -p gwt-core normalize_windows_child_process_path -- --nocapture` — PASS, including Windows-prefix cases and the Unix non-UTF-8 regression.
- [x] `cargo fmt -- --check` — PASS.
- [x] `git diff --check` — PASS.
- [x] `cargo test -p gwt-core -p gwt-git -p gwt-agent -p gwt-terminal -p gwt --all-features` — PASS.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — PASS.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — PASS.
- [x] `bunx --bun markdownlint-cli tasks/memory.md --config .markdownlint.json` — PASS.
- [x] `bunx commitlint --from origin/develop --to HEAD` — PASS.
- User Verification Result: n/a, no UI or interactive launch surface changed in this follow-up.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes, the PR only narrows path normalization behavior and adds the regression that proves byte preservation.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- #2014
- #2894

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`; `svelte-check` not applicable because no frontend files changed)
- [x] Documentation updated (not user-facing; project memory updated for recurrence prevention)
- [x] Migration/backfill plan included (not applicable because no schema or data migration changed)
- [x] CHANGELOG impact considered (patch-level fix, no breaking change)

## Context

- PR #2894 fixed Windows provider/verbatim cwd normalization, but review correctly noted that using `Path::to_string_lossy()` could corrupt valid Unix non-UTF-8 paths when this shared helper is used broadly.

## Risk / Impact

- **Affected areas**: child-process cwd and launch path normalization helper behavior.
- **Rollback plan**: revert this PR to restore the previous lossy normalization behavior.
