### PR TITLE
fix(gui): show running agents in Resume Picker and improve launch preset diagnostics

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -13646,7 +13646,10 @@ exit 1
                     agents[0].lifecycle_status,
                     Some(gwt::ResumableAgentLifecycleStatus::Running),
                 );
-                assert_eq!(agents[0].resume_kind, gwt::ResumableAgentResumeKind::Session);
+                assert_eq!(
+                    agents[0].resume_kind,
+                    gwt::ResumableAgentResumeKind::Session
+                );
             }
             other => panic!("unexpected backend event: {other:?}"),
         }

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -5422,7 +5422,7 @@ impl AppRuntime {
                 client_id,
                 BackendEvent::BranchError {
                     id: id.to_string(),
-                    message: "Window is not a Work surface".to_string(),
+                    message: format!("Window preset {:?} is not a Work surface", window.preset),
                 },
             )];
         }
@@ -6320,12 +6320,12 @@ impl AppRuntime {
             )];
         };
 
-        if window.preset != WindowPreset::Branches {
+        if window.preset != WindowPreset::Branches && window.preset != WindowPreset::Work {
             return vec![OutboundEvent::reply(
                 client_id,
                 BackendEvent::BranchError {
                     id: id.to_string(),
-                    message: "Window is not a Work surface".to_string(),
+                    message: format!("Window preset {:?} is not a Work surface", window.preset),
                 },
             )];
         }
@@ -12048,7 +12048,7 @@ exit 1
             matches!(
                 &event.event,
                 BackendEvent::BranchError { message, .. }
-                    if message == "Window is not a Work surface"
+                    if message.contains("is not a Work surface")
             )
         });
         assert!(
@@ -13599,7 +13599,7 @@ exit 1
     }
 
     #[test]
