### PR TITLE
feat(discussion): deepen gwt-discussion depth gate

### DIFF
--- a/.claude/commands/gwt-discussion.md
+++ b/.claude/commands/gwt-discussion.md
@@ -21,8 +21,8 @@ mid-implementation investigation.
 2. Search existing SPECs and Issues for context.
 3. Investigate code, map dependencies, then present findings before proposing a path.
 4. Discuss one question at a time with selection UI first. In Codex, use `request_user_input` when that UI is available.
-5. After each answer, update `Discussion TODO`, `Coverage Checks`, and `Exit Blockers`, then re-rank unresolved high-impact unknowns and ask the next highest-impact question before exiting.
-6. Do not leave Plan Mode until `Action Delta` and `Action Bundle` are ready, the depth gate is satisfied or intentionally deferred, and `Evidence Gate: complete` is backed by implementation proof, SPEC/Issue proof, gap-check proof, official docs proof when applicable, and external research proof when needed.
+5. After each answer, update `Discussion TODO`, `Coverage Checks`, `Exit Blockers`, `Question Ledger`, and `Depth Gate`, then re-rank unresolved high-impact unknowns and ask the next highest-impact question before exiting.
+6. Do not leave Plan Mode until `Action Delta` and `Action Bundle` are ready, `Depth Gate: complete` or `Depth Gate: deferred(<reason>)` is recorded, and `Evidence Gate: complete` is backed by implementation proof, SPEC/Issue proof, gap-check proof, official docs proof when applicable, and external research proof when needed.
 7. If managed hooks surface an unfinished discussion prompt, use `.gwt/discussion.md` as the source of truth and choose `Resume discussion`, `Park proposal`, or `Dismiss for now`.
 
 ## Examples

--- a/.claude/skills/gwt-discussion/SKILL.md
+++ b/.claude/skills/gwt-discussion/SKILL.md
@@ -50,7 +50,7 @@ Keep these artifacts throughout the discussion:
 
 `Discussion TODO` is not an implementation task list. It tracks unresolved
 questions, dependency checks, deferred decisions, coverage gaps, exit blockers,
-and the next question to ask.
+the next question to ask, and the depth state for the active proposal.
 
 Evidence is part of the discussion state, not a later implementation detail.
 Do not mark a proposal `[chosen]` until its evidence fields prove the outcome
@@ -69,6 +69,9 @@ Mirror structure for `.gwt/discussion.md`:
 - Coverage Checks:
 - Exit Blockers:
 - Next Question:
+- Depth Mode:
+- Question Ledger:
+- Depth Gate:
 - Implementation Proof:
 - SPEC/Issue Proof:
 - Gap Check Proof:
@@ -101,8 +104,10 @@ SPEC-1935 FR-014p routes Stop events through `skill-discussion-stop-check`,
 which inspects `.gwt/discussion.md` and blocks Stop (with
 `{"decision":"block","reason":"..."}`) while any proposal is still `[active]`
 with a non-empty `Next Question:`, unresolved `Exit Blockers:`, incomplete
-proof fields, or an `Evidence Gate:` that is not `complete`. To let Stop
-succeed, mark each proposal explicitly using the exit CLI:
+proof fields, incomplete depth fields, or an `Evidence Gate:` that is not
+`complete`. Depth fields are incomplete when `Question Ledger:` is empty,
+`Depth Gate:` is missing/open, or `Depth Gate: deferred(<reason>)` has no
+reason. To let Stop succeed, mark each proposal explicitly using the exit CLI:
 
 - `gwtd discuss resolve --proposal "Proposal A"` — active → chosen only after
   `Evidence Gate: complete`
@@ -210,9 +215,40 @@ After each answer:
 
 - update the `Intake Memo`
 - update the `Discussion TODO`
+- append or refine the active proposal's `Question Ledger`
+- update `Depth Gate` only when depth coverage is complete or explicitly
+  deferred with a reason
 - remove or refine the resolved unknown
 - re-rank the remaining unresolved questions
 - Ask the next highest-impact question if any remain
+
+## Depth Interview Loop
+
+Use this loop for every non-trivial discussion, including ordinary
+`gwt-discussion` runs. Do not wait for an explicit `--deepen` flag when the
+latest answer leaves high-impact ambiguity.
+
+After every answer:
+
+1. Record what was learned in the `Question Ledger`.
+2. Re-score unresolved unknowns across scope boundary, ownership/integration,
+   failure/edge cases, migration/compatibility, verification/success signal,
+   and alternatives/assumption challenge.
+3. Ask the next highest-impact question with the platform question tool when
+   any category can still change implementation, routing, ownership, or
+   verification.
+4. Every third question, challenge one premise directly: what breaks if the
+   preferred answer is wrong, delayed, partially implemented, or applied to an
+   adjacent subsystem?
+5. Set `Depth Gate: complete` only when the `Question Ledger` shows all
+   applicable categories are covered. Use `Depth Gate: deferred(<reason>)` only
+   when the remaining depth is intentionally out of scope for the current
+   Action Bundle.
+
+Do not treat a small number of questions as a completion signal. A broad or
+risky discussion may require many rounds. Also do not treat a top-3 priority
+list as the end of deepening; it is only the next batch to discuss before the
+remaining backlog is re-ranked.
 
 ## Discussion Depth Gate
 

