### PR TITLE
chore(release): v9.48.0

### DIFF
--- a/.claude/commands/gwt-discussion.md
+++ b/.claude/commands/gwt-discussion.md
@@ -21,8 +21,8 @@ mid-implementation investigation.
 2. Search existing SPECs and Issues for context.
 3. Investigate code, map dependencies, then present findings before proposing a path.
 4. Discuss one question at a time with selection UI first. In Codex, use `request_user_input` when that UI is available.
-5. After each answer, update `Discussion TODO`, `Coverage Checks`, and `Exit Blockers`, then re-rank unresolved high-impact unknowns and ask the next highest-impact question before exiting.
-6. Do not leave Plan Mode until `Action Delta` and `Action Bundle` are ready, the depth gate is satisfied or intentionally deferred, and `Evidence Gate: complete` is backed by implementation proof, SPEC/Issue proof, gap-check proof, official docs proof when applicable, and external research proof when needed.
+5. After each answer, update `Discussion TODO`, `Coverage Checks`, `Exit Blockers`, `Question Ledger`, and `Depth Gate`, then re-rank unresolved high-impact unknowns and ask the next highest-impact question before exiting.
+6. Do not leave Plan Mode until `Action Delta` and `Action Bundle` are ready, `Depth Gate: complete` or `Depth Gate: deferred(<reason>)` is recorded, and `Evidence Gate: complete` is backed by implementation proof, SPEC/Issue proof, gap-check proof, official docs proof when applicable, and external research proof when needed.
 7. If managed hooks surface an unfinished discussion prompt, use `.gwt/discussion.md` as the source of truth and choose `Resume discussion`, `Park proposal`, or `Dismiss for now`.
 
 ## Examples

--- a/.claude/skills/gwt-discussion/SKILL.md
+++ b/.claude/skills/gwt-discussion/SKILL.md
@@ -50,7 +50,7 @@ Keep these artifacts throughout the discussion:
 
 `Discussion TODO` is not an implementation task list. It tracks unresolved
 questions, dependency checks, deferred decisions, coverage gaps, exit blockers,
-and the next question to ask.
+the next question to ask, and the depth state for the active proposal.
 
 Evidence is part of the discussion state, not a later implementation detail.
 Do not mark a proposal `[chosen]` until its evidence fields prove the outcome
@@ -69,6 +69,9 @@ Mirror structure for `.gwt/discussion.md`:
 - Coverage Checks:
 - Exit Blockers:
 - Next Question:
+- Depth Mode:
+- Question Ledger:
+- Depth Gate:
 - Implementation Proof:
 - SPEC/Issue Proof:
 - Gap Check Proof:
@@ -101,8 +104,10 @@ SPEC-1935 FR-014p routes Stop events through `skill-discussion-stop-check`,
 which inspects `.gwt/discussion.md` and blocks Stop (with
 `{"decision":"block","reason":"..."}`) while any proposal is still `[active]`
 with a non-empty `Next Question:`, unresolved `Exit Blockers:`, incomplete
-proof fields, or an `Evidence Gate:` that is not `complete`. To let Stop
-succeed, mark each proposal explicitly using the exit CLI:
+proof fields, incomplete depth fields, or an `Evidence Gate:` that is not
+`complete`. Depth fields are incomplete when `Question Ledger:` is empty,
+`Depth Gate:` is missing/open, or `Depth Gate: deferred(<reason>)` has no
+reason. To let Stop succeed, mark each proposal explicitly using the exit CLI:
 
 - `gwtd discuss resolve --proposal "Proposal A"` — active → chosen only after
   `Evidence Gate: complete`
@@ -210,9 +215,40 @@ After each answer:
 
 - update the `Intake Memo`
 - update the `Discussion TODO`
+- append or refine the active proposal's `Question Ledger`
+- update `Depth Gate` only when depth coverage is complete or explicitly
+  deferred with a reason
 - remove or refine the resolved unknown
 - re-rank the remaining unresolved questions
 - Ask the next highest-impact question if any remain
+
+## Depth Interview Loop
+
+Use this loop for every non-trivial discussion, including ordinary
+`gwt-discussion` runs. Do not wait for an explicit `--deepen` flag when the
+latest answer leaves high-impact ambiguity.
+
+After every answer:
+
+1. Record what was learned in the `Question Ledger`.
+2. Re-score unresolved unknowns across scope boundary, ownership/integration,
+   failure/edge cases, migration/compatibility, verification/success signal,
+   and alternatives/assumption challenge.
+3. Ask the next highest-impact question with the platform question tool when
+   any category can still change implementation, routing, ownership, or
+   verification.
+4. Every third question, challenge one premise directly: what breaks if the
+   preferred answer is wrong, delayed, partially implemented, or applied to an
+   adjacent subsystem?
+5. Set `Depth Gate: complete` only when the `Question Ledger` shows all
+   applicable categories are covered. Use `Depth Gate: deferred(<reason>)` only
+   when the remaining depth is intentionally out of scope for the current
+   Action Bundle.
+
+Do not treat a small number of questions as a completion signal. A broad or
+risky discussion may require many rounds. Also do not treat a top-3 priority
+list as the end of deepening; it is only the next batch to discuss before the
+remaining backlog is re-ranked.
 
 ## Discussion Depth Gate
 

--- a/.claude/skills/gwt-discussion/references/clarification.md
+++ b/.claude/skills/gwt-discussion/references/clarification.md
@@ -70,6 +70,9 @@ Rules:
   exit criteria are satisfied or a real blocker remains.
 - Planning-ready requires covering the applicable categories from the standard
   question checklist.
+- Update the active proposal's `Question Ledger` after each answer and leave
+  `Depth Gate: open` while a category can still change implementation,
+  ownership, routing, failure handling, migration, or verification.
 
 ### Step 5: Update spec.md
 
@@ -134,6 +137,9 @@ All of the following must be true:
 - Ubiquitous Language section is consistent with user stories and FRs.
 - Planning-ready requires covering the applicable categories from the standard
   question checklist.
+- `Question Ledger` records the clarification questions that resolved those
+  categories.
+- `Depth Gate` is `complete` or `deferred(<reason>)`.
 
 ## Output format
 

--- a/.claude/skills/gwt-discussion/references/deepening.md
+++ b/.claude/skills/gwt-discussion/references/deepening.md
@@ -81,7 +81,10 @@ Look for:
 
 After presenting the report, ask the user which points to deep-dive on.
 Before asking the user to choose points, narrow the list to the top 3 highest-impact points.
-Accept numbers, ranges (e.g., "1-3"), or "all".
+This top 3 list is the first batch, not an exit condition. After the selected
+batch is answered, update the `Question Ledger`, re-rank the remaining backlog,
+and continue until `Depth Gate` is complete or explicitly deferred with a
+reason. Accept numbers, ranges (e.g., "1-3"), or "all".
 
 ## Phase 5.2: Interactive deep-dive
 
@@ -142,6 +145,9 @@ Repeat steps 1-5 for each selected deepening point.
 
 - All selected deepening points have been addressed with user input.
 - Artifact updates have been applied.
+- `Question Ledger` records the selected points, answers, and any remaining
+  backlog disposition.
+- `Depth Gate` is `complete` or `deferred(<reason>)`.
 - A summary of changes is presented:
 
 ```text

--- a/.claude/skills/gwt-discussion/references/intake.md
+++ b/.claude/skills/gwt-discussion/references/intake.md
@@ -54,6 +54,10 @@ Stop when all of these are true:
 - The first slice has a visible success condition.
 - High-impact scope ambiguity has been resolved by the user.
 - The SPEC vs Issue decision is justified.
+- `Question Ledger` records the answers used for routing, scope, integration,
+  non-goals, failure handling, and verification signal.
+- `Depth Gate` is complete or explicitly deferred with a reason for the intake
+  slice.
 - Do not stop after the first slice success condition alone. Also resolve the
   integration target, explicit non-goals, and verification signal for the
   chosen slice before leaving intake.
@@ -80,6 +84,8 @@ Maintain in conversation context (not as a file):
 - Out of scope: <what is explicitly excluded>
 - Constraints: <technical, time, or design constraints>
 - Success signal: <how to know it works>
+- Question Ledger: <routing/scope/depth answers already covered>
+- Depth Gate: <open|complete|deferred(reason)>
 - Open questions: <unresolved items>
 - Candidate owner: <existing SPEC/Issue if found, or "none">
 ```

--- a/.codex/skills/gwt-discussion/SKILL.md
+++ b/.codex/skills/gwt-discussion/SKILL.md
@@ -50,7 +50,7 @@ Keep these artifacts throughout the discussion:
 
 `Discussion TODO` is not an implementation task list. It tracks unresolved
 questions, dependency checks, deferred decisions, coverage gaps, exit blockers,
-and the next question to ask.
+the next question to ask, and the depth state for the active proposal.
 
 Evidence is part of the discussion state, not a later implementation detail.
 Do not mark a proposal `[chosen]` until its evidence fields prove the outcome
@@ -69,6 +69,9 @@ Mirror structure for `.gwt/discussion.md`:
 - Coverage Checks:
 - Exit Blockers:
 - Next Question:
+- Depth Mode:
+- Question Ledger:
+- Depth Gate:
 - Implementation Proof:
 - SPEC/Issue Proof:
 - Gap Check Proof:
@@ -101,8 +104,10 @@ SPEC-1935 FR-014p routes Stop events through `skill-discussion-stop-check`,
 which inspects `.gwt/discussion.md` and blocks Stop (with
 `{"decision":"block","reason":"..."}`) while any proposal is still `[active]`
 with a non-empty `Next Question:`, unresolved `Exit Blockers:`, incomplete
-proof fields, or an `Evidence Gate:` that is not `complete`. To let Stop
-succeed, mark each proposal explicitly using the exit CLI:
+proof fields, incomplete depth fields, or an `Evidence Gate:` that is not
+`complete`. Depth fields are incomplete when `Question Ledger:` is empty,
+`Depth Gate:` is missing/open, or `Depth Gate: deferred(<reason>)` has no
+reason. To let Stop succeed, mark each proposal explicitly using the exit CLI:
 
 - `gwtd discuss resolve --proposal "Proposal A"` — active → chosen only after
   `Evidence Gate: complete`
@@ -228,9 +233,40 @@ After each answer:
 
 - update the `Intake Memo`
 - update the `Discussion TODO`
+- append or refine the active proposal's `Question Ledger`
+- update `Depth Gate` only when depth coverage is complete or explicitly
+  deferred with a reason
 - remove or refine the resolved unknown
 - re-rank the remaining unresolved questions
 - Ask the next highest-impact question if any remain
+
+## Depth Interview Loop
+
+Use this loop for every non-trivial discussion, including ordinary
+`gwt-discussion` runs. Do not wait for an explicit `--deepen` flag when the
+latest answer leaves high-impact ambiguity.
+
+After every answer:
+
+1. Record what was learned in the `Question Ledger`.
+2. Re-score unresolved unknowns across scope boundary, ownership/integration,
+   failure/edge cases, migration/compatibility, verification/success signal,
+   and alternatives/assumption challenge.
+3. Ask the next highest-impact question with the platform question tool when
+   any category can still change implementation, routing, ownership, or
+   verification.
+4. Every third question, challenge one premise directly: what breaks if the
+   preferred answer is wrong, delayed, partially implemented, or applied to an
+   adjacent subsystem?
+5. Set `Depth Gate: complete` only when the `Question Ledger` shows all
+   applicable categories are covered. Use `Depth Gate: deferred(<reason>)` only
+   when the remaining depth is intentionally out of scope for the current
+   Action Bundle.
+
+Do not treat a small number of questions as a completion signal. A broad or
+risky discussion may require many rounds. Also do not treat a top-3 priority
+list as the end of deepening; it is only the next batch to discuss before the
+remaining backlog is re-ranked.
 
 ## Discussion Depth Gate
 

--- a/.codex/skills/gwt-discussion/references/clarification.md
+++ b/.codex/skills/gwt-discussion/references/clarification.md
@@ -70,6 +70,9 @@ Rules:
   exit criteria are satisfied or a real blocker remains.
 - Planning-ready requires covering the applicable categories from the standard
   question checklist.
+- Update the active proposal's `Question Ledger` after each answer and leave
+  `Depth Gate: open` while a category can still change implementation,
+  ownership, routing, failure handling, migration, or verification.
 
 ### Step 5: Update spec.md
 
@@ -134,6 +137,9 @@ All of the following must be true:
 - Ubiquitous Language section is consistent with user stories and FRs.
 - Planning-ready requires covering the applicable categories from the standard
   question checklist.
+- `Question Ledger` records the clarification questions that resolved those
+  categories.
+- `Depth Gate` is `complete` or `deferred(<reason>)`.
 
 ## Output format
 

--- a/.codex/skills/gwt-discussion/references/deepening.md
+++ b/.codex/skills/gwt-discussion/references/deepening.md
@@ -81,7 +81,10 @@ Look for:
 
 After presenting the report, ask the user which points to deep-dive on.
 Before asking the user to choose points, narrow the list to the top 3 highest-impact points.
