### PR TITLE
fix(gui): polish update ready modal design

### DIFF
--- a/crates/gwt/web/__tests__/update-button.test.mjs
+++ b/crates/gwt/web/__tests__/update-button.test.mjs
@@ -244,6 +244,13 @@ function createFixture({ confirmResult = true } = {}) {
   };
 }
 
+function cssRule(selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = componentsCss.match(new RegExp(`${escaped}\\s*\\{([^}]+)\\}`));
+  assert.ok(match, `expected ${selector} rule inside components.css`);
+  return match[1];
+}
+
 // SPEC-2041 Phase 19 (FR-052..066) — Post-click modal & restart UX.
 //
 // These tests pin the modal-driven state machine before implementation.
@@ -412,6 +419,53 @@ test("SPEC-2780: ready modal exposes 'View release notes' when openReleaseNotes 
   assert.ok(link, "release notes link must be present when wired");
   link.click();
   assert.deepEqual(releaseNotesCalls, ["9.40.0"]);
+});
+
+test("phase20: ready modal copy names gwt and keeps release notes out of the action group", () => {
+  const fixture = createFixture();
+  const controller = createUpdateCtaController({
+    ...fixture.options,
+    openReleaseNotes: () => {},
+  });
+  controller.showAvailable("9.48.0");
+  fixture.document.getElementById("update-cta").click();
+  controller.handleUpdateReady({ version: "9.48.0", asset_path: "/x" });
+
+  const modal = fixture.document.getElementById("update-modal");
+  const version = modal.querySelector(".update-modal__version");
+  const releaseNotes = modal.querySelector("[data-update-modal-release-notes]");
+  const actions = modal.querySelector(".update-modal__actions");
+
+  assert.equal(version.textContent, "gwt v9.48.0 is ready to install.");
+  assert.ok(releaseNotes, "release notes action must be present");
+  assert.equal(releaseNotes.className, "update-modal__link");
+  assert.equal(
+    actions.contains(releaseNotes),
+    false,
+    "release notes must not be grouped with Later / Restart now buttons",
+  );
+  assert.deepEqual(
+    [...actions.children].map((node) => node.textContent),
+    ["Later", "Restart now"],
+  );
+});
+
+test("phase20: update modal css defines compact panel and link-style release notes action", () => {
+  const modalRule = cssRule(".update-modal");
+  const panelRule = cssRule(".update-modal__panel");
+  const actionRule = cssRule(".update-modal__actions");
+  const buttonRule = cssRule(".update-modal__btn");
+  const linkRule = cssRule(".update-modal__link");
+
+  assert.match(modalRule, /background:\s*var\(--color-scrim/);
+  assert.match(panelRule, /width:\s*min\(420px,\s*calc\(100vw - 32px\)\)/);
+  assert.match(panelRule, /padding:\s*var\(--space-6\)/);
+  assert.match(actionRule, /align-items:\s*center/);
+  assert.match(buttonRule, /min-height:\s*36px/);
+  assert.match(buttonRule, /font-size:\s*var\(--type-sm\)/);
+  assert.match(linkRule, /border:\s*0/);
+  assert.match(linkRule, /background:\s*transparent/);
+  assert.match(linkRule, /color:\s*var\(--color-link\)/);
 });
 
 test("SPEC-2780: ready modal omits release notes link when openReleaseNotes is absent", () => {

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -318,46 +318,56 @@ body::after {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.55);
+  padding: var(--space-4);
+  background: var(--color-scrim);
   z-index: 10100;
 }
 
 .update-modal__panel {
-  min-width: 360px;
-  max-width: 480px;
-  padding: 24px 28px;
+  width: min(420px, calc(100vw - 32px));
+  max-height: calc(100vh - 32px);
+  overflow: auto;
+  padding: var(--space-6);
   border: 1px solid var(--color-border-strong);
-  border-radius: var(--radius-lg, 8px);
+  border-radius: var(--radius-lg);
   background: var(--color-surface-elevated);
-  color: var(--color-text-primary);
-  box-shadow: var(--shadow-3, 0 18px 48px rgba(0, 0, 0, 0.42));
-  font: var(--font-body);
+  color: var(--color-text);
+  box-shadow: var(--shadow-2);
+  font-family: var(--font-body);
+  font-size: var(--type-sm);
+  line-height: 1.5;
 }
 
 .update-modal__panel h2 {
-  margin: 0 0 12px;
-  font-size: var(--font-size-h3, 18px);
-  letter-spacing: 0.01em;
+  margin: 0 0 var(--space-4);
+  color: var(--color-text-strong);
+  font-family: var(--font-body);
+  font-size: var(--type-lg);
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1.2;
 }
 
 .update-modal__version {
-  margin: 0 0 8px;
-  font-size: var(--font-size-body, 14px);
-  color: var(--color-text-secondary);
+  margin: 0 0 var(--space-2);
+  color: var(--color-text);
+  font-size: var(--type-base);
+  line-height: 1.5;
 }
 
 .update-modal__hint {
-  margin: 0 0 16px;
-  font-size: var(--font-size-body-sm, 13px);
-  color: var(--color-text-secondary);
+  margin: 0 0 var(--space-4);
+  color: var(--color-text-muted);
+  font-size: var(--type-sm);
+  line-height: 1.5;
 }
 
 .update-modal__progress {
   position: relative;
   height: 8px;
-  margin: 12px 0 8px;
-  border-radius: var(--radius-sm, 4px);
-  background: var(--color-surface-sunken, rgba(255, 255, 255, 0.08));
+  margin: var(--space-4) 0 var(--space-2);
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklab, var(--color-text) 10%, transparent);
   overflow: hidden;
 }
 
@@ -369,29 +379,29 @@ body::after {
 }
 
 .update-modal__bytes {
-  margin: 0 0 16px;
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
-  font-size: var(--font-size-body-sm, 13px);
-  color: var(--color-text-secondary);
+  margin: 0 0 var(--space-4);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
 }
 
 .update-modal__details {
   display: grid;
   grid-template-columns: max-content 1fr;
   gap: 6px 12px;
-  margin: 0 0 16px;
-  font-size: var(--font-size-body-sm, 13px);
+  margin: 0 0 var(--space-4);
+  font-size: var(--type-sm);
 }
 
 .update-modal__details dt {
   margin: 0;
-  color: var(--color-text-secondary);
+  color: var(--color-text-muted);
   font-weight: 600;
 }
 
 .update-modal__details dd {
   margin: 0;
-  color: var(--color-text-primary);
+  color: var(--color-text);
   /* `word-break: break-word` is deprecated; modern equivalent
      for long words is `overflow-wrap: anywhere` (CodeRabbit review). */
   overflow-wrap: anywhere;
@@ -399,24 +409,31 @@ body::after {
 
 .update-modal__actions {
   display: flex;
-  gap: 8px;
+  align-items: center;
+  gap: var(--space-2);
   justify-content: flex-end;
-  margin-top: 8px;
+  margin-top: var(--space-5);
 }
 
 .update-modal__btn {
   appearance: none;
+  min-height: 36px;
   border: 1px solid var(--color-border-strong);
   background: var(--color-surface-elevated);
-  color: var(--color-text-primary);
-  padding: 8px 14px;
-  border-radius: var(--radius-sm, 4px);
-  font: inherit;
+  color: var(--color-text);
+  padding: 0 var(--space-4);
+  border-radius: var(--radius-md);
+  font-family: var(--font-body);
+  font-size: var(--type-sm);
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1;
   cursor: pointer;
+  transition: background-color var(--motion-fast), border-color var(--motion-fast), color var(--motion-fast);
 }
 
 .update-modal__btn:hover {
-  background: var(--color-surface-hover, rgba(255, 255, 255, 0.04));
+  background: color-mix(in oklab, var(--color-text) 8%, transparent);
 }
 
 .update-modal__btn:focus-visible {
@@ -426,12 +443,46 @@ body::after {
 
 .update-modal__btn--primary {
   border-color: var(--color-state-active, var(--color-focus-ring));
+  background: color-mix(in oklab, var(--color-state-active) 88%, var(--color-surface-elevated));
+  color: var(--color-canvas);
+}
+
+.update-modal__btn--primary:hover {
+  border-color: var(--color-state-active, var(--color-focus-ring));
   background: var(--color-state-active, var(--color-focus-ring));
-  color: var(--color-text-on-accent, #0a0a0a);
 }
 
 .update-modal__btn--secondary {
   background: transparent;
+}
+
+.update-modal__link {
+  appearance: none;
+  display: inline-flex;
+  width: fit-content;
+  margin: var(--space-1) 0 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--color-link);
+  cursor: pointer;
+  font-family: var(--font-body);
+  font-size: var(--type-sm);
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1.4;
+  text-align: left;
+}
+
+.update-modal__link:hover {
+  color: var(--color-link-hover);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.update-modal__link:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 3px;
 }
 
 .terminal-context-menu {

--- a/crates/gwt/web/update-cta.js
+++ b/crates/gwt/web/update-cta.js
@@ -367,7 +367,7 @@ export function createUpdateCtaController({
       el("h2", { id: "update-modal-title", text: "Update ready" }),
       el("p", {
         className: "update-modal__version",
-        text: `v${version} is ready to install.`,
+        text: `gwt v${version} is ready to install.`,
       }),
       el("p", {
         className: "update-modal__hint",


### PR DESCRIPTION
## Summary

- Polishes the update-ready modal so it reads as a compact operational dialog instead of an oversized generic overlay.
- Separates View release notes from the primary Later / Restart now action group so the hierarchy is clear.

## Changes

- `crates/gwt/web/update-cta.js`: Updates the ready-state copy to name the product as `gwt v{version}` while preserving existing `data-update-modal-*` selectors.
- `crates/gwt/web/styles/components.css`: Tightens the modal width, spacing, typography, button density, scrim token usage, and release-notes link styling.
- `crates/gwt/web/__tests__/update-button.test.mjs`: Adds Phase 20 regression coverage for ready copy, release-notes hierarchy, and compact CSS density.

## Testing

- [x] `bash scripts/run-node-tests-with-linkedom.sh crates/gwt/web/__tests__/update-button.test.mjs` — PASS, 32/32.
- [x] `bash scripts/run-frontend-unit-tests.sh` — PASS, 590/590.
- [x] `bash scripts/run-frontend-smoke-tests.sh` — PASS, 25/25.
- [x] `bash scripts/check-frontend-bundle.sh` — PASS.
- [x] `cargo fmt --check` — PASS.
- [x] `git diff --check` — PASS.
- [x] `CARGO_BUILD_JOBS=1 cargo test -p gwt embedded_web --all-features` — PASS.
- [x] `CARGO_BUILD_JOBS=1 cargo test -p gwt-core -p gwt --all-features` — PASS.
- [x] `CARGO_BUILD_JOBS=1 cargo clippy --all-targets --all-features -- -D warnings` — PASS.
- [x] `CARGO_BUILD_JOBS=1 cargo build -p gwt --bin gwt` — PASS.
- [x] `GWT_PLAYWRIGHT_BASE_URL=http://127.0.0.1:58752/ bash scripts/run-visual-tests.sh --project=chromium-dark crates/gwt/playwright/tests/update-modal.spec.ts` — PASS, 2/2.
- [x] Local visual smoke generated `/tmp/gwt-update-modal-ready-fresh.png`; ready panel measured 420px wide and rendered with View release notes as a link-style action.

## PR Readiness

- State: Ready for review
- Releaseable slice: Yes — this is limited to update-ready modal presentation and frontend regression coverage, with no backend or protocol change.
- Known blockers: None for this PR scope. User visual verification is skipped by explicit user instruction because the user can only confirm the final behavior at the real update timing: `アップデートのタイミングのみしか確認できないので、このままPRを出してください。`
- Remaining acceptance: None for Phase 20. Existing SPEC-2041 Phase 19 real update-flow gates remain separate and are not expanded by this visual polish PR.

## Closing Issues

- None

## Related Issues / Links

- #2041
- #2780

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, frontend checks)
- [x] Documentation updated (N/A: visual polish only; no user-facing docs changed)
- [x] Migration/backfill plan included (N/A: no schema or data migration)
- [x] CHANGELOG impact considered (patch-level UI fix; no breaking change)

## Context

- The prior update-ready modal looked mechanically assembled rather than intentionally designed, especially around action hierarchy and density.
- SPEC-2041 Phase 20 was added for this visual polish and its tasks T-139 through T-142 are checked off.

## Risk / Impact

- **Affected areas**: Update-ready modal copy, modal CSS, and frontend tests.
- **Rollback plan**: Revert `df71288ad` if the modal presentation regresses.

## Screenshots

| Before | After |
|--------|-------|
| User-provided screenshot in the task thread. | Local smoke artifact: `/tmp/gwt-update-modal-ready-fresh.png` (not committed). |
