### PR TITLE
fix(gui): coalesce browser resize events and adjust Blink lineHeight

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1066,9 +1066,10 @@ test("xterm content stays on the dark Operator palette across app theme changes"
 
 test("xterm developer readability defaults use larger font metrics", () => {
   assert.ok(terminalOptionNumber("fontSize") >= 14, "xterm fontSize must be at least 14px");
-  assert.ok(
-    terminalOptionNumber("lineHeight") >= 1.3,
-    "xterm lineHeight must be at least 1.30 to avoid cramped SS.mov output",
+  assert.match(
+    appSource,
+    /lineHeight:\s*isBlinkBrowser\(\)\s*\?\s*1\.3[0-9]*\s*:\s*1\.3/,
+    "xterm lineHeight must be at least 1.30 for both Blink and WebKit paths (Issue #2903)",
   );
 });
 

--- a/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
@@ -404,6 +404,81 @@ test("elementHasLayoutBox blocks 0-size containers (Issue #2832 / SPEC-2008 Phas
   assert.equal(elementHasLayoutBox({}), true);
 });
 
+test("attachHostResizeReflow coalesces rapid resize events via requestAnimationFrame (Issue #2903)", () => {
+  const window = fixtureWindow();
+  let rafCallback = null;
+  let rafIdCounter = 1;
+  let cancelledIds = [];
+  window.requestAnimationFrame = (cb) => {
+    rafCallback = cb;
+    return rafIdCounter++;
+  };
+  window.cancelAnimationFrame = (id) => {
+    cancelledIds.push(id);
+    rafCallback = null;
+  };
+
+  const fitCalls = [];
+  const beforeFanCalls = [];
+
+  const dispose = attachHostResizeReflow({
+    window,
+    terminalIds: () => ["wtA", "wtB"],
+    canRefreshViewport: (id) => id !== "wtB",
+    fitTerminal: (id, persist) => fitCalls.push([id, persist]),
+    beforeFan: () => beforeFanCalls.push("flushed"),
+  });
+
+  // Fire 5 rapid resize events (simulates Chrome maximize animation).
+  for (let i = 0; i < 5; i++) {
+    window.dispatchEvent(new window.Event("resize"));
+  }
+
+  // Nothing should have executed synchronously — all deferred to rAF.
+  assert.equal(fitCalls.length, 0, "fitTerminal must not fire synchronously when rAF is available");
+  assert.equal(beforeFanCalls.length, 0, "beforeFan must not fire synchronously when rAF is available");
+
+  // 4 intermediate rAFs should have been cancelled (5 events, only last survives).
+  assert.equal(cancelledIds.length, 4, "previous rAF frames must be cancelled on rapid resize");
+
+  // Flush the single surviving rAF callback.
+  assert.ok(rafCallback, "a rAF must be scheduled after the last resize");
+  rafCallback();
+
+  // Only one fan-out should have run.
+  assert.deepEqual(beforeFanCalls, ["flushed"], "beforeFan must fire exactly once");
+  assert.deepEqual(fitCalls, [["wtA", true]], "fitTerminal must fire once per visible terminal");
+
+  dispose();
+});
+
+test("attachHostResizeReflow dispose cancels pending rAF (Issue #2903)", () => {
+  const window = fixtureWindow();
+  let rafCallback = null;
+  let cancelCount = 0;
+  window.requestAnimationFrame = (cb) => { rafCallback = cb; return 99; };
+  window.cancelAnimationFrame = () => { cancelCount++; rafCallback = null; };
+
+  const fitCalls = [];
+  const dispose = attachHostResizeReflow({
+    window,
+    terminalIds: () => ["wtA"],
+    canRefreshViewport: () => true,
+    fitTerminal: (id, persist) => fitCalls.push([id, persist]),
+  });
+
+  window.dispatchEvent(new window.Event("resize"));
+  assert.ok(rafCallback, "rAF must be scheduled");
+
+  // Dispose before rAF fires.
+  dispose();
+  assert.equal(cancelCount, 1, "dispose must cancel pending rAF");
+
+  // Even if someone flushes an old callback ref, listener is removed.
+  window.dispatchEvent(new window.Event("resize"));
+  assert.equal(fitCalls.length, 0, "no fits after dispose");
+});
+
 test("app.js wires the reflow controller for resize, transition, and predicate", () => {
   // Source-string contract retained per the memory — limited to wiring
   // detection so a future refactor that drops the import / call surfaces
@@ -478,5 +553,19 @@ test("app.js wires the reflow controller for resize, transition, and predicate",
     appSource,
     /HANDSHAKE_RETRY_LIMIT/,
     "handshake retry must be capped by HANDSHAKE_RETRY_LIMIT",
+  );
+
+  // Issue #2903 — browser lineHeight parity: app.js must detect Blink
+  // browsers and adjust xterm lineHeight so the agent terminal line spacing
+  // matches the native WebView rendering.
+  assert.match(
+    appSource,
+    /isBlinkBrowser\b/,
+    "app.js must define isBlinkBrowser helper for engine-specific lineHeight",
+  );
+  assert.match(
+    appSource,
+    /lineHeight:\s*isBlinkBrowser/,
+    "createTerminalRuntime must use isBlinkBrowser to select lineHeight",
   );
 });

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -3757,6 +3757,11 @@
         return /mac|iphone|ipad|ipod/i.test(platform);
       }
 
