### PR TITLE
fix(gui): sync terminal grid on focus reflow

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -1831,7 +1831,7 @@ mod tests {
         // shorthand `shouldFocus,` or an explicit `shouldFocus: <expr>`
         // form, but no longer pins the value to a literal `true`.
         let activation_helper = regex::Regex::new(
-            r#"(?s)function scheduleTerminalFocusActivation\(\s*windowId,\s*\{[\s\S]*?shouldPersistGeometry\s*=\s*true[\s\S]*?\}\s*=\s*\{\},\s*\)\s*\{.*?requestAnimationFrame\(\(\) => \{.*?const activeRuntime = terminalMap\.get\(windowId\);.*?runTerminalActivationSequence\(\{[\s\S]*?runtime: activeRuntime,[\s\S]*?shouldFocus(?:\s*[,:])[\s\S]*?shouldPersistGeometry(?:\s*[,:])[\s\S]*?sendGeometry,[\s\S]*?\}\);[\s\S]*?scheduleTerminalViewportRefresh\(windowId\);"#,
+            r#"(?s)function scheduleTerminalFocusActivation\(\s*windowId,\s*\{[\s\S]*?shouldPersistGeometry\s*=\s*true[\s\S]*?\}\s*=\s*\{\},\s*\)\s*\{.*?requestAnimationFrame\(\(\) => \{.*?const activeRuntime = terminalMap\.get\(windowId\);.*?runTerminalActivationSequence\(\{[\s\S]*?runtime: activeRuntime,[\s\S]*?shouldFocus(?:\s*[,:])[\s\S]*?shouldPersistGeometry(?:\s*[,:])[\s\S]*?syncGeometryOnGridChange:\s*true,[\s\S]*?sendGeometry,[\s\S]*?\}\);[\s\S]*?scheduleTerminalViewportRefresh\(windowId\);"#,
         )
         .expect("valid regex");
 
@@ -1842,7 +1842,7 @@ mod tests {
         );
         assert!(
             activation_helper.is_match(js),
-            "expected programmatic terminal activation to refit, refresh, and pass a computed shouldFocus to xterm after render",
+            "expected programmatic terminal activation to refit, refresh, pass computed shouldFocus, and opt into grid-change geometry sync after render",
         );
         assert!(
             render_activation.is_match(js),

--- a/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
@@ -242,6 +242,109 @@ test("runTerminalActivationSequence honours shouldFocus / shouldPersistGeometry 
   assert.equal(result.ran, true);
 });
 
+test("runTerminalActivationSequence syncs geometry when focus reflow changes the xterm grid (T-266)", () => {
+  const callOrder = [];
+  const runtime = {
+    terminal: {
+      cols: 80,
+      rows: 24,
+      element: { parentElement: null },
+      refresh: () => callOrder.push("refresh"),
+      focus: () => callOrder.push("focus"),
+    },
+    fitAddon: {
+      proposeDimensions: () => ({ cols: 112, rows: 28 }),
+      fit: () => {
+        callOrder.push("fit");
+        runtime.terminal.cols = 112;
+        runtime.terminal.rows = 28;
+      },
+    },
+  };
+  let geometry = null;
+
+  const result = runTerminalActivationSequence({
+    runtime,
+    windowId: "win-focus-grid-changed",
+    shouldFocus: false,
+    shouldPersistGeometry: false,
+    syncGeometryOnGridChange: true,
+    sendGeometry: (id, cols, rows) => {
+      callOrder.push("sendGeometry");
+      geometry = { id, cols, rows };
+    },
+  });
+
+  assert.deepEqual(
+    callOrder,
+    ["refresh", "fit", "sendGeometry"],
+    "focus reflow must sync backend geometry exactly when fit changes cols/rows",
+  );
+  assert.deepEqual(geometry, { id: "win-focus-grid-changed", cols: 112, rows: 28 });
+  assert.deepEqual(result, { ran: true, cols: 112, rows: 28 });
+});
+
+test("runTerminalActivationSequence does not sync unchanged focus grids (T-266)", () => {
+  const callOrder = [];
+  const runtime = {
+    terminal: {
+      cols: 100,
+      rows: 30,
+      element: { parentElement: null },
+      refresh: () => callOrder.push("refresh"),
+      focus: () => callOrder.push("focus"),
+    },
+    fitAddon: {
+      proposeDimensions: () => ({ cols: 100, rows: 30 }),
+      fit: () => callOrder.push("fit"),
+    },
+  };
+
+  const result = runTerminalActivationSequence({
+    runtime,
+    windowId: "win-focus-grid-unchanged",
+    shouldFocus: false,
+    shouldPersistGeometry: false,
+    syncGeometryOnGridChange: true,
+    sendGeometry: () => callOrder.push("sendGeometry"),
+  });
+
+  assert.deepEqual(callOrder, ["refresh", "fit"]);
+  assert.deepEqual(result, { ran: true, cols: 100, rows: 30 });
+});
+
+test("runTerminalActivationSequence keeps viewport-only fits off grid-change sync (T-266)", () => {
+  const callOrder = [];
+  const runtime = {
+    terminal: {
+      cols: 80,
+      rows: 24,
+      element: { parentElement: null },
+      refresh: () => callOrder.push("refresh"),
+      focus: () => callOrder.push("focus"),
+    },
+    fitAddon: {
+      proposeDimensions: () => ({ cols: 120, rows: 32 }),
+      fit: () => {
+        callOrder.push("fit");
+        runtime.terminal.cols = 120;
+        runtime.terminal.rows = 32;
+      },
+    },
+  };
+
+  const result = runTerminalActivationSequence({
+    runtime,
+    windowId: "win-viewport-only",
+    shouldFocus: false,
+    shouldPersistGeometry: false,
+    sendGeometry: () => callOrder.push("sendGeometry"),
+  });
+
+  assert.deepEqual(callOrder, ["refresh", "fit"]);
+  assert.deepEqual(result, { ran: true, cols: 120, rows: 32 });
+});
+
 test("runTerminalActivationSequence waits for the terminal host layout box before fitting (#2839)", () => {
   const callOrder = [];
   const runtime = {
@@ -521,7 +624,12 @@ test("app.js wires the reflow controller for resize, transition, and predicate",
   assert.match(
     appSource,
     /scheduleTerminalFocusActivation\(topmostId,\s*\{\s*shouldPersistGeometry:\s*false,?\s*\}\)/,
-    "topmost focus activation must not persist geometry on every workspace render",
+    "topmost focus activation must not persist geometry unconditionally on every workspace render",
+  );
+  assert.match(
+    appSource,
+    /function scheduleTerminalFocusActivation\([\s\S]*?runTerminalActivationSequence\(\{[\s\S]*?shouldPersistGeometry,[\s\S]*?syncGeometryOnGridChange:\s*true,[\s\S]*?sendGeometry,[\s\S]*?\}\);/,
+    "focus activation must opt into grid-change geometry sync while keeping caller-owned persistence",
   );
 
   // Issue #2832 — SPEC-2008 Phase 26.A regression fix: completeInitialFitHandshake

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -2991,6 +2991,7 @@
             windowId,
             shouldFocus,
             shouldPersistGeometry,
+            syncGeometryOnGridChange: true,
             sendGeometry,
           });
           // SPEC-2008 Phase 26.A / FR-057: if the runtime was created in

--- a/crates/gwt/web/terminal-viewport-reflow.js
+++ b/crates/gwt/web/terminal-viewport-reflow.js
@@ -208,6 +208,7 @@ export function runTerminalActivationSequence({
   windowId,
   shouldFocus = true,
   shouldPersistGeometry = true,
+  syncGeometryOnGridChange = false,
   sendGeometry,
 }) {
   if (!runtime || !runtime.terminal || !runtime.fitAddon) {
@@ -228,11 +229,17 @@ export function runTerminalActivationSequence({
     return { ran: false, cols: currentGrid.cols, rows: currentGrid.rows };
   }
   fitAddon.fit();
-  if (shouldPersistGeometry && typeof sendGeometry === "function") {
-    sendGeometry(windowId, terminal.cols, terminal.rows);
+  const fittedGrid = currentTerminalGrid(terminal);
+  const gridChanged =
+    fittedGrid.cols !== currentGrid.cols || fittedGrid.rows !== currentGrid.rows;
+  if (
+    (shouldPersistGeometry || (syncGeometryOnGridChange && gridChanged)) &&
+    typeof sendGeometry === "function"
+  ) {
+    sendGeometry(windowId, fittedGrid.cols, fittedGrid.rows);
   }
   if (shouldFocus && typeof terminal.focus === "function") {
     terminal.focus();
   }
-  return { ran: true, cols: terminal.cols, rows: terminal.rows };
+  return { ran: true, cols: fittedGrid.cols, rows: fittedGrid.rows };
 }


### PR DESCRIPTION
## Summary
- Sync the backend terminal grid when focus activation causes xterm fit dimensions to change.
- Keep viewport-only activation from persisting geometry unless the caller explicitly opts in.
- Add frontend and embedded-web contract coverage for the focus reflow geometry path.

## Related Issues / Links
- Related: #2008
- Closing Issues: None

## PR Readiness
- State: Ready for review
- Releaseable slice: Yes. The change fixes focus-driven terminal grid drift without protocol changes.
- Known blockers: None
- Remaining acceptance: None
- User Verification Result: confirmed on 2026-05-28 via `http://127.0.0.1:64466/`.

## Testing
- PASS: `bash scripts/run-node-tests-with-linkedom.sh crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs` (17 tests)
- PASS: `bash scripts/check-frontend-bundle.sh`
- PASS: `cargo test -p gwt embedded_web_programmatic_terminal_focus_reactivates_xterm_after_render --all-features`
- PASS: `bash scripts/run-visual-tests.sh --project=chromium-dark crates/gwt/playwright/tests/agent-resize.spec.ts` (1 test)
- PASS: `bash scripts/run-frontend-unit-tests.sh` (587 tests)
- PASS: `cargo test -p gwt-core -p gwt --all-features`
- PASS: `cargo clippy --all-targets --all-features -- -D warnings`
- PASS: `cargo fmt -- --check`
- PASS: `cargo build -p gwt --bin gwt --bin gwtd`
- PASS: `git diff --check`
- PASS: `bunx commitlint --from origin/develop --to HEAD`

## Screenshots / Visual Evidence
- Not attached. User visual smoke was confirmed against the served build URL above.

## Risk / Impact
- Affected areas: Agent terminal focus activation, xterm fit geometry synchronization, embedded web contract test.
- Risk: Low. Geometry persistence remains opt-in for focus activation and preserves existing viewport-only behavior.
- Rollback: Revert this PR.

## Deployment Notes
- No special deployment steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal geometry synchronization during focus activation to properly handle grid dimension changes
  * Terminal now correctly updates dimensions when refocusing after viewport reflow
  
* **Tests**
  * Added comprehensive test coverage for geometry synchronization in grid change and viewport-only scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2925?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->