### PR TITLE
fix(gui): address Codex review on Release Notes update-to-version flow (PR #2917 follow-up)

### DIFF
--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -908,9 +908,24 @@ impl UpdateManager {
         current_exe: Option<&Path>,
     ) -> Result<UpdateState, String> {
         let release = self.fetch_release_by_tag(version)?;
-        let normalized = parse_tag_version(&release.tag_name)
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| version.trim().trim_start_matches('v').to_string());
+        // Codex review on PR #2917: refuse to stage a payload under the
+        // caller's chosen version when the server returned an unparseable
+        // or mismatched tag. Matches `check()`'s parse-or-fail behavior so
+        // a single permissive code path can't bypass the safety the rest of
+        // the apply pipeline assumes.
+        let normalized = parse_tag_version(&release.tag_name).ok_or_else(|| {
+            format!(
+                "Failed to parse release tag as version: {}",
+                release.tag_name
+            )
+        })?;
+        let requested = version.trim().trim_start_matches('v');
+        let normalized = normalized.to_string();
+        if normalized != requested {
+            return Err(format!(
+                "Release tag mismatch: requested v{requested} but server returned v{normalized}"
+            ));
+        }
 
         let platform = Platform::detect();
         let portable_asset_url = platform
@@ -3526,6 +3541,63 @@ mod tests {
             }
             other => panic!("expected UpdateState::Available, got {other:?}"),
         }