-    fn app_runtime_list_resumable_agents_excludes_live_session_ids() {
+    fn app_runtime_list_resumable_agents_includes_live_session_as_running() {
         let _env_lock = env_test_lock()
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -13624,7 +13624,6 @@ exit 1
 
         let tab = sample_project_tab("tab-1", "Repo", repo, ProjectKind::Git, &[]);
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
-        // Register the same session id as live so the picker skips it.
         let mut live = sample_active_agent_session("tab-1", "window-1");
         live.session_id = session_id.to_string();
         runtime
@@ -13638,10 +13637,16 @@ exit 1
 
         match events.first().map(|outbound| &outbound.event) {
             Some(BackendEvent::WorkspaceResumableAgents { agents, .. }) => {
-                assert!(
-                    agents.is_empty(),
-                    "live session must not appear in the Resume picker"
+                assert_eq!(
+                    agents.len(),
+                    1,
+                    "live session should appear with Running status"
                 );
+                assert_eq!(
+                    agents[0].lifecycle_status,
+                    Some(gwt::ResumableAgentLifecycleStatus::Running),
+                );
+                assert_eq!(agents[0].resume_kind, gwt::ResumableAgentResumeKind::Session);
             }
             other => panic!("unexpected backend event: {other:?}"),
         }

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -115,7 +115,15 @@ impl AppRuntime {
         };
 
         if window.preset != WindowPreset::Branches && window.preset != WindowPreset::Work {
-            return launch_agent_open_error(client_id, "Window is not a Work surface");
+            tracing::warn!(
+                preset = ?window.preset,
+                window_id = id,
+                "open_launch_wizard rejected: wrong preset"
+            );
+            return launch_agent_open_error(
+                client_id,
+                format!("Window preset {:?} is not a Work surface", window.preset),
+            );
         }
         // SPEC-1934 US-7 / FR-034
         if tab.migration_pending {
@@ -647,7 +655,15 @@ impl AppRuntime {
             return branch_error("Window not found".to_string());
         };
         if window.preset != WindowPreset::Branches && window.preset != WindowPreset::Work {
-            return branch_error("Window is not a Work surface".to_string());
+            tracing::warn!(
+                preset = ?window.preset,
+                window_id = id,
+                "resume_branch_latest_agent rejected: wrong preset"
+            );
+            return branch_error(format!(
+                "Window preset {:?} is not a Work surface",
+                window.preset
+            ));
         }
         if tab.kind != gwt::ProjectKind::Git {
             return branch_error("Resume requires a Git project".to_string());
@@ -710,10 +726,10 @@ impl AppRuntime {
     }
 
     /// Build a list of agents that the Workspace Resume picker can offer
-    /// for the currently-active Git project tab. Filters out historical
-    /// entries (`is_assigned == false`), agents that are already live in
-    /// `active_agent_sessions`, and entries whose session_id does not have
-    /// a backing Session toml on disk.
+    /// for the currently-active Git project tab. Includes live agents with
+    /// `lifecycle_status = Running` so the picker can show them and focus
+    /// their window on click. Non-live entries require a backing Session
+    /// toml on disk.
     fn collect_resumable_agents(&self) -> Vec<gwt::ResumableAgentView> {
         let Some(tab_id) = self.active_tab_id.as_deref() else {
             return Vec::new();
@@ -753,10 +769,15 @@ impl AppRuntime {
             .agents
             .iter()
             .filter(|agent| !agent.session_id.trim().is_empty())
-            .filter(|agent| !live_session_ids.contains(agent.session_id.as_str()))
             .filter_map(|agent| {
-                let session_path = sessions_dir.join(format!("{}.toml", agent.session_id));
-                let (resume_kind, lifecycle_status) =
+                let is_live = live_session_ids.contains(agent.session_id.as_str());
+                let (resume_kind, lifecycle_status) = if is_live {
+                    (
+                        gwt::ResumableAgentResumeKind::Session,
+                        Some(gwt::ResumableAgentLifecycleStatus::Running),
+                    )
+                } else {
+                    let session_path = sessions_dir.join(format!("{}.toml", agent.session_id));
                     match gwt_agent::Session::load_and_migrate(&session_path) {
                         Ok(session) => {
                             let resume_kind = if session.exact_resume_session_id().is_some() {
@@ -777,7 +798,8 @@ impl AppRuntime {
                             (resume_kind, lifecycle_status)
                         }
                         Err(_) => return None,
-                    };
+                    }
+                };
                 Some(gwt::ResumableAgentView {
                     session_id: agent.session_id.clone(),
                     agent_id: agent.agent_id.clone(),

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -198,6 +198,7 @@ pub enum ResumableAgentResumeKind {
 pub enum ResumableAgentLifecycleStatus {
     Active,
     Interrupted,
+    Running,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2893,7 +2893,7 @@ mod tests {
         assert_eq!(wrong_window_branches.len(), 1);
         assert!(matches!(
             wrong_window_branches[0].event,
-            BackendEvent::BranchError { ref message, .. } if message == "Window is not a Work surface"
+            BackendEvent::BranchError { ref message, .. } if message.contains("is not a Work surface")
         ));
         assert!(runtime
             .load_branches_events("client-1", &branches_id)
@@ -2946,7 +2946,7 @@ mod tests {
         assert!(matches!(
             cleanup_wrong[0].event,
             BackendEvent::BranchError { ref message, .. }
-                if message == "Window is not a Work surface"
+                if message.contains("is not a Work surface")
         ));
 
         let wizard_missing =
@@ -2964,7 +2964,7 @@ mod tests {
         assert!(matches!(
             wizard_wrong[0].event,
             BackendEvent::LaunchWizardOpenError { ref title, ref message }
-                if title == "Launch Agent" && message == "Window is not a Work surface"
+                if title == "Launch Agent" && message.contains("is not a Work surface")
         ));
 
         let issue_missing = runtime.open_issue_launch_wizard_events("client-1", "missing", 7);

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -3968,6 +3968,11 @@ kbd.op-kbd {
   color: rgb(253, 186, 116);
 }
 
+:root[data-theme] .workspace-resume-picker-row-tag.is-running {
+  background: rgba(56, 189, 248, 0.14);
+  color: rgb(125, 211, 252);
+}
+
 :root[data-theme] .workspace-resume-picker-row-meta {
   display: grid;
   grid-template-columns: max-content 1fr;

--- a/crates/gwt/web/workspace-resume-picker-modal.js
+++ b/crates/gwt/web/workspace-resume-picker-modal.js
@@ -129,11 +129,13 @@ export function renderWorkspaceResumePicker({
         ),
       );
       const lifecycleTag =
-        agent.lifecycle_status === "interrupted"
-          ? { className: "is-interrupted", label: "Interrupted" }
-          : agent.lifecycle_status === "active"
-            ? { className: "is-active", label: "Active" }
-            : null;
+        agent.lifecycle_status === "running"
+          ? { className: "is-running", label: "Running" }
+          : agent.lifecycle_status === "interrupted"
+            ? { className: "is-interrupted", label: "Interrupted" }
+            : agent.lifecycle_status === "active"
+              ? { className: "is-active", label: "Active" }
+              : null;
       const tagClass = lifecycleTag
         ? `workspace-resume-picker-row-tag ${lifecycleTag.className}`
         : agent.resume_kind === "metadata_only"

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6179,3 +6179,10 @@ Type: lesson
 Context: Work画面のGit BranchesタブからLaunch/Resumeすると Window is not a Work surface エラー。wizard.rsのopen_launch_wizardとresume_branch_latest_agent_eventsがWindowPreset::Branchesのみ許可していた。レガシーのlaunch_wizard_runtime.rsはBranches+Work両方許可。
 Learning: app_runtime Phase F リファクタで旧コード(launch_wizard_runtime.rs)からの移植時にプリセット条件を狭くしたリグレッション。mod.rs:5420のload_branches_eventsは正しく両方許可していたので、同一ファイル内にパターンの不整合があった。
 Future Action: wizard.rsのプリセットチェック変更時はmod.rsの同種チェック(load_branches_events等)と一貫性を確認する。Work surface embedded branches パターンでは WindowPreset::Work も許可が必要。
+
+## 2026-05-27 — collect_resumable_agents excluded running agents causing empty Resume Picker
+
+Type: lesson
+Context: Resume Picker showed 'No resumable agents' even when Codex was Running. Root cause: collect_resumable_agents in wizard.rs filtered out live_session_ids entirely. Also, branch cleanup preset check at mod.rs:6323 only allowed WindowPreset::Branches, missing Work.
+Learning: When adding a new preset check (like the Work surface unification), grep all sites with the same error message string to ensure none are missed. Four sites had 'Window is not a Work surface' but one (branch cleanup) was not updated. Also, filtering running agents from the Resume Picker was a UX anti-pattern — the user sees a Running agent in the workspace card but Resume says none exist.
+Future Action: After any WindowPreset guard change, search all occurrences of the error message to confirm all sites are consistent. For picker/list UIs, prefer including all states with appropriate badges over silently filtering items the user can see elsewhere.


### PR DESCRIPTION
## Summary

- Resume Picker で Running エージェントが除外されて「No resumable agents」と表示されるバグを修正。Running エージェントを `lifecycle_status: Running` で一覧に含め、クリックで既存ターミナルにフォーカスする
- Branch cleanup の preset チェックに `WindowPreset::Work` が漏れていたのを修正
- Launch/Resume の全 "Window is not a Work surface" エラーメッセージに実際の preset 値と `tracing::warn!` を追加し診断可能にした

## Changes

- `crates/gwt/src/launch_wizard.rs`: `ResumableAgentLifecycleStatus::Running` バリアント追加
- `crates/gwt/src/app_runtime/wizard.rs`: `collect_resumable_agents` が Running エージェントを含めるよう変更 + 診断ログ追加
- `crates/gwt/src/app_runtime/mod.rs`: branch cleanup preset チェック修正 + テスト更新
- `crates/gwt/src/main.rs`: テストのエラーメッセージ検証を `contains()` に更新
- `crates/gwt/web/workspace-resume-picker-modal.js`: Running ステータスのタグ表示追加
- `crates/gwt/web/styles/components.css`: `.is-running` バッジスタイル追加

## Testing

- `cargo test -p gwt-core -p gwt --all-features` — all pass
- `cargo clippy --all-targets --all-features -- -D warnings` — 0 warnings
- `cargo fmt --all -- --check` — clean
- `cargo build -p gwt --bin gwt --bin gwtd` — success
- Updated test: `app_runtime_list_resumable_agents_includes_live_session_as_running` verifies Running agents appear with correct lifecycle_status

## PR Readiness

- State: Draft
- User visual verification: pending (gwt GUI lock prevented headless serve)
- Automated verification: all pass

## Closing Issues

None

## Related Issues

- SPEC-2359 Phase W-9 (T-473–T-477)

## Checklist

- [x] Tests pass
- [x] Clippy clean
- [x] Formatting clean
- [x] SPEC updated
- [ ] User visual verification — pending: gwt GUI lock prevented headless browser check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Resume Picker incorrectly excluding live running agents from the resumable agents list.

* **New Features**
  * Added "Running" lifecycle status for resumable agents.
  * Improved error messages when opening workflows in incorrect window types, now displaying actual context.
  * Added visual styling indicator for running agents in the Resume Picker.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2912?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->