--- a/.claude/skills/gwt-discussion/references/clarification.md
+++ b/.claude/skills/gwt-discussion/references/clarification.md
@@ -70,6 +70,9 @@ Rules:
   exit criteria are satisfied or a real blocker remains.
 - Planning-ready requires covering the applicable categories from the standard
   question checklist.
+- Update the active proposal's `Question Ledger` after each answer and leave
+  `Depth Gate: open` while a category can still change implementation,
+  ownership, routing, failure handling, migration, or verification.
 
 ### Step 5: Update spec.md
 
@@ -134,6 +137,9 @@ All of the following must be true:
 - Ubiquitous Language section is consistent with user stories and FRs.
 - Planning-ready requires covering the applicable categories from the standard
   question checklist.
+- `Question Ledger` records the clarification questions that resolved those
+  categories.
+- `Depth Gate` is `complete` or `deferred(<reason>)`.
 
 ## Output format
 

--- a/.claude/skills/gwt-discussion/references/deepening.md
+++ b/.claude/skills/gwt-discussion/references/deepening.md
@@ -81,7 +81,10 @@ Look for:
 
 After presenting the report, ask the user which points to deep-dive on.
 Before asking the user to choose points, narrow the list to the top 3 highest-impact points.
-Accept numbers, ranges (e.g., "1-3"), or "all".
+This top 3 list is the first batch, not an exit condition. After the selected
+batch is answered, update the `Question Ledger`, re-rank the remaining backlog,
+and continue until `Depth Gate` is complete or explicitly deferred with a
+reason. Accept numbers, ranges (e.g., "1-3"), or "all".
 
 ## Phase 5.2: Interactive deep-dive
 
@@ -142,6 +145,9 @@ Repeat steps 1-5 for each selected deepening point.
 
 - All selected deepening points have been addressed with user input.
 - Artifact updates have been applied.
+- `Question Ledger` records the selected points, answers, and any remaining
+  backlog disposition.
+- `Depth Gate` is `complete` or `deferred(<reason>)`.
 - A summary of changes is presented:
 
 ```text

--- a/.claude/skills/gwt-discussion/references/intake.md
+++ b/.claude/skills/gwt-discussion/references/intake.md
@@ -54,6 +54,10 @@ Stop when all of these are true:
 - The first slice has a visible success condition.
 - High-impact scope ambiguity has been resolved by the user.
 - The SPEC vs Issue decision is justified.
+- `Question Ledger` records the answers used for routing, scope, integration,
+  non-goals, failure handling, and verification signal.
+- `Depth Gate` is complete or explicitly deferred with a reason for the intake
+  slice.
 - Do not stop after the first slice success condition alone. Also resolve the
   integration target, explicit non-goals, and verification signal for the
   chosen slice before leaving intake.
@@ -80,6 +84,8 @@ Maintain in conversation context (not as a file):
 - Out of scope: <what is explicitly excluded>
 - Constraints: <technical, time, or design constraints>
 - Success signal: <how to know it works>
+- Question Ledger: <routing/scope/depth answers already covered>
+- Depth Gate: <open|complete|deferred(reason)>
 - Open questions: <unresolved items>
 - Candidate owner: <existing SPEC/Issue if found, or "none">
 ```

--- a/.codex/skills/gwt-discussion/SKILL.md
+++ b/.codex/skills/gwt-discussion/SKILL.md
@@ -50,7 +50,7 @@ Keep these artifacts throughout the discussion:
 
 `Discussion TODO` is not an implementation task list. It tracks unresolved
 questions, dependency checks, deferred decisions, coverage gaps, exit blockers,
-and the next question to ask.
+the next question to ask, and the depth state for the active proposal.
 
 Evidence is part of the discussion state, not a later implementation detail.
 Do not mark a proposal `[chosen]` until its evidence fields prove the outcome
@@ -69,6 +69,9 @@ Mirror structure for `.gwt/discussion.md`:
 - Coverage Checks:
 - Exit Blockers:
 - Next Question:
+- Depth Mode:
+- Question Ledger:
+- Depth Gate:
 - Implementation Proof:
 - SPEC/Issue Proof:
 - Gap Check Proof:
@@ -101,8 +104,10 @@ SPEC-1935 FR-014p routes Stop events through `skill-discussion-stop-check`,
 which inspects `.gwt/discussion.md` and blocks Stop (with
 `{"decision":"block","reason":"..."}`) while any proposal is still `[active]`
 with a non-empty `Next Question:`, unresolved `Exit Blockers:`, incomplete