-Accept numbers, ranges (e.g., "1-3"), or "all".
+This top 3 list is the first batch, not an exit condition. After the selected
+batch is answered, update the `Question Ledger`, re-rank the remaining backlog,
+and continue until `Depth Gate` is complete or explicitly deferred with a
+reason. Accept numbers, ranges (e.g., "1-3"), or "all".
 
 ## Phase 5.2: Interactive deep-dive
 
@@ -142,6 +145,9 @@ Repeat steps 1-5 for each selected deepening point.
 
 - All selected deepening points have been addressed with user input.
 - Artifact updates have been applied.
+- `Question Ledger` records the selected points, answers, and any remaining
+  backlog disposition.
+- `Depth Gate` is `complete` or `deferred(<reason>)`.
 - A summary of changes is presented:
 
 ```text

--- a/.codex/skills/gwt-discussion/references/intake.md
+++ b/.codex/skills/gwt-discussion/references/intake.md
@@ -54,6 +54,10 @@ Stop when all of these are true:
 - The first slice has a visible success condition.
 - High-impact scope ambiguity has been resolved by the user.
 - The SPEC vs Issue decision is justified.
+- `Question Ledger` records the answers used for routing, scope, integration,
+  non-goals, failure handling, and verification signal.
+- `Depth Gate` is complete or explicitly deferred with a reason for the intake
+  slice.
 - Do not stop after the first slice success condition alone. Also resolve the
   integration target, explicit non-goals, and verification signal for the
   chosen slice before leaving intake.
@@ -80,6 +84,8 @@ Maintain in conversation context (not as a file):
 - Out of scope: <what is explicitly excluded>
 - Constraints: <technical, time, or design constraints>
 - Success signal: <how to know it works>
+- Question Ledger: <routing/scope/depth answers already covered>
+- Depth Gate: <open|complete|deferred(reason)>
 - Open questions: <unresolved items>
 - Candidate owner: <existing SPEC/Issue if found, or "none">
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,35 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [9.48.0] - 2026-05-28
+
+### Bug Fixes
+
+- **launch:** Accept Work window preset for Launch/Resume from Git Branches tab
+- Restore unix knowledge bridge test import
+- **gui:** Show running agents in Resume Picker and improve launch preset diagnostics
+- **launch-wizard:** Preserve claude fast mode through runtime resolution
+- **gui:** Filter Resume Picker agents by workspace_id
+- **gui:** Filter Resume Picker by Work item session_ids instead of workspace_id
+
+### Features
+
+- Deepen gwt-discussion depth gate
+- Support claude fast mode at launch
+
+### Miscellaneous Tasks
+
+- Record memory for Work preset launch fix
+- Apply cargo fmt to test assertion
+- Record Resume Picker running agent memory entry
+- Merge origin develop
+- Resolve merge conflict in tasks/memory.md
+
+### Testing
+
+- **playwright:** Cover claude fast mode launch wizard path
+- **playwright:** Launch claude fast mode smoke
+
 ## [9.47.0] - 2026-05-26
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.47.0"
+version = "9.48.0"
 dependencies = [
  "ammonia",
  "axum",
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.47.0"
+version = "9.48.0"
 dependencies = [
  "chrono",
  "dunce",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.47.0"
+version = "9.48.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -1416,7 +1416,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.47.0"
+version = "9.48.0"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.47.0"
+version = "9.48.0"
 dependencies = [
  "dirs",
  "serde",
@@ -1437,7 +1437,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.47.0"
+version = "9.48.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.47.0"
+version = "9.48.0"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.47.0"
+version = "9.48.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.47.0"
+version = "9.48.0"
 dependencies = [
  "gwt-core",
  "regex",
@@ -1509,7 +1509,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.47.0"
+version = "9.48.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -1526,7 +1526,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.47.0"
+version = "9.48.0"
 dependencies = [
  "gwt-core",
  "libc",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.47.0"
+version = "9.48.0"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.47.0"
+version = "9.48.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -12,6 +12,8 @@ use crate::{
     types::{AgentColor, AgentId, DockerLifecycleIntent, LaunchRuntimeTarget, SessionMode},
 };
 
+const CLAUDE_FAST_MODE_SETTINGS_JSON: &str = r#"{"fastMode":true}"#;
+
 /// Resolve the gwt repo hash for the directory by shelling out to
 /// `git remote get-url origin`. Returns `None` when no origin is configured.
 fn detect_repo_hash_for_dir(dir: &Path) -> Option<String> {
@@ -256,6 +258,10 @@ pub struct LaunchConfig {
     pub session_mode: SessionMode,
     pub resume_session_id: Option<String>,
     pub skip_permissions: bool,
+    pub fast_mode: bool,
+    /// Legacy Codex-only compatibility field. New callers should use
+    /// `fast_mode`; this remains populated for persisted/session consumers
+    /// that still distinguish Codex's service-tier implementation.
     pub codex_fast_mode: bool,
     pub runtime_target: LaunchRuntimeTarget,
     pub docker_service: Option<String>,
@@ -563,6 +569,7 @@ impl AgentLaunchBuilder {
         let reasoning_level = self.reasoning_level.clone();
         let session_mode = self.session_mode;
         let resume_session_id = self.resume_session_id.clone();
+        let fast_mode = self.fast_mode && self.agent_id.supports_fast_mode();
         let codex_fast_mode = matches!(self.agent_id, AgentId::Codex) && self.fast_mode;
 
         LaunchConfig {
@@ -582,6 +589,7 @@ impl AgentLaunchBuilder {
             session_mode,
             resume_session_id,
             skip_permissions,
+            fast_mode,
             codex_fast_mode,
             runtime_target: self.runtime_target,
             docker_service: self.docker_service,
@@ -654,6 +662,11 @@ impl AgentLaunchBuilder {
 
         if self.skip_permissions {
             args.push("--dangerously-skip-permissions".to_string());
+        }
+
+        if self.fast_mode {
+            args.push("--settings".to_string());
+            args.push(CLAUDE_FAST_MODE_SETTINGS_JSON.to_string());
         }
 
         // Session mode
@@ -1123,6 +1136,30 @@ mod tests {
     }
 
     #[test]
+    fn build_claude_fast_mode_injects_session_settings() {
+        let config = AgentLaunchBuilder::new(AgentId::ClaudeCode)
+            .fast_mode(true)
+            .build();
+
+        assert!(config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--settings" && pair[1] == r#"{"fastMode":true}"#));
+        assert!(config.fast_mode);
+        assert!(!config.codex_fast_mode);
+    }
+
+    #[test]
+    fn build_claude_without_fast_mode_omits_session_settings() {
+        let config = AgentLaunchBuilder::new(AgentId::ClaudeCode).build();
+
+        assert!(!config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--settings" && pair[1].contains("fastMode")));
+    }
+
+    #[test]
     fn build_codex_fast_mode() {
         let config = AgentLaunchBuilder::new(AgentId::Codex)
             .fast_mode(true)
@@ -1134,6 +1171,7 @@ mod tests {
             .windows(2)
             .any(|pair| pair[0] == "-c" && pair[1] == "service_tier=fast"));
         assert!(!config.args.contains(&"--full-auto".to_string()));
+        assert!(config.fast_mode);
         assert!(config.codex_fast_mode);
         assert!(!config.skip_permissions);
     }
@@ -2083,7 +2121,10 @@ mod tests {
             .env_vars
             .get("CODEX_HOME")
             .expect("CODEX_HOME must be set when a Codex backend profile is active");
-        assert!(codex_home.ends_with(".gwt/codex"), "got {codex_home}");
+        assert!(
+            Path::new(codex_home).ends_with(Path::new(".gwt").join("codex")),
+            "got {codex_home}"
+        );
         // API key env defaults to the GWT_CODEX_BACKEND_API_KEY_<UPPER> name.
         assert_eq!(
             config
@@ -2094,7 +2135,8 @@ mod tests {
         );
 
         // Generated config.toml exists and contains the expected provider id.
-        let body = std::fs::read_to_string(format!("{codex_home}/config.toml")).expect("read");
+        let body =
+            std::fs::read_to_string(Path::new(codex_home).join("config.toml")).expect("read");
         assert!(body.contains("model_provider = \"gwt-llmlb\""));
         assert!(body.contains("base_url = \"http://127.0.0.1:8080\""));
     }

--- a/crates/gwt-agent/src/session.rs
+++ b/crates/gwt-agent/src/session.rs
@@ -55,6 +55,10 @@ pub struct Session {
     #[serde(default)]
     pub skip_permissions: bool,
     #[serde(default)]
+    pub fast_mode: bool,
+    /// Legacy Codex-only compatibility field. Deserialization still accepts
+    /// this key so older session TOML restores retain Fast mode intent.
+    #[serde(default)]
     pub codex_fast_mode: bool,
     #[serde(default)]
     pub runtime_target: LaunchRuntimeTarget,
@@ -150,6 +154,7 @@ impl Session {
             reasoning_level: None,
             session_mode: SessionMode::Normal,
             skip_permissions: false,
+            fast_mode: false,
             codex_fast_mode: false,
             runtime_target: LaunchRuntimeTarget::Host,
             docker_service: None,
@@ -189,6 +194,7 @@ impl Session {
         session.reasoning_level = config.reasoning_level.clone();
         session.session_mode = config.session_mode;
         session.skip_permissions = config.skip_permissions;
+        session.fast_mode = config.fast_mode;
         session.codex_fast_mode = config.codex_fast_mode;
         session.runtime_target = config.runtime_target;
         session.docker_service = config.docker_service.clone();
@@ -313,8 +319,9 @@ impl Session {
     /// legacy migration applied should use [`Session::load_and_migrate`].
     pub fn load(path: &Path) -> std::io::Result<Self> {
         let content = std::fs::read_to_string(path)?;
-        let session: Self = toml::from_str(&content)
+        let mut session: Self = toml::from_str(&content)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        session.normalize_fast_mode_fields();
         Ok(session)
     }
 
@@ -352,6 +359,16 @@ impl Session {
             }
             self.schema_version = 3;
         }
+    }
+
+    fn normalize_fast_mode_fields(&mut self) {
+        if self.codex_fast_mode {
+            self.fast_mode = true;
+        }
+    }
+
+    pub fn fast_mode_enabled(&self) -> bool {
+        self.fast_mode || self.codex_fast_mode
     }
 }
 
@@ -592,6 +609,7 @@ mod tests {
         assert!(session.model.is_none());
         assert!(session.reasoning_level.is_none());
         assert!(!session.skip_permissions);
+        assert!(!session.fast_mode);
         assert!(!session.codex_fast_mode);
         assert_eq!(session.runtime_target, LaunchRuntimeTarget::Host);
         assert!(session.docker_service.is_none());
@@ -765,6 +783,52 @@ display_name = "Claude Code"
         );
         assert_eq!(loaded.workflow_bypass, Some(WorkflowBypass::Release));
         assert_eq!(loaded.display_name, "Gemini CLI");
+    }
+
+    #[test]
+    fn load_legacy_codex_fast_mode_populates_fast_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("legacy-fast-mode.toml");
+        let session = Session::new("/tmp/wt", "feature/x", AgentId::Codex);
+        let mut legacy = toml::map::Map::new();
+        legacy.insert("id".into(), toml::Value::String(session.id.clone()));
+        legacy.insert(
+            "worktree_path".into(),
+            toml::Value::String(session.worktree_path.display().to_string()),
+        );
+        legacy.insert("branch".into(), toml::Value::String(session.branch.clone()));
+        legacy.insert(
+            "agent_id".into(),
+            toml::Value::try_from(&session.agent_id).unwrap(),
+        );
+        legacy.insert(
+            "status".into(),
+            toml::Value::try_from(&session.status).unwrap(),
+        );
+        legacy.insert("codex_fast_mode".into(), toml::Value::Boolean(true));
+        legacy.insert(
+            "created_at".into(),
+            toml::Value::String(session.created_at.to_rfc3339()),
+        );
+        legacy.insert(
+            "updated_at".into(),
+            toml::Value::String(session.updated_at.to_rfc3339()),
+        );
+        legacy.insert(
+            "last_activity_at".into(),
+            toml::Value::String(session.last_activity_at.to_rfc3339()),
+        );
+        legacy.insert(
+            "display_name".into(),
+            toml::Value::String(session.display_name.clone()),
+        );
+        std::fs::write(&path, toml::to_string(&legacy).unwrap()).unwrap();
+
+        let loaded = Session::load(&path).unwrap();
+
+        assert!(loaded.fast_mode);
+        assert!(loaded.codex_fast_mode);
+        assert!(loaded.fast_mode_enabled());
     }
 
     #[test]
@@ -1261,6 +1325,7 @@ display_name = "Claude Code"
         config.model = Some("gpt-5.5".to_string());
         config.reasoning_level = Some("high".to_string());
         config.skip_permissions = true;
+        config.fast_mode = true;
         config.codex_fast_mode = true;
         config.runtime_target = LaunchRuntimeTarget::Docker;
         config.docker_service = Some("app".to_string());
@@ -1284,6 +1349,7 @@ display_name = "Claude Code"
         assert_eq!(session.model.as_deref(), Some("gpt-5.5"));
         assert_eq!(session.reasoning_level.as_deref(), Some("high"));
         assert!(session.skip_permissions);
+        assert!(session.fast_mode);
         assert!(session.codex_fast_mode);
         assert_eq!(session.runtime_target, LaunchRuntimeTarget::Docker);
         assert_eq!(session.docker_service.as_deref(), Some("app"));

--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -65,6 +65,16 @@ impl AgentId {
     pub fn supports_resume_picker(&self) -> bool {
         matches!(self, Self::ClaudeCode | Self::Codex)
     }
+
+    /// Whether this agent exposes a Fast mode launch setting that can be
+    /// enabled before the agent starts.
+    ///
+    /// SPEC-2014 2026-05-27 amendment: Claude Code supports Fast mode through
+    /// session-local settings, while Codex supports it through its service tier
+    /// config override.
+    pub fn supports_fast_mode(&self) -> bool {
+        matches!(self, Self::ClaudeCode | Self::Codex)
+    }
 }
 
 impl std::fmt::Display for AgentId {
@@ -457,6 +467,25 @@ mod tests {
             assert!(
                 !non_picker.supports_resume_picker(),
                 "{non_picker:?} should not advertise picker support"
+            );
+        }
+    }
+
+    #[test]
+    fn supports_fast_mode_only_for_fast_capable_builtins() {
+        assert!(AgentId::ClaudeCode.supports_fast_mode());
+        assert!(AgentId::Codex.supports_fast_mode());
+        for unsupported in [
+            AgentId::Gemini,
+            AgentId::OpenCode,
+            AgentId::OpenClaw,
+            AgentId::Hermes,
+            AgentId::Copilot,
+            AgentId::Custom("aider".into()),
+        ] {
+            assert!(
+                !unsupported.supports_fast_mode(),
+                "{unsupported:?} should not advertise Fast mode support"
             );
         }
     }

--- a/crates/gwt-skills/src/codex_hook_trust.rs
+++ b/crates/gwt-skills/src/codex_hook_trust.rs
@@ -749,12 +749,13 @@ enabled = false
         generate_codex_hooks(dir.path()).unwrap();
         let hooks_path = fs::canonicalize(dir.path().join(".codex/hooks.json")).unwrap();
         let pre_tool_key = format!("{}:pre_tool_use:0:0", hooks_path.display());
+        let pre_tool_key_toml = pre_tool_key.replace('\\', "\\\\").replace('"', "\\\"");
         let config_path = dir.path().join("codex-config.toml");
         fs::write(
             &config_path,
             format!(
                 r#"
-[hooks.state."{pre_tool_key}"]
+[hooks.state."{pre_tool_key_toml}"]
 enabled = false
 "#
             ),

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -844,6 +844,14 @@ mod tests {
                 "expected discussion skill to require evidence proof fields in {relative}"
             );
             assert!(
+                discussion_skill.contains("## Depth Interview Loop")
+                    && discussion_skill.contains("Question Ledger")
+                    && discussion_skill.contains("Depth Gate")
+                    && discussion_skill.contains("After every answer")
+                    && discussion_skill.contains("Do not treat a small number of questions as a completion signal"),
+                "expected discussion skill to require depth-gated follow-up questioning in {relative}"
+            );
+            assert!(
                 discussion_skill.contains("official documentation")
                     && discussion_skill.contains("X search")
                     && discussion_skill.contains("X API Search Posts"),
@@ -940,7 +948,9 @@ mod tests {
                 discussion_command.contains("Plan Mode")
                     && discussion_command.contains("leave Plan Mode")
                     && discussion_command.contains("Coverage Checks")
-                    && discussion_command.contains("Exit Blockers"),
+                    && discussion_command.contains("Exit Blockers")
+                    && discussion_command.contains("Depth Gate")
+                    && discussion_command.contains("Question Ledger"),
                 "expected discussion command to describe the Plan Mode and depth-gate contract in {relative}"
             );
             assert!(
@@ -965,6 +975,8 @@ mod tests {
             );
             assert!(
                 clarification.contains("Planning-ready requires covering the applicable categories")
+                    && clarification.contains("Depth Gate")
+                    && clarification.contains("Question Ledger")
                     && !clarification.contains("Ask at most 5 questions"),
                 "expected clarification guidance to require checklist coverage instead of a five-question cap in {relative}"
             );
@@ -978,7 +990,8 @@ mod tests {
                 .unwrap_or_else(|err| panic!("failed to read {relative}: {err}"));
             assert!(
                 deepening.contains("Escalate from the normal discussion flow into deepening")
-                    && deepening.contains("top 3 highest-impact points"),
+                    && deepening.contains("top 3 highest-impact points")
+                    && deepening.contains("first batch, not an exit condition"),
                 "expected deepening guidance to allow automatic escalation and pre-prioritization in {relative}"
             );
         }
@@ -993,7 +1006,9 @@ mod tests {
                 intake.contains("Do not stop after the first slice success condition alone.")
                     && intake.contains("integration target")
                     && intake.contains("explicit non-goals")
-                    && intake.contains("verification signal"),
+                    && intake.contains("verification signal")
+                    && intake.contains("Depth Gate")
+                    && intake.contains("Question Ledger"),
                 "expected intake guidance to continue beyond the first-slice success signal in {relative}"
             );
         }

--- a/crates/gwt-skills/src/settings_local.rs
+++ b/crates/gwt-skills/src/settings_local.rs
@@ -886,7 +886,7 @@ mod tests {
             "Stop chain must collapse to the event dispatcher; got: {stop_commands:?}"
         );
         assert!(
-            stop_commands[0].ends_with(" hook event Stop") && stop_commands[0].contains("gwtd"),
+            stop_commands[0].contains(" hook event Stop") && stop_commands[0].contains("gwtd"),
             "Stop dispatcher must target gwtd via absolute or literal path; got: {stop_commands:?}"
         );
         assert!(
@@ -2156,11 +2156,15 @@ mod tests {
     fn gwt_hook_bin_path_resolves_gui_binary_to_gwtd_sibling() {
         assert_eq!(
             gwt_hook_bin_path_with(Some(Path::new("/opt/gwt/bin/gwt")), |_| None),
-            "/opt/gwt/bin/gwtd"
+            Path::new("/opt/gwt/bin/gwt")
+                .with_file_name("gwtd")
+                .to_string_lossy()
         );
         assert_eq!(
             gwt_hook_bin_path_with(Some(Path::new("C:/tools/gwt.exe")), |_| None),
-            "C:/tools/gwtd.exe"
+            Path::new("C:/tools/gwt.exe")
+                .with_file_name("gwtd.exe")
+                .to_string_lossy()
         );
     }
 

--- a/crates/gwt/playwright/tests/launch-wizard-fast-mode-live.spec.ts
+++ b/crates/gwt/playwright/tests/launch-wizard-fast-mode-live.spec.ts
@@ -14,6 +14,9 @@ import {
 } from "./_helpers/live-gwt";
 
 const BASE = process.env.GWT_PLAYWRIGHT_BASE_URL ?? "";
+const REAL_CLAUDE_LAUNCH = process.env.GWT_PLAYWRIGHT_LAUNCH_REAL_CLAUDE === "1";
+const BRANCH_NAME =
+  process.env.GWT_PLAYWRIGHT_BRANCH_NAME ?? "work/20260527-0745";
 
 test.describe.serial("Launch Wizard Claude Code Fast mode (live backend)", () => {
   test.skip(!BASE, "GWT_PLAYWRIGHT_BASE_URL is not set; live E2E skipped");
@@ -58,6 +61,64 @@ test.describe.serial("Launch Wizard Claude Code Fast mode (live backend)", () =>
     await expect(submit).toHaveText(/^(Launch|Create and launch)$/);
     await expect(fastModeSummaryValue(page)).toHaveText("on");
   });
+
+  test("Claude Code launches with the Fast mode indicator visible", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+    test.skip(
+      !REAL_CLAUDE_LAUNCH,
+      "set GWT_PLAYWRIGHT_LAUNCH_REAL_CLAUDE=1 to launch the real Claude Code process",
+    );
+
+    const beforeIds = await claudeWindowIds(page);
+    let launchedWindowId: string | null = null;
+    try {
+      await openLaunchWizardForCurrentBranch(page);
+
+      const wizard = page.locator("#wizard-modal");
+      await expect(wizard).toBeVisible();
+      const configureButton = wizard.getByRole("button", {
+        name: "Configure and start",
+      });
+      if (await configureButton.count()) {
+        await configureButton.click();
+      }
+
+      const agentSelect = wizard.getByLabel("Agent", { exact: true });
+      await expect(agentSelect).toBeVisible();
+      await agentSelect.selectOption("claude");
+      await wizard
+        .getByLabel("Use the agent's Fast mode", { exact: true })
+        .setChecked(true);
+      await expect(fastModeSummaryValue(page)).toHaveText("on");
+
+      const submit = page.locator("#wizard-submit-button");
+      await expect(submit).toHaveText("Continue");
+      await submit.click();
+      await expect(submit).toHaveText("Launch");
+      await submit.click();
+
+      const agentWindow = await waitForNewClaudeWindow(page, beforeIds);
+      launchedWindowId = await agentWindow.getAttribute("data-id");
+      await expect(agentWindow.locator(".title-text")).toHaveText("Claude Code");
+      await expect(agentWindow.locator(".status-chip")).toBeVisible();
+      await expect(async () => {
+        const text = await agentWindow.locator(".terminal-root").textContent();
+        expect(text ?? "").toMatch(/[⚡↯]/);
+      }).toPass({ timeout: 45_000 });
+    } finally {
+      if (launchedWindowId) {
+        const launchedWindow = page.locator(
+          `.workspace-window[data-id="${launchedWindowId}"]`,
+        );
+        if (await launchedWindow.count()) {
+          await launchedWindow.getByLabel("Close window").click();
+          await expect(launchedWindow).toHaveCount(0, { timeout: 15_000 });
+        }
+      }
+    }
+  });
 });
 
 async function keepLaunchWizardModalVisible(page: Page): Promise<void> {
@@ -83,4 +144,70 @@ function fastModeSummaryValue(page: Page) {
   return page
     .locator(".wizard-summary-item", { hasText: "Fast mode" })
     .locator(".wizard-summary-value");
+}
+
+async function openLaunchWizardForCurrentBranch(page: Page): Promise<void> {
+  const workWindow = await createWorkWindow(page);
+  const workWindowId = await workWindow.getAttribute("data-id");
+  expect(workWindowId).toBeTruthy();
+  await sendLiveGwtEvent(page, {
+    kind: "open_launch_wizard",
+    id: workWindowId,
+    branch_name: BRANCH_NAME,
+  });
+}
+
+async function createWorkWindow(page: Page) {
+  const beforeIds = await page
+    .locator(".workspace-window")
+    .evaluateAll((nodes) =>
+      nodes.map((node) => (node as HTMLElement).dataset.id || ""),
+    );
+  await sendLiveGwtEvent(page, {
+    kind: "create_window",
+    preset: "work",
+    bounds: { x: 96, y: 96, width: 880, height: 520 },
+  });
+  const id = await page
+    .waitForFunction(
+      ({ beforeIds }) => {
+        const seen = new Set(beforeIds);
+        const node = Array.from(document.querySelectorAll(".workspace-window"))
+          .find((candidate) => !seen.has((candidate as HTMLElement).dataset.id || ""));
+        return node ? (node as HTMLElement).dataset.id || "" : "";
+      },
+      { beforeIds },
+    )
+    .then((handle) => handle.jsonValue());
+  return page.locator(`.workspace-window[data-id="${id}"]`);
+}
+
+async function claudeWindowIds(page: Page): Promise<string[]> {
+  return page
+    .locator(".workspace-window", { hasText: "Claude Code" })
+    .evaluateAll((nodes) =>
+      nodes
+        .map((node) => (node as HTMLElement).dataset.id || "")
+        .filter(Boolean),
+    );
+}
+
+async function waitForNewClaudeWindow(page: Page, beforeIds: string[]) {
+  const id = await page
+    .waitForFunction(
+      ({ beforeIds }) => {
+        const seen = new Set(beforeIds);
+        const node = Array.from(document.querySelectorAll(".workspace-window"))
+          .find((candidate) => {
+            const element = candidate as HTMLElement;
+            const title = element.querySelector(".title-text")?.textContent?.trim();
+            return title === "Claude Code" && !seen.has(element.dataset.id || "");
+          });
+        return node ? (node as HTMLElement).dataset.id || "" : "";
+      },
+      { beforeIds },
+      { timeout: 60_000 },
+    )
+    .then((handle) => handle.jsonValue());
+  return page.locator(`.workspace-window[data-id="${id}"]`);
 }

--- a/crates/gwt/playwright/tests/launch-wizard-fast-mode-live.spec.ts
+++ b/crates/gwt/playwright/tests/launch-wizard-fast-mode-live.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * SPEC-2014 2026-05-27 follow-up — Launch Wizard Fast mode live E2E.
+ *
+ * Runs against a real `gwt serve` backend and exercises the user-facing path
+ * that regressed: Start Work -> Configure and start -> Claude Code -> Fast mode
+ * -> runtime context resolution. The test stops before the final launch so it
+ * does not create a branch or start a real Claude Code process.
+ */
+import { expect, test, type Page } from "@playwright/test";
+import {
+  gotoLiveGwt,
+  openLiveGwtProject,
+  sendLiveGwtEvent,
+} from "./_helpers/live-gwt";
+
+const BASE = process.env.GWT_PLAYWRIGHT_BASE_URL ?? "";
+
+test.describe.serial("Launch Wizard Claude Code Fast mode (live backend)", () => {
+  test.skip(!BASE, "GWT_PLAYWRIGHT_BASE_URL is not set; live E2E skipped");
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    test.skip(
+      testInfo.project.name !== "chromium-dark",
+      "live Launch Wizard E2E runs once against the shared backend",
+    );
+    await gotoLiveGwt(page, BASE, { enableTestBridge: true });
+    await keepLaunchWizardModalVisible(page);
+    await openLiveGwtProject(page);
+  });
+
+  test("Claude Code Fast mode stays on after runtime context resolution", async ({
+    page,
+  }) => {
+    await sendLiveGwtEvent(page, { kind: "open_start_work" });
+
+    const wizard = page.locator("#wizard-modal");
+    await expect(wizard).toBeVisible();
+    await wizard.getByRole("button", { name: "Configure and start" }).click();
+
+    const agentSelect = wizard.getByLabel("Agent", { exact: true });
+    await expect(agentSelect).toBeVisible();
+    await agentSelect.selectOption("claude");
+    await expect(agentSelect).toHaveValue("claude");
+
+    const fastMode = wizard.getByLabel("Use the agent's Fast mode", {
+      exact: true,
+    });
+    await expect(fastMode).toBeVisible();
+    await fastMode.setChecked(false);
+    await expect(fastModeSummaryValue(page)).toHaveText("off");
+    await fastMode.setChecked(true);
+    await expect(fastModeSummaryValue(page)).toHaveText("on");
+
+    const submit = page.locator("#wizard-submit-button");
+    await expect(submit).toHaveText("Continue");
+    await submit.click();
+
+    await expect(submit).toHaveText(/^(Launch|Create and launch)$/);
+    await expect(fastModeSummaryValue(page)).toHaveText("on");
+  });
+});
+
+async function keepLaunchWizardModalVisible(page: Page): Promise<void> {
+  await page.addStyleTag({
+    content: `
+      #wizard-modal[aria-hidden="false"] {
+        display: flex !important;
+        pointer-events: auto !important;
+      }
+      #wizard-modal.open {
+        display: flex !important;
+        pointer-events: auto !important;
+      }
+      #wizard-modal[aria-hidden="true"] {
+        display: none !important;
+        pointer-events: none !important;
+      }
+    `,
+  });
+}
+
+function fastModeSummaryValue(page: Page) {
+  return page
+    .locator(".wizard-summary-item", { hasText: "Fast mode" })
+    .locator(".wizard-summary-value");
+}

--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -299,7 +299,7 @@ impl AppRuntime {
         if session.skip_permissions {
             builder = builder.skip_permissions(true);
         }
-        if session.codex_fast_mode {
+        if session.fast_mode_enabled() {
             builder = builder.fast_mode(true);
         }
         if let Some(docker_service) = non_empty(session.docker_service.as_deref()) {

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -210,7 +210,7 @@ fn launch_config_from_persisted_session(session: &gwt_agent::Session) -> gwt_age
     if session.skip_permissions {
         builder = builder.skip_permissions(true);
     }
-    if session.codex_fast_mode {
+    if session.fast_mode_enabled() {
         builder = builder.fast_mode(true);
     }
     builder = builder.runtime_target(session.runtime_target);
@@ -730,6 +730,7 @@ fn frontend_user_action_log(event: &FrontendEvent) -> Option<FrontendUserActionL
                     log = log.count(value.len());
                 }
                 LaunchWizardAction::SetSkipPermissions { enabled }
+                | LaunchWizardAction::SetFastMode { enabled }
                 | LaunchWizardAction::SetCodexFastMode { enabled } => {
                     log = log.force(*enabled);
                 }
@@ -7451,6 +7452,7 @@ impl AppRuntime {
             session.reasoning_level = config.reasoning_level.clone();
             session.session_mode = config.session_mode;
             session.skip_permissions = config.skip_permissions;
+            session.fast_mode = config.fast_mode;
             session.codex_fast_mode = config.codex_fast_mode;
             session.runtime_target = config.runtime_target;
             session.docker_service = config.docker_service.clone();
@@ -8196,6 +8198,7 @@ impl AppRuntime {
             gwt::LaunchWizardAction::SetLinkedIssue { .. } => "set_linked_issue",
             gwt::LaunchWizardAction::ClearLinkedIssue => "clear_linked_issue",
             gwt::LaunchWizardAction::SetSkipPermissions { .. } => "set_skip_permissions",
+            gwt::LaunchWizardAction::SetFastMode { .. } => "set_fast_mode",
             gwt::LaunchWizardAction::SetCodexFastMode { .. } => "set_codex_fast_mode",
             gwt::LaunchWizardAction::Submit => "submit",
         }
@@ -9634,9 +9637,10 @@ exit 1
         assert_eq!(prepared.bytes, None);
         assert_eq!(prepared.storage_path, None);
         assert_eq!(prepared.agent_path, source.display().to_string());
+        let escaped_source = source.display().to_string().replace('\\', "\\\\");
         assert_eq!(
             super::format_file_attachment_prompt(&[prepared.agent_path]),
-            format!("File: \"{}\"", source.display())
+            format!("File: \"{escaped_source}\"")
         );
     }
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -9636,7 +9636,10 @@ exit 1
         assert_eq!(prepared.agent_path, source.display().to_string());
         assert_eq!(
             super::format_file_attachment_prompt(&[prepared.agent_path]),
-            format!("File: \"{}\"", source.display())
+            format!(
+                "File: {}",
+                super::quote_file_attachment_path(&source.display().to_string())
+            )
         );
     }
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -13646,7 +13646,10 @@ exit 1
                     agents[0].lifecycle_status,
                     Some(gwt::ResumableAgentLifecycleStatus::Running),
                 );
-                assert_eq!(agents[0].resume_kind, gwt::ResumableAgentResumeKind::Session);
+                assert_eq!(
+                    agents[0].resume_kind,
+                    gwt::ResumableAgentResumeKind::Session
+                );
             }
             other => panic!("unexpected backend event: {other:?}"),
         }

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -5422,7 +5422,7 @@ impl AppRuntime {
                 client_id,
                 BackendEvent::BranchError {
                     id: id.to_string(),
-                    message: "Window is not a Work surface".to_string(),
+                    message: format!("Window preset {:?} is not a Work surface", window.preset),
                 },
             )];
         }
@@ -6320,12 +6320,12 @@ impl AppRuntime {
             )];
         };
 
-        if window.preset != WindowPreset::Branches {
+        if window.preset != WindowPreset::Branches && window.preset != WindowPreset::Work {
             return vec![OutboundEvent::reply(
                 client_id,
                 BackendEvent::BranchError {
                     id: id.to_string(),
-                    message: "Window is not a Work surface".to_string(),
+                    message: format!("Window preset {:?} is not a Work surface", window.preset),
                 },
             )];
         }
@@ -12048,7 +12048,7 @@ exit 1
             matches!(
                 &event.event,
                 BackendEvent::BranchError { message, .. }
-                    if message == "Window is not a Work surface"
+                    if message.contains("is not a Work surface")
             )
         });
         assert!(
@@ -13599,7 +13599,7 @@ exit 1
     }
 
     #[test]
-    fn app_runtime_list_resumable_agents_excludes_live_session_ids() {
+    fn app_runtime_list_resumable_agents_includes_live_session_as_running() {
         let _env_lock = env_test_lock()
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -13624,7 +13624,6 @@ exit 1
 
         let tab = sample_project_tab("tab-1", "Repo", repo, ProjectKind::Git, &[]);
         let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
-        // Register the same session id as live so the picker skips it.
         let mut live = sample_active_agent_session("tab-1", "window-1");
         live.session_id = session_id.to_string();
         runtime
@@ -13638,10 +13637,16 @@ exit 1
 
         match events.first().map(|outbound| &outbound.event) {
             Some(BackendEvent::WorkspaceResumableAgents { agents, .. }) => {
-                assert!(
-                    agents.is_empty(),
-                    "live session must not appear in the Resume picker"
+                assert_eq!(
+                    agents.len(),
+                    1,
+                    "live session should appear with Running status"
                 );
+                assert_eq!(
+                    agents[0].lifecycle_status,
+                    Some(gwt::ResumableAgentLifecycleStatus::Running),
+                );
+                assert_eq!(agents[0].resume_kind, gwt::ResumableAgentResumeKind::Session);
             }
             other => panic!("unexpected backend event: {other:?}"),
         }

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -11982,6 +11982,79 @@ exit 1
     }
 
     #[test]
+    fn app_runtime_open_launch_wizard_accepts_work_window_preset() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "work-1",
+            repo,
+            WindowPreset::Work,
+            WindowProcessStatus::Ready,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "work-1");
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::OpenLaunchWizard {
+                id: window_id,
+                branch_name: "main".to_string(),
+                linked_issue_number: None,
+            },
+        );
+
+        assert!(
+            runtime.launch_wizard.is_some(),
+            "Launch wizard should open from a Work window preset"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(&event.event, BackendEvent::LaunchWizardOpenError { .. })),
+            "Work preset must not be rejected as 'not a Work surface'"
+        );
+    }
+
+    #[test]
+    fn app_runtime_resume_branch_latest_agent_accepts_work_window_preset() {
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "work-1",
+            repo,
+            WindowPreset::Work,
+            WindowProcessStatus::Ready,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "work-1");
+
+        let events = runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::ResumeBranchLatestAgent {
+                id: window_id,
+                branch_name: "main".to_string(),
+                bounds: canvas_bounds(),
+            },
+        );
+
+        let has_surface_error = events.iter().any(|event| {
+            matches!(
+                &event.event,
+                BackendEvent::BranchError { message, .. }
+                    if message == "Window is not a Work surface"
+            )
+        });
+        assert!(
+            !has_surface_error,
+            "Work preset must not be rejected as 'not a Work surface'"
+        );
+    }
+
+    #[test]
     fn app_runtime_resume_workspace_failure_surfaces_launch_wizard_open_error() {
         // SPEC-2359 / Issue #2757: Resume クリックで `resume_workspace_events`
         // が早期 return / Start Work fallback 失敗を起こした場合、frontend で

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -114,7 +114,7 @@ impl AppRuntime {
             return launch_agent_open_error(client_id, "Window not found");
         };
 
-        if window.preset != WindowPreset::Branches {
+        if window.preset != WindowPreset::Branches && window.preset != WindowPreset::Work {
             return launch_agent_open_error(client_id, "Window is not a Work surface");
         }
         // SPEC-1934 US-7 / FR-034
@@ -646,7 +646,7 @@ impl AppRuntime {
         let Some(window) = tab.workspace.window(&address.raw_id) else {
             return branch_error("Window not found".to_string());
         };
-        if window.preset != WindowPreset::Branches {
+        if window.preset != WindowPreset::Branches && window.preset != WindowPreset::Work {
             return branch_error("Window is not a Work surface".to_string());
         }
         if tab.kind != gwt::ProjectKind::Git {

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -755,22 +755,27 @@ impl AppRuntime {
         };
 
         let sessions_dir = self.sessions_dir.clone();
-        // SPEC-2359 US-42 follow-up: real-world projections carry many
-        // agents with `affiliation_status = unassigned` (set when the
-        // agent did not go through an explicit `workspace ensure` /
-        // `workspace join` flow). Resume Picker still wants to surface
-        // them as candidates as long as the agent has a Session toml the
-        // launcher can drive — otherwise the picker reports "No
-        // resumable agents" even when the user can clearly see prior
-        // sessions in the Workspace card. We therefore include every
-        // agent (Assigned + Unassigned) and rely on the Session toml +
-        // `live_session_ids` filters below to keep the list correct.
+
+        let work_item_session_ids: Option<std::collections::HashSet<String>> = workspace_id
+            .and_then(|wid| {
+                gwt_core::workspace_projection::load_workspace_work_items(&project_root)
+                    .ok()
+                    .flatten()
+                    .and_then(|items| {
+                        items
+                            .work_items
+                            .into_iter()
+                            .find(|item| item.id == wid)
+                            .map(|item| item.agents.into_iter().map(|a| a.session_id).collect())
+                    })
+            });
+
         let mut entries: Vec<gwt::ResumableAgentView> = projection
             .agents
             .iter()
             .filter(|agent| !agent.session_id.trim().is_empty())
-            .filter(|agent| match workspace_id {
-                Some(id) => agent.workspace_id.as_deref() == Some(id),
+            .filter(|agent| match &work_item_session_ids {
+                Some(ids) => ids.contains(&agent.session_id),
                 None => true,
             })
             .filter_map(|agent| {

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -471,7 +471,7 @@ impl AppRuntime {
         client_id: &str,
         workspace_id: Option<String>,
     ) -> Vec<OutboundEvent> {
-        let agents = self.collect_resumable_agents();
+        let agents = self.collect_resumable_agents(workspace_id.as_deref());
         vec![OutboundEvent::reply(
             client_id.to_string(),
             BackendEvent::WorkspaceResumableAgents {
@@ -730,7 +730,7 @@ impl AppRuntime {
     /// `lifecycle_status = Running` so the picker can show them and focus
     /// their window on click. Non-live entries require a backing Session
     /// toml on disk.
-    fn collect_resumable_agents(&self) -> Vec<gwt::ResumableAgentView> {
+    fn collect_resumable_agents(&self, workspace_id: Option<&str>) -> Vec<gwt::ResumableAgentView> {
         let Some(tab_id) = self.active_tab_id.as_deref() else {
             return Vec::new();
         };
@@ -769,6 +769,10 @@ impl AppRuntime {
             .agents
             .iter()
             .filter(|agent| !agent.session_id.trim().is_empty())
+            .filter(|agent| match workspace_id {
+                Some(id) => agent.workspace_id.as_deref() == Some(id),
+                None => true,
+            })
             .filter_map(|agent| {
                 let is_live = live_session_ids.contains(agent.session_id.as_str());
                 let (resume_kind, lifecycle_status) = if is_live {

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -565,7 +565,7 @@ impl AppRuntime {
         if session.skip_permissions {
             builder = builder.skip_permissions(true);
         }
-        if session.codex_fast_mode {
+        if session.fast_mode_enabled() {
             builder = builder.fast_mode(true);
         }
         builder = builder.runtime_target(session.runtime_target);

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -115,7 +115,15 @@ impl AppRuntime {
         };
 
         if window.preset != WindowPreset::Branches && window.preset != WindowPreset::Work {
-            return launch_agent_open_error(client_id, "Window is not a Work surface");
+            tracing::warn!(
+                preset = ?window.preset,
+                window_id = id,
+                "open_launch_wizard rejected: wrong preset"
+            );
+            return launch_agent_open_error(
+                client_id,
+                format!("Window preset {:?} is not a Work surface", window.preset),
+            );
         }
         // SPEC-1934 US-7 / FR-034
         if tab.migration_pending {
@@ -647,7 +655,15 @@ impl AppRuntime {
             return branch_error("Window not found".to_string());
         };
         if window.preset != WindowPreset::Branches && window.preset != WindowPreset::Work {
-            return branch_error("Window is not a Work surface".to_string());
+            tracing::warn!(
+                preset = ?window.preset,
+                window_id = id,
+                "resume_branch_latest_agent rejected: wrong preset"
+            );
+            return branch_error(format!(
+                "Window preset {:?} is not a Work surface",
+                window.preset
+            ));
         }
         if tab.kind != gwt::ProjectKind::Git {
             return branch_error("Resume requires a Git project".to_string());
@@ -710,10 +726,10 @@ impl AppRuntime {
     }
 
     /// Build a list of agents that the Workspace Resume picker can offer
-    /// for the currently-active Git project tab. Filters out historical
-    /// entries (`is_assigned == false`), agents that are already live in
-    /// `active_agent_sessions`, and entries whose session_id does not have
-    /// a backing Session toml on disk.
+    /// for the currently-active Git project tab. Includes live agents with
+    /// `lifecycle_status = Running` so the picker can show them and focus
+    /// their window on click. Non-live entries require a backing Session
+    /// toml on disk.
     fn collect_resumable_agents(&self) -> Vec<gwt::ResumableAgentView> {
         let Some(tab_id) = self.active_tab_id.as_deref() else {
             return Vec::new();
@@ -753,10 +769,15 @@ impl AppRuntime {
             .agents
             .iter()
             .filter(|agent| !agent.session_id.trim().is_empty())
-            .filter(|agent| !live_session_ids.contains(agent.session_id.as_str()))
             .filter_map(|agent| {
-                let session_path = sessions_dir.join(format!("{}.toml", agent.session_id));
-                let (resume_kind, lifecycle_status) =
+                let is_live = live_session_ids.contains(agent.session_id.as_str());
+                let (resume_kind, lifecycle_status) = if is_live {
+                    (
+                        gwt::ResumableAgentResumeKind::Session,
+                        Some(gwt::ResumableAgentLifecycleStatus::Running),
+                    )
+                } else {
+                    let session_path = sessions_dir.join(format!("{}.toml", agent.session_id));
                     match gwt_agent::Session::load_and_migrate(&session_path) {
                         Ok(session) => {
                             let resume_kind = if session.exact_resume_session_id().is_some() {
@@ -777,7 +798,8 @@ impl AppRuntime {
                             (resume_kind, lifecycle_status)
                         }
                         Err(_) => return None,
-                    };
+                    }
+                };
                 Some(gwt::ResumableAgentView {
                     session_id: agent.session_id.clone(),
                     agent_id: agent.agent_id.clone(),

--- a/crates/gwt/src/cli/hook/skill_discussion_stop_check.rs
+++ b/crates/gwt/src/cli/hook/skill_discussion_stop_check.rs
@@ -46,7 +46,7 @@ pub fn handle_with_input(worktree: &Path, input: &str) -> HookOutput {
 
     HookOutput::stop_block(format!(
         "Discussion is still [active] on proposal \"{title}\".\n\
-         Next question or evidence blocker: {question}\n\
+         Next question, evidence blocker, or depth blocker: {question}\n\
          Continue the gwt-discussion workflow (investigate → ask the user → update Discussion TODO), \
          or call `gwtd discuss resolve|park|reject --proposal \"{label}\"` to exit the discussion explicitly.",
         title = pending.proposal_title,
