### PR TITLE
fix(ui): keep tab switcher visible when switching to Git Branches view

### DIFF
--- a/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
+++ b/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
@@ -127,6 +127,41 @@ test("Workspace resume action asks backend for resumable agents", () => {
   assert.equal(sent[0].workspace_id, "workspace-current");
 });
 
+test("Tab switcher remains visible after switching to Git Branches", () => {
+  const fixture = createFixture();
+  const surface = createSurface(fixture, sampleProjection());
+
+  surface.mount(fixture.body, fixture.windowData, {
+    focusWindowLocally() {},
+    sendFocus() {},
+  });
+
+  const tabs = fixture.body.querySelectorAll("[data-work-tab]");
+  assert.equal(tabs.length, 2, "should have Work and Git Branches tabs");
+
+  const branchTab = fixture.body.querySelector("[data-work-tab='branches']");
+  branchTab.click();
+
+  const workSection = fixture.body.querySelector("[data-work-section='work']");
+  const branchSection = fixture.body.querySelector("[data-work-section='branches']");
+  assert.equal(workSection.hidden, true, "work section should be hidden");
+  assert.equal(branchSection.hidden, false, "branches section should be visible");
+
+  const tabGroupAfter = fixture.body.querySelector(".workspace-tab-group");
+  assert.ok(tabGroupAfter, "tab group should still exist in DOM");
+  assert.equal(tabGroupAfter.hidden, false, "tab group should not be hidden");
+
+  const workTabAfter = fixture.body.querySelector("[data-work-tab='work']");
+  assert.ok(workTabAfter, "Work tab should remain accessible");
+  assert.equal(workTabAfter.classList.contains("is-active"), false);
+  assert.equal(branchTab.classList.contains("is-active"), true);
+
+  workTabAfter.click();
+  assert.equal(workSection.hidden, false, "work section should reappear");
+  assert.equal(branchSection.hidden, true, "branches section should hide");
+  assert.equal(workTabAfter.classList.contains("is-active"), true);
+});
+
 test("Workspace refresh action rerenders locally without inventing a protocol event", () => {
   const fixture = createFixture();
   const sent = [];

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -1578,6 +1578,7 @@ body {
 }
 
 .workspace-branches-shell .branch-list-root {
+  position: static;
   display: flex;
   flex-direction: column;
   flex: 1;


### PR DESCRIPTION
## Summary

- Fix the Work/Git Branches tab switcher disappearing when switching to the Git Branches view, caused by `.branch-list-root` inheriting `position: absolute; inset: 0` and covering the toolbar

## Changes

- `crates/gwt/web/styles/app.css`: Add `position: static` to `.workspace-branches-shell .branch-list-root` to reset the inherited absolute positioning
- `crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs`: Add test verifying bidirectional tab switching between Work and Git Branches views

## Testing

- [x] `bash scripts/run-frontend-unit-tests.sh` — 567 tests passed, including new tab switcher visibility test
- [x] `cargo test -p gwt-core -p gwt --all-features` — all passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] Visual verification in browser: tab switcher remains visible and functional in both views

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — isolated CSS fix with no behavioral side effects
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

None

## Related Issues / Links

- #2359 (SPEC: Workspace / Start Work — Work Unification + Branches integration)

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (if user-facing change) — N/A: no user-facing docs change needed
- [ ] Migration/backfill plan included (if schema/data change) — N/A
- [ ] CHANGELOG impact considered (breaking change flagged in commit) — patch-level fix, no breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for workspace surface tab switching between Work and Git Branches tabs, verifying correct visibility and styling behavior.

* **Bug Fixes**
  * Adjusted CSS positioning for the workspace branches component to ensure proper layout rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->