### PR TITLE
fix(active-work): ignore stopped windows when resuming agents

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -13379,6 +13379,48 @@ exit 1
     }
 
     #[test]
+    fn app_runtime_resume_workspace_agent_ignores_stopped_same_session_window() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "agent-1",
+            repo,
+            WindowPreset::Agent,
+            WindowProcessStatus::Stopped,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "agent-1");
+        let mut session = sample_active_agent_session("tab-1", &window_id);
+        session.session_id = "stopped-session".to_string();
+        session.window_id = window_id.clone();
+        runtime.active_agent_sessions.insert(window_id, session);
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::ResumeWorkspaceAgent {
+                session_id: "stopped-session".to_string(),
+                bounds: canvas_bounds(),
+            },
+        );
+
+        let event = events
+            .first()
+            .expect("ResumeWorkspaceAgent should proceed past stopped window");
+        assert!(matches!(
+            &event.event,
+            BackendEvent::WorkspaceResumeAgentError { session_id, message }
+                if session_id == "stopped-session" && !message.is_empty()
+        ));
+    }
+
+    #[test]
     fn app_runtime_latest_branch_resume_picks_newest_resumable_session() {
         let temp = tempdir().expect("tempdir");
         let repo = temp.path().join("repo");

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -507,7 +507,19 @@ impl AppRuntime {
         if let Some(window_id) = self
             .active_agent_sessions
             .iter()
-            .find(|(_, session)| session.session_id == session_id && session.tab_id == tab_id)
+            .find(|(window_id, session)| {
+                session.session_id == session_id
+                    && session.tab_id == tab_id
+                    && self.window_lookup.contains_key(window_id.as_str())
+                    && self
+                        .window_status(window_id.as_str())
+                        .is_some_and(|status| {
+                            !matches!(
+                                status,
+                                WindowProcessStatus::Stopped | WindowProcessStatus::Error
+                            )
+                        })
+            })
             .map(|(window_id, _)| window_id.clone())
         {
             return self.focus_existing_live_work_agent_events(&window_id, Some(bounds));


### PR DESCRIPTION
## Summary

- Fix resume handling so stopped or errored Agent windows do not block a replacement resume attempt.
- Address the post-merge review finding from PR #2900 with a regression test.

## Changes

- `crates/gwt/src/app_runtime/wizard.rs`: filters the same-session resume short-circuit to live, focusable Agent windows only.
- `crates/gwt/src/app_runtime/mod.rs`: adds a regression test proving stopped same-session windows fall through to the normal resume path.

## Testing

- [x] `cargo test -p gwt --bin gwt app_runtime_resume_workspace_agent_ignores_stopped_same_session_window --all-features` — RED before fix, PASS after fix.
- [x] `cargo test -p gwt --bin gwt app_runtime_resume_workspace_agent --all-features` — PASS.
- [x] `cargo fmt --check` — PASS.
- [x] `git diff --check` — PASS.
- [x] `cargo test -p gwt-core -p gwt --all-features` — PASS.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — PASS.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — PASS.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — PASS.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes; this is a narrow regression fix for resume behavior after stopped/error Agent windows.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- #2359
- #2900

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (N/A: internal resume behavior only)
- [x] Migration/backfill plan included (N/A: no data/schema migration)
- [x] CHANGELOG impact considered (patch fix, no breaking change)

## Context

- PR #2900 was auto-merged before Codex review posted an actionable P1 comment. The comment correctly identified that the same-session resume path needed the same live-window filtering as the Work-level lookup.

## Risk / Impact

- **Affected areas**: Work resume / Agent resume backend event handling.
- **Rollback plan**: revert this single commit if resume behavior regresses.