@@ -75,6 +75,9 @@ mod tests {
 - Official Docs Proof: Claude Code hooks docs checked.\n\
 - External Research Proof: not-applicable: local-only behavior.\n\
 - Exit Blockers: none\n\
+- Depth Mode: normal\n\
+- Question Ledger: scope boundary, integration, failure, migration, verification checked\n\
+- Depth Gate: complete\n\
 - Next Question:\n\
 - Evidence Gate: complete\n\
 ";
@@ -88,8 +91,27 @@ mod tests {
 - Official Docs Proof: Claude Code hooks docs checked.\n\
 - External Research Proof: not-applicable: local-only behavior.\n\
 - Exit Blockers: implementation proof is missing\n\
+- Depth Mode: normal\n\
+- Question Ledger: scope boundary checked only\n\
+- Depth Gate: open\n\
 - Next Question:\n\
 - Evidence Gate: open\n\
+";
+
+    const ACTIVE_WITH_DEPTH_BLOCKER_WITHOUT_QUESTION: &str = "## Discussion TODO\n\n\
+### Proposal A - Depth gate [active]\n\
+- Summary: Evidence is complete but depth coverage is shallow.\n\
+- Implementation Proof: crates/gwt/src/discussion_resume.rs inspected.\n\
+- SPEC/Issue Proof: SPEC-1935 checked.\n\
+- Gap Check Proof: scope/integration/failure/migration/verification checked.\n\
+- Official Docs Proof: not-applicable: local-only behavior.\n\
+- External Research Proof: not-applicable: local-only behavior.\n\
+- Exit Blockers: none\n\
+- Depth Mode: normal\n\
+- Question Ledger: scope boundary checked only\n\
+- Depth Gate: open\n\
+- Next Question:\n\
+- Evidence Gate: complete\n\
 ";
 
     const ALL_RESOLVED: &str = "## Discussion TODO\n\n\
@@ -188,7 +210,21 @@ mod tests {
             &[
                 "Evidence gate",
                 "Exit Blockers remain unresolved",
-                "Next question or evidence blocker",
+                "Next question, evidence blocker, or depth blocker",
+            ],
+        );
+    }
+
+    #[test]
+    fn blocks_when_depth_gate_is_incomplete_without_next_question() {
+        let dir = tempfile::tempdir().unwrap();
+        write_discussion(dir.path(), ACTIVE_WITH_DEPTH_BLOCKER_WITHOUT_QUESTION);
+        assert_stop_block(
+            handle_with_input(dir.path(), "{}"),
+            &[
+                "Depth gate",
+                "Depth Gate is not complete",
+                "Next question, evidence blocker, or depth blocker",
             ],
         );
     }