-proof fields, or an `Evidence Gate:` that is not `complete`. To let Stop
-succeed, mark each proposal explicitly using the exit CLI:
+proof fields, incomplete depth fields, or an `Evidence Gate:` that is not
+`complete`. Depth fields are incomplete when `Question Ledger:` is empty,
+`Depth Gate:` is missing/open, or `Depth Gate: deferred(<reason>)` has no
+reason. To let Stop succeed, mark each proposal explicitly using the exit CLI:
 
 - `gwtd discuss resolve --proposal "Proposal A"` — active → chosen only after
   `Evidence Gate: complete`
@@ -228,9 +233,40 @@ After each answer:
 
 - update the `Intake Memo`
 - update the `Discussion TODO`
+- append or refine the active proposal's `Question Ledger`
+- update `Depth Gate` only when depth coverage is complete or explicitly
+  deferred with a reason
 - remove or refine the resolved unknown
 - re-rank the remaining unresolved questions
 - Ask the next highest-impact question if any remain
+
+## Depth Interview Loop
+
+Use this loop for every non-trivial discussion, including ordinary
+`gwt-discussion` runs. Do not wait for an explicit `--deepen` flag when the
+latest answer leaves high-impact ambiguity.
+
+After every answer:
+
+1. Record what was learned in the `Question Ledger`.
+2. Re-score unresolved unknowns across scope boundary, ownership/integration,
+   failure/edge cases, migration/compatibility, verification/success signal,
+   and alternatives/assumption challenge.
+3. Ask the next highest-impact question with the platform question tool when
+   any category can still change implementation, routing, ownership, or
+   verification.
+4. Every third question, challenge one premise directly: what breaks if the
+   preferred answer is wrong, delayed, partially implemented, or applied to an
+   adjacent subsystem?
+5. Set `Depth Gate: complete` only when the `Question Ledger` shows all
+   applicable categories are covered. Use `Depth Gate: deferred(<reason>)` only
+   when the remaining depth is intentionally out of scope for the current
+   Action Bundle.
+
+Do not treat a small number of questions as a completion signal. A broad or
+risky discussion may require many rounds. Also do not treat a top-3 priority
+list as the end of deepening; it is only the next batch to discuss before the
+remaining backlog is re-ranked.
 
 ## Discussion Depth Gate
 

--- a/.codex/skills/gwt-discussion/references/clarification.md
+++ b/.codex/skills/gwt-discussion/references/clarification.md
@@ -70,6 +70,9 @@ Rules:
   exit criteria are satisfied or a real blocker remains.
 - Planning-ready requires covering the applicable categories from the standard
   question checklist.
+- Update the active proposal's `Question Ledger` after each answer and leave
+  `Depth Gate: open` while a category can still change implementation,
+  ownership, routing, failure handling, migration, or verification.
 
 ### Step 5: Update spec.md
 
@@ -134,6 +137,9 @@ All of the following must be true:
 - Ubiquitous Language section is consistent with user stories and FRs.
 - Planning-ready requires covering the applicable categories from the standard
   question checklist.
+- `Question Ledger` records the clarification questions that resolved those
+  categories.
+- `Depth Gate` is `complete` or `deferred(<reason>)`.
 
 ## Output format
 

--- a/.codex/skills/gwt-discussion/references/deepening.md
+++ b/.codex/skills/gwt-discussion/references/deepening.md
@@ -81,7 +81,10 @@ Look for:
 
 After presenting the report, ask the user which points to deep-dive on.
 Before asking the user to choose points, narrow the list to the top 3 highest-impact points.
-Accept numbers, ranges (e.g., "1-3"), or "all".
+This top 3 list is the first batch, not an exit condition. After the selected
+batch is answered, update the `Question Ledger`, re-rank the remaining backlog,
+and continue until `Depth Gate` is complete or explicitly deferred with a
+reason. Accept numbers, ranges (e.g., "1-3"), or "all".
 
 ## Phase 5.2: Interactive deep-dive
 
@@ -142,6 +145,9 @@ Repeat steps 1-5 for each selected deepening point.
 
 - All selected deepening points have been addressed with user input.
 - Artifact updates have been applied.
+- `Question Ledger` records the selected points, answers, and any remaining
+  backlog disposition.
+- `Depth Gate` is `complete` or `deferred(<reason>)`.
 - A summary of changes is presented:
 
 ```text

--- a/.codex/skills/gwt-discussion/references/intake.md
+++ b/.codex/skills/gwt-discussion/references/intake.md
@@ -54,6 +54,10 @@ Stop when all of these are true:
 - The first slice has a visible success condition.
 - High-impact scope ambiguity has been resolved by the user.
 - The SPEC vs Issue decision is justified.
+- `Question Ledger` records the answers used for routing, scope, integration,
+  non-goals, failure handling, and verification signal.
+- `Depth Gate` is complete or explicitly deferred with a reason for the intake
+  slice.
 - Do not stop after the first slice success condition alone. Also resolve the
   integration target, explicit non-goals, and verification signal for the
   chosen slice before leaving intake.
@@ -80,6 +84,8 @@ Maintain in conversation context (not as a file):
 - Out of scope: <what is explicitly excluded>
 - Constraints: <technical, time, or design constraints>
 - Success signal: <how to know it works>
+- Question Ledger: <routing/scope/depth answers already covered>
+- Depth Gate: <open|complete|deferred(reason)>
 - Open questions: <unresolved items>
 - Candidate owner: <existing SPEC/Issue if found, or "none">
 ```

