### PR TITLE
feat(gui): add update-to-selected-version button on Release Notes window (SPEC-2780 v2)

### DIFF
--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -859,19 +859,89 @@ impl UpdateManager {
             self.owner,
             self.repo
         );
+        self.fetch_release(&url, "latest release")
+    }
+
+    /// SPEC #2780 v2 Amendment (FR-011): fetch a release by its tag name so the
+    /// Release Notes window can request any historical version, not just
+    /// `latest`. The tag is normalized to the `v` prefix that GitHub uses.
+    ///
+    /// `GitHubRelease` is an internal type; external callers should use
+    /// [`Self::resolve_state_for_version`] which returns the public
+    /// [`UpdateState`] type.
+    fn fetch_release_by_tag(&self, tag: &str) -> Result<GitHubRelease, String> {
+        let normalized = tag.trim().trim_start_matches('v');
+        let url = format!(
+            "{}/repos/{}/{}/releases/tags/v{}",
+            self.api_base_url.trim_end_matches('/'),
+            self.owner,
+            self.repo,
+            normalized
+        );
+        self.fetch_release(&url, &format!("release v{normalized}"))
+    }
+
+    fn fetch_release(&self, url: &str, label: &str) -> Result<GitHubRelease, String> {
         let res = self
             .client
-            .get(&url)
+            .get(url)
             .send()
-            .map_err(|e| format!("Failed to fetch latest release: {e}"))?;
+            .map_err(|e| format!("Failed to fetch {label}: {e}"))?;
         if !res.status().is_success() {
-            return Err(format!(
-                "Failed to fetch latest release: status {}",
-                res.status()
-            ));
+            return Err(format!("Failed to fetch {label}: status {}", res.status()));
         }
         res.json::<GitHubRelease>()
             .map_err(|e| format!("Failed to parse GitHub release JSON: {e}"))
+    }
+
+    /// SPEC #2780 v2 Amendment (FR-012): build an [`UpdateState::Available`]
+    /// for an arbitrary release tag so the Release Notes window can drive
+    /// the existing apply pipeline (update / downgrade / reinstall).
+    ///
+    /// `latest` in the returned state carries the *requested* version, not the
+    /// current running version. For downgrade flows it may be strictly older
+    /// than `self.current_version`; the apply pipeline only uses `latest` as a
+    /// staging-directory label and progress label, so this is safe.
+    pub fn resolve_state_for_version(
+        &self,
+        version: &str,
+        current_exe: Option<&Path>,
+    ) -> Result<UpdateState, String> {
+        let release = self.fetch_release_by_tag(version)?;
+        let normalized = parse_tag_version(&release.tag_name)
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| version.trim().trim_start_matches('v').to_string());
+
+        let platform = Platform::detect();
+        let portable_asset_url = platform
+            .portable_asset_name()
+            .and_then(|name| release.assets.iter().find(|a| a.name == name))
+            .map(|a| a.browser_download_url.clone());
+        let installer_asset_url = find_installer_asset_url(&platform, &release.assets);
+        let asset_url = choose_apply_plan(
+            &platform,
+            current_exe,
+            portable_asset_url.as_deref(),
+            installer_asset_url.as_deref(),
+        )
+        .map(|p| match p {
+            ApplyPlan::Portable { url } => url,
+            ApplyPlan::Installer { url, .. } => url,
+        });
+
+        if asset_url.is_none() {
+            return Err(format!(
+                "No applicable update asset for v{normalized} on this platform."
+            ));
+        }
+
+        Ok(UpdateState::Available {
+            current: self.current_version.to_string(),
+            latest: normalized,
+            release_url: release.html_url,
+            asset_url,
+            checked_at: Utc::now(),
+        })
     }
 
     fn state_from_cache(&self, cache: &UpdateCacheFile, current_exe: Option<&Path>) -> UpdateState {
@@ -3343,6 +3413,149 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         fs::write(dir.path().join("manifest.json"), b"{not json").unwrap();
         assert!(load_pending_update_manifest_in(dir.path()).is_none());
+    }
+
+    // SPEC #2780 v2 Amendment (FR-011): fetch_release_by_tag hits the
+    // tag-specific endpoint and returns the parsed release payload.
+    #[test]
+    fn fetch_release_by_tag_returns_release_for_known_tag() {
+        let temp = tempfile::tempdir().unwrap();
+        let release_body = r#"{
+  "tag_name": "v9.36.0",
+  "html_url": "https://github.com/akiojin/gwt/releases/tag/v9.36.0",
+  "assets": [
+    {
+      "name": "gwt-windows-x86_64.zip",
+      "browser_download_url": "https://example.invalid/v9.36.0/gwt-windows-x86_64.zip"
+    }
+  ]
+}"#
+        .as_bytes()
+        .to_vec();
+        let base_url = serve_once("/", "200 OK", "application/json", release_body);
+        let mgr = UpdateManager::new()
+            .with_api_base_url(base_url)
+            .with_cache_path(temp.path().join("update-check.json"))
+            .with_updates_dir(temp.path().join("updates"));
+
+        let release = mgr
+            .fetch_release_by_tag("9.36.0")
+            .expect("fetch_release_by_tag should succeed for known tag");
+        assert_eq!(release.tag_name, "v9.36.0");
+        assert_eq!(release.assets.len(), 1);
+        assert_eq!(release.assets[0].name, "gwt-windows-x86_64.zip");
+    }
+
+    #[test]
+    fn fetch_release_by_tag_returns_error_for_404() {
+        let temp = tempfile::tempdir().unwrap();
+        let base_url = serve_once(
+            "/",
+            "404 Not Found",
+            "application/json",
+            b"{\"message\":\"Not Found\"}".to_vec(),
+        );
+        let mgr = UpdateManager::new()
+            .with_api_base_url(base_url)
+            .with_cache_path(temp.path().join("update-check.json"))
+            .with_updates_dir(temp.path().join("updates"));
+
+        let err = mgr
+            .fetch_release_by_tag("0.0.999")
+            .expect_err("404 must surface as error");
+        assert!(
+            err.to_lowercase().contains("status") || err.to_lowercase().contains("404"),
+            "error message should mention HTTP status: {err}"
+        );
+    }
+
+    // SPEC #2780 v2 Amendment (FR-012): resolve_state_for_version constructs
+    // UpdateState::Available for an arbitrary release tag (including
+    // downgrade targets — latest may be < current).
+    #[test]
+    fn resolve_state_for_version_returns_available_with_platform_asset() {
+        let temp = tempfile::tempdir().unwrap();
+        // Provide every platform's portable asset so the test passes on
+        // whichever host we run on. choose_apply_plan will pick the matching
+        // one via Platform::detect().
+        let release_body = r#"{
+  "tag_name": "v7.0.0",
+  "html_url": "https://github.com/akiojin/gwt/releases/tag/v7.0.0",
+  "assets": [
+    {"name": "gwt-windows-x86_64.zip", "browser_download_url": "https://example.invalid/v7.0.0/gwt-windows-x86_64.zip"},
+    {"name": "gwt-windows-aarch64.zip", "browser_download_url": "https://example.invalid/v7.0.0/gwt-windows-aarch64.zip"},
+    {"name": "gwt-macos-x86_64.tar.gz", "browser_download_url": "https://example.invalid/v7.0.0/gwt-macos-x86_64.tar.gz"},
+    {"name": "gwt-macos-aarch64.tar.gz", "browser_download_url": "https://example.invalid/v7.0.0/gwt-macos-aarch64.tar.gz"},
+    {"name": "gwt-macos-universal.dmg", "browser_download_url": "https://example.invalid/v7.0.0/gwt-macos-universal.dmg"},
+    {"name": "gwt-linux-x86_64.tar.gz", "browser_download_url": "https://example.invalid/v7.0.0/gwt-linux-x86_64.tar.gz"},
+    {"name": "gwt-linux-aarch64.tar.gz", "browser_download_url": "https://example.invalid/v7.0.0/gwt-linux-aarch64.tar.gz"}
+  ]
+}"#
+        .as_bytes()
+        .to_vec();
+        let base_url = serve_once("/", "200 OK", "application/json", release_body);
+        let mgr = UpdateManager::new()
+            .with_api_base_url(base_url)
+            .with_cache_path(temp.path().join("update-check.json"))
+            .with_updates_dir(temp.path().join("updates"));
+
+        let state = mgr
+            .resolve_state_for_version("7.0.0", None)
+            .expect("resolve_state_for_version should succeed");
+
+        match state {
+            UpdateState::Available {
+                latest,
+                release_url,
+                asset_url,
+                ..
+            } => {
+                assert_eq!(
+                    latest, "7.0.0",
+                    "`latest` field must carry the requested version (downgrade-friendly semantics)"
+                );
+                assert_eq!(
+                    release_url,
+                    "https://github.com/akiojin/gwt/releases/tag/v7.0.0"
+                );
+                let url = asset_url.expect("asset_url must be resolved for at least one platform");
+                assert!(
+                    url.contains("v7.0.0"),
+                    "platform asset URL must reference v7.0.0 release path: {url}"
+                );
+            }
+            other => panic!("expected UpdateState::Available, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_state_for_version_returns_error_when_no_platform_asset() {
+        let temp = tempfile::tempdir().unwrap();
+        // Only a non-platform asset present; choose_apply_plan returns None.
+        let release_body = r#"{
+  "tag_name": "v6.0.0",
+  "html_url": "https://github.com/akiojin/gwt/releases/tag/v6.0.0",
+  "assets": [
+    {"name": "checksums.txt", "browser_download_url": "https://example.invalid/v6.0.0/checksums.txt"}
+  ]
+}"#
+        .as_bytes()
+        .to_vec();
+        let base_url = serve_once("/", "200 OK", "application/json", release_body);
+        let mgr = UpdateManager::new()
+            .with_api_base_url(base_url)
+            .with_cache_path(temp.path().join("update-check.json"))
+            .with_updates_dir(temp.path().join("updates"));
+
+        let err = mgr
+            .resolve_state_for_version("6.0.0", None)
+            .expect_err("missing platform asset must surface as error");
+        assert!(
+            err.to_lowercase().contains("asset")
+                || err.to_lowercase().contains("platform")
+                || err.to_lowercase().contains("no applicable"),
+            "error should mention the missing platform asset: {err}"
+        );
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -842,6 +842,9 @@ fn frontend_user_action_log(event: &FrontendEvent) -> Option<FrontendUserActionL
             FrontendUserActionLog::new("open_release_notes", "release_notes")
                 .target(focus_version.as_deref().unwrap_or_default())
         }