--- a/crates/gwt/src/daemon_runtime.rs
+++ b/crates/gwt/src/daemon_runtime.rs
@@ -276,11 +276,9 @@ fn is_loopback_host(host: &str) -> bool {
 mod tests {
     use super::*;
     use std::ffi::OsString;
-    use std::sync::{Mutex, OnceLock};
 
     fn env_test_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
+        crate::env_test_lock()
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }

--- a/crates/gwt/src/discussion_resume.rs
+++ b/crates/gwt/src/discussion_resume.rs
@@ -368,10 +368,29 @@ fn evidence_gate_blocker(proposal: &ParsedProposal) -> Option<String> {
         }
     }
 
-    match field_value(proposal, "Evidence Gate") {
+    let evidence_blocker = match field_value(proposal, "Evidence Gate") {
         Some(value) if value.eq_ignore_ascii_case("complete") => None,
         Some(value) => Some(format!("Evidence Gate is not complete: {value}")),
         None => Some("Evidence Gate is missing".to_string()),
+    };
+    if evidence_blocker.is_some() {
+        return evidence_blocker;
+    }
+
+    depth_gate_blocker(proposal)
+}
+
+fn depth_gate_blocker(proposal: &ParsedProposal) -> Option<String> {
+    let question_ledger = field_value(proposal, "Question Ledger");
+    if !is_acceptable_depth_ledger(question_ledger.as_deref()) {
+        return Some("Question Ledger is missing or incomplete".to_string());
+    }
+
+    match field_value(proposal, "Depth Gate") {
+        Some(value) if value.eq_ignore_ascii_case("complete") => None,
+        Some(value) if is_deferred_depth_gate(&value) => None,
+        Some(value) => Some(format!("Depth Gate is not complete: {value}")),
+        None => Some("Depth Gate is missing".to_string()),
     }
 }
 
