### PR TITLE
fix(gui): refine profile environment grid

### DIFF
--- a/crates/gwt/playwright/tests/branch-cleanup.spec.ts
+++ b/crates/gwt/playwright/tests/branch-cleanup.spec.ts
@@ -21,13 +21,17 @@ test.describe("Branch Cleanup E2E", () => {
 
     await page.goto(APP_URL);
 
-    const branchesWindow = page.locator(".workspace-window.surface-branches");
+    const branchesWindow = page.locator(".workspace-window.surface-work");
     await expect(branchesWindow).toBeVisible({ timeout: 10_000 });
+    await branchesWindow.locator("[data-work-tab='branches']").click();
 
-    const firstBranch = branchesWindow.locator(
+    const branchSurface = branchesWindow.locator("[data-work-section='branches']");
+    await expect(branchSurface).toBeVisible();
+
+    const firstBranch = branchSurface.locator(
       ".branch-row[data-branch-name='work/cleanup-one']",
     );
-    const secondBranch = branchesWindow.locator(
+    const secondBranch = branchSurface.locator(
       ".branch-row[data-branch-name='work/cleanup-two']",
     );
     await expect(firstBranch).toContainText("safe");
@@ -36,7 +40,7 @@ test.describe("Branch Cleanup E2E", () => {
     await firstBranch.locator(".branch-cleanup-toggle").click();
     await secondBranch.locator(".branch-cleanup-toggle").click();
 
-    const cleanupTrigger = branchesWindow.getByRole("button", {
+    const cleanupTrigger = branchSurface.getByRole("button", {
       name: "Clean Up (2)",
     });
     await expect(cleanupTrigger).toBeEnabled();

--- a/crates/gwt/playwright/tests/index-status.spec.ts
+++ b/crates/gwt/playwright/tests/index-status.spec.ts
@@ -389,12 +389,12 @@ test.describe("Project Index status surface", () => {
     const { root } = await openIndexSearchPanel(page);
     await expect(root.locator(".index-search-input")).toHaveAttribute(
       "placeholder",
-      "Search by meaning, e.g. workspace lifecycle",
+      "Search by meaning, e.g. work lifecycle",
     );
     await root.locator("[data-match-mode='all_terms']").click();
     await expect(root.locator(".index-search-input")).toHaveAttribute(
       "placeholder",
-      "All terms required, e.g. Workspace discussion",
+      "All terms required, e.g. Work discussion",
     );
     await root.locator(".index-search-input").fill("Workspace volatile");
     await root.locator(".index-run-button").click();

--- a/crates/gwt/playwright/tests/profile-env-grid.spec.ts
+++ b/crates/gwt/playwright/tests/profile-env-grid.spec.ts
@@ -1,0 +1,190 @@
+import { expect, test } from "@playwright/test";
+import { APP_URL, installEmbeddedRoutes } from "./_helpers/embedded-frontend";
+
+test.describe("Profile environment variable grid", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("renders OS rows, auto-switches overrides, and saves added variables", async ({
+    page,
+  }) => {
+    await installEmbeddedRoutes(page);
+    await installProfileBackend(page);
+
+    await page.goto(APP_URL);
+
+    const profile = page.locator(".surface-profile");
+    await expect(profile.getByText("Environment Variables")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(profile.getByText("Save now")).toHaveCount(0);
+    await expect(profile.getByText("Merged preview")).toHaveCount(0);
+
+    const pathRow = profile.locator(".profile-env-row", { hasText: "PATH" });
+    await expect(pathRow.locator("select")).toHaveValue("use_os");
+    await expect(pathRow.locator(".profile-env-result")).toHaveText("/usr/bin");
+
+    await pathRow.locator('input[aria-label^="Profile value"]').fill("/custom/bin");
+    await expect(pathRow.locator("select")).toHaveValue("override");
+    await expect(pathRow.locator(".profile-env-result")).toHaveText("/custom/bin");
+    await page.waitForFunction(() =>
+      window.__profileFixtureSends.some(
+        (message) =>
+          message.kind === "save_profile" &&
+          message.env_vars.some(
+            (entry) => entry.key === "PATH" && entry.value === "/custom/bin",
+          ),
+      ),
+    );
+
+    const tokenRow = profile.locator(".profile-env-row", { hasText: "GITHUB_TOKEN" });
+    await expect(tokenRow.locator(".profile-env-os-value")).toHaveText("fixture-token");
+    await expect(tokenRow.locator("select")).toHaveValue("disabled");
+    await expect(tokenRow.locator(".profile-env-result")).toHaveText("Disabled");
+
+    await profile.getByRole("button", { name: "+ Add variable" }).click();
+    await profile
+      .locator('input[aria-label^="Environment variable key"]')
+      .last()
+      .fill("CUSTOM_FLAG");
+    await page.waitForFunction(() =>
+      window.__profileFixtureSends.some(
+        (message) =>
+          message.kind === "save_profile" &&
+          message.env_vars.some((entry) => entry.key === "CUSTOM_FLAG"),
+      ),
+    );
+
+    await profile
+      .locator('input[aria-label^="Profile value"]')
+      .last()
+      .fill("1");
+    await page.waitForFunction(() =>
+      window.__profileFixtureSends.some(
+        (message) =>
+          message.kind === "save_profile" &&
+          message.env_vars.some(
+            (entry) => entry.key === "CUSTOM_FLAG" && entry.value === "1",
+          ),
+      ),
+    );
+  });
+});
+
+async function installProfileBackend(page) {
+  await page.addInitScript(() => {
+    const recordedSends = [];
+    window.__profileFixtureSends = recordedSends;
+
+    const profileWindow = {
+      id: "profile-1",
+      title: "Profile",
+      preset: "profile",
+      geometry: { x: 96, y: 96, width: 1040, height: 680 },
+      z_index: 1,
+      status: "running",
+      minimized: false,
+      maximized: false,
+      pre_maximize_geometry: null,
+      persist: true,
+      purpose_title: null,
+      dynamic_title: null,
+      dynamic_title_detail: null,
+      agent_id: null,
+      agent_color: null,
+      tab_group_id: null,
+      tab_group_active: false,
+    };
+    const workspaceState = {
+      kind: "workspace_state",
+      workspace: {
+        app_version: "playwright",
+        tabs: [
+          {
+            id: "tab-1",
+            title: "Fixture Project",
+            project_root: "/fixture",
+            kind: "git",
+            workspace: {
+              viewport: { x: 0, y: 0, zoom: 1 },
+              windows: [profileWindow],
+            },
+          },
+        ],
+        active_tab_id: "tab-1",
+        recent_projects: [],
+      },
+    };
+    const snapshot = {
+      active_profile: "default",
+      selected_profile: "default",
+      profiles: [
+        {
+          name: "default",
+          description: "Default profile",
+          env_vars: [],
+          disabled_env: ["GITHUB_TOKEN"],
+          is_default: true,
+          is_active: true,
+        },
+      ],
+      os_env: [
+        { key: "GITHUB_TOKEN", value: "fixture-token" },
+        { key: "PATH", value: "/usr/bin" },
+      ],
+      merged_preview: [],
+    };
+
+    class FixtureWebSocket extends EventTarget {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+
+      constructor(url) {
+        super();
+        this.url = url;
+        this.readyState = FixtureWebSocket.CONNECTING;
+        setTimeout(() => {
+          this.readyState = FixtureWebSocket.OPEN;
+          this.dispatchEvent(new Event("open"));
+        }, 0);
+      }
+
+      send(raw) {
+        const message = JSON.parse(raw);
+        recordedSends.push(message);
+        if (message.kind === "frontend_ready") {
+          this.emit(workspaceState);
+          return;
+        }
+        if (message.kind === "load_profile") {
+          this.emit({ kind: "profile_snapshot", id: message.id, snapshot });
+          return;
+        }
+        if (message.kind === "save_profile") {
+          snapshot.profiles[0].env_vars = message.env_vars;
+          snapshot.profiles[0].disabled_env = message.disabled_env;
+          this.emit({ kind: "profile_snapshot", id: message.id, snapshot });
+        }
+      }
+
+      close() {
+        this.readyState = FixtureWebSocket.CLOSED;
+        this.dispatchEvent(new CloseEvent("close"));
+      }
+
+      emit(payload) {
+        setTimeout(() => {
+          this.dispatchEvent(
+            new MessageEvent("message", { data: JSON.stringify(payload) }),
+          );
+        }, 0);
+      }
+    }
+
+    Object.defineProperty(window, "WebSocket", {
+      configurable: true,
+      value: FixtureWebSocket,
+    });
+  });
+}

--- a/crates/gwt/playwright/tests/profile-env-grid.spec.ts
+++ b/crates/gwt/playwright/tests/profile-env-grid.spec.ts
@@ -20,7 +20,22 @@ test.describe("Profile environment variable grid", () => {
     await expect(profile.getByText("Merged preview")).toHaveCount(0);
 
     const pathRow = profile.locator(".profile-env-row", { hasText: "PATH" });
+    const gridMetrics = await profile.locator(".profile-env-grid").evaluate((node) => ({
+      clientWidth: node.clientWidth,
+      scrollWidth: node.scrollWidth,
+    }));
+    expect(gridMetrics.scrollWidth).toBeLessThanOrEqual(gridMetrics.clientWidth + 1);
+    await expect(pathRow).toHaveCSS("grid-template-columns", /px/);
+    const renderedColumns = await pathRow.evaluate((node) =>
+      getComputedStyle(node).gridTemplateColumns.split(/\s+/).filter(Boolean).length,
+    );
+    expect(renderedColumns).toBe(5);
     await expect(pathRow.locator("select")).toHaveValue("use_os");
+    await expect(pathRow.locator("select option")).toHaveText([
+      "Use OS",
+      "Override",
+      "Disabled",
+    ]);
     await expect(pathRow.locator(".profile-env-result")).toHaveText("/usr/bin");
 
     await pathRow.locator('input[aria-label^="Profile value"]').fill("/custom/bin");
@@ -42,6 +57,9 @@ test.describe("Profile environment variable grid", () => {
     await expect(tokenRow.locator(".profile-env-result")).toHaveText("Disabled");
 
     await profile.getByRole("button", { name: "+ Add variable" }).click();
+    const addedRow = profile.locator(".profile-env-row").last();
+    await expect(addedRow.locator("select")).toHaveValue("override");
+    await expect(addedRow.locator("select option")).toHaveText(["Enabled", "Disabled"]);
     await profile
       .locator('input[aria-label^="Environment variable key"]')
       .last()
@@ -67,6 +85,102 @@ test.describe("Profile environment variable grid", () => {
           ),
       ),
     );
+
+    await addedRow.locator("select").selectOption("disabled");
+    await expect(addedRow.locator(".profile-env-result")).toHaveText("Disabled");
+    await page.waitForFunction(() =>
+      window.__profileFixtureSends.some(
+        (message) =>
+          message.kind === "save_profile" &&
+          message.disabled_env.includes("CUSTOM_FLAG"),
+      ),
+    );
+  });
+
+  test("keeps focus while autosaving a newly added custom variable", async ({
+    page,
+  }) => {
+    await installEmbeddedRoutes(page);
+    await installProfileBackend(page);
+
+    await page.goto(APP_URL);
+
+    const profile = page.locator(".surface-profile");
+    await expect(profile.getByText("Environment Variables")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await profile.getByRole("button", { name: "+ Add variable" }).click();
+    const keyInput = profile
+      .locator('input[aria-label^="Environment variable key"]')
+      .last();
+    await keyInput.fill("CUSTOM_FOCUS");
+    await page.waitForFunction(() =>
+      window.__profileFixtureSends.some(
+        (message) =>
+          message.kind === "save_profile" &&
+          message.env_vars.some((entry) => entry.key === "CUSTOM_FOCUS"),
+      ),
+    );
+
+    await expect(keyInput).toBeFocused();
+    await page.keyboard.type("_NEXT");
+    await expect(keyInput).toHaveValue("CUSTOM_FOCUS_NEXT");
+  });
+
+  test("keeps metadata fixed while only the environment grid scrolls", async ({
+    page,
+  }) => {
+    await installEmbeddedRoutes(page);
+    await installProfileBackend(page);
+
+    await page.goto(APP_URL);
+
+    const profile = page.locator(".surface-profile");
+    await expect(profile.getByText("Environment Variables")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const editor = profile.locator(".profile-editor-pane");
+    const metadata = profile.locator(".profile-editor-pane > .profile-section").first();
+    const envSection = profile.locator(".profile-env-section");
+    const envGrid = profile.locator(".profile-env-grid");
+    const metadataName = profile.locator(".profile-field input").first();
+    const metadataBox = await metadata.boundingBox();
+    const envSectionBox = await envSection.boundingBox();
+    const nameBoxBefore = await metadataName.boundingBox();
+
+    expect(metadataBox?.height).toBeGreaterThan(160);
+    expect(envSectionBox?.y || 0).toBeGreaterThan(
+      (metadataBox?.y || 0) + (metadataBox?.height || 0),
+    );
+
+    const editorMetrics = await editor.evaluate((node) => ({
+      clientHeight: node.clientHeight,
+      overflowY: getComputedStyle(node).overflowY,
+      scrollHeight: node.scrollHeight,
+      scrollTop: node.scrollTop,
+    }));
+    expect(editorMetrics.overflowY).toBe("hidden");
+    expect(editorMetrics.scrollTop).toBe(0);
+    expect(editorMetrics.scrollHeight).toBeLessThanOrEqual(
+      editorMetrics.clientHeight + 1,
+    );
+
+    const gridMetrics = await envGrid.evaluate((node) => ({
+      clientHeight: node.clientHeight,
+      overflowY: getComputedStyle(node).overflowY,
+      scrollHeight: node.scrollHeight,
+    }));
+    expect(gridMetrics.overflowY).toBe("auto");
+    expect(gridMetrics.scrollHeight).toBeGreaterThan(gridMetrics.clientHeight);
+
+    await envGrid.evaluate((node) => {
+      node.scrollTop = node.scrollHeight;
+    });
+    const nameBoxAfter = await metadataName.boundingBox();
+    expect(nameBoxAfter?.y).toBeCloseTo(nameBoxBefore?.y || 0, 1);
+    await expect(editor).toHaveJSProperty("scrollTop", 0);
   });
 });
 
@@ -79,7 +193,7 @@ async function installProfileBackend(page) {
       id: "profile-1",
       title: "Profile",
       preset: "profile",
-      geometry: { x: 96, y: 96, width: 1040, height: 680 },
+      geometry: { x: 96, y: 96, width: 720, height: 680 },
       z_index: 1,
       status: "running",
       minimized: false,
@@ -130,6 +244,10 @@ async function installProfileBackend(page) {
       os_env: [
         { key: "GITHUB_TOKEN", value: "fixture-token" },
         { key: "PATH", value: "/usr/bin" },
+        ...Array.from({ length: 36 }, (_, index) => ({
+          key: `FIXTURE_ENV_${String(index).padStart(2, "0")}`,
+          value: `/fixture/${index}`,
+        })),
       ],
       merged_preview: [],
     };

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -3271,6 +3271,32 @@ mod tests {
         }
     }
 
+    #[test]
+    fn embedded_web_profile_root_is_constrained_to_window_body() {
+        let html = frontend_styles_bundle();
+
+        let start = html
+            .find(".profile-root")
+            .expect("expected Profile root CSS to be defined");
+        let block = &html[start..];
+        let end = block
+            .find('}')
+            .expect("expected Profile root CSS rule to close");
+        let body = &block[..end];
+
+        for prop in [
+            "position: absolute",
+            "inset: 0",
+            "display: flex",
+            "flex-direction: column",
+        ] {
+            assert!(
+                body.contains(prop),
+                "expected `.profile-root` to declare `{prop}` so Profile panes can own vertical scroll, got: {body}",
+            );
+        }
+    }
+
     /// SPEC-2008 FR-034: every panel surface must adopt the shared layout
     /// primitives in its rendered HTML so paddings, scrollbars, and splits
     /// stay in lockstep. The toolbar misnomer `.knowledge-toolbar` (which was

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -2725,10 +2725,20 @@ mod tests {
             "expected Profile surface to expose selection, CRUD, active-switch, and save events",
         );
         assert!(
-            html.contains("Merged preview")
-                && html
-                    .contains("The backend computes this preview from the current OS environment",),
-            "expected Profile surface to render the backend-owned merged preview contract",
+            html.contains("Environment Variables")
+                && html.contains("Use OS")
+                && html.contains("Override")
+                && html.contains("Disabled")
+                && html.contains("Result")
+                && html.contains("+ Add variable"),
+            "expected Profile surface to render a single environment variable grid",
+        );
+        assert!(
+            !html.contains("Save now")
+                && !html.contains("Profile variables")
+                && !html.contains("Disabled OS variables")
+                && !html.contains("Merged preview"),
+            "expected Profile Metadata lower content to be unified into the grid",
         );
     }
 

--- a/crates/gwt/src/profile_dispatch.rs
+++ b/crates/gwt/src/profile_dispatch.rs
@@ -277,8 +277,13 @@ where
         })
         .collect();
 
+    let os_env = sorted_env_pairs(base_env);
     let merged_preview = selected
-        .merged_env_pairs(base_env)
+        .merged_env_pairs(
+            os_env
+                .iter()
+                .map(|entry| (entry.key.clone(), entry.value.clone())),
+        )
         .into_iter()
         .map(mask_preview_entry)
         .collect();
@@ -287,6 +292,7 @@ where
         active_profile,
         selected_profile: selected.name.clone(),
         profiles,
+        os_env,
         merged_preview,
     })
 }
@@ -297,6 +303,18 @@ fn sorted_env_entries(
     env_vars
         .iter()
         .map(|(key, value)| (key.clone(), value.clone()))
+        .collect::<BTreeMap<_, _>>()
+        .into_iter()
+        .map(|(key, value)| ProfileEnvEntryView { key, value })
+        .collect()
+}
+
+fn sorted_env_pairs<I>(env_vars: I) -> Vec<ProfileEnvEntryView>
+where
+    I: IntoIterator<Item = (String, String)>,
+{
+    env_vars
+        .into_iter()
         .collect::<BTreeMap<_, _>>()
         .into_iter()
         .map(|(key, value)| ProfileEnvEntryView { key, value })
@@ -523,5 +541,63 @@ mod tests {
             .merged_preview
             .iter()
             .any(|entry| entry.key == "PATH" && entry.value == "/usr/bin"));
+    }
+
+    #[test]
+    fn snapshot_from_settings_exposes_plaintext_os_env_and_empty_override() {
+        let temp = tempdir().expect("tempdir");
+        let path = config_path(&temp);
+
+        save_profile_at(
+            &path,
+            "default",
+            "default",
+            "",
+            &[ProfileEnvEntryView {
+                key: "EMPTY_OVERRIDE".to_string(),
+                value: String::new(),
+            }],
+            &["SECRET".to_string()],
+        )
+        .expect("save empty override");
+
+        let mut settings = load_settings_or_default(&path).expect("load settings");
+        let snapshot = snapshot_from_settings(
+            &mut settings,
+            Some("default"),
+            [
+                ("PATH".to_string(), "/usr/bin".to_string()),
+                ("SECRET".to_string(), "plain-secret".to_string()),
+                ("GITHUB_TOKEN".to_string(), "plain-token".to_string()),
+            ],
+        )
+        .expect("snapshot");
+
+        assert_eq!(
+            snapshot.os_env,
+            vec![
+                ProfileEnvEntryView {
+                    key: "GITHUB_TOKEN".to_string(),
+                    value: "plain-token".to_string(),
+                },
+                ProfileEnvEntryView {
+                    key: "PATH".to_string(),
+                    value: "/usr/bin".to_string(),
+                },
+                ProfileEnvEntryView {
+                    key: "SECRET".to_string(),
+                    value: "plain-secret".to_string(),
+                },
+            ]
+        );
+        assert!(snapshot.profiles.iter().any(|profile| {
+            profile.name == "default"
+                && profile.env_vars
+                    == vec![ProfileEnvEntryView {
+                        key: "EMPTY_OVERRIDE".to_string(),
+                        value: String::new(),
+                    }]
+                && profile.disabled_env == vec!["SECRET".to_string()]
+        }));
     }
 }

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -794,6 +794,8 @@ pub struct ProfileSnapshotView {
     pub active_profile: String,
     pub selected_profile: String,
     pub profiles: Vec<ProfileEntryView>,
+    #[serde(default)]
+    pub os_env: Vec<ProfileEnvEntryView>,
     pub merged_preview: Vec<ProfileEnvEntryView>,
 }
 
@@ -3098,6 +3100,10 @@ mod tests {
                     is_default: true,
                     is_active: true,
                 }],
+                os_env: vec![ProfileEnvEntryView {
+                    key: "PATH".to_string(),
+                    value: "/usr/bin".to_string(),
+                }],
                 merged_preview: vec![ProfileEnvEntryView {
                     key: "TERM".to_string(),
                     value: "xterm-256color".to_string(),
@@ -3117,6 +3123,10 @@ mod tests {
         assert_eq!(
             value["snapshot"]["profiles"][0]["env_vars"][0]["key"],
             Value::String("TERM".to_string())
+        );
+        assert_eq!(
+            value["snapshot"]["os_env"][0]["value"],
+            Value::String("/usr/bin".to_string())
         );
     }
 

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1962,9 +1962,9 @@ test("Dynamically-created form fields without surrounding <label> have aria-labe
   // accordingly.
   const expected = [
     { selector: 'input\\.setAttribute\\("aria-label", "Branch name"\\)', desc: "wizard branch name" },
-    { selector: 'keyInput\\.setAttribute\\("aria-label", `Env var key, row ', desc: "env var key" },
-    { selector: 'valueInput\\.setAttribute\\("aria-label", `Env var value, row ', desc: "env var value" },
-    { selector: 'keyInput\\.setAttribute\\("aria-label", `Disabled env key, row ', desc: "disabled env key" },
+    { selector: 'keyInput\\.setAttribute\\("aria-label", `Environment variable key, row ', desc: "env var key" },
+    { selector: 'modeSelect\\.setAttribute\\("aria-label", `Environment variable mode, row ', desc: "env var mode" },
+    { selector: 'valueInput\\.setAttribute\\("aria-label", `Profile value, row ', desc: "profile env value" },
     { selector: 'select\\.setAttribute\\("aria-label", label\\)', desc: "launch-field select reuses label" },
   ];
   for (const { selector, desc } of expected) {

--- a/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
+++ b/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
@@ -255,6 +255,34 @@ test("Workspace refresh action rerenders locally without inventing a protocol ev
   assert.ok(fixture.body.querySelector(".workspace-overview-detail-pane"));
 });
 
+test("Workspace renderWindows refreshes legacy workspace preset windows", () => {
+  const fixture = createFixture();
+  let projection = null;
+  const surface = createSurface(fixture, projection, {
+    getActiveWorkProjection: () => projection,
+  });
+
+  surface.mount(fixture.body, fixture.windowData, {
+    focusWindowLocally() {},
+    sendFocus() {},
+  });
+  assert.equal(
+    fixture.body.querySelectorAll(".workspace-overview-row[data-workspace-id]").length,
+    0,
+  );
+
+  projection = sampleProjection();
+  surface.renderWindows();
+
+  const rows = Array.from(
+    fixture.body.querySelectorAll(".workspace-overview-row[data-workspace-id]"),
+  );
+  assert.deepEqual(
+    rows.map((row) => row.dataset.workspaceId),
+    ["workspace-current", "workspace-done"],
+  );
+});
+
 function sampleProjection() {
   return {
     id: "workspace-current",

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -6375,6 +6375,196 @@
         };
       }
 
+      function normalizeProfileEnvKey(key) {
+        return String(key || "").trim();
+      }
+
+      function profileDraftPayload(draft) {
+        if (!draft) {
+          return { envVars: [], disabledEnv: [] };
+        }
+        const envByKey = new Map();
+        for (const entry of draft.envVars || []) {
+          const key = normalizeProfileEnvKey(entry.key);
+          if (!key) {
+            continue;
+          }
+          envByKey.set(key, {
+            key,
+            value: entry.value ?? "",
+          });
+        }
+        const disabledSet = new Set();
+        for (const entry of draft.disabledEnv || []) {
+          const key = normalizeProfileEnvKey(entry);
+          if (key) {
+            disabledSet.add(key);
+          }
+        }
+        for (const key of disabledSet) {
+          envByKey.delete(key);
+        }
+        return {
+          envVars: Array.from(envByKey.values()).sort((left, right) =>
+            left.key.localeCompare(right.key),
+          ),
+          disabledEnv: Array.from(disabledSet).sort((left, right) =>
+            left.localeCompare(right),
+          ),
+        };
+      }
+
+      function removeProfileEnvOverride(draft, key) {
+        const normalized = normalizeProfileEnvKey(key);
+        draft.envVars = (draft.envVars || []).filter(
+          (entry) => normalizeProfileEnvKey(entry.key) !== normalized,
+        );
+      }
+
+      function removeProfileDisabledKey(draft, key) {
+        const normalized = normalizeProfileEnvKey(key);
+        draft.disabledEnv = (draft.disabledEnv || []).filter(
+          (entry) => normalizeProfileEnvKey(entry) !== normalized,
+        );
+      }
+
+      function setProfileEnvOverride(draft, key, value) {
+        const normalized = normalizeProfileEnvKey(key);
+        if (!normalized) {
+          return null;
+        }
+        removeProfileDisabledKey(draft, normalized);
+        const existing = (draft.envVars || []).find(
+          (entry) => normalizeProfileEnvKey(entry.key) === normalized,
+        );
+        if (existing) {
+          existing.key = normalized;
+          existing.value = value ?? "";
+          return existing;
+        }
+        const entry = { key: normalized, value: value ?? "" };
+        draft.envVars.push(entry);
+        return entry;
+      }
+
+      function setProfileRowMode(draft, key, mode) {
+        const normalized = normalizeProfileEnvKey(key);
+        if (!normalized) {
+          return;
+        }
+        if (mode === "use_os") {
+          removeProfileEnvOverride(draft, normalized);
+          removeProfileDisabledKey(draft, normalized);
+          return;
+        }
+        if (mode === "disabled") {
+          removeProfileEnvOverride(draft, normalized);
+          if (
+            !(draft.disabledEnv || []).some(
+              (entry) => normalizeProfileEnvKey(entry) === normalized,
+            )
+          ) {
+            draft.disabledEnv.push(normalized);
+          }
+          return;
+        }
+        const existing = (draft.envVars || []).find(
+          (entry) => normalizeProfileEnvKey(entry.key) === normalized,
+        );
+        setProfileEnvOverride(draft, normalized, existing?.value ?? "");
+      }
+
+      function profileEnvironmentRows(snapshot, draft) {
+        const payload = profileDraftPayload(draft);
+        const osEntries = (snapshot.os_env || [])
+          .map((entry) => ({
+            key: normalizeProfileEnvKey(entry.key),
+            value: entry.value ?? "",
+          }))
+          .filter((entry) => entry.key)
+          .sort((left, right) => left.key.localeCompare(right.key));
+        const overrides = new Map(payload.envVars.map((entry) => [entry.key, entry]));
+        const disabled = new Set(payload.disabledEnv);
+        const osKeys = new Set();
+        const rows = [];
+
+        for (const entry of osEntries) {
+          osKeys.add(entry.key);
+          const mode = disabled.has(entry.key)
+            ? "disabled"
+            : overrides.has(entry.key)
+              ? "override"
+              : "use_os";
+          const profileValue = overrides.get(entry.key)?.value ?? "";
+          rows.push({
+            kind: "os",
+            key: entry.key,
+            osValue: entry.value,
+            mode,
+            profileValue,
+            result:
+              mode === "disabled"
+                ? "Disabled"
+                : mode === "override"
+                  ? profileValue
+                  : entry.value,
+          });
+        }
+
+        const addedKeys = new Set();
+        for (const entry of payload.envVars) {
+          if (osKeys.has(entry.key)) {
+            continue;
+          }
+          addedKeys.add(entry.key);
+          rows.push({
+            kind: "added",
+            key: entry.key,
+            osValue: "",
+            mode: "override",
+            profileValue: entry.value,
+            result: entry.value,
+          });
+        }
+        for (const key of payload.disabledEnv) {
+          if (osKeys.has(key) || addedKeys.has(key)) {
+            continue;
+          }
+          rows.push({
+            kind: "added",
+            key,
+            osValue: "",
+            mode: "disabled",
+            profileValue: "",
+            result: "Disabled",
+          });
+        }
+
+        rows.sort((left, right) => {
+          if (left.kind !== right.kind) {
+            return left.kind === "os" ? -1 : 1;
+          }
+          return left.key.localeCompare(right.key);
+        });
+
+        (draft.envVars || []).forEach((entry, index) => {
+          if (normalizeProfileEnvKey(entry.key)) {
+            return;
+          }
+          rows.push({
+            kind: "pending",
+            key: entry.key || "",
+            osValue: "",
+            mode: "override",
+            profileValue: entry.value ?? "",
+            result: entry.value ?? "",
+            draftIndex: index,
+          });
+        });
+
+        return rows;
+      }
+
       function selectedProfileEntry(state) {
         const profiles = state.snapshot?.profiles || [];
         if (!state.selectedProfile) {
@@ -6392,15 +6582,13 @@
         if (!draft) {
           return "";
         }
+        const payload = profileDraftPayload(draft);
         return JSON.stringify({
           currentName: draft.currentName,
           name: draft.name,
           description: draft.description,
-          envVars: draft.envVars.map((entry) => ({
-            key: entry.key,
-            value: entry.value,
-          })),
-          disabledEnv: draft.disabledEnv.slice(),
+          envVars: payload.envVars,
+          disabledEnv: payload.disabledEnv,
         });
       }
 
@@ -6452,14 +6640,15 @@
         state.saving = true;
         state.error = "";
         updateProfileStatus(windowId);
+        const payload = profileDraftPayload(state.draft);
         send({
           kind: "save_profile",
           id: windowId,
           current_name: state.draft.currentName,
           name: state.draft.name,
           description: state.draft.description,
-          env_vars: state.draft.envVars.filter((entry) => entry.key.trim() || entry.value),
-          disabled_env: state.draft.disabledEnv.filter((entry) => entry.trim()),
+          env_vars: payload.envVars,
+          disabled_env: payload.disabledEnv,
         });
       }
 
@@ -6564,6 +6753,7 @@
           active_profile: "default",
           selected_profile: "default",
           profiles: [],
+          os_env: [],
           merged_preview: [],
         };
         const profiles = snapshot.profiles || [];
@@ -6599,7 +6789,7 @@
             createNode(
               "div",
               "profile-empty-copy",
-              "Create a profile to track env overrides, disabled OS variables, and merged preview output.",
+              "Create a profile to track env overrides and disabled OS variables.",
             ),
           );
           const button = createNode("button", "wizard-button primary", "New profile");
@@ -6655,7 +6845,7 @@
             createNode(
               "div",
               "profile-empty-copy",
-              "Each profile keeps its own env overrides and merged preview output.",
+              "Each profile keeps its own env overrides and disabled OS variables.",
             ),
           );
           editor.appendChild(empty);
@@ -6669,12 +6859,6 @@
         activeButton.disabled = selected.is_active || state.loading;
         activeButton.addEventListener("click", () => setActiveProfile(windowId));
         actions.appendChild(activeButton);
-
-        const saveButton = createNode("button", "wizard-button", "Save now");
-        saveButton.type = "button";
-        saveButton.disabled = !profileDraftIsDirty(state) || state.loading;
-        saveButton.addEventListener("click", () => flushProfileSave(windowId));
-        actions.appendChild(saveButton);
 
         const deleteButton = createNode("button", "wizard-button", "Delete");
         deleteButton.type = "button";
@@ -6712,134 +6896,128 @@
         metadata.appendChild(descriptionField);
         editor.appendChild(metadata);
 
-        const envSection = createNode("div", "profile-section");
-        const envHeader = createNode("div", "profile-row-header");
-        envHeader.appendChild(createNode("div", "mock-label", "Profile variables"));
-        const addEnvButton = createNode("button", "wizard-button", "Add variable");
-        addEnvButton.type = "button";
-        addEnvButton.addEventListener("click", () => {
-          state.draft.envVars.push({ key: "", value: "" });
-          renderProfile(windowId, true);
-        });
-        envHeader.appendChild(addEnvButton);
-        envSection.appendChild(envHeader);
-        const envTable = createNode("div", "profile-table");
-        if (state.draft.envVars.length === 0) {
-          envTable.appendChild(
-            createNode("div", "profile-empty-copy", "No env overrides for this profile."),
-          );
+        const envSection = createNode("div", "profile-section profile-env-section");
+        envSection.appendChild(createNode("div", "mock-label", "Environment Variables"));
+        const envGrid = createNode("div", "profile-env-grid");
+        const headerRow = createNode("div", "profile-env-grid-row profile-env-grid-head");
+        for (const label of ["Key", "OS value", "Mode", "Profile value", "Result"]) {
+          headerRow.appendChild(createNode("div", "", label));
         }
-        state.draft.envVars.forEach((entry, index) => {
-          const row = createNode("div", "profile-table-row");
-          const keyInput = document.createElement("input");
-          keyInput.type = "text";
-          keyInput.placeholder = "KEY";
-          // SPEC-2356 — env var rows have no surrounding <label>; use
-          // aria-label so screen readers announce purpose. The row index
-          // disambiguates rows within the same list.
-          keyInput.setAttribute("aria-label", `Env var key, row ${index + 1}`);
-          keyInput.value = entry.key;
-          keyInput.addEventListener("input", () => {
-            state.draft.envVars[index].key = keyInput.value;
+        envGrid.appendChild(headerRow);
+
+        const rows = profileEnvironmentRows(snapshot, state.draft);
+        rows.forEach((envRow, index) => {
+          const row = createNode(
+            "div",
+            `profile-env-grid-row profile-env-row is-${envRow.mode}`,
+          );
+
+          if (envRow.kind === "os") {
+            row.appendChild(createNode("div", "profile-env-key", envRow.key));
+          } else {
+            const keyInput = document.createElement("input");
+            keyInput.type = "text";
+            keyInput.placeholder = "KEY";
+            keyInput.value = envRow.key;
+            keyInput.setAttribute("aria-label", `Environment variable key, row ${index + 1}`);
+            keyInput.addEventListener("input", () => {
+              if (envRow.kind === "pending") {
+                state.draft.envVars[envRow.draftIndex].key = keyInput.value;
+                envRow.key = keyInput.value;
+              } else if (envRow.mode === "disabled") {
+                const previous = normalizeProfileEnvKey(envRow.key);
+                const target = (state.draft.disabledEnv || []).findIndex(
+                  (entry) => normalizeProfileEnvKey(entry) === previous,
+                );
+                if (target >= 0) {
+                  state.draft.disabledEnv[target] = keyInput.value;
+                  envRow.key = keyInput.value;
+                }
+              } else {
+                const previous = normalizeProfileEnvKey(envRow.key);
+                const target = (state.draft.envVars || []).find(
+                  (entry) => normalizeProfileEnvKey(entry.key) === previous,
+                );
+                if (target) {
+                  target.key = keyInput.value;
+                  envRow.key = keyInput.value;
+                }
+              }
+              scheduleProfileSave(windowId);
+            });
+            keyInput.addEventListener("blur", () => {
+              renderProfile(windowId, true);
+              flushProfileSave(windowId);
+            });
+            row.appendChild(keyInput);
+          }
+
+          row.appendChild(
+            createNode("div", "profile-env-os-value", envRow.osValue || "-"),
+          );
+
+          const modeSelect = document.createElement("select");
+          modeSelect.setAttribute("aria-label", `Environment variable mode, row ${index + 1}`);
+          for (const option of [
+            ["use_os", "Use OS"],
+            ["override", "Override"],
+            ["disabled", "Disabled"],
+          ]) {
+            const element = document.createElement("option");
+            element.value = option[0];
+            element.textContent = option[1];
+            modeSelect.appendChild(element);
+          }
+          modeSelect.value = envRow.mode;
+          modeSelect.addEventListener("change", () => {
+            const rowKey =
+              envRow.kind === "pending"
+                ? state.draft.envVars[envRow.draftIndex]?.key
+                : envRow.key;
+            if (envRow.kind === "pending" && !normalizeProfileEnvKey(rowKey)) {
+              if (modeSelect.value === "use_os") {
+                state.draft.envVars.splice(envRow.draftIndex, 1);
+              }
+            } else {
+              setProfileRowMode(state.draft, rowKey, modeSelect.value);
+            }
+            renderProfile(windowId, true);
             scheduleProfileSave(windowId);
           });
-          keyInput.addEventListener("blur", () => flushProfileSave(windowId));
-          row.appendChild(keyInput);
+          row.appendChild(modeSelect);
 
           const valueInput = document.createElement("input");
           valueInput.type = "text";
           valueInput.placeholder = "Value";
-          valueInput.setAttribute("aria-label", `Env var value, row ${index + 1}`);
-          valueInput.value = entry.value;
+          valueInput.value = envRow.profileValue;
+          valueInput.setAttribute("aria-label", `Profile value, row ${index + 1}`);
+          const resultCell = createNode("div", "profile-env-result", envRow.result);
           valueInput.addEventListener("input", () => {
-            state.draft.envVars[index].value = valueInput.value;
+            if (envRow.kind === "pending") {
+              state.draft.envVars[envRow.draftIndex].value = valueInput.value;
+              resultCell.textContent = valueInput.value;
+            } else {
+              setProfileEnvOverride(state.draft, envRow.key, valueInput.value);
+              modeSelect.value = "override";
+              resultCell.textContent = valueInput.value;
+            }
             scheduleProfileSave(windowId);
           });
           valueInput.addEventListener("blur", () => flushProfileSave(windowId));
           row.appendChild(valueInput);
-
-          const removeButton = createNode("button", "icon-button", "×");
-          removeButton.type = "button";
-          removeButton.setAttribute("aria-label", "Delete env var");
-          removeButton.addEventListener("click", () => {
-            state.draft.envVars.splice(index, 1);
-            renderProfile(windowId, true);
-            scheduleProfileSave(windowId);
-          });
-          row.appendChild(removeButton);
-          envTable.appendChild(row);
+          row.appendChild(resultCell);
+          envGrid.appendChild(row);
         });
-        envSection.appendChild(envTable);
-        editor.appendChild(envSection);
 
-        const disabledSection = createNode("div", "profile-section");
-        const disabledHeader = createNode("div", "profile-row-header");
-        disabledHeader.appendChild(createNode("div", "mock-label", "Disabled OS variables"));
-        const addDisabledButton = createNode("button", "wizard-button", "Add disabled key");
-        addDisabledButton.type = "button";
-        addDisabledButton.addEventListener("click", () => {
-          state.draft.disabledEnv.push("");
+        const addRow = createNode("button", "profile-env-add-row", "+ Add variable");
+        addRow.type = "button";
+        addRow.addEventListener("click", () => {
+          state.draft.envVars.push({ key: "", value: "" });
           renderProfile(windowId, true);
         });
-        disabledHeader.appendChild(addDisabledButton);
-        disabledSection.appendChild(disabledHeader);
-        const disabledTable = createNode("div", "profile-table");
-        if (state.draft.disabledEnv.length === 0) {
-          disabledTable.appendChild(
-            createNode("div", "profile-empty-copy", "No disabled OS variables for this profile."),
-          );
-        }
-        state.draft.disabledEnv.forEach((entry, index) => {
-          const row = createNode("div", "profile-table-row profile-disabled-row");
-          const keyInput = document.createElement("input");
-          keyInput.type = "text";
-          keyInput.placeholder = "SECRET_KEY";
-          keyInput.setAttribute("aria-label", `Disabled env key, row ${index + 1}`);
-          keyInput.value = entry;
-          keyInput.addEventListener("input", () => {
-            state.draft.disabledEnv[index] = keyInput.value;
-            scheduleProfileSave(windowId);
-          });
-          keyInput.addEventListener("blur", () => flushProfileSave(windowId));
-          row.appendChild(keyInput);
-
-          const removeButton = createNode("button", "icon-button", "×");
-          removeButton.type = "button";
-          removeButton.setAttribute("aria-label", "Delete disabled env key");
-          removeButton.addEventListener("click", () => {
-            state.draft.disabledEnv.splice(index, 1);
-            renderProfile(windowId, true);
-            scheduleProfileSave(windowId);
-          });
-          row.appendChild(removeButton);
-          disabledTable.appendChild(row);
-        });
-        disabledSection.appendChild(disabledTable);
-        editor.appendChild(disabledSection);
-
-        const previewSection = createNode("div", "profile-section");
-        previewSection.appendChild(createNode("div", "mock-label", "Merged preview"));
-        previewSection.appendChild(
-          createNode(
-            "div",
-            "profile-empty-copy",
-            "The backend computes this preview from the current OS environment, disabled keys, and profile overrides.",
-          ),
-        );
-        const preview = createNode("div", "profile-preview");
-        if ((snapshot.merged_preview || []).length === 0) {
-          preview.appendChild(
-            createNode("div", "profile-empty-copy", "No merged entries to preview yet."),
-          );
-        }
-        for (const entry of snapshot.merged_preview || []) {
-          const row = createNode("div", "profile-preview-row");
-          row.appendChild(createNode("div", "profile-preview-key", entry.key));
-          row.appendChild(createNode("div", "profile-preview-value", entry.value));
-          preview.appendChild(row);
-        }
-        previewSection.appendChild(preview);
-        editor.appendChild(previewSection);
+        envGrid.appendChild(addRow);
+        envSection.appendChild(envGrid);
+        editor.appendChild(envSection);
 
         updateProfileStatus(windowId);
       }

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -5516,6 +5516,7 @@
             selectedProfile: null,
             draft: null,
             saveTimer: null,
+            saveInFlight: false,
           });
         }
         return profileStateMap.get(windowId);
@@ -6623,6 +6624,17 @@
         }
       }
 
+      function profileHasEditableFocus(windowId) {
+        const element = windowMap.get(windowId);
+        const active = document.activeElement;
+        return Boolean(
+          element &&
+            active &&
+            element.contains(active) &&
+            active.matches?.("input, textarea, select"),
+        );
+      }
+
       function flushProfileSave(windowId) {
         const state = ensureProfileState(windowId);
         clearProfileSaveTimer(state);
@@ -6638,6 +6650,7 @@
         }
         state.loading = true;
         state.saving = true;
+        state.saveInFlight = true;
         state.error = "";
         updateProfileStatus(windowId);
         const payload = profileDraftPayload(state.draft);
@@ -6900,7 +6913,7 @@
         envSection.appendChild(createNode("div", "mock-label", "Environment Variables"));
         const envGrid = createNode("div", "profile-env-grid");
         const headerRow = createNode("div", "profile-env-grid-row profile-env-grid-head");
-        for (const label of ["Key", "OS value", "Mode", "Profile value", "Result"]) {
+        for (const label of ["Key", "OS", "Mode", "Profile", "Result"]) {
           headerRow.appendChild(createNode("div", "", label));
         }
         envGrid.appendChild(headerRow);
@@ -6913,7 +6926,9 @@
           );
 
           if (envRow.kind === "os") {
-            row.appendChild(createNode("div", "profile-env-key", envRow.key));
+            const keyCell = createNode("div", "profile-env-key", envRow.key);
+            keyCell.title = envRow.key;
+            row.appendChild(keyCell);
           } else {
             const keyInput = document.createElement("input");
             keyInput.type = "text";
@@ -6946,23 +6961,29 @@
               scheduleProfileSave(windowId);
             });
             keyInput.addEventListener("blur", () => {
-              renderProfile(windowId, true);
               flushProfileSave(windowId);
             });
             row.appendChild(keyInput);
           }
 
-          row.appendChild(
-            createNode("div", "profile-env-os-value", envRow.osValue || "-"),
-          );
+          const osCell = createNode("div", "profile-env-os-value", envRow.osValue || "-");
+          osCell.title = envRow.osValue || "";
+          row.appendChild(osCell);
 
           const modeSelect = document.createElement("select");
           modeSelect.setAttribute("aria-label", `Environment variable mode, row ${index + 1}`);
-          for (const option of [
-            ["use_os", "Use OS"],
-            ["override", "Override"],
-            ["disabled", "Disabled"],
-          ]) {
+          const modeOptions =
+            envRow.kind === "os"
+              ? [
+                  ["use_os", "Use OS"],
+                  ["override", "Override"],
+                  ["disabled", "Disabled"],
+                ]
+              : [
+                  ["override", "Enabled"],
+                  ["disabled", "Disabled"],
+                ];
+          for (const option of modeOptions) {
             const element = document.createElement("option");
             element.value = option[0];
             element.textContent = option[1];
@@ -6988,10 +7009,11 @@
 
           const valueInput = document.createElement("input");
           valueInput.type = "text";
-          valueInput.placeholder = "Value";
+          valueInput.placeholder = "Profile";
           valueInput.value = envRow.profileValue;
           valueInput.setAttribute("aria-label", `Profile value, row ${index + 1}`);
           const resultCell = createNode("div", "profile-env-result", envRow.result);
+          resultCell.title = envRow.result;
           valueInput.addEventListener("input", () => {
             if (envRow.kind === "pending") {
               state.draft.envVars[envRow.draftIndex].value = valueInput.value;
@@ -11546,6 +11568,8 @@
         setActiveProfile,
         flushProfileSave,
         deleteProfile,
+        updateProfileStatus,
+        hasEditableFocus: profileHasEditableFocus,
         syncDraftFromSelection: syncProfileDraftFromSelection,
       });
 
@@ -11924,11 +11948,24 @@
           }
           case "profile_snapshot": {
             const state = frontendUnits.profileSurface.ensureProfileState(event.id);
+            const previousProfile = state.selectedProfile;
+            const wasSaveInFlight = state.saveInFlight;
             state.snapshot = event.snapshot || null;
             state.loading = false;
             state.saving = Boolean(state.saveTimer);
+            state.saveInFlight = false;
             state.error = "";
             state.selectedProfile = event.snapshot?.selected_profile || null;
+            const selectedProfileUnchanged =
+              !previousProfile || previousProfile === state.selectedProfile;
+            if (
+              wasSaveInFlight &&
+              selectedProfileUnchanged &&
+              frontendUnits.profileSurface.hasEditableFocus(event.id)
+            ) {
+              frontendUnits.profileSurface.updateProfileStatus(event.id);
+              break;
+            }
             frontendUnits.profileSurface.renderProfile(event.id);
             break;
           }
@@ -12237,6 +12274,7 @@
             const state = frontendUnits.profileSurface.ensureProfileState(event.id);
             state.loading = false;
             state.saving = Boolean(state.saveTimer);
+            state.saveInFlight = false;
             state.error = event.message;
             frontendUnits.profileSurface.renderProfile(event.id, true);
             break;

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -451,7 +451,7 @@
               </button>
               <button class="preset-button" data-preset="profile">
                 <strong>Profile</strong>
-                <span>Manage env profiles and merged preview</span>
+                <span>Manage env profiles and variables</span>
               </button>
               <button class="preset-button" data-preset="logs">
                 <strong>Logs</strong>

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -2181,6 +2181,8 @@ body {
 
 .profile-field input,
 .profile-table-row input,
+.profile-env-grid input,
+.profile-env-grid select,
 .profile-textarea {
   width: 100%;
   min-width: 0;
@@ -2194,6 +2196,8 @@ body {
 }
 .profile-field input:focus,
 .profile-table-row input:focus,
+.profile-env-grid input:focus,
+.profile-env-grid select:focus,
 .profile-textarea:focus {
   outline: none;
   border-color: var(--color-focus-ring);
@@ -2225,6 +2229,95 @@ body {
   display: grid;
   gap: 10px;
   padding: 16px 12px;
+}
+
+.profile-env-section {
+  min-width: 0;
+}
+
+.profile-env-grid {
+  display: grid;
+  gap: 6px;
+  overflow: auto;
+}
+
+.profile-env-grid-row {
+  display: grid;
+  grid-template-columns:
+    minmax(140px, 0.95fr)
+    minmax(160px, 1fr)
+    minmax(118px, 0.6fr)
+    minmax(160px, 1fr)
+    minmax(160px, 1fr);
+  gap: 8px;
+  align-items: center;
+  min-width: 820px;
+}
+
+.profile-env-grid-head {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  padding: 4px 0;
+  background: var(--color-surface-elevated);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.profile-env-row {
+  padding: 6px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+.profile-env-row.is-disabled {
+  background: color-mix(in oklab, var(--color-state-blocked) 8%, var(--color-surface));
+}
+
+.profile-env-key,
+.profile-env-os-value,
+.profile-env-result {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  letter-spacing: 0;
+}
+
+.profile-env-key {
+  font-weight: 600;
+  color: var(--color-text-strong);
+}
+
+.profile-env-os-value,
+.profile-env-result {
+  color: var(--color-text-muted);
+}
+
+.profile-env-add-row {
+  display: block;
+  width: 100%;
+  min-width: 820px;
+  padding: 10px 12px;
+  border: 1px dashed var(--color-border-strong);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklab, var(--color-state-active) 6%, transparent);
+  color: var(--color-state-active);
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  font-weight: 600;
+  letter-spacing: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.profile-env-add-row:hover {
+  background: color-mix(in oklab, var(--color-state-active) 12%, transparent);
 }
 
 .profile-preview {

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -1073,6 +1073,7 @@ body {
 .logs-root,
 .knowledge-root,
 .index-search-root,
+.profile-root,
 .workspace-kanban-root,
 .workspace-overview-root,
 .mock-root {

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -2045,7 +2045,7 @@ body {
   flex: 1;
   min-height: 0;
   display: grid;
-  grid-template-columns: minmax(220px, 0.72fr) minmax(0, 1.28fr);
+  grid-template-columns: minmax(160px, 0.48fr) minmax(0, 1.52fr);
 }
 
 .profile-list-pane,
@@ -2061,10 +2061,11 @@ body {
 }
 
 .profile-editor-pane {
-  overflow: auto;
+  overflow: hidden;
   padding: 12px;
   display: grid;
-  align-content: start;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  align-content: stretch;
   gap: 12px;
 }
 
@@ -2203,6 +2204,12 @@ body {
   border-color: var(--color-focus-ring);
 }
 
+.profile-env-grid input,
+.profile-env-grid select {
+  padding: 6px 8px;
+  font-size: var(--type-xs);
+}
+
 .profile-textarea {
   min-height: 88px;
   resize: vertical;
@@ -2233,25 +2240,31 @@ body {
 
 .profile-env-section {
   min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  grid-template-rows: auto minmax(0, 1fr);
 }
 
 .profile-env-grid {
   display: grid;
   gap: 6px;
+  min-width: 0;
+  min-height: 0;
   overflow: auto;
+  align-content: start;
 }
 
 .profile-env-grid-row {
   display: grid;
   grid-template-columns:
-    minmax(140px, 0.95fr)
-    minmax(160px, 1fr)
-    minmax(118px, 0.6fr)
-    minmax(160px, 1fr)
-    minmax(160px, 1fr);
-  gap: 8px;
+    minmax(84px, 0.9fr)
+    minmax(72px, 0.75fr)
+    minmax(84px, 0.65fr)
+    minmax(100px, 1fr)
+    minmax(72px, 0.75fr);
+  gap: 6px;
   align-items: center;
-  min-width: 820px;
+  min-width: 0;
 }
 
 .profile-env-grid-head {
@@ -2266,10 +2279,13 @@ body {
   font-weight: 600;
   letter-spacing: 0;
   text-transform: uppercase;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .profile-env-row {
-  padding: 6px;
+  padding: 5px;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   background: var(--color-surface);
@@ -2283,7 +2299,10 @@ body {
 .profile-env-os-value,
 .profile-env-result {
   min-width: 0;
-  overflow-wrap: anywhere;
+  overflow: hidden;
+  overflow-wrap: normal;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-family: var(--font-mono);
   font-size: var(--type-xs);
   letter-spacing: 0;
@@ -2302,7 +2321,7 @@ body {
 .profile-env-add-row {
   display: block;
   width: 100%;
-  min-width: 820px;
+  min-width: 0;
   padding: 10px 12px;
   border: 1px dashed var(--color-border-strong);
   border-radius: var(--radius-md);

--- a/crates/gwt/web/workspace-kanban-surface.js
+++ b/crates/gwt/web/workspace-kanban-surface.js
@@ -663,7 +663,10 @@ export function createWorkspaceKanbanSurface({
 
   function renderWindows() {
     for (const windowData of activeWorkspace()?.windows || []) {
-      if (workspaceWindowById(windowData.id)?.preset !== "work") continue;
+      const preset = workspaceWindowById(windowData.id)?.preset;
+      if (preset !== "work" && preset !== "workspace" && preset !== "branches") {
+        continue;
+      }
       renderWorkspaceOverviewWindow(windowData.id);
     }
   }

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6228,3 +6228,10 @@ Type: failure-pattern
 Context: Visual E2E failures after Work unification: Quiet Work rows stayed empty for windows with preset=workspace because workspace-kanban-surface.renderWindows only refreshed preset=work. Branch Cleanup E2E also still targeted the old standalone branches surface while branches now lives under the Work surface tab.
 Learning: When a surface is renamed or consolidated, async rerender paths and E2E selectors must use the same preset alias set as the mount path. It is easy to update initial mount logic while leaving event-driven refresh paths on the new canonical preset only.
 Future Action: For future surface renames, add unit tests for renderWindows/event refresh using legacy preset aliases, then update Playwright fixtures/selectors to navigate through the canonical visible UI rather than stale standalone surface classes.
+
+## 2026-05-28 — Profile visual checks require screenshot inspection
+
+Type: lesson
+Context: Profile env grid UI was changed and headed E2E passed, but the user reported Profile Metadata was not visible. Screenshot inspection showed the metadata section was collapsed to 0px because .profile-editor-pane used a 2-row grid while renderProfile appends actions, metadata, and env sections.
+Learning: Headed browser execution alone is not visual verification. For layout changes, inspect screenshots or pixel/DOM geometry that proves the intended visible regions are actually visible and non-overlapping.
+Future Action: Before reporting UI layout work as visually verified, capture and open screenshots for the relevant state and add assertions for visible geometry/non-overlap, not only DOM presence.

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6214,3 +6214,10 @@ Type: failure-pattern
 Context: Profile window scroll bug (#2916): .profile-root had flex/min-height styles but was not included in the shared .window-body root group that applies position:absolute and inset:0.
 Learning: Child panes with overflow:auto only scroll when their root receives the window-body height constraint. A flex/grid pane can look correct in CSS but still expand past the window when the root is not anchored.
 Future Action: When adding or fixing panel surfaces, verify the surface root participates in the shared root containment rule and add an embedded-web contract test for scroll boundaries.
+
+## 2026-05-28 — Profile grid autosave rows need stable editable keys
+
+Type: lesson
+Context: SPEC-2015 Profile Environment Variables grid implemented row-level autosave and re-rendered rows from normalized profile payload.
+Learning: Editable rows that are keyed by the value being edited can lose subsequent key changes after the first autosave/re-render unless the row-local key mirror and backing draft entry are updated together. Pending added rows should also update visible Result cells immediately while debounce save is pending.
+Future Action: When adding autosaved table rows, test multi-character key edits, pending row value edits, backend roundtrip re-render, and duplicate-key collapse before declaring UI behavior complete.

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6207,3 +6207,10 @@ Type: lesson
 Context: Resume Picker returned agents from ALL branches instead of the selected Work item. Unit tests passed because they only tested presence/absence of agents, not cross-branch leakage. The bug was only caught when the user asked for a headed browser check.
 Learning: Unit tests for list/picker UIs must include a negative case: create agents for TWO different workspace_ids and assert that filtering by one excludes the other. Headed E2E is essential for verifying picker scope — automated tests alone cannot catch cross-scope leakage when only one scope is populated in the test fixture.
 Future Action: For any picker/list that accepts a scope filter (workspace_id, branch, etc.), always write a multi-scope unit test that asserts exclusion. Run headed E2E before declaring Resume/Launch picker changes complete.
+
+## 2026-05-28 — Panel roots must be anchored before pane overflow can work
+
+Type: failure-pattern
+Context: Profile window scroll bug (#2916): .profile-root had flex/min-height styles but was not included in the shared .window-body root group that applies position:absolute and inset:0.
+Learning: Child panes with overflow:auto only scroll when their root receives the window-body height constraint. A flex/grid pane can look correct in CSS but still expand past the window when the root is not anchored.
+Future Action: When adding or fixing panel surfaces, verify the surface root participates in the shared root containment rule and add an embedded-web contract test for scroll boundaries.

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6221,3 +6221,10 @@ Type: lesson
 Context: SPEC-2015 Profile Environment Variables grid implemented row-level autosave and re-rendered rows from normalized profile payload.
 Learning: Editable rows that are keyed by the value being edited can lose subsequent key changes after the first autosave/re-render unless the row-local key mirror and backing draft entry are updated together. Pending added rows should also update visible Result cells immediately while debounce save is pending.
 Future Action: When adding autosaved table rows, test multi-character key edits, pending row value edits, backend roundtrip re-render, and duplicate-key collapse before declaring UI behavior complete.
+
+## 2026-05-28 — Work surface rerender must honor legacy preset aliases
+
+Type: failure-pattern
+Context: Visual E2E failures after Work unification: Quiet Work rows stayed empty for windows with preset=workspace because workspace-kanban-surface.renderWindows only refreshed preset=work. Branch Cleanup E2E also still targeted the old standalone branches surface while branches now lives under the Work surface tab.
+Learning: When a surface is renamed or consolidated, async rerender paths and E2E selectors must use the same preset alias set as the mount path. It is easy to update initial mount logic while leaving event-driven refresh paths on the new canonical preset only.
+Future Action: For future surface renames, add unit tests for renderWindows/event refresh using legacy preset aliases, then update Playwright fixtures/selectors to navigate through the canonical visible UI rather than stale standalone surface classes.


### PR DESCRIPTION
## Summary

- Reworked Profile environment editing into a single row-based grid so OS variables, overrides, disabled entries, and added variables are handled in one place.
- Restored Profile scrolling and layout behavior so metadata stays visible and only the environment list scrolls inside the editor.
- Fixed legacy work-surface preset rerenders to keep restored windows and tests aligned after the UI surface changes.

## Changes

- `crates/gwt/web/app.js`: renders Profile env rows from OS snapshot plus profile overrides, applies realtime autosave, preserves focus during save snapshots, and hides Use OS for user-added variables.
- `crates/gwt/web/styles/app.css`: anchors the Profile body, keeps metadata fixed above the env grid, and tightens the single-line grid columns for narrower windows.
- `crates/gwt/src/profile_dispatch.rs` / `crates/gwt/src/protocol.rs`: include OS environment entries in Profile snapshots without changing the persisted profile schema.
- `crates/gwt/src/embedded_web.rs` / `crates/gwt/web/index.html`: update embedded web contracts for the Profile surface and asset bundle.
- `crates/gwt/playwright/tests/profile-env-grid.spec.ts`: covers scrolling, row modes, autosave, focus preservation, and compact grid behavior in headed/headless browser checks.
- `crates/gwt/web/workspace-kanban-surface.js` and related frontend tests: refresh legacy preset rerenders after restored work surface loading.
- `tasks/memory.md`: records Profile scroll/grid visual verification lessons.

## Testing

- [x] `node --check crates/gwt/web/app.js && git diff --check && cargo fmt --check && bunx commitlint --from origin/develop --to HEAD` — passed.
- [x] `bash scripts/run-frontend-unit-tests.sh` — passed, 584 tests.
- [x] `bash scripts/run-visual-tests.sh --headed --project=chromium-dark crates/gwt/playwright/tests/profile-env-grid.spec.ts` — passed, 3 tests.
- [x] `bash scripts/run-visual-tests.sh --project=chromium-dark --project=chromium-light crates/gwt/playwright/tests/profile-env-grid.spec.ts` — passed, 6 tests.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] User visual verification — confirmed in the gwt session after the metadata visibility and grid-only scrolling fix.

## PR Readiness

- State: Ready for review
- Releaseable slice: Yes; Profile scroll and environment-grid UX are implemented with browser, frontend, Rust, and clippy coverage.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- Closes #2916

## Related Issues / Links

- #2015

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation not required; behavior is covered by SPEC #2015 and tests
- [x] Migration/backfill not required; persisted profile schema is unchanged
- [x] CHANGELOG impact considered; no breaking change

## Context

- User reported that the Profile surface could not scroll and then requested a Profile environment-variable editor that treats OS variables as the primary list, supports row-level Override/Disabled controls, embeds + Add variable at the bottom, and autosaves without a Save Now button.

## Risk / Impact

- **Affected areas**: Profile window rendering, Profile WebSocket snapshot payloads, and restored workspace surface rerenders.
- **Rollback plan**: Revert this PR; persisted profile schema is unchanged.

## Screenshots

| Before | After |
|--------|-------|
| Profile editor could clip lower sections and later hid metadata while the full right pane scrolled. | User visual verification confirmed Profile metadata remains visible while only the Environment Variables grid scrolls. |