+      function isBlinkBrowser() {
+        const ua = navigator.userAgent || "";
+        return /Chrome\//.test(ua);
+      }
+
       function isTerminalCopyShortcut(event) {
         if (isMacPlatform()) {
           return false;
@@ -4237,7 +4242,7 @@
           fontFamily:
             "var(--font-mono), ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
           fontSize: 14,
-          lineHeight: 1.3,
+          lineHeight: isBlinkBrowser() ? 1.35 : 1.3,
           scrollback: 5000,
         });
         const fitAddon = new FitAddon();

--- a/crates/gwt/web/terminal-viewport-reflow.js
+++ b/crates/gwt/web/terminal-viewport-reflow.js
@@ -23,7 +23,10 @@ export function attachHostResizeReflow({
   if (!window || typeof window.addEventListener !== "function") {
     throw new TypeError("attachHostResizeReflow requires a DOM window");
   }
-  const handler = () => {
+  const hasRaf = typeof window.requestAnimationFrame === "function";
+  let rafId = null;
+  const run = () => {
+    rafId = null;
     if (typeof beforeFan === "function") beforeFan();
     for (const windowId of terminalIds()) {
       if (typeof canRefreshViewport === "function" && !canRefreshViewport(windowId)) {
@@ -32,8 +35,19 @@ export function attachHostResizeReflow({
       fitTerminal(windowId, true);
     }
   };
+  const handler = () => {
+    if (hasRaf) {
+      if (rafId !== null) window.cancelAnimationFrame(rafId);
+      rafId = window.requestAnimationFrame(run);
+    } else {
+      run();
+    }
+  };
   window.addEventListener("resize", handler);
-  return () => window.removeEventListener("resize", handler);
+  return () => {
+    if (rafId !== null && hasRaf) window.cancelAnimationFrame(rafId);
+    window.removeEventListener("resize", handler);
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Chrome でブラウザウィンドウを最大化した際の画面チラつきを修正し、ブラウザ版のエージェントウィンドウ行間をアプリ版 (WebView) と同等に調整。

## Changes

- **rAF coalescing 導入** (`terminal-viewport-reflow.js`): `attachHostResizeReflow` の resize ハンドラを `requestAnimationFrame` + `cancelAnimationFrame` で coalesce。Chrome の高頻度 resize イベントが毎回同期的に syncMaximizedWindowsToViewport → backend roundtrip → 再レンダリングを起動していた問題を解消。
- **Blink ブラウザ検出 + lineHeight 調整** (`app.js`): `isBlinkBrowser()` ヘルパーを追加し、Blink (Chrome/Edge/Brave) では `lineHeight: 1.35`、WebKit (WKWebView/Safari) では `lineHeight: 1.3` を適用。
- **テスト追加**: rAF coalescing の動作テスト 2件、ソースストリング契約テストの更新。

## Testing

- `cargo test -p gwt-core -p gwt --all-features`: PASS
- `cargo clippy --all-targets --all-features -- -D warnings`: PASS (0 warnings)
- JS unit tests (571 tests): PASS
- ユーザー視覚検証: **confirmed** (Chrome でブラウザ最大化チラつきなし、行間改善、ドラッグリサイズ正常)

## PR Readiness

- State: Ready
- Verification: `gwt-verify --mode full` Overall: PASS
- User Verification Result: confirmed

## Closing Issues

Closes #2903

## Related Issues

- Issue #2513 (同種の修正: Windows ドラッグリサイズ flicker)
- SPEC-2008 Phase 24 (host resize reflow 設計)

## Checklist

- [x] テスト追加・更新済み
- [x] `cargo clippy` + `cargo fmt` 通過
- [x] フロントエンドテスト全通過 (571/571)
- [x] commitlint 通過
- [x] ユーザー視覚検証 confirmed
- [x] AGENTS.md のコミットメッセージポリシー準拠