@@ -410,6 +429,25 @@ fn is_placeholder_value(value: &str) -> bool {
         value.to_ascii_lowercase().as_str(),
         "tbd" | "todo" | "unknown" | "unverified" | "none" | "n/a" | "not-applicable"
     )
+}
+
+fn is_acceptable_depth_ledger(value: Option<&str>) -> bool {
+    let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) else {
+        return false;
+    };
+    !is_placeholder_value(value)
+}
+
+fn is_deferred_depth_gate(value: &str) -> bool {
+    let value = value.trim();
+    let lower = value.to_ascii_lowercase();
+    let Some(reason) = lower
+        .strip_prefix("deferred(")
+        .and_then(|rest| rest.strip_suffix(')'))
+    else {
+        return false;
+    };
+    !reason.trim().is_empty()
 }
 
 #[cfg(test)]
@@ -692,6 +730,9 @@ mod tests {
              - Official Docs Proof: Claude Code hooks docs checked\n\
              - External Research Proof: not-applicable: local-only behavior\n\
              - Exit Blockers: none\n\
+             - Depth Mode: normal\n\
+             - Question Ledger: scope boundary, integration, failure, migration, verification checked\n\
+             - Depth Gate: complete\n\
              - Next Question:\n\
              - Evidence Gate: complete\n",
         )
@@ -702,6 +743,41 @@ mod tests {
             proposal_evidence_blocker_by_label(dir.path(), "Proposal A").unwrap(),
             None
         );
+    }
+
+    #[test]
+    fn discussion_stop_blocker_reports_depth_gate_without_next_question() {
+        let dir = tempfile::tempdir().unwrap();
+        let discussion_path = dir.path().join(DISCUSSION_RELATIVE_PATH);
+        std::fs::create_dir_all(discussion_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &discussion_path,
+            "## Discussion TODO\n\n\
+             ### Proposal A - Depth gap [active]\n\
+             - Summary: Evidence is complete but depth is not.\n\
+             - Implementation Proof: crates/gwt/src/discussion_resume.rs inspected and focused tests run\n\
+             - SPEC/Issue Proof: SPEC-1935 spec/plan/tasks checked\n\
+             - Gap Check Proof: scope/integration/failure/migration/verification checked\n\
+             - Official Docs Proof: not-applicable: local-only behavior\n\
+             - External Research Proof: not-applicable: local-only behavior\n\
+             - Exit Blockers: none\n\
+             - Depth Mode: normal\n\
+             - Question Ledger: scope boundary checked only\n\
+             - Depth Gate: open\n\
+             - Next Question:\n\
+             - Evidence Gate: complete\n",
+        )
+        .unwrap();
+
+        let pending = discussion_stop_blocker(dir.path())
+            .unwrap()
+            .expect("depth blocker should keep discussion active");
+        assert_eq!(pending.proposal_label, "Proposal A");
+        assert!(pending
+            .next_question
+            .as_deref()
+            .unwrap_or("")
+            .contains("Depth Gate is not complete"));
     }
 
     #[test]
