### PR TITLE
fix(launch): detect docker runtime from managed workspace root

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -9694,6 +9694,42 @@ exit 1
         panic!("timed out waiting for {label}: {snapshot:?}");
     }
 
+    fn resolve_launch_wizard_runtime_confirmation(
+        runtime: &mut AppRuntime,
+        recorded_events: &Arc<Mutex<Vec<UserEvent>>>,
+        label: &str,
+    ) {
+        let events = runtime.handle_launch_wizard_action(LaunchWizardAction::Submit, None);
+        assert_eq!(events.len(), 1);
+        let pending_view = runtime
+            .launch_wizard
+            .as_ref()
+            .expect("wizard")
+            .wizard
+            .view();
+        assert!(pending_view.runtime_resolution_pending);
+        assert!(!pending_view.runtime_context_resolved);
+
+        wait_for_recorded_event(label, recorded_events, |events| {
+            events
+                .iter()
+                .any(|event| matches!(event, UserEvent::LaunchWizardRuntimeResolved { .. }))
+        });
+        let resolved_event = {
+            let mut events = recorded_events.lock().expect("event log");
+            events
+                .iter()
+                .position(|event| matches!(event, UserEvent::LaunchWizardRuntimeResolved { .. }))
+                .map(|index| events.remove(index))
+                .expect("runtime resolved event")
+        };
+        let UserEvent::LaunchWizardRuntimeResolved { wizard_id, result } = resolved_event else {
+            unreachable!("matched above")
+        };
+        let resolved_events = runtime.handle_launch_wizard_runtime_resolved(wizard_id, *result);
+        assert_eq!(resolved_events.len(), 1);
+    }
+
     fn wait_for_path(label: &str, path: &Path) {
         for _ in 0..800 {
             if path.exists() {
@@ -9906,6 +9942,41 @@ exit 1
         run_git(repo, &["config", "user.email", "codex@example.com"]);
         run_git(repo, &["remote", "set-head", "origin", "-a"]);
         origin
+    }
+
+    fn init_managed_workspace_with_develop_worktree(workspace_home: &Path) -> (PathBuf, PathBuf) {
+        fs::create_dir_all(workspace_home).expect("create workspace home");
+        let seed = workspace_home.join(".seed");
+        let bare_repo = workspace_home.join("repo.git");
+        let develop_worktree = workspace_home.join("develop");
+
+        fs::create_dir_all(&seed).expect("create seed");
+        run_git(&seed, &["init", "-q", "-b", "develop"]);
+        run_git(&seed, &["config", "user.name", "Codex"]);
+        run_git(&seed, &["config", "user.email", "codex@example.com"]);
+        fs::write(seed.join("README.md"), "repo\n").expect("seed readme");
+        run_git(&seed, &["add", "README.md"]);
+        run_git(&seed, &["commit", "-qm", "init"]);
+        run_git_with_paths(&["clone", "--bare"], &[&seed, &bare_repo]);
+
+        let develop_arg = develop_worktree.to_string_lossy().to_string();
+        let output = gwt_core::process::hidden_command("git")
+            .args(["worktree", "add", "-q", &develop_arg, "develop"])
+            .current_dir(&bare_repo)
+            .output()
+            .expect("git worktree add develop");
+        assert!(
+            output.status.success(),
+            "git worktree add develop failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        run_git(&develop_worktree, &["config", "user.name", "Codex"]);
+        run_git(
+            &develop_worktree,
+            &["config", "user.email", "codex@example.com"],
+        );
+
+        (bare_repo, develop_worktree)
     }
 
     fn append_workspace_resume_journal(
@@ -10943,6 +11014,126 @@ exit 1
         assert!(view.show_runtime_target);
         assert_eq!(view.selected_runtime_target, "docker");
         assert_eq!(view.selected_docker_service.as_deref(), Some("app"));
+    }
+
+    #[test]
+    fn app_runtime_start_work_parent_root_uses_develop_checkout_for_docker_context() {
+        let temp = tempdir().expect("tempdir");
+        let workspace_home = temp.path().join("workspace");
+        let (bare_repo, develop_worktree) =
+            init_managed_workspace_with_develop_worktree(&workspace_home);
+        fs::write(
+            develop_worktree.join("docker-compose.yml"),
+            "services:\n  gwt:\n    image: alpine:3.20\n",
+        )
+        .expect("compose");
+
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            workspace_home.clone(),
+            ProjectKind::Git,
+            &[WindowPreset::Branches],
+        );
+        let (mut runtime, recorded_events) =
+            sample_runtime_with_events(temp.path(), vec![tab], Some("tab-1"));
+
+        runtime
+            .open_start_work_for_project("tab-1", &workspace_home)
+            .expect("open start work");
+        let branch_name = runtime
+            .launch_wizard
+            .as_ref()
+            .expect("wizard")
+            .wizard
+            .context
+            .normalized_branch_name
+            .clone();
+        let expected_worktree = gwt_git::worktree::sibling_worktree_path(&bare_repo, &branch_name);
+        assert!(
+            !expected_worktree.exists(),
+            "fixture branch worktree should start absent"
+        );
+
+        resolve_launch_wizard_runtime_confirmation(
+            &mut runtime,
+            &recorded_events,
+            "start work parent root docker context",
+        );
+
+        let wizard = &runtime.launch_wizard.as_ref().expect("wizard").wizard;
+        assert!(
+            wizard.context.worktree_path.is_none(),
+            "Runtime confirmation must not resolve a missing target worktree"
+        );
+        assert!(
+            !expected_worktree.exists(),
+            "Runtime confirmation must not create {expected_worktree:?}"
+        );
+        let view = wizard.view();
+        assert!(!view.runtime_resolution_pending);
+        assert!(view.runtime_context_resolved);
+        assert!(view.show_runtime_target);
+        assert_eq!(view.selected_runtime_target, "docker");
+        assert_eq!(view.selected_docker_service.as_deref(), Some("gwt"));
+    }
+
+    #[test]
+    fn app_runtime_start_work_parent_root_preserves_saved_host_while_showing_runtime_target() {
+        let temp = tempdir().expect("tempdir");
+        let workspace_home = temp.path().join("workspace");
+        let (_bare_repo, develop_worktree) =
+            init_managed_workspace_with_develop_worktree(&workspace_home);
+        fs::write(
+            develop_worktree.join("docker-compose.yml"),
+            "services:\n  gwt:\n    image: alpine:3.20\n",
+        )
+        .expect("compose");
+
+        let sessions_dir = temp.path().join("sessions");
+        fs::create_dir_all(&sessions_dir).expect("create sessions dir");
+        let mut session =
+            gwt_agent::Session::new(&develop_worktree, "develop", gwt_agent::AgentId::Codex);
+        session.runtime_target = gwt_agent::LaunchRuntimeTarget::Host;
+        session.docker_service = None;
+        session.save(&sessions_dir).expect("save session");
+
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            workspace_home.clone(),
+            ProjectKind::Git,
+            &[WindowPreset::Branches],
+        );
+        let (mut runtime, recorded_events) =
+            sample_runtime_with_events(temp.path(), vec![tab], Some("tab-1"));
+
+        runtime
+            .open_start_work_for_project("tab-1", &workspace_home)
+            .expect("open start work");
+        resolve_launch_wizard_runtime_confirmation(
+            &mut runtime,
+            &recorded_events,
+            "start work parent root saved host",
+        );
+
+        let view = runtime
+            .launch_wizard
+            .as_ref()
+            .expect("wizard")
+            .wizard
+            .view();
+        assert!(view.runtime_context_resolved);
+        assert!(view.show_runtime_target);
+        assert_eq!(view.selected_runtime_target, "host");
+        assert!(view.selected_docker_service.is_none());
+        assert_eq!(
+            view.docker_service_options
+                .iter()
+                .map(|option| option.value.as_str())
+                .collect::<Vec<_>>(),
+            vec!["gwt"]
+        );
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -1257,17 +1257,44 @@ fn launch_runtime_context_paths(
     project_root: &Path,
     branch_name: &str,
 ) -> (PathBuf, Option<PathBuf>) {
-    if let Some(worktree_path) = existing_launch_worktree_path(project_root, branch_name) {
+    let worktrees = launch_runtime_worktrees(project_root);
+    if let Some(worktree_path) = worktrees
+        .as_deref()
+        .and_then(|worktrees| usable_worktree_path_for_branch(worktrees, branch_name))
+    {
         return (worktree_path.clone(), Some(worktree_path));
+    }
+    if project_root_is_git_worktree(project_root) {
+        return (project_root.to_path_buf(), None);
+    }
+    if let Some(default_worktree_path) = worktrees
+        .as_deref()
+        .and_then(default_runtime_detection_worktree_path)
+    {
+        return (default_worktree_path, None);
     }
     (project_root.to_path_buf(), None)
 }
 
-fn existing_launch_worktree_path(project_root: &Path, branch_name: &str) -> Option<PathBuf> {
+fn launch_runtime_worktrees(project_root: &Path) -> Option<Vec<gwt_git::WorktreeInfo>> {
     let main_repo_path = gwt_git::worktree::main_worktree_root(project_root).ok()?;
-    let manager = gwt_git::WorktreeManager::new(&main_repo_path);
-    let worktrees = manager.list().ok()?;
-    usable_worktree_path_for_branch(&worktrees, branch_name)
+    gwt_git::WorktreeManager::new(&main_repo_path).list().ok()
+}
+
+fn project_root_is_git_worktree(project_root: &Path) -> bool {
+    let output = gwt_core::process::hidden_command("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(project_root)
+        .output();
+    output.is_ok_and(|output| {
+        output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "true"
+    })
+}
+
+fn default_runtime_detection_worktree_path(worktrees: &[gwt_git::WorktreeInfo]) -> Option<PathBuf> {
+    ["develop", "main"]
+        .iter()
+        .find_map(|branch| usable_worktree_path_for_branch(worktrees, branch))
 }
 
 impl AppRuntime {

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6137,3 +6137,10 @@ Type: lesson
 Context: PR #2894 review found that normalize_windows_child_process_path used Path::to_string_lossy(), which can replace valid Unix non-UTF8 path bytes with the UTF-8 replacement sequence when the shared helper is called broadly at launch/worktree boundaries.
 Learning: Windows-specific path normalization helpers must not lossy-convert Path values. Only rewrite when Path::to_str() succeeds and a known Windows provider/verbatim prefix is present; otherwise return the original PathBuf to preserve platform path bytes.
 Future Action: Before broadening any Path normalization helper, add Unix non-UTF8 byte-preservation tests alongside the Windows prefix tests, then verify the helper returns unchanged PathBuf for non-UTF8 and no-op inputs.
+
+## 2026-05-26 — Separate Launch Wizard runtime detection root from target worktree materialization
+
+Type: lesson
+Context: SPEC-2014 managed workspace parent bug: Start Work opened at /Users/akiojin/Workbench/gwt while Docker files lived in nested develop checkout, so Runtime target selection was hidden.
+Learning: Runtime confirmation must first prefer an existing target worktree, but when the target worktree does not exist it should use an existing checkout such as develop/main for Docker context detection without resolving or creating the target worktree.
+Future Action: When touching Launch Wizard runtime context, add tests for workspace parent roots and assert the target worktree remains absent until the final launch/materialization step.


### PR DESCRIPTION
## Summary

- Detect Docker runtime options for Start Work opened from a managed workspace root so Docker remains selectable before the new worktree exists.
- Keep runtime confirmation non-materializing so Start Work does not create the reserved branch worktree just to inspect Docker metadata.

## Changes

- `crates/gwt/src/app_runtime/wizard.rs`: Keeps Start Work runtime confirmation deferred while preserving the workspace-home project root as the runtime lookup input.
- `crates/gwt/src/app_runtime/mod.rs`: Resolves Docker context from the managed workspace develop checkout when the Start Work target worktree is not materialized, and adds regression coverage for saved host preferences.
- `tasks/memory.md`: Records the regression-prevention lesson for managed workspace Docker context lookup.

## Testing

- [x] `cargo fmt --check` — PASS.
- [x] `cargo test -p gwt-core -p gwt --all-features` — PASS.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — PASS.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — PASS.
- [x] `bunx commitlint --from origin/develop --to HEAD` — PASS.
- [x] Headed Playwright E2E against `target/debug/gwt serve --no-open` — PASS; Start Work from `/Users/akiojin/Workbench/gwt` exposes Runtime target `Host` / `Docker`, and selecting `Docker` exposes services `gwt` and `playwright-novnc`.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes; the fix is scoped to Start Work runtime-context detection and preserves existing launch materialization boundaries.
- Known blockers: None
- Remaining acceptance: None
- User verification: confirmed by user after serving the final behavior locally.

## Closing Issues

- Closes #2014

## Related Issues / Links

- #2014

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (N/A: no README/user-guide surface changed)
- [x] Migration/backfill plan included (N/A: no schema or data migration)
- [x] CHANGELOG impact considered (patch fix; no breaking change)

## Context

- Start Work opened from a managed workspace home can target a branch worktree that does not exist yet, while Docker Compose configuration lives in the managed develop checkout.
- The runtime confirmation step must inspect Docker metadata from the stable source checkout without materializing the reserved worktree.

## Risk / Impact

- **Affected areas**: Start Work / Launch Wizard runtime confirmation, Docker runtime option detection, saved launch profile handling.
- **Rollback plan**: Revert this PR to restore the previous runtime-context lookup behavior.

## Screenshots

- Final headed E2E screenshot artifact: `/tmp/gwt-headed-runtime-e2e-final.png`