+    }
+
+    // Codex review on PR #2917: reject mismatched / unparseable tags rather
+    // than falling back to the caller's input. `check()` already fails fast
+    // on invalid release tags and `resolve_state_for_version` should match.
+    #[test]
+    fn resolve_state_for_version_rejects_unparseable_tag_name() {
+        let temp = tempfile::tempdir().unwrap();
+        let release_body = r#"{
+  "tag_name": "totally-not-a-version",
+  "html_url": "https://example.invalid/x",
+  "assets": []
+}"#
+        .as_bytes()
+        .to_vec();
+        let base_url = serve_once("/", "200 OK", "application/json", release_body);
+        let mgr = UpdateManager::new()
+            .with_api_base_url(base_url)
+            .with_cache_path(temp.path().join("update-check.json"))
+            .with_updates_dir(temp.path().join("updates"));
+
+        let err = mgr
+            .resolve_state_for_version("7.0.0", None)
+            .expect_err("malformed tag must not be accepted");
+        assert!(
+            err.to_lowercase().contains("tag") || err.to_lowercase().contains("version"),
+            "error should mention tag/version mismatch: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_state_for_version_rejects_mismatched_tag_name() {
+        let temp = tempfile::tempdir().unwrap();
+        // Requested v7.0.0 but server returns v8.0.0 — must reject so we
+        // don't stage v8.0.0 under the user's chosen v7.0.0 label.
+        let release_body = r#"{
+  "tag_name": "v8.0.0",
+  "html_url": "https://example.invalid/v8",
+  "assets": [
+    {"name": "gwt-windows-x86_64.zip", "browser_download_url": "https://example.invalid/v8/win.zip"}
+  ]
+}"#
+        .as_bytes()
+        .to_vec();
+        let base_url = serve_once("/", "200 OK", "application/json", release_body);
+        let mgr = UpdateManager::new()
+            .with_api_base_url(base_url)
+            .with_cache_path(temp.path().join("update-check.json"))
+            .with_updates_dir(temp.path().join("updates"));
+
+        let err = mgr
+            .resolve_state_for_version("7.0.0", None)
+            .expect_err("tag mismatch must be rejected");
+        assert!(
+            err.to_lowercase().contains("tag") || err.to_lowercase().contains("mismatch"),
+            "error should mention tag mismatch: {err}"
+        );
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -3917,6 +3917,14 @@ impl AppRuntime {
     /// asset for the requested tag on a worker thread (network), then routes
     /// through the existing `ApplyUpdateStart` pipeline so the standard
     /// update modal renders downloading → ready → restart.
+    ///
+    /// Codex review on PR #2917: the resolved state is also published as
+    /// `UserEvent::UpdateAvailable` so `AppRuntime.pending_update` reflects
+    /// the chosen release. Without this step, `ApplyUpdateLater` /
+    /// `ApplyUpdateRestartNow` (which both gate on `self.pending_update`)
+    /// would either no-op or fire against an unrelated latest-update state
+    /// when the user selected a downgrade while `pending_update` was
+    /// `UpToDate`.
     fn apply_update_to_version_events(
         &self,
         client_id: &str,
@@ -3929,6 +3937,12 @@ impl AppRuntime {
             let current_exe = std::env::current_exe().ok();
             match manager.resolve_state_for_version(&version, current_exe.as_deref()) {
                 Ok(state) => {
+                    // Update `pending_update` first so Later / Restart now
+                    // read the selected release. The frontend update-cta
+                    // ignores the broadcast `UpdateState` here because its
+                    // local status is already `applying` (the modal was
+                    // opened by `beginUpdateDownloading` on click).
+                    proxy.send(UserEvent::UpdateAvailable(state.clone()));
                     proxy.send(UserEvent::ApplyUpdateStart {
                         state,
                         client_id: client_id_owned,

--- a/crates/gwt/web/__tests__/release-notes-window.test.mjs
+++ b/crates/gwt/web/__tests__/release-notes-window.test.mjs
@@ -11,12 +11,22 @@ function makeFixture({ entries = sampleEntries(), focusVersion = null } = {}) {
   );
   const sent = [];
   const send = (msg) => sent.push(msg);
+  const downloadingCalls = [];
+  const beginUpdateDownloading = (version) => downloadingCalls.push(version);
   const controller = createReleaseNotesWindow({
     document,
     send,
     generateId: () => "rn-test-1",
+    beginUpdateDownloading,
   });
-  return { document, controller, sent, entries, focusVersion };
+  return {
+    document,
+    controller,
+    sent,
+    entries,
+    focusVersion,
+    downloadingCalls,
+  };
 }
 
 function sampleEntries() {
@@ -391,6 +401,59 @@ test("button reflects selection changes via sidebar click", () => {
     .click();
   btn = document.querySelector(".release-notes-update-action");
   assert.ok(btn.classList.contains("is-downgrade"));
+});
+
+// Codex review on PR #2917: opening the update modal in `downloading`
+// state must happen BEFORE sending `apply_update_to_version`, otherwise
+// update-cta.js drops the subsequent UpdateProgress / UpdateReady events.
+test("update button click calls beginUpdateDownloading before sending apply", () => {
+  const { document, controller, sent, downloadingCalls, entries } =
+    makeFixture();
+  controller.handlePayload({
+    id: "rn-test-1",
+    entries,
+    focus_version: "9.38.0",
+    current_version: "9.36.0",
+  });
+  document.querySelector(".release-notes-update-action").click();
+  assert.deepEqual(downloadingCalls, ["9.38.0"]);
+  const applyMessage = sent.find((m) => m.kind === "apply_update_to_version");
+  assert.ok(applyMessage);
+  // Verify call order via the recorded arrays' state.
+  assert.equal(downloadingCalls[0], applyMessage.version);
+});
+
+test("downgrade Confirm also calls beginUpdateDownloading before sending apply", () => {
+  const { document, controller, sent, downloadingCalls, entries } =
+    makeFixture();
+  controller.handlePayload({
+    id: "rn-test-1",
+    entries,
+    focus_version: "9.36.0",
+    current_version: "9.38.0",
+  });
+  document.querySelector(".release-notes-update-action").click();
+  // Confirm modal is shown — no apply, no downloading yet.
+  assert.equal(downloadingCalls.length, 0);
+  document
+    .querySelector(".release-notes-downgrade-confirm__confirm")
+    .click();
+  assert.deepEqual(downloadingCalls, ["9.36.0"]);
+  const applyMessage = sent.find((m) => m.kind === "apply_update_to_version");
+  assert.equal(applyMessage.version, "9.36.0");
+});
+
+test("Cancel on downgrade modal does NOT call beginUpdateDownloading", () => {
+  const { document, controller, downloadingCalls, entries } = makeFixture();
+  controller.handlePayload({
+    id: "rn-test-1",
+    entries,
+    focus_version: "9.36.0",
+    current_version: "9.38.0",
+  });
+  document.querySelector(".release-notes-update-action").click();
+  document.querySelector(".release-notes-downgrade-confirm__cancel").click();
+  assert.equal(downloadingCalls.length, 0);
 });
 
 test("payload without current_version hides the update button (backward-compat)", () => {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1159,6 +1159,8 @@
       const releaseNotesWindow = createReleaseNotesWindow({
         document,
         send,
+        beginUpdateDownloading: (version) =>
+          updateCtaController.beginDownloadingFor(version),
       });
 
       if (appVersionLabel && !appVersionLabel.dataset.releaseNotesBound) {

--- a/crates/gwt/web/release-notes-window.js
+++ b/crates/gwt/web/release-notes-window.js
@@ -23,6 +23,13 @@ export function createReleaseNotesWindow({
   document,
   send = () => {},
   generateId = () => `release-notes-${Date.now()}`,
+  // SPEC #2780 v2 Amendment (FR-014, Codex review on PR #2917): the update
+  // CTA modal must be in `downloading` state before `apply_update_to_version`
+  // fires, otherwise UpdateProgress / UpdateReady events arriving from the
+  // backend are dropped by update-cta.js (which gates on `status ===
+  // "applying"`). The host (app.js) wires this to
+  // `updateCtaController.beginDownloadingFor`.
+  beginUpdateDownloading = () => {},
 } = {}) {
   if (!document) {
     throw new Error("createReleaseNotesWindow requires a document");
@@ -201,6 +208,16 @@ export function createReleaseNotesWindow({
   }
 
   function sendApply(version) {
+    // Open the update modal in `downloading` state BEFORE notifying the
+    // backend so the subsequent UpdateProgress / UpdateReady events land
+    // on a modal that is ready to render them (update-cta.js drops them
+    // when `status !== "applying"`).
+    try {
+      beginUpdateDownloading(version);
+    } catch {
+      // beginUpdateDownloading is a UI hint, not a hard dependency. Apply
+      // proceeds even if it throws so the backend pipeline still runs.
+    }
     send({ kind: "apply_update_to_version", version });
   }
 

--- a/crates/gwt/web/update-cta.js
+++ b/crates/gwt/web/update-cta.js
@@ -513,6 +513,23 @@ export function createUpdateCtaController({
     return `${mb.toFixed(1)} MB`;
   }
 
+  // SPEC #2780 v2 Amendment (FR-014, Codex review on PR #2917): Release
+  // Notes window drives the apply pipeline for an arbitrary version. The
+  // modal must be in `downloading` state before subsequent
+  // `UpdateProgress` / `UpdateReady` events arrive, otherwise the
+  // existing handlers above drop them silently (because `status !==
+  // "applying"`). External callers invoke this to transition the CTA into
+  // the same state `handleClick()` produces for the standard latest-update
+  // path, without sending `apply_update_start` themselves.
+  function beginDownloadingFor(version) {
+    if (!version) return;
+    pendingVersion = null;
+    lastProgress = null;
+    latestVersion = version;
+    renderCta("applying", "Applying update...");
+    renderModalDownloading(version);
+  }
+
   return {
     handleUpdateState,
     handleUpdateProgress,
@@ -522,5 +539,6 @@ export function createUpdateCtaController({
     showAvailable,
     showReadyPending,
     showError,
+    beginDownloadingFor,
   };
 }

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6214,3 +6214,10 @@ Type: lesson
 Context: SPEC-2780 v2 で Release Notes update button を実装した際、最初 --color-accent / --color-warning / --color-on-accent を fallback hex 付きで使ったが、これらは gwt のデザイン token として未定義だった。ユーザー目視で「CSS は合っていますか?」と指摘されて気付き、--color-state-active / --color-state-blocked / --color-text-disabled / --color-scrim 等の実 token に置換した。
 Learning: 新規 CSS を書くときは fallback hex 付きで未定義 token を仮置きしてはいけない。fallback だけが効くので見た目はテーマと不整合になるが、ビルド・テストは通って気付かない。
 Future Action: 新規 component の CSS を書く前に grep -E '^\s*--color-' crates/gwt/web/styles/tokens.css で実在 token を確認する。precedent component (update-modal__btn--primary / update-cta.is-error 等) を必ず参照して同じ token を使う。
+
+## 2026-05-28 — PR auto-merge can outrun review reply commits
+
+Type: lesson
+Context: SPEC-2780 v2 PR #2917 was set to auto-merge once CI passed. Codex+CodeRabbit posted P1/Major review threads after the initial push, but by the time the review reply commit was prepared and pushed, the PR had already auto-merged with the original buggy code on develop. The follow-up fix had to ship as a separate PR (#2918).
+Learning: When a PR can auto-merge, the agent must (1) check for unresolved review threads BEFORE pushing any commit that would trigger another CI cycle, AND (2) gate auto-merge on review resolution rather than just CI pass — otherwise review fixes land in a follow-up PR while the original P1 issues sit in develop unfixed.
+Future Action: Before declaring a PR ready: run gwtd pr review-threads <n> to inspect unresolved threads. If any P0/P1/Major comments exist, prefer addressing them BEFORE the auto-merge gate clears. If a PR has already auto-merged with unaddressed reviewer concerns, immediately raise a follow-up PR and Board-handoff to the user; do not stop at 'thread resolved' on the merged PR alone.


### PR DESCRIPTION
## Summary

PR #2917 (SPEC-2780 v2 — Release Notes Update-to-Version button) was auto-merged before this follow-up review patch could be folded in, so this PR ships the Codex / CodeRabbit review fixes against the now-merged code on develop.

## レビュー指摘への対応

| # | Severity | Where | Fix |
|---|----------|-------|-----|
| B1 | P1 (Codex) | `crates/gwt/web/release-notes-window.js` | `apply_update_to_version` を送る前に `beginUpdateDownloading(version)` callback で update CTA modal を `downloading` 状態に遷移。後続の `UpdateProgress` / `UpdateReady` が drop されない。 |
| B2 | P1 (Codex) | `crates/gwt/src/app_runtime/mod.rs` | worker thread が `resolve_state_for_version` 成功後に `UserEvent::UpdateAvailable(state.clone())` を先に送り `pending_update` を更新。`ApplyUpdateLater` / `ApplyUpdateRestartNow` が選択 release を読めるようになる。 |
| B3 | Major (CodeRabbit) | `crates/gwt-core/src/update.rs` | `resolve_state_for_version` の caller-supplied version フォールバックを削除。`parse_tag_version` 失敗 + tag mismatch の両方を `Err(...)` で reject。 |

## Test plan

- [x] `cargo test -p gwt-core -p gwt --all-features` — pass (1500+ tests, B3 用に 2 つ新規追加)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `scripts/run-frontend-unit-tests.sh` — pass (release-notes-window 26 tests, B1 用に 3 つ新規追加)

## Releaseability

- PR #2917 がすでに develop に入っているため、本 PR は **後方互換 fix** として独立配信可能
- B1 / B2 / B3 はすべて Release Notes ウィンドウからの update 動線にのみ影響し、既存の latest-update CTA path は変わらない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