--- a/crates/gwt-skills/src/codex_hook_trust.rs
+++ b/crates/gwt-skills/src/codex_hook_trust.rs
@@ -749,12 +749,13 @@ enabled = false
         generate_codex_hooks(dir.path()).unwrap();
         let hooks_path = fs::canonicalize(dir.path().join(".codex/hooks.json")).unwrap();
         let pre_tool_key = format!("{}:pre_tool_use:0:0", hooks_path.display());
+        let pre_tool_key_toml = pre_tool_key.replace('\\', "\\\\").replace('"', "\\\"");
         let config_path = dir.path().join("codex-config.toml");
         fs::write(
             &config_path,
             format!(
                 r#"
-[hooks.state."{pre_tool_key}"]
+[hooks.state."{pre_tool_key_toml}"]
 enabled = false
 "#
             ),

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -844,6 +844,14 @@ mod tests {
                 "expected discussion skill to require evidence proof fields in {relative}"
             );
             assert!(
+                discussion_skill.contains("## Depth Interview Loop")
+                    && discussion_skill.contains("Question Ledger")
+                    && discussion_skill.contains("Depth Gate")
+                    && discussion_skill.contains("After every answer")
+                    && discussion_skill.contains("Do not treat a small number of questions as a completion signal"),
+                "expected discussion skill to require depth-gated follow-up questioning in {relative}"
+            );
+            assert!(
                 discussion_skill.contains("official documentation")
                     && discussion_skill.contains("X search")
                     && discussion_skill.contains("X API Search Posts"),
@@ -940,7 +948,9 @@ mod tests {
                 discussion_command.contains("Plan Mode")
                     && discussion_command.contains("leave Plan Mode")
                     && discussion_command.contains("Coverage Checks")
-                    && discussion_command.contains("Exit Blockers"),
+                    && discussion_command.contains("Exit Blockers")
+                    && discussion_command.contains("Depth Gate")
+                    && discussion_command.contains("Question Ledger"),
                 "expected discussion command to describe the Plan Mode and depth-gate contract in {relative}"
             );
             assert!(
@@ -965,6 +975,8 @@ mod tests {
             );
             assert!(
                 clarification.contains("Planning-ready requires covering the applicable categories")
+                    && clarification.contains("Depth Gate")
+                    && clarification.contains("Question Ledger")
                     && !clarification.contains("Ask at most 5 questions"),
                 "expected clarification guidance to require checklist coverage instead of a five-question cap in {relative}"
             );
@@ -978,7 +990,8 @@ mod tests {
                 .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
             assert!(
                 deepening.contains("Escalate from the normal discussion flow into deepening")
-                    && deepening.contains("top 3 highest-impact points"),
+                    && deepening.contains("top 3 highest-impact points")
+                    && deepening.contains("first batch, not an exit condition"),
                 "expected deepening guidance to allow automatic escalation and pre-prioritization in {relative}"
             );
         }
@@ -993,7 +1006,9 @@ mod tests {
                 intake.contains("Do not stop after the first slice success condition alone.")
                     && intake.contains("integration target")
                     && intake.contains("explicit non-goals")
-                    && intake.contains("verification signal"),
+                    && intake.contains("verification signal")
+                    && intake.contains("Depth Gate")
+                    && intake.contains("Question Ledger"),
                 "expected intake guidance to continue beyond the first-slice success signal in {relative}"
             );
         }

--- a/crates/gwt-skills/src/settings_local.rs
+++ b/crates/gwt-skills/src/settings_local.rs
@@ -886,7 +886,7 @@ mod tests {
             "Stop chain must collapse to the event dispatcher; got: {stop_commands:?}"
         );
         assert!(
-            stop_commands[0].ends_with(" hook event Stop") && stop_commands[0].contains("gwtd"),
+            stop_commands[0].contains(" hook event Stop") && stop_commands[0].contains("gwtd"),
             "Stop dispatcher must target gwtd via absolute or literal path; got: {stop_commands:?}"
         );
         assert!(
@@ -2156,11 +2156,15 @@ mod tests {
     fn gwt_hook_bin_path_resolves_gui_binary_to_gwtd_sibling() {
         assert_eq!(
             gwt_hook_bin_path_with(Some(Path::new("/opt/gwt/bin/gwt")), |_| None),
-            "/opt/gwt/bin/gwtd"
+            Path::new("/opt/gwt/bin/gwt")
+                .with_file_name("gwtd")
+                .to_string_lossy()
         );
         assert_eq!(
             gwt_hook_bin_path_with(Some(Path::new("C:/tools/gwt.exe")), |_| None),
-            "C:/tools/gwtd.exe"
+            Path::new("C:/tools/gwt.exe")
+                .with_file_name("gwtd.exe")
+                .to_string_lossy()
         );
     }
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -9636,7 +9636,10 @@ exit 1
         assert_eq!(prepared.agent_path, source.display().to_string());
         assert_eq!(
             super::format_file_attachment_prompt(&[prepared.agent_path]),
-            format!("File: \"{}\"", source.display())
+            format!(
+                "File: {}",
+                super::quote_file_attachment_path(&source.display().to_string())
+            )
         );
     }
 

--- a/crates/gwt/src/cli/hook/skill_discussion_stop_check.rs
+++ b/crates/gwt/src/cli/hook/skill_discussion_stop_check.rs
@@ -46,7 +46,7 @@ pub fn handle_with_input(worktree: &Path, input: &str) -> HookOutput {
 
     HookOutput::stop_block(format!(
         "Discussion is still [active] on proposal \"{title}\".\n\
-         Next question or evidence blocker: {question}\n\
+         Next question, evidence blocker, or depth blocker: {question}\n\
          Continue the gwt-discussion workflow (investigate → ask the user → update Discussion TODO), \
          or call `gwtd discuss resolve|park|reject --proposal \"{label}\"` to exit the discussion explicitly.",
         title = pending.proposal_title,
@@ -75,6 +75,9 @@ mod tests {
 - Official Docs Proof: Claude Code hooks docs checked.\n\
 - External Research Proof: not-applicable: local-only behavior.\n\
 - Exit Blockers: none\n\
+- Depth Mode: normal\n\
+- Question Ledger: scope boundary, integration, failure, migration, verification checked\n\
+- Depth Gate: complete\n\
 - Next Question:\n\
 - Evidence Gate: complete\n\
 ";
@@ -88,8 +91,27 @@ mod tests {
 - Official Docs Proof: Claude Code hooks docs checked.\n\
 - External Research Proof: not-applicable: local-only behavior.\n\
 - Exit Blockers: implementation proof is missing\n\
+- Depth Mode: normal\n\
+- Question Ledger: scope boundary checked only\n\
+- Depth Gate: open\n\
 - Next Question:\n\
 - Evidence Gate: open\n\
+";
+
+    const ACTIVE_WITH_DEPTH_BLOCKER_WITHOUT_QUESTION: &str = "## Discussion TODO\n\n\
+### Proposal A - Depth gate [active]\n\
+- Summary: Evidence is complete but depth coverage is shallow.\n\
+- Implementation Proof: crates/gwt/src/discussion_resume.rs inspected.\n\
+- SPEC/Issue Proof: SPEC-1935 checked.\n\
+- Gap Check Proof: scope/integration/failure/migration/verification checked.\n\
+- Official Docs Proof: not-applicable: local-only behavior.\n\
+- External Research Proof: not-applicable: local-only behavior.\n\
+- Exit Blockers: none\n\
+- Depth Mode: normal\n\
+- Question Ledger: scope boundary checked only\n\
+- Depth Gate: open\n\
+- Next Question:\n\
+- Evidence Gate: complete\n\
 ";
 
     const ALL_RESOLVED: &str = "## Discussion TODO\n\n\
@@ -188,7 +210,21 @@ mod tests {
             &[
                 "Evidence gate",
                 "Exit Blockers remain unresolved",
-                "Next question or evidence blocker",
+                "Next question, evidence blocker, or depth blocker",
+            ],
+        );
+    }
+
+    #[test]
+    fn blocks_when_depth_gate_is_incomplete_without_next_question() {
+        let dir = tempfile::tempdir().unwrap();
+        write_discussion(dir.path(), ACTIVE_WITH_DEPTH_BLOCKER_WITHOUT_QUESTION);
+        assert_stop_block(
+            handle_with_input(dir.path(), "{}"),
+            &[
+                "Depth gate",
+                "Depth Gate is not complete",
+                "Next question, evidence blocker, or depth blocker",
             ],
         );
     }

--- a/crates/gwt/src/daemon_runtime.rs
+++ b/crates/gwt/src/daemon_runtime.rs
@@ -276,11 +276,9 @@ fn is_loopback_host(host: &str) -> bool {
 mod tests {
     use super::*;
     use std::ffi::OsString;
-    use std::sync::{Mutex, OnceLock};
 
     fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
+        crate::env_test_lock()
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }

--- a/crates/gwt/src/discussion_resume.rs
+++ b/crates/gwt/src/discussion_resume.rs
@@ -368,10 +368,29 @@ fn evidence_gate_blocker(proposal: &ParsedProposal) -> Option<String> {
         }
     }
 
-    match field_value(proposal, "Evidence Gate") {
+    let evidence_blocker = match field_value(proposal, "Evidence Gate") {
         Some(value) if value.eq_ignore_ascii_case("complete") => None,
         Some(value) => Some(format!("Evidence Gate is not complete: {value}")),
         None => Some("Evidence Gate is missing".to_string()),
+    };
+    if evidence_blocker.is_some() {
+        return evidence_blocker;
+    }
+
+    depth_gate_blocker(proposal)
+}
+
+fn depth_gate_blocker(proposal: &ParsedProposal) -> Option<String> {
+    let question_ledger = field_value(proposal, "Question Ledger");
+    if !is_acceptable_depth_ledger(question_ledger.as_deref()) {
+        return Some("Question Ledger is missing or incomplete".to_string());
+    }
+
+    match field_value(proposal, "Depth Gate") {
+        Some(value) if value.eq_ignore_ascii_case("complete") => None,
+        Some(value) if is_deferred_depth_gate(&value) => None,
+        Some(value) => Some(format!("Depth Gate is not complete: {value}")),
+        None => Some("Depth Gate is missing".to_string()),
     }
 }
 
@@ -410,6 +429,25 @@ fn is_placeholder_value(value: &str) -> bool {
         value.to_ascii_lowercase().as_str(),
         "tbd" | "todo" | "unknown" | "unverified" | "none" | "n/a" | "not-applicable"
     )
+}
+
+fn is_acceptable_depth_ledger(value: Option<&str>) -> bool {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return false;
+    };
+    !is_placeholder_value(value)
+}
+
+fn is_deferred_depth_gate(value: &str) -> bool {
+    let value = value.trim();
+    let lower = value.to_ascii_lowercase();
+    let Some(reason) = lower
+        .strip_prefix("deferred(")
+        .and_then(|rest| rest.strip_suffix(')'))
+    else {
+        return false;
+    };
+    !reason.trim().is_empty()
 }
 
 #[cfg(test)]
@@ -692,6 +730,9 @@ mod tests {
              - Official Docs Proof: Claude Code hooks docs checked\n\
              - External Research Proof: not-applicable: local-only behavior\n\
              - Exit Blockers: none\n\
+             - Depth Mode: normal\n\
+             - Question Ledger: scope boundary, integration, failure, migration, verification checked\n\
+             - Depth Gate: complete\n\
              - Next Question:\n\
              - Evidence Gate: complete\n",
         )
@@ -702,6 +743,41 @@ mod tests {
             proposal_evidence_blocker_by_label(dir.path(), "Proposal A").unwrap(),
             None
         );
+    }
+
+    #[test]
+    fn discussion_stop_blocker_reports_depth_gate_without_next_question() {
+        let dir = tempfile::tempdir().unwrap();
+        let discussion_path = dir.path().join(DISCUSSION_RELATIVE_PATH);
+        std::fs::create_dir_all(discussion_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &discussion_path,
+            "## Discussion TODO\n\n\
+             ### Proposal A - Depth gap [active]\n\
+             - Summary: Evidence is complete but depth is not.\n\
+             - Implementation Proof: crates/gwt/src/discussion_resume.rs inspected and focused tests run\n\
+             - SPEC/Issue Proof: SPEC-1935 spec/plan/tasks checked\n\
+             - Gap Check Proof: scope/integration/failure/migration/verification checked\n\
+             - Official Docs Proof: not-applicable: local-only behavior\n\
+             - External Research Proof: not-applicable: local-only behavior\n\
+             - Exit Blockers: none\n\
+             - Depth Mode: normal\n\
+             - Question Ledger: scope boundary checked only\n\
+             - Depth Gate: open\n\
+             - Next Question:\n\
+             - Evidence Gate: complete\n",
+        )
+        .unwrap();
+
+        let pending = discussion_stop_blocker(dir.path())
+            .unwrap()
+            .expect("depth blocker should keep discussion active");
+        assert_eq!(pending.proposal_label, "Proposal A");
+        assert!(pending
+            .next_question
+            .as_deref()
+            .unwrap_or("")
+            .contains("Depth Gate is not complete"));
     }
 
     #[test]
@@ -724,6 +800,66 @@ mod tests {
             .unwrap()
             .expect("missing proof should block resolve");
         assert!(blocker.contains("Implementation Proof"));
+    }
+
+    #[test]
+    fn proposal_evidence_blocker_accepts_deferred_depth_gate_with_reason() {
+        let dir = tempfile::tempdir().unwrap();
+        let discussion_path = dir.path().join(DISCUSSION_RELATIVE_PATH);
+        std::fs::create_dir_all(discussion_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &discussion_path,
+            "## Discussion TODO\n\n\
+             ### Proposal A - Deferred depth [active]\n\
+             - Summary: Defers the remaining deepening work.\n\
+             - Implementation Proof: crates/gwt/src/discussion_resume.rs inspected\n\
+             - SPEC/Issue Proof: SPEC-1935 checked\n\
+             - Gap Check Proof: scope/integration/failure/migration/verification checked\n\
+             - Official Docs Proof: not-applicable: local-only behavior\n\
+             - External Research Proof: not-applicable: local-only behavior\n\
+             - Exit Blockers: none\n\
+             - Depth Mode: normal\n\
+             - Question Ledger: scope and integration covered; remaining alternatives deferred to next SPEC phase\n\
+             - Depth Gate: deferred(remaining alternatives are out of scope for this Action Bundle)\n\
+             - Next Question:\n\
+             - Evidence Gate: complete\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            proposal_evidence_blocker_by_label(dir.path(), "Proposal A").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn proposal_evidence_blocker_rejects_deferred_depth_gate_without_reason() {
+        let dir = tempfile::tempdir().unwrap();
+        let discussion_path = dir.path().join(DISCUSSION_RELATIVE_PATH);
+        std::fs::create_dir_all(discussion_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &discussion_path,
+            "## Discussion TODO\n\n\
+             ### Proposal A - Empty deferred depth [active]\n\
+             - Summary: Defers without saying why.\n\
+             - Implementation Proof: crates/gwt/src/discussion_resume.rs inspected\n\
+             - SPEC/Issue Proof: SPEC-1935 checked\n\
+             - Gap Check Proof: scope/integration/failure/migration/verification checked\n\
+             - Official Docs Proof: not-applicable: local-only behavior\n\
+             - External Research Proof: not-applicable: local-only behavior\n\
+             - Exit Blockers: none\n\
+             - Depth Mode: normal\n\
+             - Question Ledger: scope checked\n\
+             - Depth Gate: deferred()\n\
+             - Next Question:\n\
+             - Evidence Gate: complete\n",
+        )
+        .unwrap();
+
+        let blocker = proposal_evidence_blocker_by_label(dir.path(), "Proposal A")
+            .unwrap()
+            .expect("empty deferred reason should block resolve");
+        assert!(blocker.contains("Depth Gate"));
     }
 
     #[test]

--- a/crates/gwt/src/knowledge_bridge.rs
+++ b/crates/gwt/src/knowledge_bridge.rs
@@ -1028,7 +1028,7 @@ fn load_linked_branches(repo_path: &Path) -> HashMap<u64, Vec<String>> {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, ffi::OsString, fs, path::PathBuf};
+    use std::{collections::HashMap, ffi::OsString, fs};
 
     use gwt_github::{
         client::{CommentId, CommentSnapshot, IssueNumber, IssueSnapshot, IssueState, UpdatedAt},

--- a/crates/gwt/src/knowledge_bridge.rs
+++ b/crates/gwt/src/knowledge_bridge.rs
@@ -1030,6 +1030,9 @@ fn load_linked_branches(repo_path: &Path) -> HashMap<u64, Vec<String>> {
 mod tests {
     use std::{collections::HashMap, ffi::OsString, fs};
 
+    #[cfg(unix)]
+    use std::path::PathBuf;
+
     use gwt_github::{
         client::{CommentId, CommentSnapshot, IssueNumber, IssueSnapshot, IssueState, UpdatedAt},
         Cache,

--- a/crates/gwt/tests/discussion_cli_test.rs
+++ b/crates/gwt/tests/discussion_cli_test.rs
@@ -53,7 +53,7 @@ fn discussion_update_creates_single_canonical_discussions_file() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("tasks/discussions.md"),
+        stdout.replace('\\', "/").contains("tasks/discussions.md"),
         "stdout should name updated path, got: {stdout}"
     );
     let content =

--- a/crates/gwt/tests/memory_cli_test.rs
+++ b/crates/gwt/tests/memory_cli_test.rs
@@ -46,7 +46,7 @@ fn memory_add_appends_typed_entry_to_existing_memory_file() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("tasks/memory.md"),
+        stdout.replace('\\', "/").contains("tasks/memory.md"),
         "stdout should name updated path, got: {stdout}"
     );
     let memory = fs::read_to_string(tasks.join("memory.md")).expect("read memory");

--- a/crates/gwt/tests/skill_exit_cli_test.rs
+++ b/crates/gwt/tests/skill_exit_cli_test.rs
@@ -40,6 +40,9 @@ fn discuss_resolve_flips_active_proposal_to_chosen() {
          - Official Docs Proof: Claude Code hooks docs checked\n\
          - External Research Proof: not-applicable: local-only behavior\n\
          - Exit Blockers: none\n\
+         - Depth Mode: normal\n\
+         - Question Ledger: scope boundary, integration, failure, migration, verification checked\n\
+         - Depth Gate: complete\n\
          - Next Question: Should we block on Stop?\n\
          - Evidence Gate: complete\n",
     )
@@ -65,6 +68,38 @@ fn discuss_resolve_rejects_incomplete_evidence_gate() {
         "### Proposal A - Evidence gap [active]\n\
          - Summary: Missing proof.\n\
          - Exit Blockers: none\n\
+         - Next Question:\n\
+         - Evidence Gate: complete\n",
+    )
+    .unwrap();
+
+    let code = dispatch(
+        &mut env,
+        &argv(&["gwt", "discuss", "resolve", "--proposal", "Proposal A"]),
+    );
+    assert_eq!(code, 2);
+    let updated = std::fs::read_to_string(&discussion_path).unwrap();
+    assert!(updated.contains("[active]"));
+    assert!(!updated.contains("[chosen]"));
+}
+
+#[test]
+fn discuss_resolve_rejects_incomplete_depth_gate() {
+    let (mut env, dir) = new_env();
+    let discussion_path = dir.path().join(".gwt/discussion.md");
+    std::fs::create_dir_all(discussion_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &discussion_path,
+        "### Proposal A - Depth gap [active]\n\
+         - Implementation Proof: crates/gwt/src/discussion_resume.rs inspected\n\
+         - SPEC/Issue Proof: SPEC-1935 checked\n\
+         - Gap Check Proof: scope/integration/failure/migration/verification checked\n\
+         - Official Docs Proof: not-applicable: local-only behavior\n\
+         - External Research Proof: not-applicable: local-only behavior\n\
+         - Exit Blockers: none\n\
+         - Depth Mode: normal\n\
+         - Question Ledger: scope boundary checked only\n\
+         - Depth Gate: open\n\
          - Next Question:\n\
          - Evidence Gate: complete\n",
     )


### PR DESCRIPTION
## Summary

- Deepens `gwt-discussion` so active discussions cannot finish after shallow questioning.
- Adds a depth gate and question ledger contract that blocks Stop and `gwtd discuss resolve` until depth coverage is complete or explicitly deferred.
- Updates Claude and Codex skill assets so follow-up questioning continues across scope, integration, failure, migration, verification, and assumption-challenge categories.

## Changes

- `.claude/skills/gwt-discussion` and `.codex/skills/gwt-discussion`: add the Depth Interview Loop, `Question Ledger`, `Depth Gate`, and first-batch top-3 continuation guidance.
- `.claude/commands/gwt-discussion.md`: require depth gate completion or explicit deferral before leaving discussion mode.
- `crates/gwt/src/discussion_resume.rs`: enforce depth fields in active proposal Stop-block and resolve eligibility checks, including `deferred(<reason>)` validation.
- `crates/gwt/src/cli/hook/skill_discussion_stop_check.rs`: surface depth blockers distinctly in Stop hook output.
- `crates/gwt/tests/skill_exit_cli_test.rs` and focused discussion tests: cover incomplete depth gate rejection and accepted complete/deferred cases.
- `crates/gwt-skills/src/lib.rs`: strengthen managed asset contract tests for depth-gated discussion behavior.
- `crates/gwt/src/knowledge_bridge.rs`: restore the Unix-only `PathBuf` test import needed by Linux CI.
- Windows-focused test expectations: normalize platform path expectations exposed during full verification.

## Testing

- [x] `cargo test -p gwt depth_gate` — passed.
- [x] `cargo test -p gwt deferred_depth` — passed.
- [x] `cargo test -p gwt discussion_resume` — passed.
- [x] `cargo test -p gwt skill_discussion_stop_check` — passed.
- [x] `cargo test -p gwt --test skill_exit_cli_test` — passed.
- [x] `cargo test -p gwt knowledge_bridge` — passed after the CI import fix.
- [x] `cargo test -p gwt-skills` — passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed after the PR update.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed after the PR update.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed after the PR update.
- [x] `cargo fmt -- --check` — passed.
- [x] `git diff --check` — passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — passed for both commits.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — the depth gate is fully enforced by CLI/hook logic and mirrored in Claude/Codex skill assets.
- Known blockers: None
- Remaining acceptance: None
- User Verification Result: n/a — no GUI or visual surface changed; behavior is covered by automated CLI, hook, and asset contract tests.

## Closing Issues

- None

## Related Issues / Links

- #1935

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (Claude/Codex skill assets and command guidance)
- [x] Migration/backfill plan included (N/A: no schema or data migration)
- [x] CHANGELOG impact considered (feature commit; no breaking change)

## Context

- The previous `gwt-discussion` flow could satisfy evidence requirements while still ending after only a few shallow questions.
- SPEC-1935 Phase 18 defines the new depth-gated discussion contract for managed skills and Stop hook behavior.

## Risk / Impact

- **Affected areas**: `gwt-discussion` skill assets, discussion Stop hook, and `gwtd discuss resolve` eligibility checks.
- **Rollback plan**: revert the two PR commits if the depth gate proves too strict.
