### PR TITLE
chore(release): v9.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,32 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.47.0] - 2026-05-26
+
+### Bug Fixes
+
+- **ui:** Keep tab switcher visible when switching to Git Branches view
+- **gui:** Persist agent windows in workspace.json for restore on restart
+- **gui:** Coalesce browser resize events and adjust Blink lineHeight (#2903)
+- **launch:** Detect docker runtime from managed workspace root
+- **launch:** Prevent wizard close event starvation under load
+- Ignore stopped windows when resuming agents
+
+### Features
+
+- Support multiple active works
+- Align active work identity and agent cardinality
+
+### Miscellaneous Tasks
+
+- Merge origin/develop into launch runtime fix
+- Resolve memory.md conflict from develop merge
+- Resolve memory.md conflict from develop merge
+
+### Refactor
+
+- **gui:** Unify window size to 720×420 and rename Workspace enum to Work
+
 ## [9.46.1] - 2026-05-25
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.46.1"
+version = "9.47.0"
 dependencies = [
  "ammonia",
  "axum",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.46.1"
+version = "9.47.0"
 dependencies = [
  "chrono",
  "dunce",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.46.1"
+version = "9.47.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.46.1"
+version = "9.47.0"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.46.1"
+version = "9.47.0"
 dependencies = [
  "dirs",
  "serde",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.46.1"
+version = "9.47.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.46.1"
+version = "9.47.0"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.46.1"
+version = "9.47.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.46.1"
+version = "9.47.0"
 dependencies = [
  "gwt-core",
  "regex",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.46.1"
+version = "9.47.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.46.1"
+version = "9.47.0"
 dependencies = [
  "gwt-core",
  "libc",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.46.1"
+version = "9.47.0"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.46.1"
+version = "9.47.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -6,6 +6,7 @@ use std::{
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::{
@@ -14,7 +15,7 @@ use crate::{
     paths::{
         gwt_project_dir_for_repo_path, gwt_workspace_journal_path_for_repo_path,
         gwt_workspace_projection_path_for_repo_path, gwt_workspace_work_events_path_for_repo_path,
-        gwt_workspace_work_items_path_for_repo_path,
+        gwt_workspace_work_items_path_for_repo_path, project_scope_hash,
     },
 };
 
@@ -37,6 +38,84 @@ pub enum WorkspaceAgentAffiliationStatus {
 
 fn default_workspace_agent_affiliation_status() -> WorkspaceAgentAffiliationStatus {
     WorkspaceAgentAffiliationStatus::Assigned
+}
+
+pub fn canonical_work_id(
+    project_root: &Path,
+    branch: Option<&str>,
+    worktree_path: Option<&Path>,
+) -> Option<String> {
+    let branch = branch.map(str::trim).filter(|value| !value.is_empty());
+    let (slug_source, identity_kind, identity_value) = if let Some(branch) = branch {
+        let identity = canonical_work_branch_identity(branch);
+        (identity.clone(), "branch", identity)
+    } else {
+        let worktree_path = worktree_path?;
+        let identity = canonical_worktree_identity(worktree_path);
+        if identity.trim().is_empty() {
+            return None;
+        }
+        let slug_source = worktree_path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or("worktree");
+        (slug_source.to_string(), "worktree", identity)
+    };
+
+    let project_hash = project_scope_hash(project_root);
+    let mut hasher = Sha256::new();
+    hasher.update(project_hash.as_str().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(identity_kind.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(identity_value.as_bytes());
+    let digest = hasher.finalize();
+    let hex_full = hex::encode(digest);
+    Some(format!(
+        "work-{}-{}",
+        canonical_work_slug(&slug_source),
+        &hex_full[..8]
+    ))
+}
+
+fn canonical_work_branch_identity(branch: &str) -> String {
+    if let Some(name) = branch.strip_prefix("refs/remotes/") {
+        return name.strip_prefix("origin/").unwrap_or(name).to_string();
+    }
+    branch.strip_prefix("origin/").unwrap_or(branch).to_string()
+}
+
+fn canonical_worktree_identity(path: &Path) -> String {
+    fs::canonicalize(path)
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+fn canonical_work_slug(value: &str) -> String {
+    let mut slug = String::new();
+    let mut previous_dash = false;
+    for ch in value.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch);
+            previous_dash = false;
+        } else if !previous_dash && !slug.is_empty() {
+            slug.push('-');
+            previous_dash = true;
+        }
+        if slug.len() >= 48 {
+            break;
+        }
+    }
+    while slug.ends_with('-') {
+        slug.pop();
+    }
+    if slug.is_empty() {
+        "work".to_string()
+    } else {
+        slug
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -4408,5 +4487,48 @@ mod tests {
             "first Done timestamp must be preserved on idempotent Done re-apply"
         );
         assert_eq!(item.updated_at, t2, "updated_at should still advance");
+    }
+
+    #[test]
+    fn canonical_work_id_is_stable_for_branch_and_uses_readable_slug() {
+        let repo = Path::new("/tmp/gwt/repo");
+
+        let first = super::canonical_work_id(repo, Some("work/20260526-0043"), None)
+            .expect("branch-derived work id");
+        let second = super::canonical_work_id(repo, Some("work/20260526-0043"), None)
+            .expect("branch-derived work id");
+
+        assert_eq!(first, second);
+        assert!(first.starts_with("work-work-20260526-0043-"));
+        assert_eq!(first.rsplit('-').next().expect("hash").len(), 8);
+    }
+
+    #[test]
+    fn canonical_work_id_changes_when_branch_or_project_changes() {
+        let repo_a = Path::new("/tmp/gwt/repo-a");
+        let repo_b = Path::new("/tmp/gwt/repo-b");
+
+        let work_a = super::canonical_work_id(repo_a, Some("work/a"), None).expect("work a");
+        let work_b = super::canonical_work_id(repo_a, Some("work/b"), None).expect("work b");
+        let same_branch_other_project =
+            super::canonical_work_id(repo_b, Some("work/a"), None).expect("work a in repo b");
+
+        assert_ne!(work_a, work_b);
+        assert_ne!(work_a, same_branch_other_project);
+    }
+
+    #[test]
+    fn canonical_work_id_normalizes_remote_branch_names() {
+        let repo = Path::new("/tmp/gwt/repo");
+
+        let local = super::canonical_work_id(repo, Some("feature/gui"), None).expect("local id");
+        let remote =
+            super::canonical_work_id(repo, Some("origin/feature/gui"), None).expect("remote id");
+        let ref_remote =
+            super::canonical_work_id(repo, Some("refs/remotes/origin/feature/gui"), None)
+                .expect("remote ref id");
+
+        assert_eq!(local, remote);
+        assert_eq!(local, ref_remote);
     }
 }

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -13379,6 +13379,48 @@ exit 1
     }
 
     #[test]
+    fn app_runtime_resume_workspace_agent_ignores_stopped_same_session_window() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "agent-1",
+            repo,
+            WindowPreset::Agent,
+            WindowProcessStatus::Stopped,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "agent-1");
+        let mut session = sample_active_agent_session("tab-1", &window_id);
+        session.session_id = "stopped-session".to_string();
+        session.window_id = window_id.clone();
+        runtime.active_agent_sessions.insert(window_id, session);
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::ResumeWorkspaceAgent {
+                session_id: "stopped-session".to_string(),
+                bounds: canvas_bounds(),
+            },
+        );
+
+        let event = events
+            .first()
+            .expect("ResumeWorkspaceAgent should proceed past stopped window");
+        assert!(matches!(
+            &event.event,
+            BackendEvent::WorkspaceResumeAgentError { session_id, message }
+                if session_id == "stopped-session" && !message.is_empty()
+        ));
+    }
+
+    #[test]
     fn app_runtime_latest_branch_resume_picks_newest_resumable_session() {
         let temp = tempdir().expect("tempdir");
         let repo = temp.path().join("repo");

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -922,6 +922,14 @@ enum AgentWindowPlacement {
     Exact(WindowGeometry),
 }
 
+impl AgentWindowPlacement {
+    fn bounds(&self) -> WindowGeometry {
+        match self {
+            Self::Centered(bounds) | Self::Exact(bounds) => bounds.clone(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ImagePasteFile {
     pub(crate) bytes: Vec<u8>,
@@ -1606,28 +1614,34 @@ fn active_work_projection_from_saved(
 fn active_work_projection_from_saved_with_journal(
     projection: gwt_core::workspace_projection::WorkspaceProjection,
     journal_entries: Vec<gwt::WorkspaceJournalEntryView>,
-    workspaces: Vec<gwt::WorkspaceHistoryView>,
+    works: Vec<gwt::WorkspaceHistoryView>,
     cleanup_candidate: Option<gwt::ActiveWorkCleanupCandidateView>,
 ) -> gwt::ActiveWorkProjectionView {
-    use gwt_core::workspace_projection::WorkspaceStatusCategory;
-
-    let active_agents = projection
-        .assigned_agents()
-        .filter(|agent| agent.status_category == WorkspaceStatusCategory::Active)
-        .count();
-    let blocked_agents = projection
-        .assigned_agents()
-        .filter(|agent| agent.status_category == WorkspaceStatusCategory::Blocked)
-        .count();
-    let agent_branch = projection
-        .assigned_agents()
-        .find_map(|agent| agent.branch.clone());
-    let agent_worktree = projection.assigned_agents().find_map(|agent| {
-        agent
-            .worktree_path
-            .as_ref()
-            .map(|path| path.display().to_string())
+    let project_root = projection.project_root.clone();
+    let mut agents = projection
+        .agents
+        .iter()
+        .filter(|agent| {
+            agent.is_assigned() || workspace_agent_summary_work_id(&project_root, agent).is_some()
+        })
+        .map(active_work_agent_view_from_summary)
+        .collect::<Vec<_>>();
+    agents.sort_by(|left, right| {
+        active_work_agent_priority_rank(left)
+            .cmp(&active_work_agent_priority_rank(right))
+            .then_with(|| left.display_name.cmp(&right.display_name))
+            .then_with(|| left.session_id.cmp(&right.session_id))
     });
+    let active_agents = agents
+        .iter()
+        .filter(|agent| agent.status_category == "active")
+        .count();
+    let blocked_agents = agents
+        .iter()
+        .filter(|agent| agent.status_category == "blocked")
+        .count();
+    let agent_branch = agents.iter().find_map(|agent| agent.branch.clone());
+    let agent_worktree = agents.iter().find_map(|agent| agent.worktree_path.clone());
     let status_category =
         workspace_status_category_wire(projection.effective_status_category()).to_string();
     let (branch, worktree_path, pr_number, pr_url, pr_state, pr_created_at) =
@@ -1648,18 +1662,12 @@ fn active_work_projection_from_saved_with_journal(
             ),
             None => (agent_branch, agent_worktree, None, None, None, None),
         };
-    let mut agents = projection
-        .assigned_agents()
-        .map(active_work_agent_view_from_summary)
-        .collect::<Vec<_>>();
-    agents.sort_by(|left, right| {
-        active_work_agent_priority_rank(left)
-            .cmp(&active_work_agent_priority_rank(right))
-            .then_with(|| left.display_name.cmp(&right.display_name))
-            .then_with(|| left.session_id.cmp(&right.session_id))
-    });
     let mut unassigned_agents = projection
-        .unassigned_agents()
+        .agents
+        .iter()
+        .filter(|agent| {
+            agent.is_unassigned() && workspace_agent_summary_work_id(&project_root, agent).is_none()
+        })
         .map(active_work_agent_view_from_summary)
         .collect::<Vec<_>>();
     unassigned_agents.sort_by(|left, right| {
@@ -1667,7 +1675,7 @@ fn active_work_projection_from_saved_with_journal(
             .cmp(&right.display_name)
             .then_with(|| left.session_id.cmp(&right.session_id))
     });
-    let active_works = active_work_items_from_projection(&projection, &agents, &workspaces);
+    let active_works = active_work_items_from_projection(&projection, &agents, &works);
     let active_work_count = active_works.len();
 
     gwt::ActiveWorkProjectionView {
@@ -1688,7 +1696,7 @@ fn active_work_projection_from_saved_with_journal(
         pr_created_at,
         board_refs: projection.board_refs,
         journal_entries,
-        workspaces,
+        works,
         cleanup_candidate,
         active_work_count,
         active_works,
@@ -1703,7 +1711,7 @@ fn empty_active_work_projection_view(
 ) -> gwt::ActiveWorkProjectionView {
     gwt::ActiveWorkProjectionView {
         id: tab_id.to_string(),
-        title: format!("{} workspace", tab.title),
+        title: format!("{} Work", tab.title),
         status_category: "idle".to_string(),
         status_text: String::new(),
         summary: None,
@@ -1719,7 +1727,7 @@ fn empty_active_work_projection_view(
         pr_created_at: None,
         board_refs: Vec::new(),
         journal_entries: Vec::new(),
-        workspaces: Vec::new(),
+        works: Vec::new(),
         cleanup_candidate: None,
         active_work_count: 0,
         active_works: Vec::new(),
@@ -1728,19 +1736,89 @@ fn empty_active_work_projection_view(
     }
 }
 
+fn workspace_agent_summary_work_id(
+    project_root: &Path,
+    agent: &gwt_core::workspace_projection::WorkspaceAgentSummary,
+) -> Option<String> {
+    gwt_core::workspace_projection::canonical_work_id(
+        project_root,
+        agent.branch.as_deref(),
+        agent.worktree_path.as_deref(),
+    )
+}
+
+fn active_work_agent_work_id(
+    project_root: &Path,
+    agent: &gwt::ActiveWorkAgentView,
+    legacy_fallback: Option<&str>,
+) -> Option<String> {
+    let worktree_path = agent.worktree_path.as_deref().map(Path::new);
+    gwt_core::workspace_projection::canonical_work_id(
+        project_root,
+        agent.branch.as_deref(),
+        worktree_path,
+    )
+    .or_else(|| {
+        agent
+            .workspace_id
+            .as_ref()
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    })
+    .or_else(|| legacy_fallback.map(str::to_string))
+}
+
+fn projection_matches_active_work(
+    projection: &gwt_core::workspace_projection::WorkspaceProjection,
+    work_id: &str,
+) -> bool {
+    projection
+        .git_details
+        .as_ref()
+        .and_then(|details| {
+            gwt_core::workspace_projection::canonical_work_id(
+                &projection.project_root,
+                details.branch.as_deref(),
+                details.worktree_path.as_deref(),
+            )
+        })
+        .as_deref()
+        == Some(work_id)
+}
+
+fn find_active_work_history<'a>(
+    work_id: &str,
+    first_agent: Option<&gwt::ActiveWorkAgentView>,
+    works: &'a [gwt::WorkspaceHistoryView],
+) -> Option<&'a gwt::WorkspaceHistoryView> {
+    works.iter().find(|item| item.id == work_id).or_else(|| {
+        works.iter().find(|item| {
+            item.execution_containers.iter().any(|container| {
+                let branch_matches = first_agent
+                    .and_then(|agent| agent.branch.as_deref())
+                    .zip(container.branch.as_deref())
+                    .is_some_and(|(left, right)| left == right);
+                let worktree_matches = first_agent
+                    .and_then(|agent| agent.worktree_path.as_deref())
+                    .zip(container.worktree_path.as_deref())
+                    .is_some_and(|(left, right)| Path::new(left) == Path::new(right));
+                branch_matches || worktree_matches
+            })
+        })
+    })
+}
+
 fn active_work_items_from_projection(
     projection: &gwt_core::workspace_projection::WorkspaceProjection,
     agents: &[gwt::ActiveWorkAgentView],
-    workspaces: &[gwt::WorkspaceHistoryView],
+    works: &[gwt::WorkspaceHistoryView],
 ) -> Vec<gwt::ActiveWorkItemView> {
     let mut grouped: Vec<(String, Vec<gwt::ActiveWorkAgentView>)> = Vec::new();
     for agent in agents {
-        let work_id = agent
-            .workspace_id
-            .as_ref()
-            .filter(|value| !value.trim().is_empty())
-            .cloned()
-            .unwrap_or_else(|| projection.id.clone());
+        let work_id =
+            active_work_agent_work_id(&projection.project_root, agent, Some(&projection.id))
+                .unwrap_or_else(|| projection.id.clone());
         if let Some((_, group_agents)) = grouped.iter_mut().find(|(id, _)| id == &work_id) {
             group_agents.push(agent.clone());
         } else {
@@ -1751,9 +1829,11 @@ fn active_work_items_from_projection(
     grouped
         .into_iter()
         .map(|(work_id, agents)| {
-            let history = workspaces.iter().find(|item| item.id == work_id);
+            let first_agent = agents.first();
+            let history = find_active_work_history(&work_id, first_agent, works);
             let container = history.and_then(|item| item.execution_containers.first());
-            let is_current_projection = work_id == projection.id;
+            let is_current_projection =
+                work_id == projection.id || projection_matches_active_work(projection, &work_id);
             let active_agents = agents
                 .iter()
                 .filter(|agent| agent.status_category == "active")
@@ -1786,8 +1866,6 @@ fn active_work_items_from_projection(
                         }
                     })
             };
-            let first_agent = agents.first();
-
             gwt::ActiveWorkItemView {
                 id: work_id.clone(),
                 title: history
@@ -2205,6 +2283,19 @@ fn active_work_agent_view_from_summary(
     }
 }
 
+fn active_agent_session_matches_work(
+    session: &ActiveAgentSession,
+    normalized_branch: Option<&str>,
+    worktree_path: Option<&Path>,
+) -> bool {
+    let branch_matches = normalized_branch
+        .is_some_and(|branch| normalize_branch_name(session.branch_name.trim()) == branch);
+    let worktree_matches = worktree_path.is_some_and(|path| {
+        same_worktree_path(&session.worktree_path, path) || session.worktree_path == path
+    });
+    branch_matches || worktree_matches
+}
+
 fn active_agent_summary_from_session(
     session: &ActiveAgentSession,
     updated_at: chrono::DateTime<chrono::Utc>,
@@ -2427,9 +2518,9 @@ fn reset_idle_workspace_current_identity(
 ) {
     let title = tab_title.trim();
     projection.title = if title.is_empty() {
-        "Project workspace".to_string()
+        "Project Work".to_string()
     } else {
-        format!("{title} workspace")
+        format!("{title} Work")
     };
     projection.status_category = gwt_core::workspace_projection::WorkspaceStatusCategory::Idle;
     projection.status_text = "No active work".to_string();
@@ -2480,6 +2571,13 @@ fn save_workspace_launch_projection(
         gwt_core::workspace_projection::load_or_default_workspace_projection(project_root)
             .map_err(|error| error.to_string())?;
     projection.project_root = project_root.to_path_buf();
+    let work_id = gwt_core::workspace_projection::canonical_work_id(
+        project_root,
+        Some(session.branch_name.as_str()),
+        Some(session.worktree_path.as_path()),
+    )
+    .unwrap_or_else(|| projection.id.clone());
+    projection.id = work_id;
     projection.title = workspace_resume_context
         .and_then(|context| non_empty_workspace_text(context.title.as_deref()))
         .unwrap_or_else(|| "Start Work".to_string());
@@ -4296,7 +4394,7 @@ impl AppRuntime {
         });
         let active_works = vec![gwt::ActiveWorkItemView {
             id: tab_id.to_string(),
-            title: format!("{} workspace", tab.title),
+            title: format!("{} Work", tab.title),
             status_category: "active".to_string(),
             status_text: if active_agents == 1 {
                 "1 active agent".to_string()
@@ -4338,7 +4436,7 @@ impl AppRuntime {
             pr_created_at: None,
             board_refs: Vec::new(),
             journal_entries: Vec::new(),
-            workspaces: Vec::new(),
+            works: Vec::new(),
             cleanup_candidate: None,
             active_work_count: active_works.len(),
             active_works,
@@ -7083,6 +7181,52 @@ impl AppRuntime {
         )
     }
 
+    pub(crate) fn live_agent_window_for_work(
+        &self,
+        tab_id: &str,
+        branch: Option<&str>,
+        worktree_path: Option<&Path>,
+    ) -> Option<String> {
+        let normalized_branch = branch
+            .map(normalize_branch_name)
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        self.active_agent_sessions
+            .iter()
+            .find(|(window_id, session)| {
+                session.tab_id == tab_id
+                    && self.window_lookup.contains_key(window_id.as_str())
+                    && self
+                        .window_status(window_id.as_str())
+                        .is_some_and(|status| {
+                            !matches!(
+                                status,
+                                WindowProcessStatus::Stopped | WindowProcessStatus::Error
+                            )
+                        })
+                    && active_agent_session_matches_work(
+                        session,
+                        normalized_branch.as_deref(),
+                        worktree_path,
+                    )
+            })
+            .map(|(window_id, _)| window_id.clone())
+    }
+
+    pub(crate) fn focus_existing_live_work_agent_events(
+        &mut self,
+        window_id: &str,
+        bounds: Option<WindowGeometry>,
+    ) -> Vec<OutboundEvent> {
+        let mut events = self.restore_window_events(window_id);
+        events.extend(self.focus_window_events(window_id, bounds));
+        if events.is_empty() {
+            vec![self.workspace_state_broadcast()]
+        } else {
+            events
+        }
+    }
+
     fn spawn_agent_window_with_placement(
         &mut self,
         tab_id: &str,
@@ -7091,6 +7235,15 @@ impl AppRuntime {
         workspace_resume_context: Option<WorkspaceResumeContext>,
         launch_feedback_context: Option<LaunchFeedbackContext>,
     ) -> Result<Vec<OutboundEvent>, String> {
+        if let Some(window_id) = self.live_agent_window_for_work(
+            tab_id,
+            config.branch.as_deref(),
+            config.working_dir.as_deref(),
+        ) {
+            return Ok(
+                self.focus_existing_live_work_agent_events(&window_id, Some(placement.bounds()))
+            );
+        }
         let issue_link_cache_dir = self.issue_link_cache_dir.clone();
         let tab = self
             .tab_mut(tab_id)
@@ -7195,7 +7348,7 @@ impl AppRuntime {
 
             proxy.send(UserEvent::LaunchProgress {
                 window_id: window_id.clone(),
-                message: "Configuring workspace...".to_string(),
+                message: "Configuring work...".to_string(),
             });
             let worktree_path = gwt_core::paths::normalize_windows_child_process_path(
                 &config
@@ -7251,10 +7404,7 @@ impl AppRuntime {
             install_launch_gwt_bin_env(&mut config.env_vars, config.runtime_target)?;
             apply_windows_host_shell_wrapper(&mut config)?;
 
-            let branch_name = config
-                .branch
-                .clone()
-                .unwrap_or_else(|| "workspace".to_string());
+            let branch_name = config.branch.clone().unwrap_or_else(|| "work".to_string());
 
             let agent_id = config.agent_id.clone();
             let mut session =
@@ -11642,9 +11792,9 @@ exit 1
             matches!(
                 events.first().map(|event| &event.event),
                 Some(BackendEvent::LaunchWizardOpenError { title, message })
-                    if title == "Resume Workspace" && !message.is_empty()
+                    if title == "Resume Work" && !message.is_empty()
             ),
-            "Resume failure must surface as LaunchWizardOpenError so Workspace Overview can render a visible overlay"
+            "Resume failure must surface as LaunchWizardOpenError so Work Overview can render a visible overlay"
         );
     }
 
@@ -11669,7 +11819,7 @@ exit 1
         assert!(matches!(
             events.first().map(|event| &event.event),
             Some(BackendEvent::LaunchWizardOpenError { title, message })
-                if title == "Resume Workspace"
+                if title == "Resume Work"
                     && message == "Open a project before resuming work"
         ));
     }
@@ -12148,7 +12298,7 @@ exit 1
             WorkspaceResumeContext {
                 title: Some("Suspended review".to_string()),
                 owner: Some("SPEC-2359".to_string()),
-                summary: Some("Resume the suspended Workspace card.".to_string()),
+                summary: Some("Resume the suspended Work card.".to_string()),
                 next_action: Some("Resume the review".to_string()),
             },
         );
@@ -12199,7 +12349,7 @@ exit 1
         assert_eq!(projection.owner.as_deref(), Some("SPEC-2359"));
         assert_eq!(
             projection.summary.as_deref(),
-            Some("Resume the suspended Workspace card.")
+            Some("Resume the suspended Work card.")
         );
         assert_eq!(projection.next_action.as_deref(), Some("Resume the review"));
         assert_eq!(details.branch.as_deref(), Some("work/20260507-0001"));
@@ -12329,10 +12479,10 @@ exit 1
             OutboundEvent {
                 target: DispatchTarget::Broadcast,
                 event: BackendEvent::ActiveWorkProjection { projection },
-            } if projection.active_agents == 0
-                && projection.agents.is_empty()
-                && projection.unassigned_agents.len() == 2
-                && projection.branch.is_none()
+            } if projection.active_agents == 2
+                && projection.active_work_count == 2
+                && projection.agents.len() == 2
+                && projection.unassigned_agents.is_empty()
         )));
     }
 
@@ -12351,12 +12501,14 @@ exit 1
         projection.agents.push({
             let mut agent = workspace_agent_summary_for_test("session-a", Some("work-a"));
             agent.window_id = Some("tab-1::agent-a".to_string());
+            agent.branch = Some("work/a".to_string());
             agent.title_summary = Some("Parser cleanup".to_string());
             agent
         });
         projection.agents.push({
             let mut agent = workspace_agent_summary_for_test("session-b", Some("work-b"));
             agent.window_id = Some("tab-1::agent-b".to_string());
+            agent.branch = Some("work/b".to_string());
             agent.title_summary = Some("UI polish".to_string());
             agent
         });
@@ -12364,17 +12516,24 @@ exit 1
             .expect("save projection");
         let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
-        for (window_id, session_id) in [
-            ("tab-1::agent-a", "session-a"),
-            ("tab-1::agent-b", "session-b"),
+        for (window_id, session_id, branch) in [
+            ("tab-1::agent-a", "session-a", "work/a"),
+            ("tab-1::agent-b", "session-b", "work/b"),
         ] {
             let mut session = sample_active_agent_session("tab-1", window_id);
             session.session_id = session_id.to_string();
+            session.branch_name = branch.to_string();
             session.window_id = window_id.to_string();
             runtime
                 .active_agent_sessions
                 .insert(window_id.to_string(), session);
         }
+        let expected_a =
+            gwt_core::workspace_projection::canonical_work_id(&repo, Some("work/a"), None)
+                .expect("work a id");
+        let expected_b =
+            gwt_core::workspace_projection::canonical_work_id(&repo, Some("work/b"), None)
+                .expect("work b id");
 
         let view = runtime
             .active_work_projection_for_tab("tab-1", &runtime.tabs[0])
@@ -12384,12 +12543,12 @@ exit 1
         assert_eq!(view.active_works.len(), 2);
         assert_eq!(view.active_works[0].agents.len(), 1);
         assert_eq!(view.active_works[1].agents.len(), 1);
-        assert!(view.active_works.iter().any(|work| work.id == "work-a"
+        assert!(view.active_works.iter().any(|work| work.id == expected_a
             && work
                 .agents
                 .iter()
                 .any(|agent| agent.session_id == "session-a")));
-        assert!(view.active_works.iter().any(|work| work.id == "work-b"
+        assert!(view.active_works.iter().any(|work| work.id == expected_b
             && work
                 .agents
                 .iter()
@@ -12414,6 +12573,7 @@ exit 1
         ] {
             let mut agent = workspace_agent_summary_for_test(session_id, Some("work-shared"));
             agent.window_id = Some(window_id.to_string());
+            agent.branch = Some("work/shared".to_string());
             projection.agents.push(agent);
         }
         gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
@@ -12426,11 +12586,15 @@ exit 1
         ] {
             let mut session = sample_active_agent_session("tab-1", window_id);
             session.session_id = session_id.to_string();
+            session.branch_name = "work/shared".to_string();
             session.window_id = window_id.to_string();
             runtime
                 .active_agent_sessions
                 .insert(window_id.to_string(), session);
         }
+        let expected_work_id =
+            gwt_core::workspace_projection::canonical_work_id(&repo, Some("work/shared"), None)
+                .expect("shared work id");
 
         let view = runtime
             .active_work_projection_for_tab("tab-1", &runtime.tabs[0])
@@ -12438,12 +12602,155 @@ exit 1
 
         assert_eq!(view.active_work_count, 1);
         assert_eq!(view.active_works.len(), 1);
-        assert_eq!(view.active_works[0].id, "work-shared");
+        assert_eq!(view.active_works[0].id, expected_work_id);
         assert_eq!(view.active_works[0].agents.len(), 2);
     }
 
     #[test]
-    fn app_runtime_active_work_projection_keeps_unassigned_agents_out_of_active_works() {
+    fn app_runtime_active_work_projection_uses_branch_derived_work_id_over_workspace_id() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let expected_work_id =
+            gwt_core::workspace_projection::canonical_work_id(&repo, Some("work/test"), None)
+                .expect("canonical work id");
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+        projection.agents.push({
+            let mut agent = workspace_agent_summary_for_test("session-a", Some("legacy-work-id"));
+            agent.window_id = Some("tab-1::agent-a".to_string());
+            agent.branch = Some("work/test".to_string());
+            agent.title_summary = Some("Parser cleanup".to_string());
+            agent
+        });
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+        let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let mut session = sample_active_agent_session("tab-1", "tab-1::agent-a");
+        session.session_id = "session-a".to_string();
+        session.branch_name = "work/test".to_string();
+        session.window_id = "tab-1::agent-a".to_string();
+        runtime
+            .active_agent_sessions
+            .insert(session.window_id.clone(), session);
+
+        let view = runtime
+            .active_work_projection_for_tab("tab-1", &runtime.tabs[0])
+            .expect("projection view");
+
+        assert_eq!(view.active_work_count, 1);
+        assert_eq!(view.active_works[0].id, expected_work_id);
+        assert_ne!(view.active_works[0].id, "legacy-work-id");
+    }
+
+    #[test]
+    fn app_runtime_active_work_projection_resolves_branch_known_unassigned_agents_as_work() {
+        let _env_guard = env_test_lock().lock().expect("env lock");
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+        projection.register_unassigned_agent({
+            let mut agent = workspace_agent_summary_for_test("session-unassigned", None);
+            agent.window_id = Some("tab-1::agent-unassigned".to_string());
+            agent.branch = Some("work/unassigned-but-known".to_string());
+            agent
+        });
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+        let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let mut session = sample_active_agent_session("tab-1", "tab-1::agent-unassigned");
+        session.session_id = "session-unassigned".to_string();
+        session.branch_name = "work/unassigned-but-known".to_string();
+        runtime
+            .active_agent_sessions
+            .insert(session.window_id.clone(), session);
+
+        let view = runtime
+            .active_work_projection_for_tab("tab-1", &runtime.tabs[0])
+            .expect("projection view");
+
+        assert_eq!(view.active_work_count, 1);
+        assert_eq!(view.active_works.len(), 1);
+        assert_eq!(view.active_works[0].agents.len(), 1);
+        assert!(view.unassigned_agents.is_empty());
+    }
+
+    #[test]
+    fn app_runtime_open_active_work_launch_wizard_focuses_existing_agent_for_branch() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "agent-1",
+            repo,
+            WindowPreset::Agent,
+            WindowProcessStatus::Running,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "agent-1");
+        let mut session = sample_active_agent_session("tab-1", &window_id);
+        session.branch_name = "work/test".to_string();
+        session.window_id = window_id.clone();
+        runtime
+            .active_agent_sessions
+            .insert(window_id.clone(), session);
+
+        let events = runtime.open_active_work_launch_wizard("client-1", "work/test", None);
+
+        assert!(runtime.launch_wizard.is_none());
+        assert!(events.iter().any(|event| matches!(
+            event,
+            OutboundEvent {
+                target: DispatchTarget::Broadcast,
+                event: BackendEvent::WorkspaceState { .. },
+            }
+        )));
+    }
+
+    #[test]
+    fn app_runtime_live_work_agent_lookup_ignores_stopped_or_error_windows() {
+        for status in [WindowProcessStatus::Stopped, WindowProcessStatus::Error] {
+            let temp = tempdir().expect("tempdir");
+            let repo = temp.path().join("repo");
+            fs::create_dir_all(&repo).expect("create repo");
+            let tab = sample_project_tab_with_window_at(
+                "tab-1",
+                "agent-1",
+                repo,
+                WindowPreset::Agent,
+                status,
+            );
+            let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+            let window_id = combined_window_id("tab-1", "agent-1");
+            let mut session = sample_active_agent_session("tab-1", &window_id);
+            session.branch_name = "work/test".to_string();
+            session.window_id = window_id.clone();
+            runtime
+                .active_agent_sessions
+                .insert(window_id.clone(), session);
+
+            assert_eq!(
+                runtime.live_agent_window_for_work("tab-1", Some("work/test"), None),
+                None,
+                "{status:?} windows must not block a later launch"
+            );
+        }
+    }
+
+    #[test]
+    fn app_runtime_active_work_projection_promotes_branch_known_unassigned_agents_to_active_work() {
         let _env_guard = env_test_lock().lock().expect("env lock");
         let temp = tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", temp.path());
@@ -12471,9 +12778,10 @@ exit 1
             .active_work_projection_for_tab("tab-1", &runtime.tabs[0])
             .expect("projection view");
 
-        assert_eq!(view.active_work_count, 0);
-        assert!(view.active_works.is_empty());
-        assert_eq!(view.unassigned_agents.len(), 1);
+        assert_eq!(view.active_work_count, 1);
+        assert_eq!(view.active_works.len(), 1);
+        assert_eq!(view.active_works[0].agents.len(), 1);
+        assert!(view.unassigned_agents.is_empty());
     }
 
     #[test]
@@ -12657,7 +12965,7 @@ exit 1
             .active_work_projection_for_tab("tab-1", &runtime.tabs[0])
             .expect("projection view");
 
-        assert_eq!(view.title, "Repo workspace");
+        assert_eq!(view.title, "Repo Work");
         assert_eq!(view.status_category, "idle");
         assert_eq!(view.status_text, "No active work");
         assert_eq!(view.summary, None);
@@ -12810,7 +13118,7 @@ exit 1
             "journal-reuse",
             temp.path().join("work").join("20260507-0001"),
             "SPEC-2359",
-            "Resume the suspended Workspace card.",
+            "Resume the suspended Work card.",
         );
         assert_eq!(
             super::workspace_resume_branch_from_journal_project_root(
@@ -12843,7 +13151,7 @@ exit 1
         assert_eq!(context.owner.as_deref(), Some("SPEC-2359"));
         assert_eq!(
             context.summary.as_deref(),
-            Some("Resume the suspended Workspace card.")
+            Some("Resume the suspended Work card.")
         );
     }
 
@@ -14155,7 +14463,7 @@ exit 1
             .workspace_resume_context
             .as_ref()
             .expect("workspace resume context");
-        assert_eq!(context.title.as_deref(), Some("Repo workspace"));
+        assert_eq!(context.title.as_deref(), Some("Repo Work"));
         assert_eq!(context.owner, None);
         assert_eq!(context.summary, None);
     }

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -9694,6 +9694,42 @@ exit 1
         panic!("timed out waiting for {label}: {snapshot:?}");
     }
 
+    fn resolve_launch_wizard_runtime_confirmation(
+        runtime: &mut AppRuntime,
+        recorded_events: &Arc<Mutex<Vec<UserEvent>>>,
+        label: &str,
+    ) {
+        let events = runtime.handle_launch_wizard_action(LaunchWizardAction::Submit, None);
+        assert_eq!(events.len(), 1);
+        let pending_view = runtime
+            .launch_wizard
+            .as_ref()
+            .expect("wizard")
+            .wizard
+            .view();
+        assert!(pending_view.runtime_resolution_pending);
+        assert!(!pending_view.runtime_context_resolved);
+
+        wait_for_recorded_event(label, recorded_events, |events| {
+            events
+                .iter()
+                .any(|event| matches!(event, UserEvent::LaunchWizardRuntimeResolved { .. }))
+        });
+        let resolved_event = {
+            let mut events = recorded_events.lock().expect("event log");
+            events
+                .iter()
+                .position(|event| matches!(event, UserEvent::LaunchWizardRuntimeResolved { .. }))
+                .map(|index| events.remove(index))
+                .expect("runtime resolved event")
+        };
+        let UserEvent::LaunchWizardRuntimeResolved { wizard_id, result } = resolved_event else {
+            unreachable!("matched above")
+        };
+        let resolved_events = runtime.handle_launch_wizard_runtime_resolved(wizard_id, *result);
+        assert_eq!(resolved_events.len(), 1);
+    }
+
     fn wait_for_path(label: &str, path: &Path) {
         for _ in 0..800 {
             if path.exists() {
@@ -9906,6 +9942,41 @@ exit 1
         run_git(repo, &["config", "user.email", "codex@example.com"]);
         run_git(repo, &["remote", "set-head", "origin", "-a"]);
         origin
+    }
+
+    fn init_managed_workspace_with_develop_worktree(workspace_home: &Path) -> (PathBuf, PathBuf) {
+        fs::create_dir_all(workspace_home).expect("create workspace home");
+        let seed = workspace_home.join(".seed");
+        let bare_repo = workspace_home.join("repo.git");
+        let develop_worktree = workspace_home.join("develop");
+
+        fs::create_dir_all(&seed).expect("create seed");
+        run_git(&seed, &["init", "-q", "-b", "develop"]);
+        run_git(&seed, &["config", "user.name", "Codex"]);
+        run_git(&seed, &["config", "user.email", "codex@example.com"]);
+        fs::write(seed.join("README.md"), "repo\n").expect("seed readme");
+        run_git(&seed, &["add", "README.md"]);
+        run_git(&seed, &["commit", "-qm", "init"]);
+        run_git_with_paths(&["clone", "--bare"], &[&seed, &bare_repo]);
+
+        let develop_arg = develop_worktree.to_string_lossy().to_string();
+        let output = gwt_core::process::hidden_command("git")
+            .args(["worktree", "add", "-q", &develop_arg, "develop"])
+            .current_dir(&bare_repo)
+            .output()
+            .expect("git worktree add develop");
+        assert!(
+            output.status.success(),
+            "git worktree add develop failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        run_git(&develop_worktree, &["config", "user.name", "Codex"]);
+        run_git(
+            &develop_worktree,
+            &["config", "user.email", "codex@example.com"],
+        );
+
+        (bare_repo, develop_worktree)
     }
 
     fn append_workspace_resume_journal(
@@ -10943,6 +11014,126 @@ exit 1
         assert!(view.show_runtime_target);
         assert_eq!(view.selected_runtime_target, "docker");
         assert_eq!(view.selected_docker_service.as_deref(), Some("app"));
+    }
+
+    #[test]
+    fn app_runtime_start_work_parent_root_uses_develop_checkout_for_docker_context() {
+        let temp = tempdir().expect("tempdir");
+        let workspace_home = temp.path().join("workspace");
+        let (bare_repo, develop_worktree) =
+            init_managed_workspace_with_develop_worktree(&workspace_home);
+        fs::write(
+            develop_worktree.join("docker-compose.yml"),
+            "services:\n  gwt:\n    image: alpine:3.20\n",
+        )
+        .expect("compose");
+
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            workspace_home.clone(),
+            ProjectKind::Git,
+            &[WindowPreset::Branches],
+        );
+        let (mut runtime, recorded_events) =
+            sample_runtime_with_events(temp.path(), vec![tab], Some("tab-1"));
+
+        runtime
+            .open_start_work_for_project("tab-1", &workspace_home)
+            .expect("open start work");
+        let branch_name = runtime
+            .launch_wizard
+            .as_ref()
+            .expect("wizard")
+            .wizard
+            .context
+            .normalized_branch_name
+            .clone();
+        let expected_worktree = gwt_git::worktree::sibling_worktree_path(&bare_repo, &branch_name);
+        assert!(
+            !expected_worktree.exists(),
+            "fixture branch worktree should start absent"
+        );
+
+        resolve_launch_wizard_runtime_confirmation(
+            &mut runtime,
+            &recorded_events,
+            "start work parent root docker context",
+        );
+
+        let wizard = &runtime.launch_wizard.as_ref().expect("wizard").wizard;
+        assert!(
+            wizard.context.worktree_path.is_none(),
+            "Runtime confirmation must not resolve a missing target worktree"
+        );
+        assert!(
+            !expected_worktree.exists(),
+            "Runtime confirmation must not create {expected_worktree:?}"
+        );
+        let view = wizard.view();
+        assert!(!view.runtime_resolution_pending);
+        assert!(view.runtime_context_resolved);
+        assert!(view.show_runtime_target);
+        assert_eq!(view.selected_runtime_target, "docker");
+        assert_eq!(view.selected_docker_service.as_deref(), Some("gwt"));
+    }
+
+    #[test]
+    fn app_runtime_start_work_parent_root_preserves_saved_host_while_showing_runtime_target() {
+        let temp = tempdir().expect("tempdir");
+        let workspace_home = temp.path().join("workspace");
+        let (_bare_repo, develop_worktree) =
+            init_managed_workspace_with_develop_worktree(&workspace_home);
+        fs::write(
+            develop_worktree.join("docker-compose.yml"),
+            "services:\n  gwt:\n    image: alpine:3.20\n",
+        )
+        .expect("compose");
+
+        let sessions_dir = temp.path().join("sessions");
+        fs::create_dir_all(&sessions_dir).expect("create sessions dir");
+        let mut session =
+            gwt_agent::Session::new(&develop_worktree, "develop", gwt_agent::AgentId::Codex);
+        session.runtime_target = gwt_agent::LaunchRuntimeTarget::Host;
+        session.docker_service = None;
+        session.save(&sessions_dir).expect("save session");
+
+        let tab = sample_project_tab(
+            "tab-1",
+            "Repo",
+            workspace_home.clone(),
+            ProjectKind::Git,
+            &[WindowPreset::Branches],
+        );
+        let (mut runtime, recorded_events) =
+            sample_runtime_with_events(temp.path(), vec![tab], Some("tab-1"));
+
+        runtime
+            .open_start_work_for_project("tab-1", &workspace_home)
+            .expect("open start work");
+        resolve_launch_wizard_runtime_confirmation(
+            &mut runtime,
+            &recorded_events,
+            "start work parent root saved host",
+        );
+
+        let view = runtime
+            .launch_wizard
+            .as_ref()
+            .expect("wizard")
+            .wizard
+            .view();
+        assert!(view.runtime_context_resolved);
+        assert!(view.show_runtime_target);
+        assert_eq!(view.selected_runtime_target, "host");
+        assert!(view.selected_docker_service.is_none());
+        assert_eq!(
+            view.docker_service_options
+                .iter()
+                .map(|option| option.value.as_str())
+                .collect::<Vec<_>>(),
+            vec!["gwt"]
+        );
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -3075,7 +3075,13 @@ impl AppRuntime {
                 .keys()
                 .cloned()
                 .collect::<std::collections::HashSet<_>>();
-            let geometry = startup_auto_resume_window_geometry(index, total, bounds.clone());
+            let stale_geometry = self.remove_stale_paused_agent_window(
+                &pending_session.tab_id,
+                &pending_session.session.id,
+            );
+            let geometry = stale_geometry.unwrap_or_else(|| {
+                startup_auto_resume_window_geometry(index, total, bounds.clone())
+            });
             match self.spawn_agent_window_at_geometry(
                 &pending_session.tab_id,
                 config,
@@ -3103,6 +3109,31 @@ impl AppRuntime {
             }
         }
         events
+    }
+
+    fn remove_stale_paused_agent_window(
+        &mut self,
+        tab_id: &str,
+        session_id: &str,
+    ) -> Option<WindowGeometry> {
+        let tab = self.tab_mut(tab_id)?;
+        let stale = tab
+            .workspace
+            .persisted()
+            .windows
+            .iter()
+            .find(|w| {
+                w.preset == WindowPreset::Agent
+                    && w.status == WindowProcessStatus::Stopped
+                    && w.session_id.as_deref() == Some(session_id)
+            })
+            .map(|w| (w.id.clone(), w.geometry.clone()));
+        let (raw_id, geometry) = stale?;
+        tab.workspace.close_window(&raw_id);
+        let combined = combined_window_id(tab_id, &raw_id);
+        self.window_lookup.remove(&combined);
+        self.window_details.remove(&combined);
+        Some(geometry)
     }
 
     fn auto_resume_tab_id_for_session(&self, session: &gwt_agent::Session) -> Option<String> {
@@ -6478,6 +6509,11 @@ impl AppRuntime {
                     &session_id_for_restore,
                     true,
                 );
+                if let Some(tab) = self.tab_mut(&tab_id) {
+                    let _ = tab
+                        .workspace
+                        .set_session_id(&address.raw_id, Some(session_id_for_restore.clone()));
+                }
                 if let Some(source_session_id) = auto_resume_source_session_id {
                     mark_auto_resume_source_completed(&self.sessions_dir, &source_session_id);
                 }
@@ -6933,11 +6969,11 @@ impl AppRuntime {
         let window = match placement {
             AgentWindowPlacement::Centered(bounds) => {
                 tab.workspace
-                    .add_window_with_title(WindowPreset::Agent, title, false, bounds)
+                    .add_window_with_title(WindowPreset::Agent, title, true, bounds)
             }
             AgentWindowPlacement::Exact(geometry) => tab
                 .workspace
-                .add_window_at_geometry_with_title(WindowPreset::Agent, title, false, geometry),
+                .add_window_at_geometry_with_title(WindowPreset::Agent, title, true, geometry),
         };
         if let Some(purpose_title) = purpose_title {
             let _ = tab
@@ -8922,6 +8958,7 @@ exit 1
             agent_color: None,
             tab_group_id: None,
             tab_group_active: false,
+            session_id: None,
         }
     }
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -5109,7 +5109,7 @@ impl AppRuntime {
             )];
         };
 
-        if window.preset != WindowPreset::Branches && window.preset != WindowPreset::Workspace {
+        if window.preset != WindowPreset::Branches && window.preset != WindowPreset::Work {
             return vec![OutboundEvent::reply(
                 client_id,
                 BackendEvent::BranchError {

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1667,6 +1667,8 @@ fn active_work_projection_from_saved_with_journal(
             .cmp(&right.display_name)
             .then_with(|| left.session_id.cmp(&right.session_id))
     });
+    let active_works = active_work_items_from_projection(&projection, &agents, &workspaces);
+    let active_work_count = active_works.len();
 
     gwt::ActiveWorkProjectionView {
         id: projection.id,
@@ -1688,6 +1690,8 @@ fn active_work_projection_from_saved_with_journal(
         journal_entries,
         workspaces,
         cleanup_candidate,
+        active_work_count,
+        active_works,
         agents,
         unassigned_agents,
     }
@@ -1717,9 +1721,160 @@ fn empty_active_work_projection_view(
         journal_entries: Vec::new(),
         workspaces: Vec::new(),
         cleanup_candidate: None,
+        active_work_count: 0,
+        active_works: Vec::new(),
         agents: Vec::new(),
         unassigned_agents: Vec::new(),
     }
+}
+
+fn active_work_items_from_projection(
+    projection: &gwt_core::workspace_projection::WorkspaceProjection,
+    agents: &[gwt::ActiveWorkAgentView],
+    workspaces: &[gwt::WorkspaceHistoryView],
+) -> Vec<gwt::ActiveWorkItemView> {
+    let mut grouped: Vec<(String, Vec<gwt::ActiveWorkAgentView>)> = Vec::new();
+    for agent in agents {
+        let work_id = agent
+            .workspace_id
+            .as_ref()
+            .filter(|value| !value.trim().is_empty())
+            .cloned()
+            .unwrap_or_else(|| projection.id.clone());
+        if let Some((_, group_agents)) = grouped.iter_mut().find(|(id, _)| id == &work_id) {
+            group_agents.push(agent.clone());
+        } else {
+            grouped.push((work_id, vec![agent.clone()]));
+        }
+    }
+
+    grouped
+        .into_iter()
+        .map(|(work_id, agents)| {
+            let history = workspaces.iter().find(|item| item.id == work_id);
+            let container = history.and_then(|item| item.execution_containers.first());
+            let is_current_projection = work_id == projection.id;
+            let active_agents = agents
+                .iter()
+                .filter(|agent| agent.status_category == "active")
+                .count();
+            let blocked_agents = agents
+                .iter()
+                .filter(|agent| agent.status_category == "blocked")
+                .count();
+            let status_category = if blocked_agents > 0 {
+                "blocked".to_string()
+            } else if active_agents > 0 {
+                "active".to_string()
+            } else if let Some(history) = history {
+                history.status_category.clone()
+            } else {
+                workspace_status_category_wire(projection.effective_status_category()).to_string()
+            };
+            let status_text = if is_current_projection {
+                projection.status_text.clone()
+            } else {
+                history
+                    .and_then(|item| item.summary.clone().or_else(|| item.intent.clone()))
+                    .unwrap_or_else(|| {
+                        if blocked_agents > 0 {
+                            format!("{blocked_agents} blocked agents")
+                        } else if active_agents == 1 {
+                            "1 active agent".to_string()
+                        } else {
+                            format!("{} active agents", agents.len())
+                        }
+                    })
+            };
+            let first_agent = agents.first();
+
+            gwt::ActiveWorkItemView {
+                id: work_id.clone(),
+                title: history
+                    .map(|item| item.title.clone())
+                    .filter(|value| !value.trim().is_empty())
+                    .or_else(|| is_current_projection.then(|| projection.title.clone()))
+                    .or_else(|| first_agent.and_then(|agent| agent.title_summary.clone()))
+                    .or_else(|| first_agent.and_then(|agent| agent.current_focus.clone()))
+                    .unwrap_or(work_id),
+                status_category,
+                status_text,
+                summary: history
+                    .and_then(|item| item.summary.clone().or_else(|| item.intent.clone()))
+                    .or_else(|| {
+                        is_current_projection
+                            .then(|| projection.summary.clone())
+                            .flatten()
+                    }),
+                owner: history.and_then(|item| item.owner.clone()).or_else(|| {
+                    is_current_projection
+                        .then(|| projection.owner.clone())
+                        .flatten()
+                }),
+                next_action: if is_current_projection {
+                    projection.next_action.clone()
+                } else {
+                    None
+                },
+                active_agents,
+                blocked_agents,
+                branch: if is_current_projection {
+                    projection
+                        .git_details
+                        .as_ref()
+                        .and_then(|details| details.branch.clone())
+                } else {
+                    container
+                        .and_then(|value| value.branch.clone())
+                        .or_else(|| first_agent.and_then(|agent| agent.branch.clone()))
+                },
+                worktree_path: if is_current_projection {
+                    projection.git_details.as_ref().and_then(|details| {
+                        details
+                            .worktree_path
+                            .as_ref()
+                            .map(|path| path.display().to_string())
+                    })
+                } else {
+                    container
+                        .and_then(|value| value.worktree_path.clone())
+                        .or_else(|| first_agent.and_then(|agent| agent.worktree_path.clone()))
+                },
+                pr_number: if is_current_projection {
+                    projection
+                        .git_details
+                        .as_ref()
+                        .and_then(|details| details.pr_number)
+                } else {
+                    container.and_then(|value| value.pr_number)
+                },
+                pr_url: if is_current_projection {
+                    projection
+                        .git_details
+                        .as_ref()
+                        .and_then(|details| details.pr_url.clone())
+                } else {
+                    container.and_then(|value| value.pr_url.clone())
+                },
+                pr_state: if is_current_projection {
+                    projection
+                        .git_details
+                        .as_ref()
+                        .and_then(|details| details.pr_state.clone())
+                } else {
+                    container.and_then(|value| value.pr_state.clone())
+                },
+                board_refs: if is_current_projection {
+                    projection.board_refs.clone()
+                } else {
+                    history
+                        .map(|item| item.board_refs.clone())
+                        .unwrap_or_default()
+                },
+                agents,
+            }
+        })
+        .collect()
 }
 
 fn active_work_cleanup_candidate_view_from_candidate(
@@ -4139,6 +4294,28 @@ impl AppRuntime {
                 .cmp(&right.display_name)
                 .then_with(|| left.session_id.cmp(&right.session_id))
         });
+        let active_works = vec![gwt::ActiveWorkItemView {
+            id: tab_id.to_string(),
+            title: format!("{} workspace", tab.title),
+            status_category: "active".to_string(),
+            status_text: if active_agents == 1 {
+                "1 active agent".to_string()
+            } else {
+                format!("{active_agents} active agents")
+            },
+            summary: None,
+            owner: None,
+            next_action: Some("Check Board for latest updates".to_string()),
+            active_agents,
+            blocked_agents: 0,
+            branch: Some(first.branch_name.clone()),
+            worktree_path: Some(first.worktree_path.display().to_string()),
+            pr_number: None,
+            pr_url: None,
+            pr_state: None,
+            board_refs: Vec::new(),
+            agents: agents.clone(),
+        }];
         Some(gwt::ActiveWorkProjectionView {
             id: tab_id.to_string(),
             title: format!("{} workspace", tab.title),
@@ -4163,6 +4340,8 @@ impl AppRuntime {
             journal_entries: Vec::new(),
             workspaces: Vec::new(),
             cleanup_candidate: None,
+            active_work_count: active_works.len(),
+            active_works,
             agents,
             unassigned_agents: Vec::new(),
         })
@@ -12155,6 +12334,146 @@ exit 1
                 && projection.unassigned_agents.len() == 2
                 && projection.branch.is_none()
         )));
+    }
+
+    #[test]
+    fn app_runtime_active_work_projection_groups_live_assigned_agents_by_work_id() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+        projection.agents.push({
+            let mut agent = workspace_agent_summary_for_test("session-a", Some("work-a"));
+            agent.window_id = Some("tab-1::agent-a".to_string());
+            agent.title_summary = Some("Parser cleanup".to_string());
+            agent
+        });
+        projection.agents.push({
+            let mut agent = workspace_agent_summary_for_test("session-b", Some("work-b"));
+            agent.window_id = Some("tab-1::agent-b".to_string());
+            agent.title_summary = Some("UI polish".to_string());
+            agent
+        });
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+        let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        for (window_id, session_id) in [
+            ("tab-1::agent-a", "session-a"),
+            ("tab-1::agent-b", "session-b"),
+        ] {
+            let mut session = sample_active_agent_session("tab-1", window_id);
+            session.session_id = session_id.to_string();
+            session.window_id = window_id.to_string();
+            runtime
+                .active_agent_sessions
+                .insert(window_id.to_string(), session);
+        }
+
+        let view = runtime
+            .active_work_projection_for_tab("tab-1", &runtime.tabs[0])
+            .expect("projection view");
+
+        assert_eq!(view.active_work_count, 2);
+        assert_eq!(view.active_works.len(), 2);
+        assert_eq!(view.active_works[0].agents.len(), 1);
+        assert_eq!(view.active_works[1].agents.len(), 1);
+        assert!(view.active_works.iter().any(|work| work.id == "work-a"
+            && work
+                .agents
+                .iter()
+                .any(|agent| agent.session_id == "session-a")));
+        assert!(view.active_works.iter().any(|work| work.id == "work-b"
+            && work
+                .agents
+                .iter()
+                .any(|agent| agent.session_id == "session-b")));
+    }
+
+    #[test]
+    fn app_runtime_active_work_projection_groups_multiple_agents_in_one_work_row() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+        for (session_id, window_id) in [
+            ("session-a", "tab-1::agent-a"),
+            ("session-b", "tab-1::agent-b"),
+        ] {
+            let mut agent = workspace_agent_summary_for_test(session_id, Some("work-shared"));
+            agent.window_id = Some(window_id.to_string());
+            projection.agents.push(agent);
+        }
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+        let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        for (window_id, session_id) in [
+            ("tab-1::agent-a", "session-a"),
+            ("tab-1::agent-b", "session-b"),
+        ] {
+            let mut session = sample_active_agent_session("tab-1", window_id);
+            session.session_id = session_id.to_string();
+            session.window_id = window_id.to_string();
+            runtime
+                .active_agent_sessions
+                .insert(window_id.to_string(), session);
+        }
+
+        let view = runtime
+            .active_work_projection_for_tab("tab-1", &runtime.tabs[0])
+            .expect("projection view");
+
+        assert_eq!(view.active_work_count, 1);
+        assert_eq!(view.active_works.len(), 1);
+        assert_eq!(view.active_works[0].id, "work-shared");
+        assert_eq!(view.active_works[0].agents.len(), 2);
+    }
+
+    #[test]
+    fn app_runtime_active_work_projection_keeps_unassigned_agents_out_of_active_works() {
+        let _env_guard = env_test_lock().lock().expect("env lock");
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+        projection.register_unassigned_agent({
+            let mut agent = workspace_agent_summary_for_test("session-unassigned", None);
+            agent.window_id = Some("tab-1::agent-unassigned".to_string());
+            agent
+        });
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
+            .expect("save projection");
+        let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let mut session = sample_active_agent_session("tab-1", "tab-1::agent-unassigned");
+        session.session_id = "session-unassigned".to_string();
+        runtime
+            .active_agent_sessions
+            .insert(session.window_id.clone(), session);
+
+        let view = runtime
+            .active_work_projection_for_tab("tab-1", &runtime.tabs[0])
+            .expect("projection view");
+
+        assert_eq!(view.active_work_count, 0);
+        assert!(view.active_works.is_empty());
+        assert_eq!(view.unassigned_agents.len(), 1);
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -1149,7 +1149,7 @@ impl AppRuntime {
                             };
                         match spawn_result {
                             Ok(mut events) => {
-                                events.push(self.launch_wizard_state_broadcast(None));
+                                events.insert(0, self.launch_wizard_state_broadcast(None));
                                 events
                             }
                             Err(error) => {
@@ -1169,7 +1169,7 @@ impl AppRuntime {
                     LaunchWizardLaunchRequest::Shell(config) => {
                         match self.spawn_wizard_shell_window(&session.tab_id, *config, bounds) {
                             Ok(mut events) => {
-                                events.push(self.launch_wizard_state_broadcast(None));
+                                events.insert(0, self.launch_wizard_state_broadcast(None));
                                 events
                             }
                             Err(error) => {

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -1257,17 +1257,44 @@ fn launch_runtime_context_paths(
     project_root: &Path,
     branch_name: &str,
 ) -> (PathBuf, Option<PathBuf>) {
-    if let Some(worktree_path) = existing_launch_worktree_path(project_root, branch_name) {
+    let worktrees = launch_runtime_worktrees(project_root);
+    if let Some(worktree_path) = worktrees
+        .as_deref()
+        .and_then(|worktrees| usable_worktree_path_for_branch(worktrees, branch_name))
+    {
         return (worktree_path.clone(), Some(worktree_path));
+    }
+    if project_root_is_git_worktree(project_root) {
+        return (project_root.to_path_buf(), None);
+    }
+    if let Some(default_worktree_path) = worktrees
+        .as_deref()
+        .and_then(default_runtime_detection_worktree_path)
+    {
+        return (default_worktree_path, None);
     }
     (project_root.to_path_buf(), None)
 }
 
-fn existing_launch_worktree_path(project_root: &Path, branch_name: &str) -> Option<PathBuf> {
+fn launch_runtime_worktrees(project_root: &Path) -> Option<Vec<gwt_git::WorktreeInfo>> {
     let main_repo_path = gwt_git::worktree::main_worktree_root(project_root).ok()?;
-    let manager = gwt_git::WorktreeManager::new(&main_repo_path);
-    let worktrees = manager.list().ok()?;
-    usable_worktree_path_for_branch(&worktrees, branch_name)
+    gwt_git::WorktreeManager::new(&main_repo_path).list().ok()
+}
+
+fn project_root_is_git_worktree(project_root: &Path) -> bool {
+    let output = gwt_core::process::hidden_command("git")
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .current_dir(project_root)
+        .output();
+    output.is_ok_and(|output| {
+        output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "true"
+    })
+}
+
+fn default_runtime_detection_worktree_path(worktrees: &[gwt_git::WorktreeInfo]) -> Option<PathBuf> {
+    ["develop", "main"]
+        .iter()
+        .find_map(|branch| usable_worktree_path_for_branch(worktrees, branch))
 }
 
 impl AppRuntime {

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -507,7 +507,19 @@ impl AppRuntime {
         if let Some(window_id) = self
             .active_agent_sessions
             .iter()
-            .find(|(_, session)| session.session_id == session_id && session.tab_id == tab_id)
+            .find(|(window_id, session)| {
+                session.session_id == session_id
+                    && session.tab_id == tab_id
+                    && self.window_lookup.contains_key(window_id.as_str())
+                    && self
+                        .window_status(window_id.as_str())
+                        .is_some_and(|status| {
+                            !matches!(
+                                status,
+                                WindowProcessStatus::Stopped | WindowProcessStatus::Error
+                            )
+                        })
+            })
             .map(|(window_id, _)| window_id.clone())
         {
             return self.focus_existing_live_work_agent_events(&window_id, Some(bounds));

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -283,6 +283,9 @@ impl AppRuntime {
         }
 
         let project_root = tab.project_root.clone();
+        if let Some(window_id) = self.live_agent_window_for_work(&tab_id, Some(branch_name), None) {
+            return self.focus_existing_live_work_agent_events(&window_id, None);
+        }
         match self.open_launch_wizard_for_branch(
             &tab_id,
             &project_root,
@@ -340,13 +343,8 @@ impl AppRuntime {
         // legacy `ProjectOpenError` broadcast, which the frontend renders only
         // on the project picker overlay and is therefore invisible while a
         // project tab is already open.
-        let error_event = |message: &str| {
-            vec![launch_wizard_open_error(
-                client_id,
-                "Resume Workspace",
-                message,
-            )]
-        };
+        let error_event =
+            |message: &str| vec![launch_wizard_open_error(client_id, "Resume Work", message)];
 
         let Some(tab_id) = self.active_tab_id.clone() else {
             return error_event("Open a project before resuming work");
@@ -355,7 +353,7 @@ impl AppRuntime {
             return error_event("Project tab not found");
         };
         if tab.kind != gwt::ProjectKind::Git {
-            return error_event("Resume Workspace requires a Git project");
+            return error_event("Resume Work requires a Git project");
         }
         // SPEC-1934 US-7 / FR-034
         if tab.migration_pending {
@@ -391,7 +389,7 @@ impl AppRuntime {
                     .as_ref()
                     .map(workspace_resume_context_from_projection)
                     .unwrap_or_else(|| WorkspaceResumeContext {
-                        title: Some(format!("{tab_title} workspace")),
+                        title: Some(format!("{tab_title} Work")),
                         owner: None,
                         summary: None,
                         next_action: None,
@@ -400,7 +398,7 @@ impl AppRuntime {
             }
             gwt::WorkspaceResumeSource::Journal => {
                 let Some(journal_id) = journal_id else {
-                    return error_event("Workspace journal id is required");
+                    return error_event("Work journal id is required");
                 };
                 let Ok(entries) =
                     gwt_core::workspace_projection::load_recent_workspace_journal_entries(
@@ -408,10 +406,10 @@ impl AppRuntime {
                         WORKSPACE_OVERVIEW_JOURNAL_LIMIT,
                     )
                 else {
-                    return error_event("Workspace journal could not be loaded");
+                    return error_event("Work journal could not be loaded");
                 };
                 let Some(entry) = entries.into_iter().find(|entry| entry.id == journal_id) else {
-                    return error_event("Workspace journal entry not found");
+                    return error_event("Work journal entry not found");
                 };
                 (
                     workspace_resume_branch_from_journal_project_root(
@@ -429,6 +427,11 @@ impl AppRuntime {
             .filter(|branch| !branch.trim().is_empty())
         {
             if workspace_resume_branch_exists(&project_root, &branch_name) {
+                if let Some(window_id) =
+                    self.live_agent_window_for_work(&tab_id, Some(&branch_name), None)
+                {
+                    return self.focus_existing_live_work_agent_events(&window_id, None);
+                }
                 let linked_issue_number =
                     workspace_resume_owner_issue_number(context.owner.as_deref());
                 return match self.open_launch_wizard_for_branch_with_context(
@@ -501,15 +504,13 @@ impl AppRuntime {
             );
         }
 
-        // Reject double-spawn: if this session id is already live in this
-        // tab, surface a visible error so the picker can keep its modal
-        // open and the user can pick a different entry.
-        if self
+        if let Some(window_id) = self
             .active_agent_sessions
-            .values()
-            .any(|session| session.session_id == session_id && session.tab_id == tab_id)
+            .iter()
+            .find(|(_, session)| session.session_id == session_id && session.tab_id == tab_id)
+            .map(|(window_id, _)| window_id.clone())
         {
-            return reply_error("That agent is already running".to_string());
+            return self.focus_existing_live_work_agent_events(&window_id, Some(bounds));
         }
 
         let sessions_dir = self.sessions_dir.clone();
@@ -523,6 +524,13 @@ impl AppRuntime {
                 );
             }
         };
+        if let Some(window_id) = self.live_agent_window_for_work(
+            &tab_id,
+            (!session.branch.trim().is_empty()).then_some(session.branch.as_str()),
+            Some(session.worktree_path.as_path()),
+        ) {
+            return self.focus_existing_live_work_agent_events(&window_id, Some(bounds));
+        }
 
         // Build a fresh LaunchConfig from the persisted Session and add the
         // resume_session_id only when the agent CLI captured a previous
@@ -641,6 +649,11 @@ impl AppRuntime {
         let tab_id = address.tab_id.clone();
         let project_root = tab.project_root.clone();
         let normalized_branch_name = normalize_branch_name(branch_name);
+        if let Some(window_id) =
+            self.live_agent_window_for_work(&tab_id, Some(&normalized_branch_name), None)
+        {
+            return self.focus_existing_live_work_agent_events(&window_id, Some(bounds.clone()));
+        }
         let Some(session) =
             self.latest_resumable_branch_session(&project_root, &normalized_branch_name)
         else {
@@ -1284,7 +1297,7 @@ impl AppRuntime {
         let title = format!(
             "{} · {}",
             config.display_name,
-            config.branch.as_ref().unwrap_or(&"workspace".to_string())
+            config.branch.as_ref().unwrap_or(&"work".to_string())
         );
         let window = tab
             .workspace

--- a/crates/gwt/src/board_view.rs
+++ b/crates/gwt/src/board_view.rs
@@ -114,6 +114,7 @@ mod tests {
             agent_color: None,
             tab_group_id: None,
             tab_group_active: false,
+            session_id: None,
         }
     }
 

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -545,6 +545,7 @@ pub fn should_dispatch_cli(args: &[String]) -> bool {
                     | "register"
                     | "daemon"
                     | "workspace"
+                    | "work"
                     | "pane"
             )
         })

--- a/crates/gwt/src/cli/hook/runtime_state.rs
+++ b/crates/gwt/src/cli/hook/runtime_state.rs
@@ -55,7 +55,7 @@ pub fn status_for_event(event: &str) -> Option<&'static str> {
 /// to `path`. On success, no `.tmp-*` siblings remain.
 pub fn write_for_event(path: &Path, event: &str) -> Result<(), HookError> {
     let sessions_dir = gwt_core::paths::gwt_sessions_dir();
-    let session = current_session_from_env(&sessions_dir)?;
+    let session = current_session_from_env(&sessions_dir);
     let pending_discussion = session.as_ref().and_then(|session| {
         pending_discussion_for_session(&sessions_dir, &session.id)
             .ok()
@@ -105,22 +105,26 @@ fn pending_discussion_for_session(
     load_pending_resume(&session.worktree_path)
 }
 
-fn current_session_from_env(sessions_dir: &Path) -> io::Result<Option<Session>> {
-    let Some(session_id) = GwtSessionId::from_env() else {
-        return Ok(None);
-    };
+fn current_session_from_env(sessions_dir: &Path) -> Option<Session> {
+    let session_id = GwtSessionId::from_env()?;
     current_session_for_id(sessions_dir, &session_id)
 }
 
-fn current_session_for_id(
-    sessions_dir: &Path,
-    gwt_session_id: &GwtSessionId,
-) -> io::Result<Option<Session>> {
+fn current_session_for_id(sessions_dir: &Path, gwt_session_id: &GwtSessionId) -> Option<Session> {
     let path = sessions_dir.join(format!("{}.toml", gwt_session_id.as_str()));
     if !path.exists() {
-        return Ok(None);
+        return None;
     }
-    Session::load_and_migrate(&path).map(Some)
+    match Session::load_and_migrate(&path) {
+        Ok(session) => Some(session),
+        Err(error) => {
+            eprintln!(
+                "gwtd hook runtime-state: failed to load session metadata {}: {error}",
+                path.display()
+            );
+            None
+        }
+    }
 }
 
 fn sync_agent_session_id(
@@ -197,7 +201,7 @@ pub fn handle_with_input(event: &str, input: &str) -> Result<(), HookError> {
     };
     let sessions_dir = sessions_dir_for_runtime_path(&runtime_path);
     let gwt_session_id = GwtSessionId::required_from_env(event)?;
-    let session = current_session_for_id(&sessions_dir, &gwt_session_id)?;
+    let session = current_session_for_id(&sessions_dir, &gwt_session_id);
     let agent_session_id = validated_hook_agent_session_id(
         event,
         &gwt_session_id,
@@ -240,7 +244,7 @@ pub fn record_blocked_stop_from_env() -> Result<(), HookError> {
     };
     let runtime_path = PathBuf::from(runtime_path);
     let sessions_dir = sessions_dir_for_runtime_path(&runtime_path);
-    let session = current_session_for_id(&sessions_dir, &gwt_session_id)?;
+    let session = current_session_for_id(&sessions_dir, &gwt_session_id);
     if session.is_some() {
         persist_session_status(&sessions_dir, gwt_session_id.as_str(), AgentStatus::Running)?;
     }
@@ -422,6 +426,29 @@ mod tests {
         assert_eq!(status_for_event("PreToolUse"), Some("Running"));
         assert_eq!(status_for_event("PostToolUse"), Some("Running"));
         assert_eq!(status_for_event("Stop"), Some("Idle"));
+    }
+
+    #[test]
+    fn handle_with_input_ignores_corrupt_session_metadata() {
+        let _lock = env_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let sessions_dir = dir.path().join("sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+        std::fs::write(sessions_dir.join("session-corrupt.toml"), "odex\"").unwrap();
+        let runtime_path = gwt_agent::runtime_state_path(&sessions_dir, "session-corrupt");
+        let mut env = EnvGuard::new();
+        env.set(GWT_SESSION_ID_ENV, "session-corrupt");
+        env.set(
+            gwt_agent::GWT_SESSION_RUNTIME_PATH_ENV,
+            runtime_path.as_os_str(),
+        );
+
+        handle_with_input("PostToolUse", "{}").expect("corrupt metadata must not fail the hook");
+
+        let raw = std::fs::read_to_string(&runtime_path).unwrap();
+        let state: RuntimeState = serde_json::from_str(&raw).unwrap();
+        assert_eq!(state.status, "Running");
+        assert_eq!(state.source_event, "PostToolUse");
     }
 
     #[test]

--- a/crates/gwt/src/cli/pane.rs
+++ b/crates/gwt/src/cli/pane.rs
@@ -445,6 +445,7 @@ mod tests {
             agent_color: None,
             tab_group_id: None,
             tab_group_active: false,
+            session_id: None,
         }
     }
 

--- a/crates/gwt/src/daemon_runtime.rs
+++ b/crates/gwt/src/daemon_runtime.rs
@@ -1,4 +1,4 @@
-use std::{io, path::PathBuf, time::Duration};
+use std::{path::PathBuf, time::Duration};
 
 use chrono::{SecondsFormat, Utc};
 use gwt_agent::{
@@ -93,7 +93,7 @@ pub fn handle_runtime_state(event: &str, input: &str) -> Result<(), HookError> {
         Some(event),
         runtime_state::status_for_event(event).map(str::to_string),
         None,
-        current_session_from_env()?,
+        current_session_from_env(),
         parse_hook_event_best_effort(input),
     ));
     Ok(())
@@ -109,7 +109,7 @@ pub fn handle_blocked_stop_runtime_state(input: &str) -> Result<(), HookError> {
         Some("Stop"),
         Some("Running".to_string()),
         Some("blocked-stop".to_string()),
-        current_session_from_env()?,
+        current_session_from_env(),
         parse_hook_event_best_effort(input),
     ));
     Ok(())
@@ -122,7 +122,7 @@ pub fn handle_coordination_event(event: &str, input: &str) -> Result<(), HookErr
         Some(event),
         None,
         Some(format!("coordination:{event}")),
-        current_session_from_env()?,
+        current_session_from_env(),
         parse_hook_event_best_effort(input),
     ));
     Ok(())
@@ -135,7 +135,7 @@ pub fn handle_forward(input: &str) -> Result<(), HookError> {
         None,
         None,
         None,
-        current_session_from_env()?,
+        current_session_from_env(),
         parse_hook_event_best_effort(input),
     ));
     Ok(())
@@ -243,17 +243,24 @@ fn parse_hook_event_best_effort(input: &str) -> Option<RawHookEvent> {
     RawHookEvent::read_from_str(input).ok().flatten()
 }
 
-fn current_session_from_env() -> io::Result<Option<Session>> {
-    let Some(session_id) = std::env::var_os(GWT_SESSION_ID_ENV) else {
-        return Ok(None);
-    };
+fn current_session_from_env() -> Option<Session> {
+    let session_id = std::env::var_os(GWT_SESSION_ID_ENV)?;
     let sessions_dir =
         session_dir_from_runtime_path_env().unwrap_or_else(gwt_core::paths::gwt_sessions_dir);
     let path = sessions_dir.join(format!("{}.toml", session_id.to_string_lossy()));
     if !path.exists() {
-        return Ok(None);
+        return None;
     }
-    Session::load_and_migrate(&path).map(Some)
+    match Session::load_and_migrate(&path) {
+        Ok(session) => Some(session),
+        Err(error) => {
+            eprintln!(
+                "gwtd hook live event: failed to load session metadata {}: {error}",
+                path.display()
+            );
+            None
+        }
+    }
 }
 
 fn session_dir_from_runtime_path_env() -> Option<PathBuf> {
@@ -268,6 +275,44 @@ fn is_loopback_host(host: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    struct ScopedEnvVar {
+        key: &'static str,
+        previous: Option<OsString>,
+    }
+
+    impl ScopedEnvVar {
+        fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for ScopedEnvVar {
+        fn drop(&mut self) {
+            if let Some(previous) = self.previous.as_ref() {
+                std::env::set_var(self.key, previous);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
 
     #[test]
     fn loopback_target_rejects_remote_hosts() {
@@ -288,5 +333,25 @@ mod tests {
         };
 
         target.validate().expect("loopback target");
+    }
+
+    #[test]
+    fn forward_hook_ignores_corrupt_session_metadata() {
+        let _env_lock = env_test_lock();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sessions_dir = dir.path().join("sessions");
+        std::fs::create_dir_all(&sessions_dir).expect("sessions dir");
+        std::fs::write(sessions_dir.join("session-1.toml"), "odex\"")
+            .expect("corrupt session file");
+        let runtime_path = sessions_dir
+            .join("runtime")
+            .join("42")
+            .join("session-1.json");
+        let _session_id = ScopedEnvVar::set(GWT_SESSION_ID_ENV, "session-1");
+        let _runtime_path = ScopedEnvVar::set(GWT_SESSION_RUNTIME_PATH_ENV, &runtime_path);
+        let _forward_url = ScopedEnvVar::unset(GWT_HOOK_FORWARD_URL_ENV);
+        let _forward_token = ScopedEnvVar::unset(GWT_HOOK_FORWARD_TOKEN_ENV);
+
+        handle_forward("{}").expect("forward hook remains fail-open");
     }
 }

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -2562,9 +2562,9 @@ mod tests {
     fn embedded_web_active_work_uses_short_title_summary_before_long_focus_detail() {
         let html = frontend_bundle_source();
         let active_work_block = html
-            .split("function renderActiveWorkOverview()")
+            .split("function renderActiveWorkAgentCard(agent)")
             .nth(1)
-            .and_then(|tail| tail.split("function mapAgentTelemetryState").next())
+            .and_then(|tail| tail.split("function formatActiveWorkLifecycleLabel").next())
             .expect("active work render block");
 
         assert!(

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -2992,7 +2992,7 @@ mod tests {
 
         assert!(
             html.contains("Open a project")
-                && html.contains("Restore previous workspaces or choose a new folder.")
+                && html.contains("Restore previous work or choose a new folder.")
                 && html.contains("Launch Agent")
                 && html.contains("Connected")
                 && html.contains("Reconnecting"),

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -3429,7 +3429,7 @@ mod tests {
             (WindowSurface::Logs, "logs"),
             (WindowSurface::Knowledge, "knowledge"),
             (WindowSurface::Index, "index"),
-            (WindowSurface::Workspace, "workspace"),
+            (WindowSurface::Work, "work"),
             (WindowSurface::Mock, "mock"),
         ];
 
@@ -3447,8 +3447,8 @@ mod tests {
         }
 
         assert!(
-            js.contains("preset === \"branches\"") && js.contains("return \"workspace\";"),
-            "expected JS `presetSurface()` to route branches preset to workspace surface",
+            js.contains("preset === \"branches\"") && js.contains("return \"work\";"),
+            "expected JS `presetSurface()` to route branches preset to work surface",
         );
     }
 

--- a/crates/gwt/src/launch_wizard_runtime.rs
+++ b/crates/gwt/src/launch_wizard_runtime.rs
@@ -45,7 +45,7 @@ impl AppRuntime {
         };
 
         if window.preset != WindowPreset::Branches
-            && window.preset != WindowPreset::Workspace
+            && window.preset != WindowPreset::Work
         {
             return vec![OutboundEvent::broadcast(BackendEvent::BranchError {
                 id: id.to_string(),

--- a/crates/gwt/src/launch_wizard_runtime.rs
+++ b/crates/gwt/src/launch_wizard_runtime.rs
@@ -344,7 +344,7 @@ impl AppRuntime {
                 LaunchWizardLaunchRequest::Agent(config) => {
                     match self.spawn_agent_window(&session.tab_id, *config, bounds) {
                         Ok(mut events) => {
-                            events.push(self.launch_wizard_state_broadcast(None));
+                            events.insert(0, self.launch_wizard_state_broadcast(None));
                             events
                         }
                         Err(error) => {
@@ -357,7 +357,7 @@ impl AppRuntime {
                 LaunchWizardLaunchRequest::Shell(config) => {
                     match self.spawn_wizard_shell_window(&session.tab_id, *config, bounds) {
                         Ok(mut events) => {
-                            events.push(self.launch_wizard_state_broadcast(None));
+                            events.insert(0, self.launch_wizard_state_broadcast(None));
                             events
                         }
                         Err(error) => {

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -124,15 +124,15 @@ pub use preset::{
     WindowPreset, WindowSurface,
 };
 pub use protocol::{
-    ActiveWorkAgentView, ActiveWorkCleanupCandidateView, ActiveWorkProjectionView, AppStateView,
-    ArrangeMode, BackendEvent, BranchEntriesPhase, CustomAgentErrorCode, FileAttachment,
-    FileContentErrorKind, FileContentMode, FileContentSaveErrorKind, FocusCycleDirection,
-    FrontendEvent, GitHubRepositorySearchResultView, IndexSearchMatchMode, IndexSearchResult,
-    IndexSearchScope, IndexSearchTarget, ProfileEntryView, ProfileEnvEntryView,
-    ProfileSnapshotView, ProjectTabView, RecentProjectView, RunningAgentSummary, UiTraceEntry,
-    UiTracePayload, WorkspaceExecutionContainerView, WorkspaceHistoryAgentView,
-    WorkspaceHistoryEventView, WorkspaceHistoryView, WorkspaceJournalEntryView,
-    WorkspaceResumeSource, WorkspaceView, WorkspaceWorkAgentView, WorkspaceWorkEventView,
-    WorkspaceWorkItemView,
+    ActiveWorkAgentView, ActiveWorkCleanupCandidateView, ActiveWorkItemView,
+    ActiveWorkProjectionView, AppStateView, ArrangeMode, BackendEvent, BranchEntriesPhase,
+    CustomAgentErrorCode, FileAttachment, FileContentErrorKind, FileContentMode,
+    FileContentSaveErrorKind, FocusCycleDirection, FrontendEvent, GitHubRepositorySearchResultView,
+    IndexSearchMatchMode, IndexSearchResult, IndexSearchScope, IndexSearchTarget, ProfileEntryView,
+    ProfileEnvEntryView, ProfileSnapshotView, ProjectTabView, RecentProjectView,
+    RunningAgentSummary, UiTraceEntry, UiTracePayload, WorkspaceExecutionContainerView,
+    WorkspaceHistoryAgentView, WorkspaceHistoryEventView, WorkspaceHistoryView,
+    WorkspaceJournalEntryView, WorkspaceResumeSource, WorkspaceView, WorkspaceWorkAgentView,
+    WorkspaceWorkEventView, WorkspaceWorkItemView,
 };
 pub use workspace::WorkspaceState;

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2441,14 +2441,14 @@ mod tests {
             .raw_id
             .clone();
         assert!(
-            runtime
+            !runtime
                 .tab("tab-1")
                 .expect("tab")
                 .workspace
                 .window(&file_tree_raw_id)
                 .expect("window")
                 .maximized,
-            "non-agent windows should be maximized on create"
+            "windows should not be auto-maximized on create"
         );
 
         assert_eq!(
@@ -2563,7 +2563,7 @@ mod tests {
                 .window(&board_raw_id)
                 .expect("board window")
                 .maximized,
-            "pre-existing Board windows can be restored from normal floating persistence",
+            "Board windows should not auto-maximize",
         );
         assert_eq!(
             runtime
@@ -2572,14 +2572,14 @@ mod tests {
             1
         );
         assert!(
-            runtime
+            !runtime
                 .tab("tab-1")
                 .expect("tab")
                 .workspace
                 .window(&board_raw_id)
                 .expect("board window")
                 .maximized,
-            "focusing a Board window with viewport bounds should maximize it",
+            "focusing a window should not auto-maximize it",
         );
 
         let shell_id = window_id_for_preset(&runtime, "tab-1", WindowPreset::Shell, 0);
@@ -2603,7 +2603,7 @@ mod tests {
                 .window(&shell_raw_id)
                 .expect("shell window")
                 .maximized,
-            "agent-capable terminal windows should keep their normal floating size",
+            "shell windows should keep their normal floating size",
         );
 
         for preset in [
@@ -2614,7 +2614,7 @@ mod tests {
             WindowPreset::Logs,
             WindowPreset::Issue,
             WindowPreset::Spec,
-            WindowPreset::Workspace,
+            WindowPreset::Work,
             WindowPreset::Pr,
         ] {
             assert_eq!(
@@ -2635,11 +2635,9 @@ mod tests {
                 .workspace
                 .window(&raw_id)
                 .expect("window");
-            assert!(window.maximized, "{id} should open maximized");
-            assert_eq!(window.geometry.x, 24.0);
-            assert_eq!(window.geometry.y, 24.0);
-            assert_eq!(window.geometry.width, 1352.0);
-            assert_eq!(window.geometry.height, 852.0);
+            assert!(!window.maximized, "{id} should not be auto-maximized");
+            assert_eq!(window.geometry.width, 720.0);
+            assert_eq!(window.geometry.height, 420.0);
         }
     }
 

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1272,6 +1272,7 @@ mod tests {
             agent_color: None,
             tab_group_id: None,
             tab_group_active: false,
+            session_id: None,
         }
     }
 

--- a/crates/gwt/src/persistence.rs
+++ b/crates/gwt/src/persistence.rs
@@ -98,6 +98,8 @@ pub struct PersistedWindowState {
     /// Marks the visible tab inside a tab group. Ignored for ungrouped windows.
     #[serde(default)]
     pub tab_group_active: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -194,6 +196,7 @@ pub fn default_workspace_state() -> PersistedWorkspaceState {
                 agent_color: None,
                 tab_group_id: None,
                 tab_group_active: false,
+                session_id: None,
             },
             PersistedWindowState {
                 id: "codex-1".to_string(),
@@ -219,6 +222,7 @@ pub fn default_workspace_state() -> PersistedWorkspaceState {
                 agent_color: None,
                 tab_group_id: None,
                 tab_group_active: false,
+                session_id: None,
             },
         ],
         next_z_index: 3,
@@ -559,6 +563,7 @@ mod tests {
                     agent_color: None,
                     tab_group_id: None,
                     tab_group_active: false,
+                    session_id: None,
                 },
                 PersistedWindowState {
                     id: "branches-1".to_string(),
@@ -584,6 +589,7 @@ mod tests {
                     agent_color: None,
                     tab_group_id: None,
                     tab_group_active: false,
+                    session_id: None,
                 },
             ],
             next_z_index: 6,
@@ -692,6 +698,92 @@ mod tests {
     }
 
     #[test]
+    fn persisted_window_state_round_trips_session_id() {
+        let mut window = default_workspace_state().windows.remove(0);
+        window.session_id = Some("sess-abc-123".to_string());
+
+        let json = serde_json::to_string(&window).expect("serialize");
+        assert!(
+            json.contains("\"session_id\""),
+            "session_id must persist for auto-resume deduplication"
+        );
+
+        let parsed: PersistedWindowState = serde_json::from_str(&json).expect("parse");
+        assert_eq!(parsed.session_id.as_deref(), Some("sess-abc-123"));
+    }
+
+    #[test]
+    fn persisted_window_state_omits_session_id_when_none() {
+        let window = default_workspace_state().windows.remove(0);
+        assert!(window.session_id.is_none());
+
+        let json = serde_json::to_string(&window).expect("serialize");
+        assert!(
+            !json.contains("session_id"),
+            "session_id must be omitted when None to keep legacy payloads clean"
+        );
+    }
+
+    #[test]
+    fn persisted_window_state_defaults_missing_session_id() {
+        let json = r#"{
+  "id": "agent-1",
+  "title": "Agent",
+  "preset": "agent",
+  "geometry": { "x": 0.0, "y": 0.0, "width": 720.0, "height": 420.0 },
+  "z_index": 1,
+  "status": "running",
+  "persist": true
+}"#;
+        let parsed: PersistedWindowState = serde_json::from_str(json).expect("parse legacy");
+        assert!(
+            parsed.session_id.is_none(),
+            "legacy payloads without session_id must default to None"
+        );
+    }
+
+    #[test]
+    fn pause_process_windows_for_restore_pauses_agent_windows() {
+        let mut state = PersistedWorkspaceState {
+            viewport: default_canvas_viewport(),
+            windows: vec![PersistedWindowState {
+                id: "agent-1".to_string(),
+                title: "Agent".to_string(),
+                preset: WindowPreset::Agent,
+                geometry: WindowGeometry {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 720.0,
+                    height: 420.0,
+                },
+                geometry_revision: 0,
+                z_index: 1,
+                status: WindowProcessStatus::Running,
+                minimized: false,
+                maximized: false,
+                pre_maximize_geometry: None,
+                persist: true,
+                purpose_title: None,
+                dynamic_title: None,
+                dynamic_title_detail: None,
+                agent_id: Some("claude".into()),
+                agent_color: None,
+                tab_group_id: None,
+                tab_group_active: false,
+                session_id: Some("sess-1".into()),
+            }],
+            next_z_index: 2,
+        };
+
+        pause_process_windows_for_restore(&mut state);
+        assert_eq!(
+            state.windows[0].status,
+            WindowState::Stopped,
+            "Agent windows must be paused on restore"
+        );
+    }
+
+    #[test]
     fn persisted_window_state_defaults_missing_geometry_revision() {
         let json = r#"{
   "id": "terminal-1",
@@ -769,6 +861,7 @@ mod tests {
             agent_color: Some(AgentColor::Yellow),
             tab_group_id: None,
             tab_group_active: false,
+            session_id: None,
         };
         let json = serde_json::to_string(&original).expect("serialize");
         assert!(
@@ -840,6 +933,7 @@ mod tests {
                     agent_color: None,
                     tab_group_id: None,
                     tab_group_active: false,
+                    session_id: None,
                 },
                 PersistedWindowState {
                     id: "file-tree-1".to_string(),
@@ -865,6 +959,7 @@ mod tests {
                     agent_color: None,
                     tab_group_id: None,
                     tab_group_active: false,
+                    session_id: None,
                 },
             ],
             next_z_index: 3,
@@ -1075,6 +1170,7 @@ mod tests {
                     agent_color: None,
                     tab_group_id: None,
                     tab_group_active: false,
+                    session_id: None,
                 },
                 PersistedWindowState {
                     id: "branches-1".to_string(),
@@ -1100,6 +1196,7 @@ mod tests {
                     agent_color: None,
                     tab_group_id: None,
                     tab_group_active: false,
+                    session_id: None,
                 },
             ],
             next_z_index: 3,

--- a/crates/gwt/src/preset.rs
+++ b/crates/gwt/src/preset.rs
@@ -20,7 +20,8 @@ pub enum WindowPreset {
     Logs,
     Issue,
     Spec,
-    Workspace,
+    #[serde(alias = "workspace")]
+    Work,
     Index,
     Board,
     Pr,
@@ -40,7 +41,7 @@ pub enum WindowSurface {
     Logs,
     Knowledge,
     Index,
-    Workspace,
+    Work,
     Console,
     Mock,
 }
@@ -60,7 +61,7 @@ impl WindowSurface {
             Self::Logs => "logs",
             Self::Knowledge => "knowledge",
             Self::Index => "index",
-            Self::Workspace => "workspace",
+            Self::Work => "work",
             Self::Console => "console",
             Self::Mock => "mock",
         }
@@ -79,7 +80,7 @@ impl WindowPreset {
         WindowPreset::Logs,
         WindowPreset::Issue,
         WindowPreset::Spec,
-        WindowPreset::Workspace,
+        WindowPreset::Work,
         WindowPreset::Index,
         WindowPreset::Board,
         WindowPreset::Pr,
@@ -100,7 +101,7 @@ impl WindowPreset {
             Self::Logs => "Logs",
             Self::Issue => "Issue",
             Self::Spec => "SPEC",
-            Self::Workspace => "Work",
+            Self::Work => "Work",
             Self::Index => "Index",
             Self::Board => "Board",
             Self::Pr => "PR",
@@ -122,7 +123,7 @@ impl WindowPreset {
             Self::Logs => "Placeholder logs surface",
             Self::Issue => "Placeholder issue surface",
             Self::Spec => "Placeholder SPEC surface",
-            Self::Workspace => "Work overview",
+            Self::Work => "Work overview",
             Self::Index => "Search indexed project knowledge",
             Self::Board => "Placeholder board surface",
             Self::Pr => "Placeholder PR surface",
@@ -144,7 +145,7 @@ impl WindowPreset {
             Self::Logs => "logs",
             Self::Issue => "issue",
             Self::Spec => "spec",
-            Self::Workspace => "workspace",
+            Self::Work => "work",
             Self::Index => "index",
             Self::Board => "board",
             Self::Pr => "pr",
@@ -162,7 +163,7 @@ impl WindowPreset {
             Self::Logs => WindowSurface::Logs,
             Self::Board => WindowSurface::Board,
             Self::Issue | Self::Spec | Self::Pr => WindowSurface::Knowledge,
-            Self::Workspace => WindowSurface::Workspace,
+            Self::Work => WindowSurface::Work,
             Self::Index => WindowSurface::Index,
             Self::Console => WindowSurface::Console,
             Self::Settings => WindowSurface::Mock,
@@ -174,22 +175,13 @@ impl WindowPreset {
     }
 
     pub fn default_size(self) -> (f64, f64) {
-        match self.surface() {
-            WindowSurface::Terminal => (720.0, 420.0),
-            WindowSurface::FileTree => (420.0, 520.0),
-            WindowSurface::Branches => (520.0, 420.0),
-            WindowSurface::Knowledge => (560.0, 420.0),
-            WindowSurface::Index => (760.0, 520.0),
-            WindowSurface::Workspace => (1040.0, 680.0),
-            WindowSurface::Profile | WindowSurface::Logs => (560.0, 420.0),
-            WindowSurface::Board => (520.0, 480.0),
-            WindowSurface::Console => (720.0, 420.0),
-            WindowSurface::Mock => (420.0, 300.0),
-        }
+        let _ = self;
+        (720.0, 420.0)
     }
 
     pub fn opens_maximized_by_default(self) -> bool {
-        !self.requires_process() && !self.is_removed_legacy()
+        let _ = self;
+        false
     }
 
     pub fn command_name(self) -> Option<&'static str> {
@@ -206,7 +198,7 @@ impl WindowPreset {
             | Self::Logs
             | Self::Issue
             | Self::Spec
-            | Self::Workspace
+            | Self::Work
             | Self::Index
             | Self::Board
             | Self::Pr
@@ -352,7 +344,7 @@ where
         | WindowPreset::Logs
         | WindowPreset::Issue
         | WindowPreset::Spec
-        | WindowPreset::Workspace
+        | WindowPreset::Work
         | WindowPreset::Index
         | WindowPreset::Board
         | WindowPreset::Pr
@@ -478,11 +470,11 @@ mod tests {
         assert_eq!(WindowPreset::ALL.len(), 15);
         assert_eq!(WindowPreset::Issue.title(), "Issue");
         assert_eq!(WindowPreset::Spec.title(), "SPEC");
-        assert_eq!(WindowPreset::Workspace.title(), "Work");
+        assert_eq!(WindowPreset::Work.title(), "Work");
         assert_eq!(WindowPreset::Index.title(), "Index");
         assert_eq!(WindowPreset::Pr.title(), "PR");
         assert_eq!(WindowPreset::Board.id_prefix(), "board");
-        assert_eq!(WindowPreset::Workspace.id_prefix(), "workspace");
+        assert_eq!(WindowPreset::Work.id_prefix(), "work");
         assert_eq!(WindowPreset::Index.id_prefix(), "index");
         assert_eq!(WindowPreset::Agent.id_prefix(), "agent");
         assert_eq!(WindowPreset::Profile.surface(), WindowSurface::Profile);
@@ -490,43 +482,19 @@ mod tests {
         assert_eq!(WindowPreset::Logs.surface(), WindowSurface::Logs);
         assert_eq!(WindowPreset::Issue.surface(), WindowSurface::Knowledge);
         assert_eq!(WindowPreset::Spec.surface(), WindowSurface::Knowledge);
-        assert_eq!(WindowPreset::Workspace.surface(), WindowSurface::Workspace);
+        assert_eq!(WindowPreset::Work.surface(), WindowSurface::Work);
         assert_eq!(WindowPreset::Index.surface(), WindowSurface::Index);
         assert_eq!(WindowPreset::Pr.surface(), WindowSurface::Knowledge);
         assert_eq!(WindowPreset::Settings.surface(), WindowSurface::Mock);
-        assert_eq!(WindowPreset::Logs.default_size(), (560.0, 420.0));
-        assert_eq!(WindowPreset::Shell.default_size(), (720.0, 420.0));
-        assert_eq!(WindowPreset::FileTree.default_size(), (420.0, 520.0));
-        assert_eq!(WindowPreset::Branches.default_size(), (520.0, 420.0));
-        for preset in [
-            WindowPreset::FileTree,
-            WindowPreset::Branches,
-            WindowPreset::Settings,
-            WindowPreset::Profile,
-            WindowPreset::Logs,
-            WindowPreset::Issue,
-            WindowPreset::Spec,
-            WindowPreset::Workspace,
-            WindowPreset::Index,
-            WindowPreset::Board,
-            WindowPreset::Pr,
-            WindowPreset::Console,
-        ] {
-            assert!(
-                preset.opens_maximized_by_default(),
-                "{preset:?} should open maximized by default",
+        for preset in WindowPreset::ALL {
+            assert_eq!(
+                preset.default_size(),
+                (720.0, 420.0),
+                "{preset:?} should have uniform 720×420 default size",
             );
-        }
-        for preset in [
-            WindowPreset::Shell,
-            WindowPreset::Claude,
-            WindowPreset::Codex,
-            WindowPreset::Agent,
-            WindowPreset::Memo,
-        ] {
             assert!(
                 !preset.opens_maximized_by_default(),
-                "{preset:?} should keep normal floating geometry by default",
+                "{preset:?} should not open maximized by default",
             );
         }
         assert_eq!(WindowPreset::Shell.command_name(), None);
@@ -592,8 +560,8 @@ mod tests {
             assert!(!preset.subtitle().is_empty());
 
             let (width, height) = preset.default_size();
-            assert!(width >= 420.0);
-            assert!(height >= 300.0);
+            assert_eq!(width, 720.0);
+            assert_eq!(height, 420.0);
 
             match preset {
                 WindowPreset::Shell => {
@@ -644,8 +612,8 @@ mod tests {
                     assert!(!preset.requires_process());
                     assert_eq!(preset.command_name(), None);
                 }
-                WindowPreset::Workspace => {
-                    assert_eq!(preset.surface(), WindowSurface::Workspace);
+                WindowPreset::Work => {
+                    assert_eq!(preset.surface(), WindowSurface::Work);
                     assert!(!preset.requires_process());
                     assert_eq!(preset.command_name(), None);
                 }

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -945,8 +945,8 @@ pub struct ActiveWorkProjectionView {
     pub pr_created_at: Option<String>,
     pub board_refs: Vec<String>,
     pub journal_entries: Vec<WorkspaceJournalEntryView>,
-    #[serde(default, alias = "work_items")]
-    pub workspaces: Vec<WorkspaceHistoryView>,
+    #[serde(default, alias = "workspaces", alias = "work_items")]
+    pub works: Vec<WorkspaceHistoryView>,
     pub cleanup_candidate: Option<ActiveWorkCleanupCandidateView>,
     #[serde(default)]
     pub active_work_count: usize,
@@ -2395,7 +2395,7 @@ mod tests {
                     agent_current_focus: Some("Run launch tests".to_string()),
                     agent_title_summary: Some("Launch tests".to_string()),
                 }],
-                workspaces: Vec::new(),
+                works: Vec::new(),
                 cleanup_candidate: Some(super::ActiveWorkCleanupCandidateView {
                     branch: "work/20260504-1200".to_string(),
                     worktree_path: Some("/tmp/repo/work/20260504-1200".to_string()),
@@ -2455,8 +2455,10 @@ mod tests {
                 .pointer("/projection/agents/0/display_name")
                 .and_then(Value::as_str),
             Some("Codex"),
-            "active work projection must expose per-agent summaries for Workspace UI"
+            "active work projection must expose per-agent summaries for Work UI"
         );
+        assert!(value.pointer("/projection/works").is_some());
+        assert!(value.pointer("/projection/workspaces").is_none());
         assert_eq!(
             value
                 .pointer("/projection/agents/0/last_board_entry_id")
@@ -2490,14 +2492,14 @@ mod tests {
                 .pointer("/projection/journal_entries/0/summary")
                 .and_then(Value::as_str),
             Some("Launching from Project Bar"),
-            "Workspace Overview should receive recent summary journal entries without replaying Board history"
+            "Work Overview should receive recent summary journal entries without replaying Board history"
         );
         assert_eq!(
             value
                 .pointer("/projection/cleanup_candidate/default_delete_remote")
                 .and_then(Value::as_bool),
             Some(false),
-            "Workspace cleanup must default to local-only deletion"
+            "Work cleanup must default to local-only deletion"
         );
     }
 

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -907,6 +907,26 @@ pub struct ActiveWorkCleanupCandidateView {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActiveWorkItemView {
+    pub id: String,
+    pub title: String,
+    pub status_category: String,
+    pub status_text: String,
+    pub summary: Option<String>,
+    pub owner: Option<String>,
+    pub next_action: Option<String>,
+    pub active_agents: usize,
+    pub blocked_agents: usize,
+    pub branch: Option<String>,
+    pub worktree_path: Option<String>,
+    pub pr_number: Option<u64>,
+    pub pr_url: Option<String>,
+    pub pr_state: Option<String>,
+    pub board_refs: Vec<String>,
+    pub agents: Vec<ActiveWorkAgentView>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ActiveWorkProjectionView {
     pub id: String,
     pub title: String,
@@ -928,6 +948,10 @@ pub struct ActiveWorkProjectionView {
     #[serde(default, alias = "work_items")]
     pub workspaces: Vec<WorkspaceHistoryView>,
     pub cleanup_candidate: Option<ActiveWorkCleanupCandidateView>,
+    #[serde(default)]
+    pub active_work_count: usize,
+    #[serde(default)]
+    pub active_works: Vec<ActiveWorkItemView>,
     pub agents: Vec<ActiveWorkAgentView>,
     #[serde(default)]
     pub unassigned_agents: Vec<ActiveWorkAgentView>,
@@ -2379,6 +2403,25 @@ mod tests {
                     default_delete_remote: false,
                     remote_delete_available: true,
                 }),
+                active_work_count: 1,
+                active_works: vec![super::ActiveWorkItemView {
+                    id: "work-1".to_string(),
+                    title: "Implement Start Work".to_string(),
+                    status_category: "active".to_string(),
+                    status_text: "Launching from Project Bar".to_string(),
+                    summary: Some("Launching from Project Bar".to_string()),
+                    owner: Some("SPEC-2359".to_string()),
+                    next_action: Some("Run launch tests".to_string()),
+                    active_agents: 1,
+                    blocked_agents: 0,
+                    branch: Some("work/20260504-1200".to_string()),
+                    worktree_path: Some("/tmp/repo/work/20260504-1200".to_string()),
+                    pr_number: Some(2538),
+                    pr_url: Some("https://github.com/akiojin/gwt/pull/2538".to_string()),
+                    pr_state: Some("OPEN".to_string()),
+                    board_refs: vec!["board-1".to_string()],
+                    agents: Vec::new(),
+                }],
                 agents: vec![super::ActiveWorkAgentView {
                     session_id: "session-1".to_string(),
                     window_id: Some("tab-1::agent-1".to_string()),

--- a/crates/gwt/src/workspace.rs
+++ b/crates/gwt/src/workspace.rs
@@ -67,6 +67,19 @@ impl WorkspaceState {
         true
     }
 
+    pub fn set_session_id(&mut self, id: &str, session_id: Option<String>) -> bool {
+        let Some(window) = self
+            .persisted
+            .windows
+            .iter_mut()
+            .find(|window| window.id == id)
+        else {
+            return false;
+        };
+        window.session_id = session_id;
+        true
+    }
+
     pub fn set_purpose_title(&mut self, id: &str, title: Option<String>) -> bool {
         let Some(window) = self
             .persisted
@@ -333,6 +346,7 @@ impl WorkspaceState {
             agent_color: None,
             tab_group_id: None,
             tab_group_active: false,
+            session_id: None,
         };
         self.persisted.next_z_index += 1;
         self.persisted.windows.push(window.clone());
@@ -1023,6 +1037,7 @@ mod tests {
                 agent_color: None,
                 tab_group_id: None,
                 tab_group_active: false,
+                session_id: None,
             }],
             next_z_index: 2,
         });

--- a/crates/gwt/web/__tests__/board-surface.test.mjs
+++ b/crates/gwt/web/__tests__/board-surface.test.mjs
@@ -72,10 +72,10 @@ test("Board surface exposes a Workspace audience filter toggle (SPEC-2359 FR-101
   assert.match(appSource, /state\.audienceFilter\s*===\s*"workspace"/);
 });
 
-test("Board surface wires Workspace projection's primary assigned agent into currentWorkspaceId (SPEC-2359 FR-098)", () => {
-  assert.match(appSource, /deriveCurrentProjectWorkspaceId/);
+test("Board surface wires all active Work ids into currentWorkspaceIds (SPEC-2359 FR-098)", () => {
+  assert.match(appSource, /deriveCurrentProjectWorkspaceIds/);
   assert.match(appSource, /refreshBoardCurrentWorkspaceId/);
-  assert.match(appSource, /affiliation_status[\s\S]{0,60}assigned/);
+  assert.match(appSource, /active_works[\s\S]{0,220}map/);
   assert.match(appSource, /currentWorkspaceId:\s*currentProjectWorkspaceId/);
 });
 
@@ -178,6 +178,16 @@ test("entryVisibleForWorkspace treats absent or empty audience as broadcast (FR-
   assert.equal(entryVisibleForWorkspace(scopedAB, "ws-3"), false);
   assert.equal(entryVisibleForWorkspace(scopedOther, "ws-1"), false);
   assert.equal(entryVisibleForWorkspace(scopedAB, null), false);
+});
+
+test("entryVisibleForWorkspace accepts multiple active Work ids", () => {
+  const scopedA = { id: "a", audience: ["work-a"] };
+  const scopedB = { id: "b", audience: ["work-b"] };
+  const scopedOther = { id: "other", audience: ["work-c"] };
+
+  assert.equal(entryVisibleForWorkspace(scopedA, ["work-a", "work-b"]), true);
+  assert.equal(entryVisibleForWorkspace(scopedB, ["work-a", "work-b"]), true);
+  assert.equal(entryVisibleForWorkspace(scopedOther, ["work-a", "work-b"]), false);
 });
 
 test("visibleBoardEntries 'workspace' filter scopes by current workspace audience plus broadcast (FR-098)", () => {

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -509,8 +509,8 @@ test("Workspace Overview is separate from live-only Active Work", () => {
   );
   assert.match(
     appSource,
-    /function\s+openWorkspaceOverview\(\)\s*\{[\s\S]{0,300}?focusOrSpawnPreset\("workspace"\)/,
-    "expected Workspace Overview to open the Workspace window instead of a drawer",
+    /function\s+openWorkspaceOverview\(\)\s*\{[\s\S]{0,300}?focusOrSpawnPreset\("work"\)/,
+    "expected Workspace Overview to open the Work window instead of a drawer",
   );
   assert.match(
     appSource,
@@ -531,8 +531,8 @@ test("Workspace Overview uses the Quiet Work full-window List + Detail layout", 
   );
   assert.match(
     appSource,
-    /presetSurface\(preset\)[\s\S]+preset\s*===\s*"workspace"[\s\S]+return\s+"workspace"/,
-    "expected Workspace to be a first-class window surface",
+    /presetSurface\(preset\)[\s\S]+preset\s*===\s*"work"[\s\S]+return\s+"work"/,
+    "expected Work to be a first-class window surface",
   );
   assert.match(
     workspaceOverviewSource,
@@ -598,16 +598,11 @@ test("Workspace Overview legacy drawer scaffold is retired", () => {
   );
 });
 
-test("non-agent surface presets open maximized from command focus paths", () => {
+test("no surface presets auto-maximize — uniform 720×420 floating windows", () => {
   assert.match(
     appSource,
-    /function\s+isAutoMaximizedSurfacePreset\([^)]*\)[\s\S]+file_tree[\s\S]+branches[\s\S]+settings[\s\S]+profile[\s\S]+logs[\s\S]+issue[\s\S]+spec[\s\S]+workspace[\s\S]+board[\s\S]+pr/,
-    "expected frontend focus/spawn path to identify every non-agent surface preset as auto-maximized",
-  );
-  assert.match(
-    appSource,
-    /focusOrSpawnPreset\(preset\)[\s\S]+isAutoMaximizedSurfacePreset\(preset\)[\s\S]+bounds:\s*visibleBounds\(\)/,
-    "expected focusOrSpawnPreset to send viewport bounds when focusing existing non-agent surfaces",
+    /function\s+isAutoMaximizedSurfacePreset\([^)]*\)\s*\{[^}]*return\s+false/,
+    "expected isAutoMaximizedSurfacePreset to always return false (auto-maximize abolished)",
   );
 });
 
@@ -2460,7 +2455,7 @@ test("mountWindowBody clears every known surface class before applying the activ
     "surface-logs",
     "surface-knowledge",
     "surface-index",
-    "surface-workspace",
+    "surface-work",
     "surface-profile",
     "surface-console",
     "surface-mock",
@@ -2481,7 +2476,7 @@ test("every readable non-terminal surface participates in the opaque window chro
     "logs",
     "knowledge",
     "index",
-    "workspace",
+    "work",
     "profile",
     "console",
     "mock",

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1066,9 +1066,10 @@ test("xterm content stays on the dark Operator palette across app theme changes"
 
 test("xterm developer readability defaults use larger font metrics", () => {
   assert.ok(terminalOptionNumber("fontSize") >= 14, "xterm fontSize must be at least 14px");
-  assert.ok(
-    terminalOptionNumber("lineHeight") >= 1.3,
-    "xterm lineHeight must be at least 1.30 to avoid cramped SS.mov output",
+  assert.match(
+    appSource,
+    /lineHeight:\s*isBlinkBrowser\(\)\s*\?\s*1\.3[0-9]*\s*:\s*1\.3/,
+    "xterm lineHeight must be at least 1.30 for both Blink and WebKit paths (Issue #2903)",
   );
 });
 

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -155,6 +155,11 @@ test("frontend handles active work projection as status-strip telemetry", () => 
     /activeWorkProjection[\s\S]+applyTelemetryCounts/,
     "expected active work projection to feed Operator telemetry",
   );
+  assert.match(
+    appSource,
+    /counts\.branches[\s\S]+activeWorks\.length/,
+    "expected Status Strip Work telemetry to count active Works, not only branch-list rows",
+  );
 });
 
 test("Sidebar Layers Agents counter filters non-agent preset windows", () => {
@@ -186,21 +191,26 @@ test("Sidebar Layers Agents counter filters non-agent preset windows", () => {
 test("Workspace sidebar exposes active work and per-agent overview", () => {
   assert.ok(
     document.querySelector("#op-active-work"),
-    "expected Workspace shell to expose an active work overview region",
+    "expected Workspace shell to expose an Active Works overview region",
   );
   assert.ok(
     document.querySelector("#op-active-work-agents"),
-    "expected Workspace shell to expose a per-agent list region",
+    "expected Workspace shell to expose a per-Work list region",
   );
   assert.match(
     appSource,
-    /function\s+renderActiveWorkOverview\(\)[\s\S]+activeWorkFocusableAgents\(activeWorkProjection\)/,
-    "expected frontend to render focusable per-agent projection data, not only aggregate counters",
+    /function\s+activeWorkItemsFromProjection\(\)[\s\S]+active_works/,
+    "expected frontend to render plural active_works data, not only a single aggregate projection",
   );
   assert.match(
     appSource,
-    /op-agent-card[\s\S]+last_board_entry_id/,
-    "expected agent cards to preserve board linkage for handoff/debugging",
+    /op-work-card[\s\S]+renderActiveWorkAgentCard\(agent\)/,
+    "expected Active Works rows to render their live Agent cards",
+  );
+  assert.match(
+    appSource,
+    /function\s+renderActiveWorkAgentCard\(agent\)[\s\S]+op-agent-card[\s\S]+last_board_entry_id/,
+    "expected Active Works rows to preserve agent board linkage for handoff/debugging",
   );
 });
 
@@ -211,8 +221,8 @@ test("Workspace sidebar keeps Quick before the expanding active work list", () =
   );
   assert.deepEqual(
     headings.slice(0, 3),
-    ["Layers", "Quick", "Active Work"],
-    "Quick must stay above Active Work so agent cards do not push it off-screen",
+    ["Layers", "Quick", "Active Works"],
+    "Quick must stay above Active Works so Work cards do not push it off-screen",
   );
 });
 
@@ -417,7 +427,7 @@ test("Active Work title prefers concrete work context over Start Work workflow l
   );
   assert.match(
     appSource,
-    /createNode\("div",\s*"op-work-title",\s*activeWorkDisplayTitle\(activeWorkProjection,\s*agents\)\)/,
+    /createNode\("div",\s*"op-work-title",\s*activeWorkDisplayTitle\(work,\s*work\.agents\)\)/,
     "expected Active Work summary title to use the display-title helper",
   );
   assert.doesNotMatch(
@@ -430,7 +440,7 @@ test("Active Work title prefers concrete work context over Start Work workflow l
 test("Active Work sidebar only renders while live Agent windows are focusable", () => {
   assert.match(
     appSource,
-    /function\s+activeWorkFocusableAgents\(projection\)[\s\S]+workspaceWindowById\(agent\.window_id\)/,
+    /function\s+activeWorkFocusableAgents\(work\)[\s\S]+workspaceWindowById\(agent\.window_id\)/,
     "expected Active Work cards to be filtered against live workspace windows",
   );
   assert.match(
@@ -445,7 +455,7 @@ test("Active Work sidebar only renders while live Agent windows are focusable", 
   );
   assert.match(
     appSource,
-    /if\s*\(agentCount\s*===\s*0\)\s*\{[\s\S]+setActiveWorkSectionVisible\(false\)[\s\S]+return;/,
+    /if\s*\(workCount\s*===\s*0\)\s*\{[\s\S]+setActiveWorkSectionVisible\(false\)[\s\S]+return;/,
     "expected no focusable Agent windows to remove the Active Work sidebar section",
   );
   assert.match(

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -556,8 +556,8 @@ test("Workspace Overview uses the Quiet Work full-window List + Detail layout", 
   );
   assert.match(
     workspaceOverviewSource,
-    /function\s+workspacesFromProjection\([^)]*\)[\s\S]+projection\.workspaces[\s\S]+projection\.work_items/,
-    "expected Workspace Overview to render Workspace entries from active_work_projection",
+    /function\s+workspacesFromProjection\([^)]*\)[\s\S]+projection\.works[\s\S]+projection\.workspaces[\s\S]+projection\.work_items/,
+    "expected Work Overview to render Work entries from active_work_projection",
   );
   // SPEC-2359 US-42 — Resume action now opens the Workspace Resume
   // Picker via `list_resumable_agents` instead of the legacy

--- a/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
@@ -404,6 +404,81 @@ test("elementHasLayoutBox blocks 0-size containers (Issue #2832 / SPEC-2008 Phas
   assert.equal(elementHasLayoutBox({}), true);
 });
 
+test("attachHostResizeReflow coalesces rapid resize events via requestAnimationFrame (Issue #2903)", () => {
+  const window = fixtureWindow();
+  let rafCallback = null;
+  let rafIdCounter = 1;
+  let cancelledIds = [];
+  window.requestAnimationFrame = (cb) => {
+    rafCallback = cb;
+    return rafIdCounter++;
+  };
+  window.cancelAnimationFrame = (id) => {
+    cancelledIds.push(id);
+    rafCallback = null;
+  };
+
+  const fitCalls = [];
+  const beforeFanCalls = [];
+
+  const dispose = attachHostResizeReflow({
+    window,
+    terminalIds: () => ["wtA", "wtB"],
+    canRefreshViewport: (id) => id !== "wtB",
+    fitTerminal: (id, persist) => fitCalls.push([id, persist]),
+    beforeFan: () => beforeFanCalls.push("flushed"),
+  });
+
+  // Fire 5 rapid resize events (simulates Chrome maximize animation).
+  for (let i = 0; i < 5; i++) {
+    window.dispatchEvent(new window.Event("resize"));
+  }
+
+  // Nothing should have executed synchronously — all deferred to rAF.
+  assert.equal(fitCalls.length, 0, "fitTerminal must not fire synchronously when rAF is available");
+  assert.equal(beforeFanCalls.length, 0, "beforeFan must not fire synchronously when rAF is available");
+
+  // 4 intermediate rAFs should have been cancelled (5 events, only last survives).
+  assert.equal(cancelledIds.length, 4, "previous rAF frames must be cancelled on rapid resize");
+
+  // Flush the single surviving rAF callback.
+  assert.ok(rafCallback, "a rAF must be scheduled after the last resize");
+  rafCallback();
+
+  // Only one fan-out should have run.
+  assert.deepEqual(beforeFanCalls, ["flushed"], "beforeFan must fire exactly once");
+  assert.deepEqual(fitCalls, [["wtA", true]], "fitTerminal must fire once per visible terminal");
+
+  dispose();
+});
+
+test("attachHostResizeReflow dispose cancels pending rAF (Issue #2903)", () => {
+  const window = fixtureWindow();
+  let rafCallback = null;
+  let cancelCount = 0;
+  window.requestAnimationFrame = (cb) => { rafCallback = cb; return 99; };
+  window.cancelAnimationFrame = () => { cancelCount++; rafCallback = null; };
+
+  const fitCalls = [];
+  const dispose = attachHostResizeReflow({
+    window,
+    terminalIds: () => ["wtA"],
+    canRefreshViewport: () => true,
+    fitTerminal: (id, persist) => fitCalls.push([id, persist]),
+  });
+
+  window.dispatchEvent(new window.Event("resize"));
+  assert.ok(rafCallback, "rAF must be scheduled");
+
+  // Dispose before rAF fires.
+  dispose();
+  assert.equal(cancelCount, 1, "dispose must cancel pending rAF");
+
+  // Even if someone flushes an old callback ref, listener is removed.
+  window.dispatchEvent(new window.Event("resize"));
+  assert.equal(fitCalls.length, 0, "no fits after dispose");
+});
+
 test("app.js wires the reflow controller for resize, transition, and predicate", () => {
   // Source-string contract retained per the memory — limited to wiring
   // detection so a future refactor that drops the import / call surfaces
@@ -478,5 +553,19 @@ test("app.js wires the reflow controller for resize, transition, and predicate",
     appSource,
     /HANDSHAKE_RETRY_LIMIT/,
     "handshake retry must be capped by HANDSHAKE_RETRY_LIMIT",
+  );
+
+  // Issue #2903 — browser lineHeight parity: app.js must detect Blink
+  // browsers and adjust xterm lineHeight so the agent terminal line spacing
+  // matches the native WebView rendering.
+  assert.match(
+    appSource,
+    /isBlinkBrowser\b/,
+    "app.js must define isBlinkBrowser helper for engine-specific lineHeight",
+  );
+  assert.match(
+    appSource,
+    /lineHeight:\s*isBlinkBrowser/,
+    "createTerminalRuntime must use isBlinkBrowser to select lineHeight",
   );
 });

--- a/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
+++ b/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
@@ -127,6 +127,41 @@ test("Workspace resume action asks backend for resumable agents", () => {
   assert.equal(sent[0].workspace_id, "workspace-current");
 });
 
+test("Tab switcher remains visible after switching to Git Branches", () => {
+  const fixture = createFixture();
+  const surface = createSurface(fixture, sampleProjection());
+
+  surface.mount(fixture.body, fixture.windowData, {
+    focusWindowLocally() {},
+    sendFocus() {},
+  });
+
+  const tabs = fixture.body.querySelectorAll("[data-work-tab]");
+  assert.equal(tabs.length, 2, "should have Work and Git Branches tabs");
+
+  const branchTab = fixture.body.querySelector("[data-work-tab='branches']");
+  branchTab.click();
+
+  const workSection = fixture.body.querySelector("[data-work-section='work']");
+  const branchSection = fixture.body.querySelector("[data-work-section='branches']");
+  assert.equal(workSection.hidden, true, "work section should be hidden");
+  assert.equal(branchSection.hidden, false, "branches section should be visible");
+
+  const tabGroupAfter = fixture.body.querySelector(".workspace-tab-group");
+  assert.ok(tabGroupAfter, "tab group should still exist in DOM");
+  assert.equal(tabGroupAfter.hidden, false, "tab group should not be hidden");
+
+  const workTabAfter = fixture.body.querySelector("[data-work-tab='work']");
+  assert.ok(workTabAfter, "Work tab should remain accessible");
+  assert.equal(workTabAfter.classList.contains("is-active"), false);
+  assert.equal(branchTab.classList.contains("is-active"), true);
+
+  workTabAfter.click();
+  assert.equal(workSection.hidden, false, "work section should reappear");
+  assert.equal(branchSection.hidden, true, "branches section should hide");
+  assert.equal(workTabAfter.classList.contains("is-active"), true);
+});
+
 test("Workspace refresh action rerenders locally without inventing a protocol event", () => {
   const fixture = createFixture();
   const sent = [];

--- a/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
+++ b/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
@@ -254,7 +254,7 @@ function sampleProjection() {
         board_entry_id: "board-claim-1",
       },
     ],
-    workspaces: [
+    works: [
       {
         id: "workspace-current",
         title: "Release Notes cleanup",

--- a/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
+++ b/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
@@ -40,13 +40,87 @@ test("Workspace Overview keeps unassigned agents in an explicit queue outside Wo
 
   const queue = fixture.body.querySelector(".workspace-agent-queue");
   assert.ok(queue, "unassigned agents should have a dedicated queue");
-  assert.match(queue.textContent, /Unassigned agents/);
+  assert.match(queue.textContent, /Unassigned Agents/);
   assert.match(queue.textContent, /No Work selected/);
   assert.match(queue.textContent, /Codex/);
   assert.equal(
     queue.querySelectorAll(".workspace-overview-agent-row").length,
     1,
   );
+});
+
+test("Workspace Overview renders Active Works from active_works and keeps Unassigned Agents separate", () => {
+  const fixture = createFixture();
+  const surface = createSurface(fixture, {
+    id: "legacy-current",
+    title: "Legacy current projection",
+    status_category: "active",
+    active_work_count: 2,
+    active_works: [
+      {
+        id: "work-parser",
+        title: "Parser cleanup",
+        status_category: "active",
+        summary: "Parser Work summary",
+        owner: "SPEC-2359",
+        agents: [
+          {
+            session_id: "agent-parser",
+            display_name: "Codex",
+            status_category: "active",
+            title_summary: "Parser cleanup",
+          },
+        ],
+      },
+      {
+        id: "work-ui",
+        title: "UI polish",
+        status_category: "blocked",
+        blocked_agents: 1,
+        agents: [
+          {
+            session_id: "agent-ui",
+            display_name: "Claude Code",
+            status_category: "blocked",
+            title_summary: "UI polish",
+          },
+        ],
+      },
+    ],
+    unassigned_agents: [
+      {
+        session_id: "agent-unassigned",
+        display_name: "Codex",
+        status_category: "active",
+        affiliation_status: "unassigned",
+      },
+    ],
+  });
+
+  surface.mount(fixture.body, fixture.windowData, {
+    focusWindowLocally() {},
+    sendFocus() {},
+  });
+
+  assert.match(fixture.body.textContent, /Active Works/);
+  assert.match(fixture.body.textContent, /Unassigned Agents/);
+  assert.match(
+    fixture.body.querySelector(".workspace-overview-status-line").textContent,
+    /2 Active Works · 1 Unassigned Agents/,
+  );
+  const rows = Array.from(
+    fixture.body.querySelectorAll(".workspace-overview-row[data-workspace-id]"),
+  );
+  assert.deepEqual(
+    rows.map((row) => row.dataset.workspaceId),
+    ["work-parser", "work-ui"],
+  );
+  assert.match(rows[0].textContent, /Parser cleanup/);
+  assert.match(rows[1].textContent, /UI polish/);
+  const queue = fixture.body.querySelector(".workspace-agent-queue");
+  assert.ok(queue);
+  assert.equal(queue.querySelectorAll(".workspace-overview-agent-row").length, 1);
+  assert.match(queue.textContent, /No Work selected/);
 });
 
 test("Workspace detail renders structured body sections without preformatted dumps", () => {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -9236,7 +9236,7 @@
           case "remote_tracking_without_local":
             return "Remote-tracking branch without a local counterpart";
           case "non_workspace_branch":
-            return "Only gwt-managed workspaces can be cleaned up";
+            return "Only gwt-managed work can be cleaned up";
           default:
             return "This branch cannot be cleaned up";
         }
@@ -9797,7 +9797,7 @@
                 <div class="workspace-toolbar-actions">
                   <button class="text-button board-all-filter" data-action="toggle-board-all" type="button" aria-pressed="false">All</button>
                   <button class="text-button board-for-you-filter" data-action="toggle-board-for-you" type="button" aria-pressed="false">For you</button>
-                  <button class="text-button board-workspace-filter" data-action="toggle-board-workspace" type="button" aria-pressed="false">Workspace</button>
+                  <button class="text-button board-workspace-filter" data-action="toggle-board-workspace" type="button" aria-pressed="false">Work</button>
                   <button class="icon-button" data-action="refresh-board" aria-label="Refresh board">↻</button>
                 </div>
               </div>

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -3757,6 +3757,11 @@
         return /mac|iphone|ipad|ipod/i.test(platform);
       }
 
+      function isBlinkBrowser() {
+        const ua = navigator.userAgent || "";
+        return /Chrome\//.test(ua);
+      }
+
       function isTerminalCopyShortcut(event) {
         if (isMacPlatform()) {
           return false;
@@ -4237,7 +4242,7 @@
           fontFamily:
             "var(--font-mono), ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
           fontSize: 14,
-          lineHeight: 1.3,
+          lineHeight: isBlinkBrowser() ? 1.35 : 1.3,
           scrollback: 5000,
         });
         const fitAddon = new FitAddon();

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -526,7 +526,7 @@
           return "file-tree";
         }
         if (preset === "branches") {
-          return "workspace";
+          return "work";
         }
         if (preset === "profile") {
           return "profile";
@@ -543,8 +543,8 @@
         if (preset === "index") {
           return "index";
         }
-        if (preset === "workspace") {
-          return "workspace";
+        if (preset === "work" || preset === "workspace") {
+          return "work";
         }
         if (preset === "console") {
           return "console";
@@ -2370,7 +2370,7 @@
       }
 
       function openWorkspaceOverview() {
-        focusOrSpawnPreset("workspace");
+        focusOrSpawnPreset("work");
       }
 
       function workspaceCleanupEntry(candidate) {
@@ -9389,7 +9389,7 @@
           "surface-logs",
           "surface-knowledge",
           "surface-index",
-          "surface-workspace",
+          "surface-work",
           "surface-profile",
           "surface-console",
           "surface-mock",
@@ -9868,7 +9868,7 @@
           return;
         }
 
-        if (surface === "workspace") {
+        if (surface === "work") {
           workspaceOverviewSurface.mount(body, windowData, {
             focusWindowLocally,
             sendFocus: (id) => socketTransport.send({ kind: "focus_window", id }),
@@ -13184,24 +13184,12 @@
       // surface dispatch. Each command either focuses an existing window or
       // creates a new one through the same socket transport the preset
       // buttons use, so they share the legacy invariants.
-      function isAutoMaximizedSurfacePreset(preset) {
-        return (
-          preset === "file_tree" ||
-          preset === "branches" ||
-          preset === "settings" ||
-          preset === "profile" ||
-          preset === "logs" ||
-          preset === "issue" ||
-          preset === "spec" ||
-          preset === "index" ||
-          preset === "workspace" ||
-          preset === "board" ||
-          preset === "pr"
-        );
+      function isAutoMaximizedSurfacePreset(_preset) {
+        return false;
       }
 
       function focusOrSpawnPreset(preset) {
-        if (preset === "branches") preset = "workspace";
+        if (preset === "branches") preset = "work";
         const allWindows = activeWorkspace().windows || [];
         const existing = allWindows.find(
           (w) => w.preset === preset && !w.minimized,
@@ -13234,13 +13222,13 @@
             focusOrSpawnPreset("board");
             return;
           case "open-git":
-            focusOrSpawnPreset("workspace");
+            focusOrSpawnPreset("work");
             return;
           case "open-logs":
             focusOrSpawnPreset("logs");
             return;
           case "open-branches":
-            focusOrSpawnPreset("workspace");
+            focusOrSpawnPreset("work");
             return;
           case "open-files":
             focusOrSpawnPreset("file_tree");

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -2267,8 +2267,8 @@
             const tab = activeProjectTab();
             renderProjectOnboarding(tab);
             renderWorkspace(tab?.workspace || emptyWorkspace());
-            const nextWorkspaceId = deriveCurrentProjectWorkspaceId(tab?.workspace || {});
-            if (nextWorkspaceId !== currentProjectWorkspaceId) {
+            const nextWorkspaceId = deriveCurrentProjectWorkspaceIds(tab?.workspace || {});
+            if (JSON.stringify(nextWorkspaceId) !== JSON.stringify(currentProjectWorkspaceId)) {
               currentProjectWorkspaceId = nextWorkspaceId;
               refreshBoardCurrentWorkspaceId();
             }
@@ -3063,15 +3063,35 @@
           counts.agents += 1;
         }
         if (activeWorkProjection) {
-          const category = activeWorkProjection.status_category || "unknown";
-          const activeAgents = Number(activeWorkProjection.active_agents || 0);
-          const blockedAgents = Number(activeWorkProjection.blocked_agents || 0);
-          if (category === "active") counts.active = Math.max(counts.active, activeAgents || 1);
-          if (category === "idle") counts.idle = Math.max(counts.idle, 1);
-          if (category === "blocked") counts.blocked = Math.max(counts.blocked, blockedAgents || 1);
-          if (category === "done") counts.done = Math.max(counts.done, 1);
-          counts.blocked = Math.max(counts.blocked, blockedAgents);
-          counts.agents = Math.max(counts.agents, activeAgents + blockedAgents);
+          const activeWorks = activeWorkItemsFromProjection();
+          if (activeWorks.length > 0) {
+            const activeAgents = activeWorks.reduce(
+              (total, work) => total + Number(work.active_agents || 0),
+              0,
+            );
+            const blockedAgents = activeWorks.reduce(
+              (total, work) => total + Number(work.blocked_agents || 0),
+              0,
+            );
+            const totalAgents = activeWorks.reduce(
+              (total, work) => total + (Array.isArray(work.agents) ? work.agents.length : 0),
+              0,
+            );
+            counts.active = Math.max(counts.active, activeAgents || activeWorks.length);
+            counts.blocked = Math.max(counts.blocked, blockedAgents);
+            counts.agents = Math.max(counts.agents, totalAgents || activeAgents + blockedAgents);
+            counts.branches = Math.max(Number(counts.branches || 0), activeWorks.length);
+          } else {
+            const category = activeWorkProjection.status_category || "unknown";
+            const activeAgents = Number(activeWorkProjection.active_agents || 0);
+            const blockedAgents = Number(activeWorkProjection.blocked_agents || 0);
+            if (category === "active") counts.active = Math.max(counts.active, activeAgents || 1);
+            if (category === "idle") counts.idle = Math.max(counts.idle, 1);
+            if (category === "blocked") counts.blocked = Math.max(counts.blocked, blockedAgents || 1);
+            if (category === "done") counts.done = Math.max(counts.done, 1);
+            counts.blocked = Math.max(counts.blocked, blockedAgents);
+            counts.agents = Math.max(counts.agents, activeAgents + blockedAgents);
+          }
         }
         try {
           window.__operatorShell.applyTelemetryCounts(counts);
@@ -3080,8 +3100,8 @@
         }
       }
 
-      function activeWorkFocusableAgents(projection) {
-        const agents = Array.isArray(projection?.agents) ? projection.agents : [];
+      function activeWorkFocusableAgents(work) {
+        const agents = Array.isArray(work?.agents) ? work.agents : [];
         return agents.filter((agent) => {
           if (!agent?.window_id) return false;
           const windowData = workspaceWindowById(agent.window_id);
@@ -3089,6 +3109,21 @@
           const status = runtimeStateForWindow(windowData);
           return status !== "stopped" && status !== "exited" && status !== "error";
         });
+      }
+
+      function activeWorkItemsFromProjection() {
+        if (!activeWorkProjection) return [];
+        const source = Array.isArray(activeWorkProjection.active_works)
+          ? activeWorkProjection.active_works
+          : [];
+        if (source.length > 0) {
+          return source
+            .map((work) => ({ ...work, agents: activeWorkFocusableAgents(work) }))
+            .filter((work) => work.agents.length > 0);
+        }
+        const agents = activeWorkFocusableAgents(activeWorkProjection);
+        if (agents.length === 0) return [];
+        return [{ ...activeWorkProjection, agents }];
       }
 
       function activeWorkDisplayTitle(projection, agents) {
@@ -3107,6 +3142,67 @@
           return title;
         }
         return "Active Work";
+      }
+
+      function renderActiveWorkAgentCard(agent) {
+        const state = String(agent.status_category || "unknown").toLowerCase();
+        const coordinationKind = String(agent.last_board_entry_kind || "").toLowerCase();
+        const coordinationLabel = coordinationKindLabel(coordinationKind);
+        const card = createNode("article", "op-agent-card");
+        card.dataset.state = state;
+        if (coordinationKind) card.dataset.kind = coordinationKind;
+        if (agent.last_board_entry_id) card.dataset.boardRef = agent.last_board_entry_id;
+
+        const head = createNode("div", "op-agent-head");
+        head.appendChild(
+          createNode("div", "op-agent-name", agent.display_name || agent.agent_id || "Agent"),
+        );
+        const chips = createNode("div", "op-agent-chips");
+        if (coordinationLabel) {
+          chips.appendChild(createNode("div", "op-agent-kind", coordinationLabel));
+        }
+        chips.appendChild(createNode("div", "op-agent-state", agentRuntimeStatusLabel(agent)));
+        head.appendChild(chips);
+        card.appendChild(head);
+
+        const agentMeta = createNode("div", "op-agent-meta");
+        appendMeta(agentMeta, agent.last_board_entry_id ? "Board linked" : "");
+        card.appendChild(agentMeta);
+
+        if (agent.coordination_scope) {
+          card.appendChild(createNode("div", "op-agent-scope", agent.coordination_scope));
+        }
+
+        const agentFocusText = agent.title_summary || agent.current_focus;
+        if (agentFocusText) {
+          const focusText = coordinationLabel
+            ? `${coordinationLabel}: ${agentFocusText}`
+            : agentFocusText;
+          const agentFocus = createNode("div", "op-agent-focus", focusText);
+          if (agent.current_focus && agent.current_focus !== agentFocusText) {
+            agentFocus.title = agent.current_focus;
+          }
+          card.appendChild(agentFocus);
+        }
+
+        const agentActions = createNode("div", "op-agent-actions");
+        const focusButton = createNode("button", "op-agent-action", "Focus");
+        focusButton.type = "button";
+        focusButton.addEventListener("click", () => {
+          focusActiveWorkAgentWindow(agent);
+        });
+        agentActions.appendChild(focusButton);
+        if (agent.last_board_entry_id) {
+          const boardButton = createNode("button", "op-agent-action", "Open Entry");
+          boardButton.type = "button";
+          boardButton.addEventListener("click", () => focusBoardEntry(agent.last_board_entry_id));
+          agentActions.appendChild(boardButton);
+        }
+        if (agentActions.childNodes.length > 0) {
+          card.appendChild(agentActions);
+        }
+
+        return card;
       }
 
       // SPEC-2359 Phase U-7 (FR-148): human-readable label for the Phase
@@ -3264,11 +3360,12 @@
           return;
         }
 
-        const agents = activeWorkFocusableAgents(activeWorkProjection);
-        const agentCount = agents.length;
-        if (activeWorkCount) activeWorkCount.textContent = String(agentCount);
+        const works = activeWorkItemsFromProjection();
+        const workCount = works.length;
+        const agentCount = works.reduce((total, work) => total + work.agents.length, 0);
+        if (activeWorkCount) activeWorkCount.textContent = String(workCount);
 
-        if (agentCount === 0) {
+        if (workCount === 0) {
           setActiveWorkSectionVisible(false);
           return;
         }
@@ -3276,10 +3373,14 @@
         setActiveWorkSectionVisible(true);
 
         activeWorkSummary.appendChild(
-          createNode("div", "op-work-title", activeWorkDisplayTitle(activeWorkProjection, agents)),
+          createNode(
+            "div",
+            "op-work-title",
+            `${workCount} Active Work${workCount === 1 ? "" : "s"}`,
+          ),
         );
         const meta = createNode("div", "op-work-meta");
-        appendMeta(meta, activeWorkProjection.owner);
+        appendMeta(meta, `${agentCount} assigned Agent${agentCount === 1 ? "" : "s"}`);
         const activePr = createWorkspacePrMeta(activeWorkProjection);
         if (activePr) meta.appendChild(activePr);
         // SPEC-2359 Phase U-7 (FR-148, FR-149): render the Phase U-6
@@ -3317,89 +3418,68 @@
         }
         activeWorkSummary.appendChild(statusNode);
 
-        const actions = createNode("div", "op-work-actions");
-        if (activeWorkProjection.branch) {
-          const addAgent = createNode("button", "op-work-action", "Add Agent to This Work");
-          addAgent.type = "button";
-          addAgent.addEventListener("click", () => {
-            send({
-              kind: "open_active_work_launch_wizard",
-              branch_name: activeWorkProjection.branch,
-              linked_issue_number: projectionIssueNumber(activeWorkProjection),
-            });
-          });
-          actions.appendChild(addAgent);
-        }
-        const boardRefs = activeWorkProjection.board_refs || [];
-        const latestBoardRef = boardRefs.length > 0 ? boardRefs[boardRefs.length - 1] : "";
-        if (latestBoardRef) {
-          const openBoard = createNode("button", "op-work-action", "Open Latest Board Entry");
-          openBoard.type = "button";
-          openBoard.addEventListener("click", () => focusBoardEntry(latestBoardRef));
-          actions.appendChild(openBoard);
-        }
-        if (actions.childNodes.length > 0) {
-          activeWorkSummary.appendChild(actions);
-        }
-
-        for (const agent of agents) {
-          const state = String(agent.status_category || "unknown").toLowerCase();
-          const coordinationKind = String(agent.last_board_entry_kind || "").toLowerCase();
-          const coordinationLabel = coordinationKindLabel(coordinationKind);
-          const card = createNode("article", "op-agent-card");
+        for (const work of works) {
+          const state = String(work.status_category || "unknown").toLowerCase();
+          const card = createNode("article", "op-work-card");
           card.dataset.state = state;
-          if (coordinationKind) card.dataset.kind = coordinationKind;
-          if (agent.last_board_entry_id) card.dataset.boardRef = agent.last_board_entry_id;
-
-          const head = createNode("div", "op-agent-head");
-          head.appendChild(
-            createNode("div", "op-agent-name", agent.display_name || agent.agent_id || "Agent"),
+          card.appendChild(
+            createNode("div", "op-work-title", activeWorkDisplayTitle(work, work.agents)),
           );
-          const chips = createNode("div", "op-agent-chips");
-          if (coordinationLabel) {
-            chips.appendChild(createNode("div", "op-agent-kind", coordinationLabel));
-          }
-          chips.appendChild(createNode("div", "op-agent-state", agentRuntimeStatusLabel(agent)));
-          head.appendChild(chips);
-          card.appendChild(head);
 
-          const agentMeta = createNode("div", "op-agent-meta");
-          appendMeta(agentMeta, agent.last_board_entry_id ? "Board linked" : "");
-          card.appendChild(agentMeta);
+          const workMeta = createNode("div", "op-work-meta");
+          appendMeta(workMeta, work.owner);
+          appendMeta(workMeta, `${work.agents.length} Agent${work.agents.length === 1 ? "" : "s"}`);
+          const workPr = createWorkspacePrMeta(work);
+          if (workPr) workMeta.appendChild(workPr);
+          const lifecycleStage = work.lifecycle_stage;
+          if (lifecycleStage) {
+            const chip = createNode(
+              "span",
+              `op-work-lifecycle-chip lifecycle-chip lifecycle-chip--${lifecycleStage}`,
+              formatActiveWorkLifecycleLabel(lifecycleStage),
+            );
+            workMeta.appendChild(chip);
+          }
+          card.appendChild(workMeta);
 
-          if (agent.coordination_scope) {
-            card.appendChild(createNode("div", "op-agent-scope", agent.coordination_scope));
+          const workBlockedReason =
+            typeof work.blocked_reason === "string" ? work.blocked_reason.trim() : "";
+          const workStatusBody =
+            workBlockedReason || work.next_action || work.status_text || work.summary || "Work is active";
+          const workStatus = createNode("div", "op-work-status", workStatusBody);
+          if (workBlockedReason) workStatus.classList.add("op-work-status--blocked");
+          card.appendChild(workStatus);
+
+          const actions = createNode("div", "op-work-actions");
+          if (work.branch) {
+            const addAgent = createNode("button", "op-work-action", "Add Agent to This Work");
+            addAgent.type = "button";
+            addAgent.addEventListener("click", () => {
+              send({
+                kind: "open_active_work_launch_wizard",
+                branch_name: work.branch,
+                linked_issue_number: projectionIssueNumber(work),
+              });
+            });
+            actions.appendChild(addAgent);
+          }
+          const boardRefs = work.board_refs || [];
+          const latestBoardRef = boardRefs.length > 0 ? boardRefs[boardRefs.length - 1] : "";
+          if (latestBoardRef) {
+            const openBoard = createNode("button", "op-work-action", "Open Latest Board Entry");
+            openBoard.type = "button";
+            openBoard.addEventListener("click", () => focusBoardEntry(latestBoardRef));
+            actions.appendChild(openBoard);
+          }
+          if (actions.childNodes.length > 0) {
+            card.appendChild(actions);
           }
 
-          const agentFocusText = agent.title_summary || agent.current_focus;
-          if (agentFocusText) {
-            const focusText = coordinationLabel
-              ? `${coordinationLabel}: ${agentFocusText}`
-              : agentFocusText;
-            const agentFocus = createNode("div", "op-agent-focus", focusText);
-            if (agent.current_focus && agent.current_focus !== agentFocusText) {
-              agentFocus.title = agent.current_focus;
-            }
-            card.appendChild(agentFocus);
+          const agentList = createNode("div", "op-agent-list");
+          for (const agent of work.agents) {
+            agentList.appendChild(renderActiveWorkAgentCard(agent));
           }
-
-          const agentActions = createNode("div", "op-agent-actions");
-          const focusButton = createNode("button", "op-agent-action", "Focus");
-          focusButton.type = "button";
-          focusButton.addEventListener("click", () => {
-            focusActiveWorkAgentWindow(agent);
-          });
-          agentActions.appendChild(focusButton);
-          if (agent.last_board_entry_id) {
-            const boardButton = createNode("button", "op-agent-action", "Open Entry");
-            boardButton.type = "button";
-            boardButton.addEventListener("click", () => focusBoardEntry(agent.last_board_entry_id));
-            agentActions.appendChild(boardButton);
-          }
-          if (agentActions.childNodes.length > 0) {
-            card.appendChild(agentActions);
-          }
-
+          card.appendChild(agentList);
           activeWorkAgents.appendChild(card);
         }
       }
@@ -5600,24 +5680,38 @@
         return boardStateMap.get(windowId);
       }
 
-      // SPEC-2359 FR-098/101: track the project's "primary" assigned
-      // workspace id for the Board Workspace filter. Picks the first
-      // assigned agent's workspace_id from the workspace state event.
-      // When no agent in the project is assigned (all Unassigned), the
-      // filter degrades to broadcast-only via FR-103. Multi-workspace
-      // selection UX is a follow-up.
-      let currentProjectWorkspaceId = null;
-      function deriveCurrentProjectWorkspaceId(workspaceState) {
+      // SPEC-2359 FR-098/101 + US-53: track every live assigned Work id for
+      // the Board Work filter. Broadcast entries remain visible everywhere;
+      // scoped entries match when their audience includes any active Work id.
+      let currentProjectWorkspaceId = [];
+      function uniqueWorkIds(values) {
+        const ids = [];
+        for (const value of values || []) {
+          const id = String(value || "").trim();
+          if (id && !ids.includes(id)) ids.push(id);
+        }
+        return ids;
+      }
+      function deriveCurrentProjectWorkspaceIds(workspaceState) {
+        const activeWorkIds = Array.isArray(activeWorkProjection?.active_works)
+          ? activeWorkProjection.active_works.map((work) => work?.id)
+          : [];
+        if (activeWorkIds.length > 0) {
+          return uniqueWorkIds(activeWorkIds);
+        }
         const agents = workspaceState?.workspace?.agents
           || workspaceState?.agents
           || [];
-        const assigned = agents.find(
-          (agent) =>
-            String(agent?.affiliation_status || "").toLowerCase() === "assigned"
-            && typeof agent?.workspace_id === "string"
-            && agent.workspace_id.length > 0,
+        return uniqueWorkIds(
+          agents
+            .filter(
+              (agent) =>
+                String(agent?.affiliation_status || "").toLowerCase() === "assigned"
+                && typeof agent?.workspace_id === "string"
+                && agent.workspace_id.length > 0,
+            )
+            .map((agent) => agent.workspace_id),
         );
-        return assigned ? assigned.workspace_id : null;
       }
       function refreshBoardCurrentWorkspaceId() {
         for (const state of boardStateMap.values()) {
@@ -6876,10 +6970,7 @@
           state.focusEntryId = pendingBoardEntryFocusId;
           state.pendingFocusScroll = true;
         }
-        state.currentWorkspaceId =
-          activeWorkProjection && (activeWorkProjection.agents || []).length > 0
-            ? activeWorkProjection.id || ""
-            : "";
+        state.currentWorkspaceId = currentProjectWorkspaceId;
 
         const entryCountLabel = `${state.entries.length} entr${state.entries.length === 1 ? "y" : "ies"}`;
         status.textContent = state.error
@@ -11363,6 +11454,10 @@
             break;
           case "active_work_projection":
             activeWorkProjection = event.projection || null;
+            currentProjectWorkspaceId = deriveCurrentProjectWorkspaceIds(
+              activeWorkspace() || {},
+            );
+            refreshBoardCurrentWorkspaceId();
             renderActiveWorkOverview();
             workspaceOverviewSurface.renderWindows();
             recomputeOperatorTelemetry();

--- a/crates/gwt/web/board-surface.js
+++ b/crates/gwt/web/board-surface.js
@@ -126,8 +126,13 @@ export function mentionsForBoardSubmit(state) {
 export function entryVisibleForWorkspace(entry, currentWorkspaceId) {
   const audience = normalizedBoardWorkspaceAudience(entry);
   if (audience.length === 0) return true;
-  const workspaceId = String(currentWorkspaceId || "").trim();
-  return Boolean(workspaceId) && audience.includes(workspaceId);
+  const workspaceIds = Array.isArray(currentWorkspaceId)
+    ? currentWorkspaceId
+    : [currentWorkspaceId];
+  return workspaceIds
+    .map((workspaceId) => String(workspaceId || "").trim())
+    .filter(Boolean)
+    .some((workspaceId) => audience.includes(workspaceId));
 }
 
 export function boardEntryVisibleForWorkspace(entry, workspaceId) {

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -201,7 +201,7 @@
             <div class="project-picker-card">
               <h2 class="project-picker-title">Open a project</h2>
               <p class="project-picker-copy">
-                Restore previous workspaces or choose a new folder.
+                Restore previous work or choose a new folder.
               </p>
               <div class="project-picker-error" id="project-picker-error" role="alert" hidden></div>
               <button class="wizard-button primary" id="picker-open-project">
@@ -348,7 +348,7 @@
             ▪ connecting daemon
           </div>
           <div class="op-briefing__line" data-state="ok" style="animation-delay: 380ms">
-            ▪ loading workspace
+            ▪ loading work
           </div>
           <div class="op-briefing__line" data-state="ok" style="animation-delay: 540ms">
             ▪ board sync

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -178,11 +178,11 @@
           </div>
           <div class="op-sidebar__section op-active-work" id="op-active-work" aria-live="polite" hidden>
             <h3 class="op-sidebar__heading">
-              <span>Active Work</span>
+              <span>Active Works</span>
               <span class="op-sidebar__count" id="op-active-work-count">0</span>
             </h3>
             <div class="op-work-summary" id="op-active-work-summary">
-              <div class="op-work-empty">No active work</div>
+              <div class="op-work-empty">No active works</div>
             </div>
             <div class="op-agent-list" id="op-active-work-agents"></div>
           </div>

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -465,7 +465,7 @@
                 <strong>SPEC</strong>
                 <span>Open the SPEC surface</span>
               </button>
-              <button class="preset-button" data-preset="workspace">
+              <button class="preset-button" data-preset="work">
                 <strong>Work</strong>
                 <span>Open the Work overview</span>
               </button>

--- a/crates/gwt/web/socket-receive-dispatcher.js
+++ b/crates/gwt/web/socket-receive-dispatcher.js
@@ -104,7 +104,11 @@ export function createSocketReceiveDispatcher({
           threw: true,
           error_name: error && error.name,
         });
-        throw error;
+        console.warn(
+          "[ws-dispatcher] receive threw for %s — continuing with remaining events",
+          event && event.kind,
+          error,
+        );
       }
       cursor += 1;
       if (cursor < ready.length && nowImpl() - start > budgetMs) {

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -1578,6 +1578,7 @@ body {
 }
 
 .workspace-branches-shell .branch-list-root {
+  position: static;
   display: flex;
   flex-direction: column;
   flex: 1;

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -610,7 +610,7 @@ body {
 .workspace-window.surface-board,
 .workspace-window.surface-logs,
 .workspace-window.surface-mock,
-.workspace-window.surface-workspace,
+.workspace-window.surface-work,
 .workspace-window.surface-knowledge,
 .workspace-window.surface-index,
 .workspace-window.surface-profile,
@@ -643,7 +643,7 @@ body {
 .surface-mock .titlebar,
 .surface-knowledge .titlebar,
 .surface-index .titlebar,
-.surface-workspace .titlebar,
+.surface-work .titlebar,
 .surface-profile .titlebar,
 .surface-console .titlebar {
   background: var(--color-surface-elevated);
@@ -731,7 +731,7 @@ body {
 .surface-logs .status-chip,
 .surface-knowledge .status-chip,
 .surface-index .status-chip,
-.surface-workspace .status-chip,
+.surface-work .status-chip,
 .surface-profile .status-chip,
 .surface-console .status-chip,
 .surface-mock .status-chip {
@@ -796,7 +796,7 @@ body {
 .surface-logs .icon-button,
 .surface-knowledge .icon-button,
 .surface-index .icon-button,
-.surface-workspace .icon-button,
+.surface-work .icon-button,
 .surface-profile .icon-button,
 .surface-console .icon-button,
 .surface-mock .icon-button {
@@ -951,7 +951,7 @@ body {
 .surface-logs .window-body,
 .surface-knowledge .window-body,
 .surface-index .window-body,
-.surface-workspace .window-body,
+.surface-work .window-body,
 .surface-console .window-body,
 .surface-mock .window-body,
 .surface-profile .window-body {

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -686,13 +686,15 @@ body::after {
 }
 
 .op-work-summary,
+.op-work-card,
 .op-agent-card {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   background: var(--color-surface-elevated);
 }
 
-.op-work-summary {
+.op-work-summary,
+.op-work-card {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
@@ -767,6 +769,23 @@ body::after {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+}
+
+.op-work-card[data-state="blocked"] {
+  border-color: var(--color-state-blocked);
+}
+
+.op-work-card[data-state="active"] {
+  border-color: var(--color-state-active);
+}
+
+.op-work-card[data-state="idle"] {
+  border-color: color-mix(in oklab, var(--color-state-idle) 55%, var(--color-border));
+}
+
+.op-work-card[data-state="done"] {
+  border-color: color-mix(in oklab, var(--color-state-done) 60%, var(--color-border));
+  opacity: 0.82;
 }
 
 .op-agent-card {

--- a/crates/gwt/web/terminal-viewport-reflow.js
+++ b/crates/gwt/web/terminal-viewport-reflow.js
@@ -23,7 +23,10 @@ export function attachHostResizeReflow({
   if (!window || typeof window.addEventListener !== "function") {
     throw new TypeError("attachHostResizeReflow requires a DOM window");
   }
-  const handler = () => {
+  const hasRaf = typeof window.requestAnimationFrame === "function";
+  let rafId = null;
+  const run = () => {
+    rafId = null;
     if (typeof beforeFan === "function") beforeFan();
     for (const windowId of terminalIds()) {
       if (typeof canRefreshViewport === "function" && !canRefreshViewport(windowId)) {
@@ -32,8 +35,19 @@ export function attachHostResizeReflow({
       fitTerminal(windowId, true);
     }
   };
+  const handler = () => {
+    if (hasRaf) {
+      if (rafId !== null) window.cancelAnimationFrame(rafId);
+      rafId = window.requestAnimationFrame(run);
+    } else {
+      run();
+    }
+  };
   window.addEventListener("resize", handler);
-  return () => window.removeEventListener("resize", handler);
+  return () => {
+    if (rafId !== null && hasRaf) window.cancelAnimationFrame(rafId);
+    window.removeEventListener("resize", handler);
+  };
 }
 
 /**

--- a/crates/gwt/web/workspace-kanban-surface.js
+++ b/crates/gwt/web/workspace-kanban-surface.js
@@ -142,17 +142,19 @@ export function createWorkspaceKanbanSurface({
     if (activeWorks.length > 0) {
       return activeWorks.map((item) => normalizeWorkspaceItem(item, projection));
     }
-    const sourceItems = Array.isArray(projection.workspaces)
-      ? projection.workspaces
-      : Array.isArray(projection.work_items)
-        ? projection.work_items
-        : [];
+    const sourceItems = Array.isArray(projection.works)
+      ? projection.works
+      : Array.isArray(projection.workspaces)
+        ? projection.workspaces
+        : Array.isArray(projection.work_items)
+          ? projection.work_items
+          : [];
     if (sourceItems.length > 0) {
       return sourceItems.map((item) => normalizeWorkspaceItem(item, projection));
     }
 
     const current = normalizeWorkspaceItem(projection, {
-      id: projection.id || "__current_workspace__",
+      id: projection.id || "__current_work__",
       title: projection.title || activeWorkspace()?.title,
     });
     const journalEntries = Array.isArray(projection.journal_entries)

--- a/crates/gwt/web/workspace-kanban-surface.js
+++ b/crates/gwt/web/workspace-kanban-surface.js
@@ -655,7 +655,7 @@ export function createWorkspaceKanbanSurface({
 
   function renderWindows() {
     for (const windowData of activeWorkspace()?.windows || []) {
-      if (workspaceWindowById(windowData.id)?.preset !== "workspace") continue;
+      if (workspaceWindowById(windowData.id)?.preset !== "work") continue;
       renderWorkspaceOverviewWindow(windowData.id);
     }
   }

--- a/crates/gwt/web/workspace-kanban-surface.js
+++ b/crates/gwt/web/workspace-kanban-surface.js
@@ -136,6 +136,12 @@ export function createWorkspaceKanbanSurface({
 
   function workspacesFromProjection(projection) {
     if (!projection) return [];
+    const activeWorks = Array.isArray(projection.active_works)
+      ? projection.active_works
+      : [];
+    if (activeWorks.length > 0) {
+      return activeWorks.map((item) => normalizeWorkspaceItem(item, projection));
+    }
     const sourceItems = Array.isArray(projection.workspaces)
       ? projection.workspaces
       : Array.isArray(projection.work_items)
@@ -214,11 +220,11 @@ export function createWorkspaceKanbanSurface({
     const section = createNode("section", "workspace-agent-queue");
     section.dataset.role = "unassigned-agents";
     section.appendChild(
-      createNode("div", "workspace-overview-section-label", "Unassigned agents"),
+      createNode("div", "workspace-overview-section-label", "Unassigned Agents"),
     );
     if (agents.length === 0) {
       section.appendChild(
-        createNode("div", "workspace-overview-empty", "No unassigned agents"),
+        createNode("div", "workspace-overview-empty", "No Unassigned Agents"),
       );
       container.appendChild(section);
       return;
@@ -483,7 +489,7 @@ export function createWorkspaceKanbanSurface({
     const status = root.querySelector(".workspace-overview-status-line");
     if (status) {
       status.textContent = projection
-        ? `${workspaces.length} Work · ${unassignedAgents.length} unassigned agents`
+        ? `${workspaces.length} Active Works · ${unassignedAgents.length} Unassigned Agents`
         : "No Work projection";
     }
 
@@ -536,7 +542,7 @@ export function createWorkspaceKanbanSurface({
     workShell.dataset.workSection = "work";
     const listPane = createNode("aside", "workspace-overview-list-pane");
     listPane.setAttribute("aria-label", "Work list");
-    listPane.appendChild(createNode("div", "workspace-overview-section-label", "Work"));
+    listPane.appendChild(createNode("div", "workspace-overview-section-label", "Active Works"));
     const listBox = createNode("div", "workspace-overview-list");
     listBox.setAttribute("role", "listbox");
     listPane.appendChild(listBox);

--- a/crates/gwt/web/workspace-resume-picker-modal.js
+++ b/crates/gwt/web/workspace-resume-picker-modal.js
@@ -96,7 +96,7 @@ export function renderWorkspaceResumePicker({
   modalEl.removeAttribute("aria-hidden");
   while (dialogEl.firstChild) dialogEl.removeChild(dialogEl.firstChild);
 
-  dialogEl.appendChild(createNode("h2", "workspace-resume-picker-title", "Resume Workspace"));
+  dialogEl.appendChild(createNode("h2", "workspace-resume-picker-title", "Resume Work"));
   dialogEl.appendChild(
     createNode(
       "p",
@@ -111,7 +111,7 @@ export function renderWorkspaceResumePicker({
       createNode(
         "div",
         "workspace-resume-picker-empty",
-        "No resumable agents for this Workspace.",
+        "No resumable agents for this Work.",
       ),
     );
   } else {

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6144,3 +6144,10 @@ Type: lesson
 Context: SPEC-2014 managed workspace parent bug: Start Work opened at /Users/akiojin/Workbench/gwt while Docker files lived in nested develop checkout, so Runtime target selection was hidden.
 Learning: Runtime confirmation must first prefer an existing target worktree, but when the target worktree does not exist it should use an existing checkout such as develop/main for Docker context detection without resolving or creating the target worktree.
 Future Action: When touching Launch Wizard runtime context, add tests for workspace parent roots and assert the target worktree remains absent until the final launch/materialization step.
+
+## 2026-05-26 — session.json project_root が非 git ディレクトリを指すと workspace.json ハッシュ不一致で空 workspace が読み込まれる
+
+Type: lesson
+Context: gwt serve 検証時、session.json の gwt タブが /Users/akiojin/Workbench/gwt（bare repo 親ディレクトリ、git リポジトリではない）を指していたため、detect_repo_hash が失敗し compute_path_hash（パスベース b19aac38305901f5）にフォールバック。実際の workspace.json は remote URL ベースハッシュ 99a8660247f5bc49 に保存されており、空の workspace が読み込まれてウィンドウが 0 件になった。
+Learning: project_scope_hash は (1) origin URL ベースと (2) パスベースの 2 種類のハッシュを返す。session.json の project_root が git リポジトリでない場合、パスベースにフォールバックし、production app が書いた workspace.json と別ファイルを読む。
+Future Action: ウィンドウ復元テスト時は session.json の project_root が実際の git ワーキングツリーを指しているか確認する。非 git ディレクトリ → パスハッシュフォールバック問題は別 Issue として登録する。

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6137,3 +6137,10 @@ Type: lesson
 Context: PR #2894 review found that normalize_windows_child_process_path used Path::to_string_lossy(), which can replace valid Unix non-UTF8 path bytes with the UTF-8 replacement sequence when the shared helper is called broadly at launch/worktree boundaries.
 Learning: Windows-specific path normalization helpers must not lossy-convert Path values. Only rewrite when Path::to_str() succeeds and a known Windows provider/verbatim prefix is present; otherwise return the original PathBuf to preserve platform path bytes.
 Future Action: Before broadening any Path normalization helper, add Unix non-UTF8 byte-preservation tests alongside the Windows prefix tests, then verify the helper returns unchanged PathBuf for non-UTF8 and no-op inputs.
+
+## 2026-05-26 — Separate Launch Wizard runtime detection root from target worktree materialization
+
+Type: lesson
+Context: SPEC-2014 managed workspace parent bug: Start Work opened at /Users/akiojin/Workbench/gwt while Docker files lived in nested develop checkout, so Runtime target selection was hidden.
+Learning: Runtime confirmation must first prefer an existing target worktree, but when the target worktree does not exist it should use an existing checkout such as develop/main for Docker context detection without resolving or creating the target worktree.
+Future Action: When touching Launch Wizard runtime context, add tests for workspace parent roots and assert the target worktree remains absent until the final launch/materialization step.

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6151,3 +6151,24 @@ Type: lesson
 Context: gwt serve 検証時、session.json の gwt タブが /Users/akiojin/Workbench/gwt（bare repo 親ディレクトリ、git リポジトリではない）を指していたため、detect_repo_hash が失敗し compute_path_hash（パスベース b19aac38305901f5）にフォールバック。実際の workspace.json は remote URL ベースハッシュ 99a8660247f5bc49 に保存されており、空の workspace が読み込まれてウィンドウが 0 件になった。
 Learning: project_scope_hash は (1) origin URL ベースと (2) パスベースの 2 種類のハッシュを返す。session.json の project_root が git リポジトリでない場合、パスベースにフォールバックし、production app が書いた workspace.json と別ファイルを読む。
 Future Action: ウィンドウ復元テスト時は session.json の project_root が実際の git ワーキングツリーを指しているか確認する。非 git ディレクトリ → パスハッシュフォールバック問題は別 Issue として登録する。
+
+## 2026-05-25 — 既存ブランチの実装確認は git log --all で先に行う
+
+Type: lesson
+Context: SPEC-2359 Phase W (Workspace → Work) を develop で実装し始めたが、work/20260524-0442 ブランチで既に完全に実装済み (PR #2885) だった
+Learning: 新しい作業を始める前に git log --all --oneline --grep でキーワード検索し、他ブランチで既に実装されていないか確認する。SPEC の tasks が unchecked でも、別の worktree/agent が実装済みの可能性がある
+Future Action: 実装着手前に git log --all --grep と gh pr list で既存実装・オープン PR を確認する preflight を必ず行う
+
+## 2026-05-25 — visual regression workflow 削除後の required check 残骸
+
+Type: lesson
+Context: v9.46.0 リリースで visual-regression.yml を削除したが、main branch protection の required status checks に Operator Design System (Playwright) が残っていたため PR が BLOCKED になった
+Learning: CI workflow を削除する際は、対応する branch protection required status checks も同時に削除する必要がある
+Future Action: workflow ファイルを削除する commit を含むリリースでは、branch protection required checks の棚卸しを行う
+
+## 2026-05-25 — git status の M (tracked modified) を untracked と誤認しない
+
+Type: lesson
+Context: リリース作業中に tasks/memory.md の stash pop コンフリクトを解消する際、git status で M (modified/tracked) と表示されていたファイルを「バージョン管理対象外のローカルファイル」と誤認し、--theirs で一方的に上書きした
+Learning: git status の M は tracked file の変更を示す。?? が untracked。ファイルがバージョン管理対象かどうかは git status の表記で判断でき、思い込みで判断してはならない
+Future Action: stash pop コンフリクト解消時は、必ず両側の差分を確認し、tracked file であれば両方の変更を保持するマージを行う。一方的に --theirs / --ours で上書きしない


### PR DESCRIPTION
## Summary

Release v9.47.0 — multiple active works support, agent window persistence, and several GUI/launch bug fixes.

## Changes

### Features
- Support multiple active works
- Align active work identity and agent cardinality

### Bug Fixes
- Keep tab switcher visible when switching to Git Branches view
- Persist agent windows in workspace.json for restore on restart
- Coalesce browser resize events and adjust Blink lineHeight (#2903)
- Detect docker runtime from managed workspace root
- Prevent wizard close event starvation under load
- Ignore stopped windows when resuming agents

### Refactor
- Unify window size to 720×420 and rename Workspace enum to Work

## Version

v9.47.0

## Closing Issues

Closes #2903

## Related Issues / Links

#2014
#2359
#2900


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session persistence tracking for window state management.

* **Bug Fixes**
  * Improved handling of corrupted session metadata to prevent startup failures.
  * Fixed active work agent focus and reuse when resuming previously suspended work.
  * Enhanced browser resize event coalescing for terminal viewport responsiveness.

* **Refactor**
  * Updated terminology from "Workspace" to "Work" throughout the UI and system.
  * Reorganized active work projection to support multiple active works per project.
  * Improved work identification and grouping logic.

* **Documentation**
  * Added operational lessons for Launch Wizard, work restoration, and CI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->