### PR TITLE
refactor(gui): unify window size to 720×420 and rename Workspace to Work

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -5109,7 +5109,7 @@ impl AppRuntime {
             )];
         };
 
-        if window.preset != WindowPreset::Branches && window.preset != WindowPreset::Workspace {
+        if window.preset != WindowPreset::Branches && window.preset != WindowPreset::Work {
             return vec![OutboundEvent::reply(
                 client_id,
                 BackendEvent::BranchError {

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -545,6 +545,7 @@ pub fn should_dispatch_cli(args: &[String]) -> bool {
                     | "register"
                     | "daemon"
                     | "workspace"
+                    | "work"
                     | "pane"
             )
         })

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -3429,7 +3429,7 @@ mod tests {
             (WindowSurface::Logs, "logs"),
             (WindowSurface::Knowledge, "knowledge"),
             (WindowSurface::Index, "index"),
-            (WindowSurface::Workspace, "workspace"),
+            (WindowSurface::Work, "work"),
             (WindowSurface::Mock, "mock"),
         ];
 
@@ -3447,8 +3447,8 @@ mod tests {
         }
 
         assert!(
-            js.contains("preset === \"branches\"") && js.contains("return \"workspace\";"),
-            "expected JS `presetSurface()` to route branches preset to workspace surface",
+            js.contains("preset === \"branches\"") && js.contains("return \"work\";"),
+            "expected JS `presetSurface()` to route branches preset to work surface",
         );
     }
 

--- a/crates/gwt/src/launch_wizard_runtime.rs
+++ b/crates/gwt/src/launch_wizard_runtime.rs
@@ -45,7 +45,7 @@ impl AppRuntime {
         };
 
         if window.preset != WindowPreset::Branches
-            && window.preset != WindowPreset::Workspace
+            && window.preset != WindowPreset::Work
         {
             return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
                 id: id.to_string(),

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2441,14 +2441,14 @@ mod tests {
             .raw_id
             .clone();
         assert!(
-            runtime
+            !runtime
                 .tab("tab-1")
                 .expect("tab")
                 .workspace
                 .window(&file_tree_raw_id)
                 .expect("window")
                 .maximized,
-            "non-agent windows should be maximized on create"
+            "windows should not be auto-maximized on create"
         );
 
         assert_eq!(
@@ -2563,7 +2563,7 @@ mod tests {
                 .window(&board_raw_id)
                 .expect("board window")
                 .maximized,
-            "pre-existing Board windows can be restored from normal floating persistence",
+            "Board windows should not auto-maximize",
         );
         assert_eq!(
             runtime
@@ -2572,14 +2572,14 @@ mod tests {
             1
         );
         assert!(
-            runtime
+            !runtime
                 .tab("tab-1")
                 .expect("tab")
                 .workspace
                 .window(&board_raw_id)
                 .expect("board window")
                 .maximized,
-            "focusing a Board window with viewport bounds should maximize it",
+            "focusing a window should not auto-maximize it",
         );
 
         let shell_id = window_id_for_preset(&runtime, "tab-1", WindowPreset::Shell, 0);
@@ -2603,7 +2603,7 @@ mod tests {
                 .window(&shell_raw_id)
                 .expect("shell window")
                 .maximized,
-            "agent-capable terminal windows should keep their normal floating size",
+            "shell windows should keep their normal floating size",
         );
 
         for preset in [
@@ -2614,7 +2614,7 @@ mod tests {
             WindowPreset::Logs,
             WindowPreset::Issue,
             WindowPreset::Spec,
-            WindowPreset::Workspace,
+            WindowPreset::Work,
             WindowPreset::Pr,
         ] {
             assert_eq!(
@@ -2635,11 +2635,9 @@ mod tests {
                 .workspace
                 .window(&raw_id)
                 .expect("window");
-            assert!(window.maximized, "{id} should open maximized");
-            assert_eq!(window.geometry.x, 24.0);
-            assert_eq!(window.geometry.y, 24.0);
-            assert_eq!(window.geometry.width, 1352.0);
-            assert_eq!(window.geometry.height, 852.0);
+            assert!(!window.maximized, "{id} should not be auto-maximized");
+            assert_eq!(window.geometry.width, 720.0);
+            assert_eq!(window.geometry.height, 420.0);
         }
     }
 

--- a/crates/gwt/src/preset.rs
+++ b/crates/gwt/src/preset.rs
@@ -20,7 +20,8 @@ pub enum WindowPreset {
     Logs,
     Issue,
     Spec,
-    Workspace,
+    #[serde(alias = "workspace")]
+    Work,
     Index,
     Board,
     Pr,
@@ -40,7 +41,7 @@ pub enum WindowSurface {
     Logs,
     Knowledge,
     Index,
-    Workspace,
+    Work,
     Console,
     Mock,
 }
@@ -60,7 +61,7 @@ impl WindowSurface {
             Self::Logs => "logs",
             Self::Knowledge => "knowledge",
             Self::Index => "index",
-            Self::Workspace => "workspace",
+            Self::Work => "work",
             Self::Console => "console",
             Self::Mock => "mock",
         }
@@ -79,7 +80,7 @@ impl WindowPreset {
         WindowPreset::Logs,
         WindowPreset::Issue,
         WindowPreset::Spec,
-        WindowPreset::Workspace,
+        WindowPreset::Work,
         WindowPreset::Index,
         WindowPreset::Board,
         WindowPreset::Pr,
@@ -100,7 +101,7 @@ impl WindowPreset {
             Self::Logs => "Logs",
             Self::Issue => "Issue",
             Self::Spec => "SPEC",
-            Self::Workspace => "Work",
+            Self::Work => "Work",
             Self::Index => "Index",
             Self::Board => "Board",
             Self::Pr => "PR",
@@ -122,7 +123,7 @@ impl WindowPreset {
             Self::Logs => "Placeholder logs surface",
             Self::Issue => "Placeholder issue surface",
             Self::Spec => "Placeholder SPEC surface",
-            Self::Workspace => "Work overview",
+            Self::Work => "Work overview",
             Self::Index => "Search indexed project knowledge",
             Self::Board => "Placeholder board surface",
             Self::Pr => "Placeholder PR surface",
@@ -144,7 +145,7 @@ impl WindowPreset {
             Self::Logs => "logs",
             Self::Issue => "issue",
             Self::Spec => "spec",
-            Self::Workspace => "workspace",
+            Self::Work => "work",
             Self::Index => "index",
             Self::Board => "board",
             Self::Pr => "pr",
@@ -162,7 +163,7 @@ impl WindowPreset {
             Self::Logs => WindowSurface::Logs,
             Self::Board => WindowSurface::Board,
             Self::Issue | Self::Spec | Self::Pr => WindowSurface::Knowledge,
-            Self::Workspace => WindowSurface::Workspace,
+            Self::Work => WindowSurface::Work,
             Self::Index => WindowSurface::Index,
             Self::Console => WindowSurface::Console,
             Self::Settings => WindowSurface::Mock,
@@ -174,22 +175,13 @@ impl WindowPreset {
     }
 
     pub fn default_size(self) -> (f64, f64) {
-        match self.surface() {
-            WindowSurface::Terminal => (720.0, 420.0),
-            WindowSurface::FileTree => (420.0, 520.0),
-            WindowSurface::Branches => (520.0, 420.0),
-            WindowSurface::Knowledge => (560.0, 420.0),
-            WindowSurface::Index => (760.0, 520.0),
-            WindowSurface::Workspace => (1040.0, 680.0),
-            WindowSurface::Profile | WindowSurface::Logs => (560.0, 420.0),
-            WindowSurface::Board => (520.0, 480.0),
-            WindowSurface::Console => (720.0, 420.0),
-            WindowSurface::Mock => (420.0, 300.0),
-        }
+        let _ = self;
+        (720.0, 420.0)
     }
 
     pub fn opens_maximized_by_default(self) -> bool {
-        !self.requires_process() && !self.is_removed_legacy()
+        let _ = self;
+        false
     }
 
     pub fn command_name(self) -> Option<&'static str> {
@@ -206,7 +198,7 @@ impl WindowPreset {
             | Self::Logs
             | Self::Issue
             | Self::Spec
-            | Self::Workspace
+            | Self::Work
             | Self::Index
             | Self::Board
             | Self::Pr
@@ -352,7 +344,7 @@ where
         | WindowPreset::Logs
         | WindowPreset::Issue
         | WindowPreset::Spec
-        | WindowPreset::Workspace
+        | WindowPreset::Work
         | WindowPreset::Index
         | WindowPreset::Board
         | WindowPreset::Pr
@@ -478,11 +470,11 @@ mod tests {
         assert_eq!(WindowPreset::ALL.len(), 15);
         assert_eq!(WindowPreset::Issue.title(), "Issue");
         assert_eq!(WindowPreset::Spec.title(), "SPEC");
-        assert_eq!(WindowPreset::Workspace.title(), "Work");
+        assert_eq!(WindowPreset::Work.title(), "Work");
         assert_eq!(WindowPreset::Index.title(), "Index");
         assert_eq!(WindowPreset::Pr.title(), "PR");
         assert_eq!(WindowPreset::Board.id_prefix(), "board");
-        assert_eq!(WindowPreset::Workspace.id_prefix(), "workspace");
+        assert_eq!(WindowPreset::Work.id_prefix(), "work");
         assert_eq!(WindowPreset::Index.id_prefix(), "index");
         assert_eq!(WindowPreset::Agent.id_prefix(), "agent");
         assert_eq!(WindowPreset::Profile.surface(), WindowSurface::Profile);
@@ -490,43 +482,19 @@ mod tests {
         assert_eq!(WindowPreset::Logs.surface(), WindowSurface::Logs);
         assert_eq!(WindowPreset::Issue.surface(), WindowSurface::Knowledge);
         assert_eq!(WindowPreset::Spec.surface(), WindowSurface::Knowledge);
-        assert_eq!(WindowPreset::Workspace.surface(), WindowSurface::Workspace);
+        assert_eq!(WindowPreset::Work.surface(), WindowSurface::Work);
         assert_eq!(WindowPreset::Index.surface(), WindowSurface::Index);
         assert_eq!(WindowPreset::Pr.surface(), WindowSurface::Knowledge);
         assert_eq!(WindowPreset::Settings.surface(), WindowSurface::Mock);
-        assert_eq!(WindowPreset::Logs.default_size(), (560.0, 420.0));
-        assert_eq!(WindowPreset::Shell.default_size(), (720.0, 420.0));
-        assert_eq!(WindowPreset::FileTree.default_size(), (420.0, 520.0));
-        assert_eq!(WindowPreset::Branches.default_size(), (520.0, 420.0));
-        for preset in [
-            WindowPreset::FileTree,
-            WindowPreset::Branches,
-            WindowPreset::Settings,
-            WindowPreset::Profile,
-            WindowPreset::Logs,
-            WindowPreset::Issue,
-            WindowPreset::Spec,
-            WindowPreset::Workspace,
-            WindowPreset::Index,
-            WindowPreset::Board,
-            WindowPreset::Pr,
-            WindowPreset::Console,
-        ] {
-            assert!(
-                preset.opens_maximized_by_default(),
-                "{preset:?} should open maximized by default",
+        for preset in WindowPreset::ALL {
+            assert_eq!(
+                preset.default_size(),
+                (720.0, 420.0),
+                "{preset:?} should have uniform 720×420 default size",
             );
-        }
-        for preset in [
-            WindowPreset::Shell,
-            WindowPreset::Claude,
-            WindowPreset::Codex,
-            WindowPreset::Agent,
-            WindowPreset::Memo,
-        ] {
             assert!(
                 !preset.opens_maximized_by_default(),
-                "{preset:?} should keep normal floating geometry by default",
+                "{preset:?} should not open maximized by default",
             );
         }
         assert_eq!(WindowPreset::Shell.command_name(), None);
@@ -592,8 +560,8 @@ mod tests {
             assert!(!preset.subtitle().is_empty());
 
             let (width, height) = preset.default_size();
-            assert!(width >= 420.0);
-            assert!(height >= 300.0);
+            assert_eq!(width, 720.0);
+            assert_eq!(height, 420.0);
 
             match preset {
                 WindowPreset::Shell => {
@@ -644,8 +612,8 @@ mod tests {
                     assert!(!preset.requires_process());
                     assert_eq!(preset.command_name(), None);
                 }
-                WindowPreset::Workspace => {
-                    assert_eq!(preset.surface(), WindowSurface::Workspace);
+                WindowPreset::Work => {
+                    assert_eq!(preset.surface(), WindowSurface::Work);
                     assert!(!preset.requires_process());
                     assert_eq!(preset.command_name(), None);
                 }

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -509,8 +509,8 @@ test("Workspace Overview is separate from live-only Active Work", () => {
   );
   assert.match(
     appSource,
-    /function\s+openWorkspaceOverview\(\)\s*\{[\s\S]{0,300}?focusOrSpawnPreset\("workspace"\)/,
-    "expected Workspace Overview to open the Workspace window instead of a drawer",
+    /function\s+openWorkspaceOverview\(\)\s*\{[\s\S]{0,300}?focusOrSpawnPreset\("work"\)/,
+    "expected Workspace Overview to open the Work window instead of a drawer",
   );
   assert.match(
     appSource,
@@ -531,8 +531,8 @@ test("Workspace Overview uses the Quiet Work full-window List + Detail layout", 
   );
   assert.match(
     appSource,
-    /presetSurface\(preset\)[\s\S]+preset\s*===\s*"workspace"[\s\S]+return\s+"workspace"/,
-    "expected Workspace to be a first-class window surface",
+    /presetSurface\(preset\)[\s\S]+preset\s*===\s*"work"[\s\S]+return\s+"work"/,
+    "expected Work to be a first-class window surface",
   );
   assert.match(
     workspaceOverviewSource,
@@ -598,16 +598,11 @@ test("Workspace Overview legacy drawer scaffold is retired", () => {
   );
 });
 
-test("non-agent surface presets open maximized from command focus paths", () => {
+test("no surface presets auto-maximize — uniform 720×420 floating windows", () => {
   assert.match(
     appSource,
-    /function\s+isAutoMaximizedSurfacePreset\([^)]*\)[\s\S]+file_tree[\s\S]+branches[\s\S]+settings[\s\S]+profile[\s\S]+logs[\s\S]+issue[\s\S]+spec[\s\S]+workspace[\s\S]+board[\s\S]+pr/,
-    "expected frontend focus/spawn path to identify every non-agent surface preset as auto-maximized",
-  );
-  assert.match(
-    appSource,
-    /focusOrSpawnPreset\(preset\)[\s\S]+isAutoMaximizedSurfacePreset\(preset\)[\s\S]+bounds:\s*visibleBounds\(\)/,
-    "expected focusOrSpawnPreset to send viewport bounds when focusing existing non-agent surfaces",
+    /function\s+isAutoMaximizedSurfacePreset\([^)]*\)\s*\{[^}]*return\s+false/,
+    "expected isAutoMaximizedSurfacePreset to always return false (auto-maximize abolished)",
   );
 });
 
@@ -2460,7 +2455,7 @@ test("mountWindowBody clears every known surface class before applying the activ
     "surface-logs",
     "surface-knowledge",
     "surface-index",
-    "surface-workspace",
+    "surface-work",
     "surface-profile",
     "surface-console",
     "surface-mock",
@@ -2481,7 +2476,7 @@ test("every readable non-terminal surface participates in the opaque window chro
     "logs",
     "knowledge",
     "index",
-    "workspace",
+    "work",
     "profile",
     "console",
     "mock",

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -526,7 +526,7 @@
           return "file-tree";
         }
         if (preset === "branches") {
-          return "workspace";
+          return "work";
         }
         if (preset === "profile") {
           return "profile";
@@ -543,8 +543,8 @@
         if (preset === "index") {
           return "index";
         }
-        if (preset === "workspace") {
-          return "workspace";
+        if (preset === "work" || preset === "workspace") {
+          return "work";
         }
         if (preset === "console") {
           return "console";
@@ -2370,7 +2370,7 @@
       }
 
       function openWorkspaceOverview() {
-        focusOrSpawnPreset("workspace");
+        focusOrSpawnPreset("work");
       }
 
       function workspaceCleanupEntry(candidate) {
@@ -9389,7 +9389,7 @@
           "surface-logs",
           "surface-knowledge",
           "surface-index",
-          "surface-workspace",
+          "surface-work",
           "surface-profile",
           "surface-console",
           "surface-mock",
@@ -9868,7 +9868,7 @@
           return;
         }
 
-        if (surface === "workspace") {
+        if (surface === "work") {
           workspaceOverviewSurface.mount(body, windowData, {
             focusWindowLocally,
             sendFocus: (id) => socketTransport.send({ kind: "focus_window", id }),
@@ -13184,24 +13184,12 @@
       // surface dispatch. Each command either focuses an existing window or
       // creates a new one through the same socket transport the preset
       // buttons use, so they share the legacy invariants.
-      function isAutoMaximizedSurfacePreset(preset) {
-        return (
-          preset === "file_tree" ||
-          preset === "branches" ||
-          preset === "settings" ||
-          preset === "profile" ||
-          preset === "logs" ||
-          preset === "issue" ||
-          preset === "spec" ||
-          preset === "index" ||
-          preset === "workspace" ||
-          preset === "board" ||
-          preset === "pr"
-        );
+      function isAutoMaximizedSurfacePreset(_preset) {
+        return false;
       }
 
       function focusOrSpawnPreset(preset) {
-        if (preset === "branches") preset = "workspace";
+        if (preset === "branches") preset = "work";
         const allWindows = activeWorkspace().windows || [];
         const existing = allWindows.find(
           (w) => w.preset === preset && !w.minimized,
@@ -13234,13 +13222,13 @@
             focusOrSpawnPreset("board");
             return;
           case "open-git":
-            focusOrSpawnPreset("workspace");
+            focusOrSpawnPreset("work");
             return;
           case "open-logs":
             focusOrSpawnPreset("logs");
             return;
           case "open-branches":
-            focusOrSpawnPreset("workspace");
+            focusOrSpawnPreset("work");
             return;
           case "open-files":
             focusOrSpawnPreset("file_tree");

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -465,7 +465,7 @@
                 <strong>SPEC</strong>
                 <span>Open the SPEC surface</span>
               </button>
-              <button class="preset-button" data-preset="workspace">
+              <button class="preset-button" data-preset="work">
                 <strong>Work</strong>
                 <span>Open the Work overview</span>
               </button>

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -610,7 +610,7 @@ body {
 .workspace-window.surface-board,
 .workspace-window.surface-logs,
 .workspace-window.surface-mock,
-.workspace-window.surface-workspace,
+.workspace-window.surface-work,
 .workspace-window.surface-knowledge,
 .workspace-window.surface-index,
 .workspace-window.surface-profile,
@@ -643,7 +643,7 @@ body {
 .surface-mock .titlebar,
 .surface-knowledge .titlebar,
 .surface-index .titlebar,
-.surface-workspace .titlebar,
+.surface-work .titlebar,
 .surface-profile .titlebar,
 .surface-console .titlebar {
   background: var(--color-surface-elevated);
@@ -731,7 +731,7 @@ body {
 .surface-logs .status-chip,
 .surface-knowledge .status-chip,
 .surface-index .status-chip,
-.surface-workspace .status-chip,
+.surface-work .status-chip,
 .surface-profile .status-chip,
 .surface-console .status-chip,
 .surface-mock .status-chip {
@@ -796,7 +796,7 @@ body {
 .surface-logs .icon-button,
 .surface-knowledge .icon-button,
 .surface-index .icon-button,
-.surface-workspace .icon-button,
+.surface-work .icon-button,
 .surface-profile .icon-button,
 .surface-console .icon-button,
 .surface-mock .icon-button {
@@ -951,7 +951,7 @@ body {
 .surface-logs .window-body,
 .surface-knowledge .window-body,
 .surface-index .window-body,
-.surface-workspace .window-body,
+.surface-work .window-body,
 .surface-console .window-body,
 .surface-mock .window-body,
 .surface-profile .window-body {

--- a/crates/gwt/web/workspace-kanban-surface.js
+++ b/crates/gwt/web/workspace-kanban-surface.js
@@ -655,7 +655,7 @@ export function createWorkspaceKanbanSurface({
 
   function renderWindows() {
     for (const windowData of activeWorkspace()?.windows || []) {
-      if (workspaceWindowById(windowData.id)?.preset !== "workspace") continue;
+      if (workspaceWindowById(windowData.id)?.preset !== "work") continue;
       renderWorkspaceOverviewWindow(windowData.id);
     }
   }


### PR DESCRIPTION
## Summary

- Unify all window preset default sizes to 720×420, matching agent windows
- Abolish auto-maximize on window creation (`opens_maximized_by_default` → always `false`)
- Rename `WindowPreset::Workspace` → `WindowPreset::Work` and `WindowSurface::Workspace` → `WindowSurface::Work`
- Update serialized strings from `"workspace"` to `"work"` across Rust, JS, and CSS
- Add `#[serde(alias = "workspace")]` for backward-compatible deserialization of existing workspace state files

## Changes

### Window Size Unification (SPEC-2359 US-51)

- `preset.rs`: Simplified `default_size()` to return `(720.0, 420.0)` for all surfaces
- `preset.rs`: Changed `opens_maximized_by_default()` to always return `false`
- `app.js`: Simplified `isAutoMaximizedSurfacePreset()` to always return `false`

### Enum Rename (SPEC-2359 US-52)

- Rust: `WindowPreset::Workspace` → `Work`, `WindowSurface::Workspace` → `Work`
- Serialized strings: `id_prefix`, `as_str`, `title_slug` changed from `"workspace"` to `"work"`
- Frontend JS: preset/surface string `"workspace"` → `"work"` in `app.js`, `index.html`, `workspace-kanban-surface.js`
- CSS: `surface-workspace` → `surface-work` in `app.css`
- Backward compat: `#[serde(alias = "workspace")]` on `WindowPreset::Work`

## Testing

- `cargo test -p gwt-core -p gwt --all-features` — all passed (0 failures)
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean
- Frontend unit tests — 566 passed
- GUI visual verification — confirmed all windows open at 720×420 without auto-maximize

## PR Readiness

- State: Ready
- User Verification Result: confirmed
- gwt-verify: PASS (cargo test, clippy, fmt, frontend tests all green)

## Closing Issues

None

## Related Issues

- SPEC-2359 Phase W-6 (US-51, US-52)

## Checklist

- [x] Code compiles without warnings
- [x] All tests pass
- [x] Backward compatibility maintained (serde alias)
- [x] Frontend tests updated
- [x] Visual verification confirmed
