### PR TITLE
fix(gui): bound native close shutdown

### DIFF
--- a/crates/gwt-terminal/src/pty.rs
+++ b/crates/gwt-terminal/src/pty.rs
@@ -449,6 +449,36 @@ mod tests {
         command_config(sleep_command(secs))
     }
 
+    fn cwd_output_matches(text: &str, canonical_cwd: &str) -> bool {
+        let normalized_text = text.replace('/', "\\").to_ascii_lowercase();
+        let normalized_cwd = canonical_cwd.replace('/', "\\").to_ascii_lowercase();
+        if normalized_text.contains(&normalized_cwd)
+            || normalized_cwd.contains(normalized_text.trim())
+        {
+            return true;
+        }
+
+        #[cfg(windows)]
+        {
+            let components = std::path::Path::new(canonical_cwd)
+                .components()
+                .filter_map(|component| match component {
+                    std::path::Component::Normal(value) => {
+                        Some(value.to_string_lossy().to_ascii_lowercase())
+                    }
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            if components.len() >= 2 {
+                let suffix_len = components.len().min(3);
+                let suffix = components[components.len() - suffix_len..].join("\\");
+                return normalized_text.contains(&suffix);
+            }
+        }
+
+        false
+    }
+
     #[cfg(unix)]
     #[test]
     fn normalize_spawn_config_resolves_command_from_config_path() {
@@ -642,7 +672,7 @@ mod tests {
             .unwrap_or(&canonical_temp)
             .to_string();
         assert!(
-            text.contains(&canonical_temp) || canonical_temp.contains(text.trim()),
+            cwd_output_matches(&text, &canonical_temp),
             "Expected temp dir path in output.\n  output: {text}\n  expected: {canonical_temp}"
         );
     }

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -282,6 +282,95 @@ fn frontend_event_may_change_project_tabs(event: &FrontendEvent) -> bool {
     )
 }
 
+const GUI_SHUTDOWN_BACKSTOP_GRACE: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GuiShutdownReason {
+    NativeClose,
+    QuitApp,
+    LoopDestroyed,
+}
+
+impl GuiShutdownReason {
+    fn arms_backstop(self) -> bool {
+        !matches!(self, Self::LoopDestroyed)
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::NativeClose => "native close",
+            Self::QuitApp => "quit app",
+            Self::LoopDestroyed => "loop destroyed",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GuiShutdownOutcome {
+    Started,
+    AlreadyStarted,
+}
+
+#[derive(Debug, Default)]
+struct GuiShutdownCoordinator {
+    started: bool,
+}
+
+fn request_gui_shutdown(
+    coordinator: &mut GuiShutdownCoordinator,
+    reason: GuiShutdownReason,
+    arm_backstop: impl FnOnce(GuiShutdownReason, Duration),
+    cleanup: impl FnOnce(),
+) -> GuiShutdownOutcome {
+    if coordinator.started {
+        tracing::debug!(
+            target: "gwt::shutdown",
+            reason = reason.label(),
+            "gui shutdown already started; skipping duplicate cleanup"
+        );
+        return GuiShutdownOutcome::AlreadyStarted;
+    }
+
+    coordinator.started = true;
+    tracing::info!(
+        target: "gwt::shutdown",
+        reason = reason.label(),
+        backstop = reason.arms_backstop(),
+        grace_ms = GUI_SHUTDOWN_BACKSTOP_GRACE.as_millis() as u64,
+        "gui shutdown requested"
+    );
+    if reason.arms_backstop() {
+        arm_backstop(reason, GUI_SHUTDOWN_BACKSTOP_GRACE);
+    }
+    cleanup();
+    tracing::info!(
+        target: "gwt::shutdown",
+        reason = reason.label(),
+        "gui shutdown cleanup completed"
+    );
+    GuiShutdownOutcome::Started
+}
+
+fn spawn_gui_exit_backstop(reason: GuiShutdownReason, grace: Duration) {
+    thread::Builder::new()
+        .name("gwt-gui-exit-backstop".to_string())
+        .spawn(move || {
+            thread::sleep(grace);
+            eprintln!(
+                "gwt gui: {} shutdown timed out after {grace:?}; exiting now",
+                reason.label()
+            );
+            tracing::error!(
+                target: "gwt::shutdown",
+                reason = reason.label(),
+                grace_ms = grace.as_millis() as u64,
+                "gui shutdown timed out; forcing process exit"
+            );
+            std::process::exit(0);
+        })
+        .expect("spawn gui exit backstop thread");
+}
+
 enum BoardProjectionWatcherMessage {
     Changed(Vec<PathBuf>),
     Stop,
@@ -1068,6 +1157,70 @@ mod tests {
             42,
         )
         .is_none());
+    }
+
+    #[test]
+    fn gui_shutdown_arms_backstop_before_cleanup_and_only_once() {
+        let mut coordinator = super::GuiShutdownCoordinator::default();
+        let calls = std::cell::RefCell::new(Vec::new());
+
+        let outcome = super::request_gui_shutdown(
+            &mut coordinator,
+            super::GuiShutdownReason::NativeClose,
+            |reason, grace| {
+                calls
+                    .borrow_mut()
+                    .push(format!("backstop:{reason:?}:{grace:?}"))
+            },
+            || calls.borrow_mut().push("cleanup".to_string()),
+        );
+
+        assert_eq!(outcome, super::GuiShutdownOutcome::Started);
+        assert_eq!(
+            calls.borrow().as_slice(),
+            vec!["backstop:NativeClose:5s".to_string(), "cleanup".to_string()].as_slice()
+        );
+
+        let duplicate = super::request_gui_shutdown(
+            &mut coordinator,
+            super::GuiShutdownReason::QuitApp,
+            |reason, grace| {
+                calls
+                    .borrow_mut()
+                    .push(format!("duplicate-backstop:{reason:?}:{grace:?}"))
+            },
+            || calls.borrow_mut().push("duplicate-cleanup".to_string()),
+        );
+
+        assert_eq!(duplicate, super::GuiShutdownOutcome::AlreadyStarted);
+        assert_eq!(
+            calls.borrow().len(),
+            2,
+            "duplicate shutdown must not rerun cleanup"
+        );
+    }
+
+    #[test]
+    fn loop_destroyed_cleanup_runs_without_backstop_when_no_prior_shutdown() {
+        let mut coordinator = super::GuiShutdownCoordinator::default();
+        let calls = std::cell::RefCell::new(Vec::new());
+
+        let outcome = super::request_gui_shutdown(
+            &mut coordinator,
+            super::GuiShutdownReason::LoopDestroyed,
+            |reason, grace| {
+                calls
+                    .borrow_mut()
+                    .push(format!("backstop:{reason:?}:{grace:?}"))
+            },
+            || calls.borrow_mut().push("cleanup".to_string()),
+        );
+
+        assert_eq!(outcome, super::GuiShutdownOutcome::Started);
+        assert_eq!(
+            calls.borrow().as_slice(),
+            vec!["cleanup".to_string()].as_slice()
+        );
     }
 
     #[test]
@@ -6366,6 +6519,9 @@ fn main() -> wry::Result<()> {
         }
     }
 
+    let is_headless = serve_args.is_some();
+    let mut gui_shutdown = GuiShutdownCoordinator::default();
+
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
         let _ = webview_surface.as_ref();
@@ -6378,23 +6534,41 @@ fn main() -> wry::Result<()> {
                 event: WindowEvent::CloseRequested,
                 ..
             } => {
-                // Kill every PTY / agent before the event loop exits so no
-                // child process outlives the window.
-                app.stop_all_runtimes();
-                board_projection_watchers.shutdown();
-                workspace_projection_watchers.shutdown();
-                #[cfg(unix)]
-                board_daemon_subscribers.shutdown();
-                server.shutdown();
+                request_gui_shutdown(
+                    &mut gui_shutdown,
+                    GuiShutdownReason::NativeClose,
+                    spawn_gui_exit_backstop,
+                    || {
+                        // Kill every PTY / agent before the event loop exits so no
+                        // child process outlives the window.
+                        app.stop_all_runtimes();
+                        board_projection_watchers.shutdown();
+                        workspace_projection_watchers.shutdown();
+                        #[cfg(unix)]
+                        board_daemon_subscribers.shutdown();
+                        server.shutdown();
+                    },
+                );
                 *control_flow = ControlFlow::Exit;
             }
             Event::UserEvent(UserEvent::QuitApp) => {
-                app.stop_all_runtimes();
-                board_projection_watchers.shutdown();
-                workspace_projection_watchers.shutdown();
-                #[cfg(unix)]
-                board_daemon_subscribers.shutdown();
-                server.shutdown();
+                request_gui_shutdown(
+                    &mut gui_shutdown,
+                    GuiShutdownReason::QuitApp,
+                    |reason, grace| {
+                        if !is_headless {
+                            spawn_gui_exit_backstop(reason, grace);
+                        }
+                    },
+                    || {
+                        app.stop_all_runtimes();
+                        board_projection_watchers.shutdown();
+                        workspace_projection_watchers.shutdown();
+                        #[cfg(unix)]
+                        board_daemon_subscribers.shutdown();
+                        server.shutdown();
+                    },
+                );
                 *control_flow = ControlFlow::Exit;
             }
             Event::UserEvent(UserEvent::Frontend { client_id, event }) => {
@@ -6795,14 +6969,21 @@ fn main() -> wry::Result<()> {
                 }
             }
             Event::LoopDestroyed => {
-                // Belt-and-suspenders: if the event loop is torn down via a
-                // path other than CloseRequested, still release PTY children.
-                app.stop_all_runtimes();
-                board_projection_watchers.shutdown();
-                workspace_projection_watchers.shutdown();
-                #[cfg(unix)]
-                board_daemon_subscribers.shutdown();
-                server.shutdown();
+                request_gui_shutdown(
+                    &mut gui_shutdown,
+                    GuiShutdownReason::LoopDestroyed,
+                    |_, _| {},
+                    || {
+                        // Belt-and-suspenders: if the event loop is torn down via a
+                        // path other than CloseRequested, still release PTY children.
+                        app.stop_all_runtimes();
+                        board_projection_watchers.shutdown();
+                        workspace_projection_watchers.shutdown();
+                        #[cfg(unix)]
+                        board_daemon_subscribers.shutdown();
+                        server.shutdown();
+                    },
+                );
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary

- Adds a bounded native-close shutdown path so Windows GUI close requests cannot leave `gwt.exe` running indefinitely.
- Keeps shutdown cleanup idempotent across native close, app quit, and event-loop destruction.
- Makes the Windows PTY cwd test tolerate short 8.3 user-profile paths returned by `cmd`.

## Changes

- `crates/gwt/src/main.rs`: adds `GuiShutdownCoordinator`, a 5-second GUI shutdown backstop, and shared cleanup wiring for `CloseRequested`, `QuitApp`, and `LoopDestroyed`.
- `crates/gwt/src/main.rs`: adds regression tests for backstop-before-cleanup ordering and duplicate cleanup suppression.
- `crates/gwt-terminal/src/pty.rs`: updates the cwd assertion helper so Windows short path output still proves the spawned PTY used the requested cwd.

## Testing

- [x] `cargo test -p gwt-terminal` — PASS
- [x] `cargo test -p gwt-core -p gwt --all-features` — PASS after merging `origin/develop`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — PASS
- [x] `cargo fmt --check` — PASS
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — PASS
- [x] Windows manual close smoke — PASS: user closed the launched GUI with the native `X`; the target `gwt.exe` PID exited, with a short delay observed.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes; the change is a bounded shutdown fix plus test compatibility adjustment and does not expose incomplete behavior.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- #1942

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (N/A: no docs surface changed)
- [x] Migration/backfill plan included (N/A: no schema or data migration)
- [x] CHANGELOG impact considered (patch fix; no breaking change)

## Context

- SPEC #1942 tracks the Windows GUI close behavior where pressing the app `X` could leave the process alive.

## Risk / Impact

- **Affected areas**: Windows GUI shutdown and PTY cwd test assertions.
- **Rollback plan**: revert this PR; no data migration or persistent state change is involved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refactored application shutdown handling for more reliable graceful termination.
  * Added optional backstop timer to force exit if shutdown exceeds grace period.
  * Ensured shutdown cleanup executes exactly once, eliminating duplicate cleanup actions.
  * Improved consistency of shutdown behavior across GUI and headless modes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2919?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->