+        FrontendEvent::ApplyUpdateToVersion { version } => {
+            FrontendUserActionLog::new("apply_update_to_version", "update").target(version)
+        }
         // These events can contain high-volume, high-frequency, or sensitive
         // payloads. They are handled by more specific logs or diagnostics.
         FrontendEvent::StartupAutoResumeReady { .. }
@@ -3798,6 +3801,9 @@ impl AppRuntime {
             }
             FrontendEvent::ApplyUpdate => self.apply_pending_update_events(&client_id),
             FrontendEvent::ApplyUpdateStart => self.apply_update_start_events(&client_id),
+            FrontendEvent::ApplyUpdateToVersion { version } => {
+                self.apply_update_to_version_events(&client_id, version)
+            }
             FrontendEvent::CancelUpdateDownload => self.cancel_update_download_events(&client_id),
             FrontendEvent::ApplyUpdateLater => self.apply_update_later_events(&client_id),
             FrontendEvent::ApplyUpdateRestartNow => {
@@ -3880,6 +3886,9 @@ impl AppRuntime {
     /// SPEC #2780: serve the bundled `CHANGELOG.md` to the Release Notes
     /// window. The parse runs once per process (cached) so this handler is
     /// effectively a copy from a static slice.
+    ///
+    /// SPEC #2780 v2 Amendment (FR-013): `current_version` is included so the
+    /// frontend can label the Update / Downgrade / Current action button.
     fn release_notes_events(
         &self,
         client_id: ClientId,
@@ -3897,9 +3906,43 @@ impl AppRuntime {
                 id,
                 entries: entries.to_vec(),
                 focus_version,
+                current_version: env!("CARGO_PKG_VERSION").to_string(),
             }
         };
         vec![OutboundEvent::reply(client_id, event)]
+    }
+
+    /// SPEC #2780 v2 Amendment (FR-014): user clicked Update / Downgrade on
+    /// a specific release in the Release Notes window. Resolves the platform
+    /// asset for the requested tag on a worker thread (network), then routes
+    /// through the existing `ApplyUpdateStart` pipeline so the standard
+    /// update modal renders downloading → ready → restart.
+    fn apply_update_to_version_events(
+        &self,
+        client_id: &str,
+        version: String,
+    ) -> Vec<OutboundEvent> {
+        let proxy = self.proxy.clone();
+        let client_id_owned = client_id.to_string();
+        self.blocking_tasks.spawn(move || {
+            let manager = gwt_core::update::UpdateManager::new();
+            let current_exe = std::env::current_exe().ok();
+            match manager.resolve_state_for_version(&version, current_exe.as_deref()) {
+                Ok(state) => {
+                    proxy.send(UserEvent::ApplyUpdateStart {
+                        state,
+                        client_id: client_id_owned,
+                    });
+                }
+                Err(message) => {
+                    proxy.send(UserEvent::Dispatch(vec![OutboundEvent::reply(
+                        client_id_owned,
+                        update_apply_error_failed("Resolve release", &message),
+                    )]));
+                }
+            }
+        });
+        vec![]
     }
 
     fn save_ui_trace_events(

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -657,6 +657,17 @@ pub enum FrontendEvent {
         #[serde(default)]
         focus_version: Option<String>,
     },
+    /// SPEC #2780 v2 Amendment (FR-014): user clicked the Update / Downgrade
+    /// action button in the Release Notes window. Backend resolves the
+    /// release-by-tag, builds [`gwt_core::update::UpdateState::Available`]
+    /// with the chosen version's platform-specific asset, then drives the
+    /// existing prepare → apply pipeline. Progress and completion broadcast
+    /// via [`BackendEvent::UpdateProgress`] / [`BackendEvent::UpdateReady`]
+    /// / [`BackendEvent::UpdateApplyError`] (the same modal the standard
+    /// update CTA uses).
+    ApplyUpdateToVersion {
+        version: String,
+    },
 }
 
 /// Browser-side metadata-only UI trace payload sent by Diagnostics > Stop UI
@@ -1438,11 +1449,16 @@ pub enum BackendEvent {
     /// SPEC #2780 Release Notes window payload. Carries the parsed entries
     /// from the bundled `CHANGELOG.md` so the frontend can render the
     /// sidebar + content pane without further round-trips.
+    ///
+    /// `current_version` (SPEC #2780 v2 Amendment / FR-013) lets the frontend
+    /// label the Update / Downgrade / Current action button without a second
+    /// round-trip. The value is the running binary's `CARGO_PKG_VERSION`.
     ReleaseNotesPayload {
         id: String,
         entries: Vec<gwt_core::release_notes::ReleaseEntry>,
         #[serde(skip_serializing_if = "Option::is_none")]
         focus_version: Option<String>,
+        current_version: String,
     },
     /// SPEC #2780 Release Notes window error. Emitted only when the bundled
     /// changelog yielded no entries; the UI renders an error pane pointing

--- a/crates/gwt/tests/release_notes_protocol_test.rs
+++ b/crates/gwt/tests/release_notes_protocol_test.rs
@@ -54,6 +54,7 @@ fn serializes_release_notes_payload_with_snake_case_kind() {
         id: "project-1::release-notes-1".into(),
         entries,
         focus_version: Some("9.38.0".into()),
+        current_version: "9.36.0".into(),
     };
 
     let v = serde_json::to_value(&event).expect("should serialize");
@@ -72,12 +73,46 @@ fn omits_focus_version_when_none_for_payload() {
         id: "project-1::release-notes-1".into(),
         entries: vec![],
         focus_version: None,
+        current_version: "9.36.0".into(),
     };
     let v = serde_json::to_value(&event).expect("should serialize");
     assert!(
         v.get("focus_version").is_none(),
         "focus_version must be omitted when None: {v}"
     );
+}
+
+// SPEC #2780 v2 Amendment (FR-013): payload carries the current running
+// version so the frontend can label the Update action button correctly.
+#[test]
+fn serializes_release_notes_payload_with_current_version() {
+    let event = BackendEvent::ReleaseNotesPayload {
+        id: "project-1::release-notes-1".into(),
+        entries: vec![],
+        focus_version: None,
+        current_version: "9.36.0".into(),
+    };
+    let v = serde_json::to_value(&event).expect("should serialize");
+    assert_eq!(v["current_version"], "9.36.0");
+}
+
+// SPEC #2780 v2 Amendment (FR-014): FrontendEvent::ApplyUpdateToVersion
+// carries the user's chosen version so the backend can resolve the matching
+// release tag.
+#[test]
+fn deserializes_apply_update_to_version() {
+    let msg = serde_json::from_value::<FrontendEvent>(json!({
+        "kind": "apply_update_to_version",
+        "version": "9.36.0"
+    }))
+    .expect("apply_update_to_version should deserialize");
+
+    match msg {
+        FrontendEvent::ApplyUpdateToVersion { version } => {
+            assert_eq!(version, "9.36.0");
+        }
+        other => panic!("unexpected event: {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/gwt/web/__tests__/release-notes-window.test.mjs
+++ b/crates/gwt/web/__tests__/release-notes-window.test.mjs
@@ -237,3 +237,170 @@ test("handlePayload with empty entries falls back to the empty state", () => {
   const empty = document.querySelector(".release-notes-empty");
   assert.ok(empty);
 });
+
+// SPEC #2780 v2 Amendment (FR-015): update action button states.
+
+test("content header shows 'Current version' (disabled) for the running version", () => {
+  const { document, controller, entries } = makeFixture();
+  controller.handlePayload({
+    id: "rn-test-1",
+    entries,
+    focus_version: "9.37.0",
+    current_version: "9.37.0",
+  });
+  const btn = document.querySelector(".release-notes-update-action");
+  assert.ok(btn, "update action button must be rendered");
+  assert.equal(btn.textContent.trim(), "Current version");
+  assert.equal(btn.disabled, true);
+  assert.ok(btn.classList.contains("is-current"));
+});
+
+test("content header shows 'Update to v{x}' (primary) for a newer version", () => {
+  const { document, controller, entries } = makeFixture();
+  controller.handlePayload({
+    id: "rn-test-1",
+    entries,
+    focus_version: "9.38.0",
+    current_version: "9.36.0",
+  });
+  const btn = document.querySelector(".release-notes-update-action");
+  assert.ok(btn);
+  assert.equal(btn.textContent.trim(), "Update to v9.38.0");
+  assert.equal(btn.disabled, false);
+  assert.ok(btn.classList.contains("is-update"));
+});
+
+test("content header shows 'Downgrade to v{x}' (caution) for an older version", () => {
+  const { document, controller, entries } = makeFixture();
+  controller.handlePayload({
+    id: "rn-test-1",
+    entries,
+    focus_version: "9.36.0",
+    current_version: "9.38.0",
+  });
+  const btn = document.querySelector(".release-notes-update-action");
+  assert.ok(btn);
+  assert.equal(btn.textContent.trim(), "Downgrade to v9.36.0");
+  assert.equal(btn.disabled, false);
+  assert.ok(btn.classList.contains("is-downgrade"));
+});
+
+test("update button click sends apply_update_to_version with the selected version", () => {
+  const { document, controller, sent, entries } = makeFixture();
+  controller.handlePayload({
+    id: "rn-test-1",
+    entries,
+    focus_version: "9.38.0",
+    current_version: "9.36.0",
+  });
+  const btn = document.querySelector(".release-notes-update-action");
+  btn.click();
+  const applyMessage = sent.find((m) => m.kind === "apply_update_to_version");
+  assert.ok(applyMessage, "apply_update_to_version message must be sent");
+  assert.equal(applyMessage.version, "9.38.0");
+  // The window should close after apply.
+  assert.equal(controller.isOpen(), false);
+});
+
+test("downgrade button click opens an in-app confirm modal and does NOT send apply yet", () => {
+  const { document, controller, sent, entries } = makeFixture();
+  controller.handlePayload({
+    id: "rn-test-1",
+    entries,
+    focus_version: "9.36.0",
+    current_version: "9.38.0",
+  });
+  const btn = document.querySelector(".release-notes-update-action");
+  btn.click();
+  const confirmModal = document.querySelector(".release-notes-downgrade-confirm");
+  assert.ok(confirmModal, "downgrade confirm modal must appear");
+  assert.equal(
+    sent.find((m) => m.kind === "apply_update_to_version"),
+    undefined,
+    "apply must not fire until user confirms downgrade",
+  );
+});
+
+test("downgrade confirm modal Confirm button sends apply_update_to_version", () => {
+  const { document, controller, sent, entries } = makeFixture();
+  controller.handlePayload({
+    id: "rn-test-1",
+    entries,
+    focus_version: "9.36.0",
+    current_version: "9.38.0",
+  });
+  document.querySelector(".release-notes-update-action").click();
+  const confirmBtn = document.querySelector(
+    ".release-notes-downgrade-confirm__confirm",
+  );
+  assert.ok(confirmBtn);
+  confirmBtn.click();
+  const applyMessage = sent.find((m) => m.kind === "apply_update_to_version");
+  assert.ok(applyMessage);
+  assert.equal(applyMessage.version, "9.36.0");
+  assert.equal(controller.isOpen(), false);
+});
+
+test("downgrade confirm modal Cancel button does NOT send and keeps Release Notes open", () => {
+  const { document, controller, sent, entries } = makeFixture();
+  controller.handlePayload({
+    id: "rn-test-1",
+    entries,
+    focus_version: "9.36.0",
+    current_version: "9.38.0",
+  });
+  document.querySelector(".release-notes-update-action").click();
+  const cancelBtn = document.querySelector(
+    ".release-notes-downgrade-confirm__cancel",
+  );
+  cancelBtn.click();
+  assert.equal(
+    sent.find((m) => m.kind === "apply_update_to_version"),
+    undefined,
+  );
+  assert.equal(controller.isOpen(), true);
+  assert.equal(
+    document.querySelector(".release-notes-downgrade-confirm"),
+    null,
+  );
+});
+
+test("button reflects selection changes via sidebar click", () => {
+  const { document, controller, entries } = makeFixture();
+  controller.handlePayload({
+    id: "rn-test-1",
+    entries,
+    focus_version: "9.38.0",
+    current_version: "9.37.0",
+  });
+  // Initially newer (9.38.0 > 9.37.0) → Update.
+  let btn = document.querySelector(".release-notes-update-action");
+  assert.ok(btn.classList.contains("is-update"));
+
+  // Switch to 9.37.0 (current) → disabled.
+  document
+    .querySelectorAll(".release-notes-sidebar-item")[1]
+    .click();
+  btn = document.querySelector(".release-notes-update-action");
+  assert.ok(btn.classList.contains("is-current"));
+  assert.equal(btn.disabled, true);
+
+  // Switch to 9.36.0 (older) → Downgrade.
+  document
+    .querySelectorAll(".release-notes-sidebar-item")[2]
+    .click();
+  btn = document.querySelector(".release-notes-update-action");
+  assert.ok(btn.classList.contains("is-downgrade"));
+});
+
+test("payload without current_version hides the update button (backward-compat)", () => {
+  const { document, controller, entries } = makeFixture();
+  controller.handlePayload({
+    id: "rn-test-1",
+    entries,
+    focus_version: null,
+    // current_version omitted
+  });
+  const btn = document.querySelector(".release-notes-update-action");
+  assert.equal(btn, null, "no current_version → no action button");
+});

--- a/crates/gwt/web/release-notes-window.js
+++ b/crates/gwt/web/release-notes-window.js
@@ -38,7 +38,40 @@ export function createReleaseNotesWindow({
     selectedVersion: null,
     pendingFocusVersion: null,
     lastRequestId: null,
+    currentVersion: null,
+    confirmModal: null,
   };
+
+  // SPEC #2780 v2 Amendment (FR-015): minimal `major.minor.patch` comparison.
+  // Returns -1 / 0 / 1; returns null when either value is unparseable so the
+  // caller can fall back to a safe "disabled" state.
+  function compareVersions(a, b) {
+    if (typeof a !== "string" || typeof b !== "string") {
+      return null;
+    }
+    const parse = (v) => {
+      const parts = v.trim().replace(/^v/, "").split(".");
+      if (parts.length < 3) {
+        return null;
+      }
+      const nums = parts.slice(0, 3).map((p) => Number.parseInt(p, 10));
+      return nums.some((n) => Number.isNaN(n)) ? null : nums;
+    };
+    const pa = parse(a);
+    const pb = parse(b);
+    if (!pa || !pb) {
+      return null;
+    }
+    for (let i = 0; i < 3; i++) {
+      if (pa[i] < pb[i]) {
+        return -1;
+      }
+      if (pa[i] > pb[i]) {
+        return 1;
+      }
+    }
+    return 0;
+  }
 
   function clearChildren(node) {
     while (node.firstChild) {
@@ -75,15 +108,25 @@ export function createReleaseNotesWindow({
 
     const header = document.createElement("header");
     header.className = "release-notes-version-header";
+
+    const titleGroup = document.createElement("div");
+    titleGroup.className = "release-notes-version-title";
     const h2 = document.createElement("h2");
     h2.textContent = `v${entry.version}`;
-    header.appendChild(h2);
+    titleGroup.appendChild(h2);
     if (entry.date) {
       const dateEl = document.createElement("span");
       dateEl.className = "release-notes-date";
       dateEl.textContent = entry.date;
-      header.appendChild(dateEl);
+      titleGroup.appendChild(dateEl);
     }
+    header.appendChild(titleGroup);
+
+    const actionBtn = buildUpdateActionButton(entry.version);
+    if (actionBtn) {
+      header.appendChild(actionBtn);
+    }
+
     fragment.appendChild(header);
 
     const sectionsWrap = document.createElement("div");
@@ -109,6 +152,121 @@ export function createReleaseNotesWindow({
     }
     fragment.appendChild(sectionsWrap);
     return fragment;
+  }
+
+  // SPEC #2780 v2 Amendment (FR-015): build the sticky action button rendered
+  // at the top-right of the content pane header. Returns `null` when the
+  // backend payload did not provide `current_version` (older clients), so the
+  // existing read-only Release Notes layout still renders.
+  function buildUpdateActionButton(version) {
+    if (!state.currentVersion) {
+      return null;
+    }
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "release-notes-update-action";
+
+    const cmp = compareVersions(version, state.currentVersion);
+    if (cmp === 0) {
+      btn.classList.add("is-current");
+      btn.disabled = true;
+      btn.textContent = "Current version";
+      btn.setAttribute("aria-disabled", "true");
+    } else if (cmp === 1) {
+      btn.classList.add("is-update");
+      btn.textContent = `Update to v${version}`;
+      btn.addEventListener("click", () => requestApply(version, false));
+    } else if (cmp === -1) {
+      btn.classList.add("is-downgrade");
+      btn.textContent = `Downgrade to v${version}`;
+      btn.addEventListener("click", () => requestApply(version, true));
+    } else {
+      // Unparseable version — render disabled so we never silently apply a
+      // malformed tag to the update pipeline.
+      btn.classList.add("is-current");
+      btn.disabled = true;
+      btn.textContent = "Unavailable";
+      btn.setAttribute("aria-disabled", "true");
+    }
+    return btn;
+  }
+
+  function requestApply(version, requiresConfirm) {
+    if (requiresConfirm) {
+      showDowngradeConfirm(version);
+      return;
+    }
+    sendApply(version);
+    close();
+  }
+
+  function sendApply(version) {
+    send({ kind: "apply_update_to_version", version });
+  }
+
+  function showDowngradeConfirm(version) {
+    if (state.confirmModal) {
+      return;
+    }
+    const overlay = document.createElement("div");
+    overlay.className = "release-notes-downgrade-confirm";
+    overlay.setAttribute("role", "dialog");
+    overlay.setAttribute("aria-modal", "true");
+    overlay.setAttribute(
+      "aria-label",
+      `Confirm downgrade to v${version}`,
+    );
+
+    const dialog = document.createElement("div");
+    dialog.className = "release-notes-downgrade-confirm__dialog";
+
+    const heading = document.createElement("h2");
+    heading.className = "release-notes-downgrade-confirm__title";
+    heading.textContent = `Downgrade to v${version}?`;
+    dialog.appendChild(heading);
+
+    const body = document.createElement("p");
+    body.className = "release-notes-downgrade-confirm__body";
+    body.textContent =
+      "Downgrading installs an older build. Data formats are not guaranteed to be backward-compatible across versions.";
+    dialog.appendChild(body);
+
+    const actions = document.createElement("div");
+    actions.className = "release-notes-downgrade-confirm__actions";
+
+    const cancelBtn = document.createElement("button");
+    cancelBtn.type = "button";
+    cancelBtn.className = "release-notes-downgrade-confirm__cancel";
+    cancelBtn.textContent = "Cancel";
+    cancelBtn.addEventListener("click", () => dismissDowngradeConfirm());
+    actions.appendChild(cancelBtn);
+
+    const confirmBtn = document.createElement("button");
+    confirmBtn.type = "button";
+    confirmBtn.className = "release-notes-downgrade-confirm__confirm";
+    confirmBtn.textContent = "Confirm downgrade";
+    confirmBtn.addEventListener("click", () => {
+      dismissDowngradeConfirm();
+      sendApply(version);
+      close();
+    });
+    actions.appendChild(confirmBtn);
+
+    dialog.appendChild(actions);
+    overlay.appendChild(dialog);
+    if (state.root) {
+      state.root.appendChild(overlay);
+    } else {
+      document.body.appendChild(overlay);
+    }
+    state.confirmModal = overlay;
+  }
+
+  function dismissDowngradeConfirm() {
+    if (state.confirmModal && state.confirmModal.parentElement) {
+      state.confirmModal.parentElement.removeChild(state.confirmModal);
+    }
+    state.confirmModal = null;
   }
 
   function buildEmptyStateNode(message) {
@@ -278,6 +436,12 @@ export function createReleaseNotesWindow({
       return;
     }
     state.entries = payload.entries;
+    // SPEC #2780 v2 Amendment (FR-013): payload now carries the running
+    // version so the Update action button can pick the right label.
+    state.currentVersion =
+      typeof payload.current_version === "string"
+        ? payload.current_version
+        : null;
     const requested =
       payload.focus_version ||
       state.pendingFocusVersion ||
@@ -304,6 +468,7 @@ export function createReleaseNotesWindow({
   }
 
   function close() {
+    dismissDowngradeConfirm();
     if (state.keydownHandler) {
       document.removeEventListener("keydown", state.keydownHandler);
     }

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1800,13 +1800,144 @@ kbd.op-kbd {
 }
 .release-notes-version-header {
   display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.release-notes-version-title {
+  display: flex;
   align-items: baseline;
   gap: 8px;
-  margin-bottom: 12px;
+  min-width: 0;
 }
 .release-notes-date {
   color: var(--color-text-muted);
   font-size: 12px;
+}
+/* SPEC #2780 v2 Amendment (FR-015): per-version update action button.
+   Color tokens follow the same conventions as `.update-modal__btn--primary`
+   and `.update-cta.is-error` so the action button matches the global
+   update CTA design language. */
+.release-notes-update-action {
+  appearance: none;
+  font-family: var(--font-body);
+  font-size: var(--type-xs);
+  font-weight: 600;
+  letter-spacing: var(--tracking-normal);
+  padding: 6px 12px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border-strong);
+  background: var(--color-surface-elevated);
+  color: var(--color-text);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+}
+.release-notes-update-action:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+.release-notes-update-action.is-update {
+  background: var(--color-state-active);
+  border-color: var(--color-state-active);
+  color: var(--color-text-on-accent, #0a0a0a);
+}
+.release-notes-update-action.is-update:hover {
+  background: color-mix(in oklab, var(--color-state-active) 88%, #000000);
+  border-color: color-mix(in oklab, var(--color-state-active) 88%, #000000);
+}
+.release-notes-update-action.is-downgrade {
+  background: transparent;
+  border-color: var(--color-state-blocked);
+  color: var(--color-state-blocked);
+}
+.release-notes-update-action.is-downgrade:hover {
+  background: color-mix(in oklab, var(--color-state-blocked) 14%, transparent);
+}
+.release-notes-update-action.is-current,
+.release-notes-update-action[disabled] {
+  background: transparent;
+  border-color: var(--color-border);
+  color: var(--color-text-disabled);
+  cursor: default;
+}
+
+/* SPEC #2780 v2 Amendment (FR-016): downgrade confirm modal. Mirrors
+   `.update-modal` panel + `.update-modal__btn` button conventions so the
+   confirm dialog feels native to the update flow it triggers. */
+.release-notes-downgrade-confirm {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-scrim);
+  z-index: 2;
+}
+.release-notes-downgrade-confirm__dialog {
+  min-width: 360px;
+  max-width: 480px;
+  width: calc(100% - 48px);
+  padding: 24px 28px;
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface-elevated);
+  color: var(--color-text);
+  box-shadow: var(--shadow-2);
+  font-family: var(--font-body);
+}
+.release-notes-downgrade-confirm__title {
+  margin: 0 0 12px;
+  font-size: var(--type-md);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  color: var(--color-text-strong);
+}
+.release-notes-downgrade-confirm__body {
+  margin: 0 0 16px;
+  color: var(--color-text-muted);
+  font-size: var(--type-sm);
+  line-height: 1.5;
+}
+.release-notes-downgrade-confirm__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+.release-notes-downgrade-confirm__cancel,
+.release-notes-downgrade-confirm__confirm {
+  appearance: none;
+  font-family: var(--font-body);
+  font-size: var(--type-sm);
+  font-weight: 600;
+  padding: 8px 14px;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+}
+.release-notes-downgrade-confirm__cancel:focus-visible,
+.release-notes-downgrade-confirm__confirm:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+.release-notes-downgrade-confirm__cancel {
+  background: transparent;
+  border: 1px solid var(--color-border-strong);
+  color: var(--color-text);
+}
+.release-notes-downgrade-confirm__cancel:hover {
+  background: color-mix(in oklab, var(--color-text) 10%, transparent);
+}
+.release-notes-downgrade-confirm__confirm {
+  background: var(--color-state-blocked);
+  border: 1px solid var(--color-state-blocked);
+  color: var(--color-text-on-accent, #0a0a0a);
+}
+.release-notes-downgrade-confirm__confirm:hover {
+  background: color-mix(in oklab, var(--color-state-blocked) 88%, #000000);
+  border-color: color-mix(in oklab, var(--color-state-blocked) 88%, #000000);
 }
 .release-notes-content h3 {
   margin: 14px 0 6px 0;

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6207,3 +6207,10 @@ Type: lesson
 Context: Resume Picker returned agents from ALL branches instead of the selected Work item. Unit tests passed because they only tested presence/absence of agents, not cross-branch leakage. The bug was only caught when the user asked for a headed browser check.
 Learning: Unit tests for list/picker UIs must include a negative case: create agents for TWO different workspace_ids and assert that filtering by one excludes the other. Headed E2E is essential for verifying picker scope — automated tests alone cannot catch cross-scope leakage when only one scope is populated in the test fixture.
 Future Action: For any picker/list that accepts a scope filter (workspace_id, branch, etc.), always write a multi-scope unit test that asserts exclusion. Run headed E2E before declaring Resume/Launch picker changes complete.
+
+## 2026-05-28 — Verify CSS tokens exist before using them in new components
+
+Type: lesson
+Context: SPEC-2780 v2 で Release Notes update button を実装した際、最初 --color-accent / --color-warning / --color-on-accent を fallback hex 付きで使ったが、これらは gwt のデザイン token として未定義だった。ユーザー目視で「CSS は合っていますか?」と指摘されて気付き、--color-state-active / --color-state-blocked / --color-text-disabled / --color-scrim 等の実 token に置換した。
+Learning: 新規 CSS を書くときは fallback hex 付きで未定義 token を仮置きしてはいけない。fallback だけが効くので見た目はテーマと不整合になるが、ビルド・テストは通って気付かない。
+Future Action: 新規 component の CSS を書く前に grep -E '^\s*--color-' crates/gwt/web/styles/tokens.css で実在 token を確認する。precedent component (update-modal__btn--primary / update-cta.is-error 等) を必ず参照して同じ token を使う。


### PR DESCRIPTION
## Summary

- リリースノートウィンドウのコンテンツペイン右上に、選択中のバージョンに更新できるアクションボタンを追加
- 新しいバージョン → `Update to v{x}` (primary) / 古いバージョン → `Downgrade to v{x}` (caution, 確認モーダル付き) / 現バージョン → `Current version` (disabled)
- 既存の `update_cta` modal と `UpdateManager` のダウンロード・apply パイプラインを再利用するため、新規追加はバックエンドの `fetch_release_by_tag` / `resolve_state_for_version` と protocol の `ApplyUpdateToVersion` のみ

## 関連 SPEC

- SPEC #2780 v2 Amendment (2026-05-28): FR-011〜FR-019、Acceptance Scenarios 6〜9

## 変更ファイル

| 領域 | 変更内容 |
|------|---------|
| `crates/gwt-core/src/update.rs` | `fetch_release_by_tag` + `resolve_state_for_version` 追加、`fetch_release` ヘルパで `fetch_latest_release` と DRY |
| `crates/gwt/src/protocol.rs` | `FrontendEvent::ApplyUpdateToVersion`、`BackendEvent::ReleaseNotesPayload.current_version` field 追加 |
| `crates/gwt/src/app_runtime/mod.rs` | `apply_update_to_version_events` ハンドラ + release_notes_events に current_version を埋め込み |
| `crates/gwt/web/release-notes-window.js` | content header に action button、downgrade confirm modal、簡易 semver 比較 |
| `crates/gwt/web/styles/components.css` | `.release-notes-update-action` (is-update / is-downgrade / is-current) + `.release-notes-downgrade-confirm` |
| tests | Rust unit (update::tests) + Rust serde (release_notes_protocol_test) + frontend DOM (release-notes-window.test.mjs) |

## デザイン

CSS は実在の design token のみで構成し、precedent (`update-modal__btn--primary` / `update-cta.is-error` / `update-modal` panel) と同じ色言語に揃える:

- `--color-state-active` for Update primary
- `--color-state-blocked` for Downgrade caution
- `--color-text-disabled` for Current disabled
- `--color-scrim` overlay + `--color-surface-elevated` panel + `--shadow-2` for confirm modal

## Test plan

- [x] `cargo test -p gwt-core update::tests` (`fetch_release_by_tag` / `resolve_state_for_version` 含む 47 tests)
- [x] `cargo test -p gwt --test release_notes_protocol_test` (7 tests, current_version + apply_update_to_version serde 含む)
- [x] `cargo test -p gwt-core -p gwt --all-features` (1500+ tests, regression なし)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `bash scripts/run-frontend-unit-tests.sh` (580/580 pass, release-notes-window 23 new tests 含む)
- [x] User visual verification — button states (Current / Update / Downgrade) + downgrade confirm modal + 切替時のラベル連動 + CSS design token alignment 全 OK

## Out of Scope

- 過去バージョンのバイナリのローカルアーカイブ化 (毎回 GitHub から fetch)
- データ migration の双方向対応 (downgrade で破損するデータの自動 rollback は別 SPEC)
- 複数 update channel 管理
- CLI からの version 指定 update (将来 `gwtd update --version v1.2.3` は v3 候補)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release Notes window now displays action buttons to update or downgrade to specific versions.
  * Current version is labeled as "Current version"; newer versions show "Update to vX"; older versions show "Downgrade to vX".
  * Downgrade actions require confirmation via a modal dialog before applying.

* **Tests**
  * Added comprehensive test coverage for version resolution, update/downgrade button behavior, and confirmation flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->