### PR TITLE
fix(launch): accept Work window preset for Launch/Resume from Git Branches tab

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -11982,6 +11982,79 @@ exit 1
     }
 
     #[test]
+    fn app_runtime_open_launch_wizard_accepts_work_window_preset() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "work-1",
+            repo,
+            WindowPreset::Work,
+            WindowProcessStatus::Ready,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "work-1");
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::OpenLaunchWizard {
+                id: window_id,
+                branch_name: "main".to_string(),
+                linked_issue_number: None,
+            },
+        );
+
+        assert!(
+            runtime.launch_wizard.is_some(),
+            "Launch wizard should open from a Work window preset"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(&event.event, BackendEvent::LaunchWizardOpenError { .. })),
+            "Work preset must not be rejected as 'not a Work surface'"
+        );
+    }
+
+    #[test]
+    fn app_runtime_resume_branch_latest_agent_accepts_work_window_preset() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "work-1",
+            repo,
+            WindowPreset::Work,
+            WindowProcessStatus::Ready,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "work-1");
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::ResumeBranchLatestAgent {
+                id: window_id,
+                branch_name: "main".to_string(),
+                bounds: canvas_bounds(),
+            },
+        );
+
+        let has_surface_error = events.iter().any(|event| {
+            matches!(
+                &event.event,
+                BackendEvent::BranchError { message, .. }
+                    if message == "Window is not a Work surface"
+            )
+        });
+        assert!(
+            !has_surface_error,
+            "Work preset must not be rejected as 'not a Work surface'"
+        );
+    }
+
+    #[test]
     fn app_runtime_resume_workspace_failure_surfaces_launch_wizard_open_error() {
         // SPEC-2359 / Issue #2757: Resume クリックで `resume_workspace_events`
         // が早期 return / Start Work fallback 失敗を起こした場合、frontend で

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -114,7 +114,7 @@ impl AppRuntime {
             return launch_agent_open_error(client_id, "Window not found");
         };
 
-        if window.preset != WindowPreset::Branches {
+        if window.preset != WindowPreset::Branches && window.preset != WindowPreset::Work {
             return launch_agent_open_error(client_id, "Window is not a Work surface");
         }
         // SPEC-1934 US-7 / FR-034
@@ -646,7 +646,7 @@ impl AppRuntime {
         let Some(window) = tab.workspace.window(&address.raw_id) else {
             return branch_error("Window not found".to_string());
         };
-        if window.preset != WindowPreset::Branches {
+        if window.preset != WindowPreset::Branches && window.preset != WindowPreset::Work {
             return branch_error("Window is not a Work surface".to_string());
         }
         if tab.kind != gwt::ProjectKind::Git {

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6151,3 +6151,10 @@ Type: lesson
 Context: gwt serve 検証時、session.json の gwt タブが /Users/akiojin/Workbench/gwt（bare repo 親ディレクトリ、git リポジトリではない）を指していたため、detect_repo_hash が失敗し compute_path_hash（パスベース b19aac38305901f5）にフォールバック。実際の workspace.json は remote URL ベースハッシュ 99a8660247f5bc49 に保存されており、空の workspace が読み込まれてウィンドウが 0 件になった。
 Learning: project_scope_hash は (1) origin URL ベースと (2) パスベースの 2 種類のハッシュを返す。session.json の project_root が git リポジトリでない場合、パスベースにフォールバックし、production app が書いた workspace.json と別ファイルを読む。
 Future Action: ウィンドウ復元テスト時は session.json の project_root が実際の git ワーキングツリーを指しているか確認する。非 git ディレクトリ → パスハッシュフォールバック問題は別 Issue として登録する。
+
+## 2026-05-26 — Work preset missing in Phase F wizard refactor
+
+Type: lesson
+Context: Work画面のGit BranchesタブからLaunch/Resumeすると Window is not a Work surface エラー。wizard.rsのopen_launch_wizardとresume_branch_latest_agent_eventsがWindowPreset::Branchesのみ許可していた。レガシーのlaunch_wizard_runtime.rsはBranches+Work両方許可。
+Learning: app_runtime Phase F リファクタで旧コード(launch_wizard_runtime.rs)からの移植時にプリセット条件を狭くしたリグレッション。mod.rs:5420のload_branches_eventsは正しく両方許可していたので、同一ファイル内にパターンの不整合があった。
+Future Action: wizard.rsのプリセットチェック変更時はmod.rsの同種チェック(load_branches_events等)と一貫性を確認する。Work surface embedded branches パターンでは WindowPreset::Work も許可が必要。


### PR DESCRIPTION
## Summary

- Work画面内の「Git Branches」タブからLaunch/Resumeボタンを押すと "Window is not a Work surface" エラーが表示されるリグレッションを修正
- Phase Fリファクタ時に `wizard.rs` のプリセットチェックから `WindowPreset::Work` の許可が抜け落ちていた

## Changes

- `crates/gwt/src/app_runtime/wizard.rs`: `open_launch_wizard()` と `resume_branch_latest_agent_events()` のプリセットチェックに `WindowPreset::Work` を追加（レガシー実装と同等に復元）
- `crates/gwt/src/app_runtime/mod.rs`: Work プリセットからの Launch/Resume がプリセット拒否されないことを検証する2つの回帰テストを追加

## Testing

- [x] `cargo test -p gwt-core -p gwt --all-features` — 全テスト PASS
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — 0 warnings
- [x] `cargo fmt -- --check` — clean
- [x] GUI視覚確認: Work → Git Branches タブ → Launch ボタン → ウィザード正常表示

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — 独立した2行のバグ修正 + 回帰テスト
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

None

## Related Issues / Links

None

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (if user-facing change) — N/A: 内部バグ修正のためドキュメント変更不要
- [ ] Migration/backfill plan included (if schema/data change) — N/A
- [x] CHANGELOG impact considered (breaking change flagged in commit)