@@ -724,6 +800,66 @@ mod tests {
             .unwrap()
             .expect("missing proof should block resolve");
         assert!(blocker.contains("Implementation Proof"));
+    }
+
+    #[test]
+    fn proposal_evidence_blocker_accepts_deferred_depth_gate_with_reason() {
+        let dir = tempfile::tempdir().unwrap();
+        let discussion_path = dir.path().join(DISCUSSION_RELATIVE_PATH);
+        std::fs::create_dir_all(discussion_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &discussion_path,
+            "## Discussion TODO\n\n\
+             ### Proposal A - Deferred depth [active]\n\
+             - Summary: Defers the remaining deepening work.\n\
+             - Implementation Proof: crates/gwt/src/discussion_resume.rs inspected\n\
+             - SPEC/Issue Proof: SPEC-1935 checked\n\
+             - Gap Check Proof: scope/integration/failure/migration/verification checked\n\
+             - Official Docs Proof: not-applicable: local-only behavior\n\
+             - External Research Proof: not-applicable: local-only behavior\n\
+             - Exit Blockers: none\n\
+             - Depth Mode: normal\n\
+             - Question Ledger: scope and integration covered; remaining alternatives deferred to next SPEC phase\n\
+             - Depth Gate: deferred(remaining alternatives are out of scope for this Action Bundle)\n\
+             - Next Question:\n\
+             - Evidence Gate: complete\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            proposal_evidence_blocker_by_label(dir.path(), "Proposal A").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn proposal_evidence_blocker_rejects_deferred_depth_gate_without_reason() {
+        let dir = tempfile::tempdir().unwrap();
+        let discussion_path = dir.path().join(DISCUSSION_RELATIVE_PATH);
+        std::fs::create_dir_all(discussion_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &discussion_path,
+            "## Discussion TODO\n\n\
+             ### Proposal A - Empty deferred depth [active]\n\
+             - Summary: Defers without saying why.\n\
+             - Implementation Proof: crates/gwt/src/discussion_resume.rs inspected\n\
+             - SPEC/Issue Proof: SPEC-1935 checked\n\
+             - Gap Check Proof: scope/integration/failure/migration/verification checked\n\
+             - Official Docs Proof: not-applicable: local-only behavior\n\
+             - External Research Proof: not-applicable: local-only behavior\n\
+             - Exit Blockers: none\n\
+             - Depth Mode: normal\n\
+             - Question Ledger: scope checked\n\
+             - Depth Gate: deferred()\n\
+             - Next Question:\n\
+             - Evidence Gate: complete\n",
+        )
+        .unwrap();
+
+        let blocker = proposal_evidence_blocker_by_label(dir.path(), "Proposal A")
+            .unwrap()
+            .expect("empty deferred reason should block resolve");
+        assert!(blocker.contains("Depth Gate"));
     }
 
     #[test]

--- a/crates/gwt/src/knowledge_bridge.rs
+++ b/crates/gwt/src/knowledge_bridge.rs
@@ -1028,7 +1028,7 @@ fn load_linked_branches(repo_path: &Path) -> HashMap<u64, Vec<String>> {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, ffi::OsString, fs, path::PathBuf};
+    use std::{collections::HashMap, ffi::OsString, fs};
 
     use gwt_github::{
         client::{CommentId, CommentSnapshot, IssueNumber, IssueSnapshot, IssueState, UpdatedAt},

--- a/crates/gwt/src/knowledge_bridge.rs
+++ b/crates/gwt/src/knowledge_bridge.rs
@@ -1030,6 +1030,9 @@ fn load_linked_branches(repo_path: &Path) -> HashMap<u64, Vec<String>> {
 mod tests {
     use std::{collections::HashMap, ffi::OsString, fs};
 
+    #[cfg(unix)]
+    use std::path::PathBuf;
+
     use gwt_github::{
         client::{CommentId, CommentSnapshot, IssueNumber, IssueSnapshot, IssueState, UpdatedAt},
         Cache,

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -272,6 +272,8 @@ pub struct LaunchWizardView {
     pub show_version: bool,
     pub show_execution_mode: bool,
     pub show_skip_permissions: bool,
+    pub show_fast_mode: bool,
+    /// Legacy Codex-only compatibility field for older frontend payloads.
     pub show_codex_fast_mode: bool,
     pub show_branch_controls: bool,
     pub show_start_methods: bool,
@@ -287,6 +289,8 @@ pub struct LaunchWizardView {
     pub primary_action_label: String,
     pub primary_action_enabled: bool,
     pub progress_steps: Vec<LaunchWizardProgressStepView>,
+    pub fast_mode: bool,
+    /// Legacy Codex-only compatibility field for older frontend payloads.
     pub codex_fast_mode: bool,
     pub launch_summary: Vec<LaunchWizardSummaryView>,
     pub error: Option<String>,
@@ -548,6 +552,7 @@ pub fn quick_start_entries_from_sessions(
 }
 
 fn previous_profile_from_session(session: gwt_agent::Session) -> LaunchWizardPreviousProfile {
+    let fast_mode = session.fast_mode_enabled();
     LaunchWizardPreviousProfile {
         agent_id: session.agent_id.command().to_string(),
         model: session.model,
@@ -560,7 +565,7 @@ fn previous_profile_from_session(session: gwt_agent::Session) -> LaunchWizardPre
         }),
         session_mode: session.session_mode,
         skip_permissions: session.skip_permissions,
-        codex_fast_mode: session.codex_fast_mode,
+        codex_fast_mode: fast_mode,
         runtime_target: session.runtime_target,
         docker_service: session.docker_service,
         docker_lifecycle_intent: session.docker_lifecycle_intent,
@@ -841,6 +846,9 @@ pub enum LaunchWizardAction {
     SetSkipPermissions {
         enabled: bool,
     },
+    SetFastMode {
+        enabled: bool,
+    },
     SetCodexFastMode {
         enabled: bool,
     },
@@ -1115,6 +1123,10 @@ impl LaunchWizardState {
         let show_back_button = self.show_back_button();
         let show_manual_setup = self.show_manual_setup();
         let show_runtime_confirmation = self.show_runtime_confirmation();
+        let show_fast_mode = show_manual_setup
+            && self.launch_target_is_agent()
+            && self.current_agent_supports_fast_mode();
+        let fast_mode = self.fast_mode_enabled_for_current_agent();
         LaunchWizardView {
             title: if self.wizard_mode == LaunchWizardMode::StartWork {
                 "Start Work".to_string()
@@ -1185,6 +1197,7 @@ impl LaunchWizardState {
                 && agent_has_npm_package(self.effective_agent_id()),
             show_execution_mode: show_manual_setup && self.launch_target_is_agent(),
             show_skip_permissions: show_manual_setup && self.launch_target_is_agent(),
+            show_fast_mode,
             show_codex_fast_mode: show_manual_setup
                 && self.launch_target_is_agent()
                 && self.agent_is_codex(),
@@ -1202,7 +1215,8 @@ impl LaunchWizardState {
             primary_action_label: self.primary_action_label(),
             primary_action_enabled: self.primary_action_enabled(),
             progress_steps: self.progress_steps_view(),
-            codex_fast_mode: self.codex_fast_mode,
+            fast_mode,
+            codex_fast_mode: self.codex_fast_mode && self.agent_is_codex(),
             launch_summary: self.launch_summary_view(),
             error: self.error.clone(),
         }
@@ -1405,6 +1419,9 @@ impl LaunchWizardState {
             LaunchWizardAction::ClearLinkedIssue => {
                 self.linked_issue_number = None;
             }
+            LaunchWizardAction::SetFastMode { enabled } => {
+                self.codex_fast_mode = enabled && self.current_agent_supports_fast_mode();
+            }
             LaunchWizardAction::SetCodexFastMode { enabled } => {
                 self.codex_fast_mode = enabled && self.agent_is_codex();
             }
@@ -1537,7 +1554,7 @@ impl LaunchWizardState {
             builder = builder.skip_permissions(true);
         }
 
-        if self.agent_is_codex() && self.codex_fast_mode {
+        if self.fast_mode_enabled_for_current_agent() {
             builder = builder.fast_mode(true);
         }
 
@@ -1747,7 +1764,8 @@ impl LaunchWizardState {
                 self.skip_permissions = self.selected == 0;
             }
             LaunchWizardStep::CodexFastMode => {
-                self.codex_fast_mode = self.selected == 0;
+                self.codex_fast_mode =
+                    self.selected == 0 && self.current_agent_supports_fast_mode();
             }
             LaunchWizardStep::BranchNameInput => {}
         }
@@ -1901,7 +1919,7 @@ impl LaunchWizardState {
             self.version = version;
         }
         self.skip_permissions = entry.skip_permissions;
-        self.codex_fast_mode = entry.codex_fast_mode && self.agent_is_codex();
+        self.codex_fast_mode = entry.codex_fast_mode && self.current_agent_supports_fast_mode();
         self.mode = "resume".to_string();
         self.resume_session_id = Some(resume_session_id);
         self.finish_launch_request();
@@ -1950,7 +1968,7 @@ impl LaunchWizardState {
             self.version = version;
         }
         self.skip_permissions = entry.skip_permissions;
-        self.codex_fast_mode = entry.codex_fast_mode && self.agent_is_codex();
+        self.codex_fast_mode = entry.codex_fast_mode && self.current_agent_supports_fast_mode();
         match mode {
             QuickStartLaunchMode::Resume => {
                 if let Some(window_id) = entry.live_window_id {
@@ -2028,7 +2046,7 @@ impl LaunchWizardState {
         self.mode = execution_mode_value_from_session_mode(profile.session_mode).to_string();
         self.resume_session_id = None;
         self.skip_permissions = profile.skip_permissions;
-        self.codex_fast_mode = profile.codex_fast_mode && self.agent_is_codex();
+        self.codex_fast_mode = profile.codex_fast_mode && self.current_agent_supports_fast_mode();
     }
 
     fn focus_existing_session(&mut self, index: usize) {
@@ -2560,10 +2578,10 @@ impl LaunchWizardState {
                 },
             });
         }
-        if self.agent_is_codex() {
+        if self.current_agent_supports_fast_mode() {
             summary.push(LaunchWizardSummaryView {
                 label: "Fast mode".to_string(),
-                value: if self.codex_fast_mode {
+                value: if self.fast_mode_enabled_for_current_agent() {
                     "on".to_string()
                 } else {
                     "off".to_string()
@@ -2842,6 +2860,15 @@ impl LaunchWizardState {
         self.launch_target_is_agent() && self.effective_agent_id() == "codex"
     }
 
+    fn current_agent_supports_fast_mode(&self) -> bool {
+        self.launch_target_is_agent()
+            && agent_id_from_key(self.effective_agent_id()).supports_fast_mode()
+    }
+
+    fn fast_mode_enabled_for_current_agent(&self) -> bool {
+        self.codex_fast_mode && self.current_agent_supports_fast_mode()
+    }
+
     /// SPEC-2014 2026-05-18 amendment FR-D: filtered Execution Mode option
     /// list seen by both the wizard-step path (`current_options`) and the
     /// default-selection helper. Mirrors the LaunchWizardView's
@@ -3002,7 +3029,7 @@ impl LaunchWizardState {
                 mode: self.mode.clone(),
                 resume_session_id: self.resume_session_id.clone(),
                 skip_permissions: self.skip_permissions,
-                codex_fast_mode: self.codex_fast_mode && self.agent_is_codex(),
+                codex_fast_mode: self.fast_mode_enabled_for_current_agent(),
             },
         );
     }
@@ -3031,7 +3058,7 @@ impl LaunchWizardState {
         self.mode = draft.mode;
         self.resume_session_id = draft.resume_session_id;
         self.skip_permissions = draft.skip_permissions;
-        self.codex_fast_mode = draft.codex_fast_mode && self.agent_is_codex();
+        self.codex_fast_mode = draft.codex_fast_mode && self.current_agent_supports_fast_mode();
     }
 
     fn reset_agent_draft_defaults(&mut self) {
@@ -3162,7 +3189,7 @@ impl LaunchWizardState {
             self.version = version;
         }
         self.skip_permissions = entry.skip_permissions;
-        self.codex_fast_mode = entry.codex_fast_mode && self.agent_is_codex();
+        self.codex_fast_mode = entry.codex_fast_mode && self.current_agent_supports_fast_mode();
 
         match selected_action {
             QuickStartAction::ReuseEntry { .. } => {
@@ -3643,7 +3670,7 @@ const YES_NO_OPTIONS: [ChoiceOption; 2] = [
 const FAST_MODE_OPTIONS: [ChoiceOption; 2] = [
     ChoiceOption {
         label: "On",
-        description: "Use Codex fast service tier",
+        description: "Use the agent's Fast mode",
     },
     ChoiceOption {
         label: "Off",
@@ -3799,7 +3826,7 @@ impl<'a> LaunchWizardFlow<'a> {
             LaunchWizardStep::VersionSelect => Some(LaunchWizardStep::ExecutionMode),
             LaunchWizardStep::ExecutionMode => Some(LaunchWizardStep::SkipPermissions),
             LaunchWizardStep::SkipPermissions => {
-                if self.state.agent_is_codex() {
+                if self.state.current_agent_supports_fast_mode() {
                     Some(LaunchWizardStep::CodexFastMode)
                 } else {
                     None
@@ -4030,7 +4057,9 @@ fn step_default_selection(step: LaunchWizardStep, state: &LaunchWizardState) -> 
             .position(|option| option.value == state.mode)
             .unwrap_or(0),
         LaunchWizardStep::SkipPermissions => usize::from(!state.skip_permissions),
-        LaunchWizardStep::CodexFastMode => usize::from(!state.codex_fast_mode),
+        LaunchWizardStep::CodexFastMode => {
+            usize::from(!state.fast_mode_enabled_for_current_agent())
+        }
     }
 }
 
@@ -6617,6 +6646,75 @@ mod tests {
             .launch_summary
             .iter()
             .any(|item| item.label == "Fast mode" && item.value == "on"));
+    }
+
+    #[test]
+    fn claude_fast_mode_is_exposed_and_applied_to_launch_config() {
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            sample_agent_options(),
+            Vec::new(),
+        );
+
+        state.apply(LaunchWizardAction::SetAgent {
+            agent_id: "claude".to_string(),
+        });
+        state.apply(LaunchWizardAction::SetFastMode { enabled: true });
+
+        let view = state.view();
+        assert_eq!(view.selected_agent_id, "claude");
+        assert!(view.show_fast_mode);
+        assert!(view.fast_mode);
+        assert!(!view.show_codex_fast_mode);
+        assert!(!view.codex_fast_mode);
+        assert!(view
+            .launch_summary
+            .iter()
+            .any(|item| item.label == "Fast mode" && item.value == "on"));
+
+        let config = state.build_launch_config().expect("launch config");
+        assert_eq!(config.agent_id, gwt_agent::AgentId::ClaudeCode);
+        assert!(config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--settings" && pair[1] == r#"{"fastMode":true}"#));
+    }
+
+    #[test]
+    fn unsupported_agent_hides_and_ignores_fast_mode() {
+        let mut agent_options = sample_agent_options();
+        agent_options.push(AgentOption {
+            id: "aider".to_string(),
+            name: "Aider".to_string(),
+            available: true,
+            installed_version: None,
+            versions: Vec::new(),
+            custom_agent: None,
+        });
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            agent_options,
+            Vec::new(),
+        );
+
+        state.apply(LaunchWizardAction::SetAgent {
+            agent_id: "aider".to_string(),
+        });
+        state.apply(LaunchWizardAction::SetFastMode { enabled: true });
+
+        let view = state.view();
+        assert_eq!(view.selected_agent_id, "aider");
+        assert!(!view.show_fast_mode);
+        assert!(!view.fast_mode);
+        assert!(!view.show_codex_fast_mode);
+        assert!(!view.codex_fast_mode);
+
+        let config = state.build_launch_config().expect("launch config");
+        assert_eq!(config.agent_id, gwt_agent::AgentId::Custom("aider".into()));
+        assert!(!config
+            .args
+            .windows(2)
+            .any(|pair| pair[0] == "--settings" && pair[1].contains("fastMode")));
     }
 
     #[test]

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -198,6 +198,7 @@ pub enum ResumableAgentResumeKind {
 pub enum ResumableAgentLifecycleStatus {
     Active,
     Interrupted,
+    Running,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -2768,7 +2768,7 @@ impl LaunchWizardState {
             };
         }
 
-        if !self.agent_is_codex() {
+        if !self.current_agent_supports_fast_mode() {
             self.codex_fast_mode = false;
         }
         self.sync_reasoning_state();
@@ -6678,6 +6678,68 @@ mod tests {
             .args
             .windows(2)
             .any(|pair| pair[0] == "--settings" && pair[1] == r#"{"fastMode":true}"#));
+    }
+
+    #[test]
+    fn runtime_context_resolution_preserves_claude_fast_mode_draft() {
+        let mut state = LaunchWizardState::open_start_work_with_previous_profile(
+            context(branch("origin/develop"), "work/20260527-fast"),
+            "origin/develop".to_string(),
+            sample_agent_options(),
+            Vec::new(),
+            None,
+        );
+        state.mark_runtime_context_unresolved();
+
+        state.apply(LaunchWizardAction::UseStartMethod {
+            method: LaunchWizardStartMethodKind::ConfigureAndStart,
+        });
+        state.apply(LaunchWizardAction::SetAgent {
+            agent_id: "claude".to_string(),
+        });
+        state.apply(LaunchWizardAction::SetFastMode { enabled: true });
+        assert!(state.view().fast_mode);
+
+        state.apply(LaunchWizardAction::Submit);
+        match state.completion.as_ref() {
+            Some(LaunchWizardCompletion::ResolveRuntime(config)) => match config.as_ref() {
+                LaunchWizardLaunchRequest::Agent(config) => {
+                    assert_eq!(config.agent_id, gwt_agent::AgentId::ClaudeCode);
+                    assert!(config.fast_mode);
+                }
+                other => panic!("expected agent runtime resolve request, got {other:?}"),
+            },
+            other => panic!("expected runtime resolve request, got {other:?}"),
+        }
+
+        state.completion = None;
+        state.apply_runtime_context(LaunchWizardHydration {
+            selected_branch: None,
+            normalized_branch_name: "work/20260527-fast".to_string(),
+            worktree_path: None,
+            quick_start_root: PathBuf::from("/tmp/repo"),
+            docker_context: None,
+            docker_service_status: gwt_docker::ComposeServiceStatus::NotFound,
+            agent_options: sample_agent_options(),
+            quick_start_entries: Vec::new(),
+            previous_profiles: Some(Default::default()),
+        });
+
+        assert!(state.view().fast_mode);
+        state.apply(LaunchWizardAction::Submit);
+        match state.completion.as_ref() {
+            Some(LaunchWizardCompletion::Launch(config)) => match config.as_ref() {
+                LaunchWizardLaunchRequest::Agent(config) => {
+                    assert_eq!(config.agent_id, gwt_agent::AgentId::ClaudeCode);
+                    assert!(config.fast_mode);
+                    assert!(config.args.windows(2).any(|pair| {
+                        pair[0] == "--settings" && pair[1] == r#"{"fastMode":true}"#
+                    }));
+                }
+                other => panic!("expected agent launch request, got {other:?}"),
+            },
+            other => panic!("expected launch request, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/gwt/src/launch_wizard/quick_start.rs
+++ b/crates/gwt/src/launch_wizard/quick_start.rs
@@ -77,7 +77,7 @@ pub(super) fn collect_quick_start_entries_from_sessions(
             resume_session_id: agent_session_resume_id(&session),
             live_window_id: None,
             skip_permissions: session.skip_permissions,
-            codex_fast_mode: session.codex_fast_mode,
+            codex_fast_mode: session.fast_mode_enabled(),
             runtime_target: session.runtime_target,
             docker_service: session.docker_service.clone(),
             docker_lifecycle_intent: session.docker_lifecycle_intent,

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2893,7 +2893,7 @@ mod tests {
         assert_eq!(wrong_window_branches.len(), 1);
         assert!(matches!(
             wrong_window_branches[0].event,
-            BackendEvent::BranchError { ref message, .. } if message == "Window is not a Work surface"
+            BackendEvent::BranchError { ref message, .. } if message.contains("is not a Work surface")
         ));
         assert!(runtime
             .load_branches_events("client-1", &branches_id)
@@ -2946,7 +2946,7 @@ mod tests {
         assert!(matches!(
             cleanup_wrong[0].event,
             BackendEvent::BranchError { ref message, .. }
-                if message == "Window is not a Work surface"
+                if message.contains("is not a Work surface")
         ));
 
         let wizard_missing =
@@ -2964,7 +2964,7 @@ mod tests {
         assert!(matches!(
             wizard_wrong[0].event,
             BackendEvent::LaunchWizardOpenError { ref title, ref message }
-                if title == "Launch Agent" && message == "Window is not a Work surface"
+                if title == "Launch Agent" && message.contains("is not a Work surface")
         ));
 
         let issue_missing = runtime.open_issue_launch_wizard_events("client-1", "missing", 7);

--- a/crates/gwt/tests/discussion_cli_test.rs
+++ b/crates/gwt/tests/discussion_cli_test.rs
@@ -53,7 +53,7 @@ fn discussion_update_creates_single_canonical_discussions_file() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("tasks/discussions.md"),
+        stdout.replace('\\', "/").contains("tasks/discussions.md"),
         "stdout should name updated path, got: {stdout}"
     );
     let content =

--- a/crates/gwt/tests/discussion_cli_test.rs
+++ b/crates/gwt/tests/discussion_cli_test.rs
@@ -52,8 +52,9 @@ fn discussion_update_creates_single_canonical_discussions_file() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
+    let normalized_stdout = stdout.replace('\\', "/");
     assert!(
-        stdout.contains("tasks/discussions.md"),
+        normalized_stdout.contains("tasks/discussions.md"),
         "stdout should name updated path, got: {stdout}"
     );
     let content =

--- a/crates/gwt/tests/memory_cli_test.rs
+++ b/crates/gwt/tests/memory_cli_test.rs
@@ -46,7 +46,7 @@ fn memory_add_appends_typed_entry_to_existing_memory_file() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("tasks/memory.md"),
+        stdout.replace('\\', "/").contains("tasks/memory.md"),
         "stdout should name updated path, got: {stdout}"
     );
     let memory = fs::read_to_string(tasks.join("memory.md")).expect("read memory");

--- a/crates/gwt/tests/memory_cli_test.rs
+++ b/crates/gwt/tests/memory_cli_test.rs
@@ -45,8 +45,9 @@ fn memory_add_appends_typed_entry_to_existing_memory_file() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
+    let normalized_stdout = stdout.replace('\\', "/");
     assert!(
-        stdout.contains("tasks/memory.md"),
+        normalized_stdout.contains("tasks/memory.md"),
         "stdout should name updated path, got: {stdout}"
     );
     let memory = fs::read_to_string(tasks.join("memory.md")).expect("read memory");

--- a/crates/gwt/tests/skill_exit_cli_test.rs
+++ b/crates/gwt/tests/skill_exit_cli_test.rs
@@ -40,6 +40,9 @@ fn discuss_resolve_flips_active_proposal_to_chosen() {
          - Official Docs Proof: Claude Code hooks docs checked\n\
          - External Research Proof: not-applicable: local-only behavior\n\
          - Exit Blockers: none\n\
+         - Depth Mode: normal\n\
+         - Question Ledger: scope boundary, integration, failure, migration, verification checked\n\
+         - Depth Gate: complete\n\
          - Next Question: Should we block on Stop?\n\
          - Evidence Gate: complete\n",
     )
@@ -65,6 +68,38 @@ fn discuss_resolve_rejects_incomplete_evidence_gate() {
         "### Proposal A - Evidence gap [active]\n\
          - Summary: Missing proof.\n\
          - Exit Blockers: none\n\
+         - Next Question:\n\
+         - Evidence Gate: complete\n",
+    )
+    .unwrap();
+
+    let code = dispatch(
+        &mut env,
+        &argv(&["gwt", "discuss", "resolve", "--proposal", "Proposal A"]),
+    );
+    assert_eq!(code, 2);
+    let updated = std::fs::read_to_string(&discussion_path).unwrap();
+    assert!(updated.contains("[active]"));
+    assert!(!updated.contains("[chosen]"));
+}
+
+#[test]
+fn discuss_resolve_rejects_incomplete_depth_gate() {
+    let (mut env, dir) = new_env();
+    let discussion_path = dir.path().join(".gwt/discussion.md");
+    std::fs::create_dir_all(discussion_path.parent().unwrap()).unwrap();
+    std::fs::write(
+        &discussion_path,
+        "### Proposal A - Depth gap [active]\n\
+         - Implementation Proof: crates/gwt/src/discussion_resume.rs inspected\n\
+         - SPEC/Issue Proof: SPEC-1935 checked\n\
+         - Gap Check Proof: scope/integration/failure/migration/verification checked\n\
+         - Official Docs Proof: not-applicable: local-only behavior\n\
+         - External Research Proof: not-applicable: local-only behavior\n\
+         - Exit Blockers: none\n\
+         - Depth Mode: normal\n\
+         - Question Ledger: scope boundary checked only\n\
+         - Depth Gate: open\n\
          - Next Question:\n\
          - Evidence Gate: complete\n",
     )

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1588,7 +1588,7 @@ test("Launch wizard separates launch settings from runtime controls", () => {
     launchSettingsStart,
     linkedIssueStart,
   );
-  for (const copy of ["Version", "Skip permission prompts", "Codex fast mode"]) {
+  for (const copy of ["Version", "Skip permission prompts", "Fast mode"]) {
     assert.ok(
       launchSettingsBlock.includes(`"${copy}"`),
       `expected Launch settings to include ${copy}`,
@@ -1610,7 +1610,7 @@ test("Launch wizard separates launch settings from runtime controls", () => {
       `expected Runtime to include ${copy}`,
     );
   }
-  for (const copy of ["Version", "Skip permission prompts", "Codex fast mode"]) {
+  for (const copy of ["Version", "Skip permission prompts", "Fast mode"]) {
     assert.equal(
       runtimeBlock.includes(`"${copy}"`),
       false,
@@ -1657,8 +1657,18 @@ test("Launch wizard runtime confirmation shows summary without setup forms", () 
   );
   assert.match(
     appSource,
-    /if\s*\(\s*showSetupForms\s*&&[\s\S]*?launchWizard\.show_codex_fast_mode[\s\S]*?\)\s*\{[\s\S]*?createLaunchSection\(\s*"Launch settings"/,
+    /if\s*\(\s*showSetupForms\s*&&[\s\S]*?launchWizard\.show_fast_mode[\s\S]*?\)\s*\{[\s\S]*?createLaunchSection\(\s*"Launch settings"/,
     "expected Launch settings controls to be part of setup forms only",
+  );
+  assert.match(
+    appSource,
+    /appendCheckboxField\(\s*grid,\s*"Fast mode"[\s\S]*?launchWizard\.fast_mode[\s\S]*?kind:\s*"set_fast_mode"/,
+    "expected Launch settings to wire provider-neutral Fast mode controls",
+  );
+  assert.doesNotMatch(
+    appSource,
+    /Codex fast mode/,
+    "expected Launch settings copy to avoid Codex-only Fast mode wording",
   );
   // SPEC-2014 Amendment 2026-05-20 (FR-057): Linked issue is gated by its
   // dedicated `show_linked_issue` flag so it only appears when the wizard

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -7966,9 +7966,13 @@
           (
             launchWizard.show_version ||
             launchWizard.show_skip_permissions ||
+            launchWizard.show_fast_mode ||
             launchWizard.show_codex_fast_mode
           )
         ) {
+          const showFastMode = Boolean(
+            launchWizard.show_fast_mode ?? launchWizard.show_codex_fast_mode,
+          );
           const section = createLaunchSection(
             "Launch settings",
             "Version, permissions, and tool-specific launch behavior.",
@@ -8000,15 +8004,15 @@
                 }),
             );
           }
-          if (launchWizard.show_codex_fast_mode) {
+          if (showFastMode) {
             appendCheckboxField(
               grid,
-              "Codex fast mode",
-              "Use the fast service tier",
-              launchWizard.codex_fast_mode,
+              "Fast mode",
+              "Use the agent's Fast mode",
+              Boolean(launchWizard.fast_mode ?? launchWizard.codex_fast_mode),
               (enabled) =>
                 sendWizardAction({
-                  kind: "set_codex_fast_mode",
+                  kind: "set_fast_mode",
                   enabled,
                 }),
             );

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -3968,6 +3968,11 @@ kbd.op-kbd {
   color: rgb(253, 186, 116);
 }
 
+:root[data-theme] .workspace-resume-picker-row-tag.is-running {
+  background: rgba(56, 189, 248, 0.14);
+  color: rgb(125, 211, 252);
+}
+
 :root[data-theme] .workspace-resume-picker-row-meta {
   display: grid;
   grid-template-columns: max-content 1fr;

--- a/crates/gwt/web/workspace-resume-picker-modal.js
+++ b/crates/gwt/web/workspace-resume-picker-modal.js
@@ -129,11 +129,13 @@ export function renderWorkspaceResumePicker({
         ),
       );
       const lifecycleTag =
-        agent.lifecycle_status === "interrupted"
-          ? { className: "is-interrupted", label: "Interrupted" }
-          : agent.lifecycle_status === "active"
-            ? { className: "is-active", label: "Active" }
-            : null;
+        agent.lifecycle_status === "running"
+          ? { className: "is-running", label: "Running" }
+          : agent.lifecycle_status === "interrupted"
+            ? { className: "is-interrupted", label: "Interrupted" }
+            : agent.lifecycle_status === "active"
+              ? { className: "is-active", label: "Active" }
+              : null;
       const tagClass = lifecycleTag
         ? `workspace-resume-picker-row-tag ${lifecycleTag.className}`
         : agent.resume_kind === "metadata_only"

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6179,3 +6179,10 @@ Type: lesson
 Context: Work画面のGit BranchesタブからLaunch/Resumeすると Window is not a Work surface エラー。wizard.rsのopen_launch_wizardとresume_branch_latest_agent_eventsがWindowPreset::Branchesのみ許可していた。レガシーのlaunch_wizard_runtime.rsはBranches+Work両方許可。
 Learning: app_runtime Phase F リファクタで旧コード(launch_wizard_runtime.rs)からの移植時にプリセット条件を狭くしたリグレッション。mod.rs:5420のload_branches_eventsは正しく両方許可していたので、同一ファイル内にパターンの不整合があった。
 Future Action: wizard.rsのプリセットチェック変更時はmod.rsの同種チェック(load_branches_events等)と一貫性を確認する。Work surface embedded branches パターンでは WindowPreset::Work も許可が必要。
+
+## 2026-05-27 — collect_resumable_agents excluded running agents causing empty Resume Picker
+
+Type: lesson
+Context: Resume Picker showed 'No resumable agents' even when Codex was Running. Root cause: collect_resumable_agents in wizard.rs filtered out live_session_ids entirely. Also, branch cleanup preset check at mod.rs:6323 only allowed WindowPreset::Branches, missing Work.
+Learning: When adding a new preset check (like the Work surface unification), grep all sites with the same error message string to ensure none are missed. Four sites had 'Window is not a Work surface' but one (branch cleanup) was not updated. Also, filtering running agents from the Resume Picker was a UX anti-pattern — the user sees a Running agent in the workspace card but Resume says none exist.
+Future Action: After any WindowPreset guard change, search all occurrences of the error message to confirm all sites are consistent. For picker/list UIs, prefer including all states with appropriate badges over silently filtering items the user can see elsewhere.

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6186,3 +6186,10 @@ Type: lesson
 Context: During Claude Code Fast mode startup support, I initially reported completion after Rust tests and user visual confirmation, then admitted no automated E2E had been run when the user asked.
 Learning: Manual visual confirmation is not a substitute for an automated live E2E when the changed behavior crosses Launch Wizard frontend, WebSocket/backend state, and runtime context resolution.
 Future Action: For Launch Wizard or Start Work UI changes, add or run a live Playwright E2E that drives the actual user path before claiming E2E coverage; report manual checks separately from automated E2E.
+
+## 2026-05-27 — Claude Code startup alone is not a billing reason to skip E2E
+
+Type: lesson
+Context: After adding a live E2E for Claude Code Fast mode, I incorrectly justified not launching real Claude Code by saying it could incur billing. The user corrected that starting Claude Code alone does not charge.
+Learning: Do not cite billing as a reason to avoid a Claude Code launch smoke. The valid concerns are environment/auth availability, external process stability, and cleanup; if those are acceptable, launch smoke should be performed.
+Future Action: When explaining why an E2E stops before an external AI tool, separate real constraints from assumptions. For Claude Code startup, prefer an env-gated real-launch smoke with explicit cleanup instead of claiming startup cost risk.

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6200,3 +6200,10 @@ Type: lesson
 Context: After adding a live E2E for Claude Code Fast mode, I incorrectly justified not launching real Claude Code by saying it could incur billing. The user corrected that starting Claude Code alone does not charge.
 Learning: Do not cite billing as a reason to avoid a Claude Code launch smoke. The valid concerns are environment/auth availability, external process stability, and cleanup; if those are acceptable, launch smoke should be performed.
 Future Action: When explaining why an E2E stops before an external AI tool, separate real constraints from assumptions. For Claude Code startup, prefer an env-gated real-launch smoke with explicit cleanup instead of claiming startup cost risk.
+
+## 2026-05-27 — Resume Picker must filter by workspace_id — headed E2E caught what unit tests missed
+
+Type: lesson
+Context: Resume Picker returned agents from ALL branches instead of the selected Work item. Unit tests passed because they only tested presence/absence of agents, not cross-branch leakage. The bug was only caught when the user asked for a headed browser check.
+Learning: Unit tests for list/picker UIs must include a negative case: create agents for TWO different workspace_ids and assert that filtering by one excludes the other. Headed E2E is essential for verifying picker scope — automated tests alone cannot catch cross-scope leakage when only one scope is populated in the test fixture.
+Future Action: For any picker/list that accepts a scope filter (workspace_id, branch, etc.), always write a multi-scope unit test that asserts exclusion. Run headed E2E before declaring Resume/Launch picker changes complete.

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6151,3 +6151,10 @@ Type: lesson
 Context: gwt serve 検証時、session.json の gwt タブが /Users/akiojin/Workbench/gwt（bare repo 親ディレクトリ、git リポジトリではない）を指していたため、detect_repo_hash が失敗し compute_path_hash（パスベース b19aac38305901f5）にフォールバック。実際の workspace.json は remote URL ベースハッシュ 99a8660247f5bc49 に保存されており、空の workspace が読み込まれてウィンドウが 0 件になった。
 Learning: project_scope_hash は (1) origin URL ベースと (2) パスベースの 2 種類のハッシュを返す。session.json の project_root が git リポジトリでない場合、パスベースにフォールバックし、production app が書いた workspace.json と別ファイルを読む。
 Future Action: ウィンドウ復元テスト時は session.json の project_root が実際の git ワーキングツリーを指しているか確認する。非 git ディレクトリ → パスハッシュフォールバック問題は別 Issue として登録する。
+
+## 2026-05-26 — Work preset missing in Phase F wizard refactor
+
+Type: lesson
+Context: Work画面のGit BranchesタブからLaunch/Resumeすると Window is not a Work surface エラー。wizard.rsのopen_launch_wizardとresume_branch_latest_agent_eventsがWindowPreset::Branchesのみ許可していた。レガシーのlaunch_wizard_runtime.rsはBranches+Work両方許可。
+Learning: app_runtime Phase F リファクタで旧コード(launch_wizard_runtime.rs)からの移植時にプリセット条件を狭くしたリグレッション。mod.rs:5420のload_branches_eventsは正しく両方許可していたので、同一ファイル内にパターンの不整合があった。
+Future Action: wizard.rsのプリセットチェック変更時はmod.rsの同種チェック(load_branches_events等)と一貫性を確認する。Work surface embedded branches パターンでは WindowPreset::Work も許可が必要。

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6179,3 +6179,10 @@ Type: lesson
 Context: Work画面のGit BranchesタブからLaunch/Resumeすると Window is not a Work surface エラー。wizard.rsのopen_launch_wizardとresume_branch_latest_agent_eventsがWindowPreset::Branchesのみ許可していた。レガシーのlaunch_wizard_runtime.rsはBranches+Work両方許可。
 Learning: app_runtime Phase F リファクタで旧コード(launch_wizard_runtime.rs)からの移植時にプリセット条件を狭くしたリグレッション。mod.rs:5420のload_branches_eventsは正しく両方許可していたので、同一ファイル内にパターンの不整合があった。
 Future Action: wizard.rsのプリセットチェック変更時はmod.rsの同種チェック(load_branches_events等)と一貫性を確認する。Work surface embedded branches パターンでは WindowPreset::Work も許可が必要。
+
+## 2026-05-27 — Do not treat manual visual confirmation as E2E
+
+Type: lesson
+Context: During Claude Code Fast mode startup support, I initially reported completion after Rust tests and user visual confirmation, then admitted no automated E2E had been run when the user asked.
+Learning: Manual visual confirmation is not a substitute for an automated live E2E when the changed behavior crosses Launch Wizard frontend, WebSocket/backend state, and runtime context resolution.
+Future Action: For Launch Wizard or Start Work UI changes, add or run a live Playwright E2E that drives the actual user path before claiming E2E coverage; report manual checks separately from automated E2E.


### PR DESCRIPTION
## Summary

Release v9.48.0 — minor bump driven by two new features (claude fast mode at launch, deeper gwt-discussion depth gate) plus six fixes targeting the Launch/Resume Picker, the launch wizard runtime resolution, and a knowledge-bridge test import.

## Changes

### Features
- Deepen gwt-discussion depth gate
- Support claude fast mode at launch

### Bug Fixes
- **launch:** Accept Work window preset for Launch/Resume from Git Branches tab
- Restore unix knowledge bridge test import
- **gui:** Show running agents in Resume Picker and improve launch preset diagnostics
- **launch-wizard:** Preserve claude fast mode through runtime resolution
- **gui:** Filter Resume Picker agents by workspace_id
- **gui:** Filter Resume Picker by Work item session_ids instead of workspace_id

### Testing
- **playwright:** Cover claude fast mode launch wizard path
- **playwright:** Launch claude fast mode smoke

### Miscellaneous
- Record memory for Work preset launch fix
- Record Resume Picker running agent memory entry
- Apply cargo fmt to test assertion
- Merge origin develop / resolve merge conflict in tasks/memory.md

## Version

v9.48.0 (previous: v9.47.0)

## Closing Issues

None

## Related Issues / Links

- #1935
- #2014

> Note: #1935 and #2014 are referenced via `Related Issues / Links` and will **not** auto-close on release.

## Release Notes

PR head is `work/20260528-0341` (identical to `origin/develop` tip) because the develop branch could not be launched directly in this session. Merging this PR into `main` will trigger `.github/workflows/release.yml` to tag `v9.48.0`, publish the GitHub Release, and upload cross-compiled binaries.
