### PR TITLE
feat(launch-wizard): update default Claude model label to Opus 4.8

### DIFF
--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -1063,11 +1063,11 @@ mod tests {
     #[test]
     fn build_claude_with_model() {
         let config = AgentLaunchBuilder::new(AgentId::ClaudeCode)
-            .model("claude-opus-4-7")
+            .model("claude-opus-4-8")
             .build();
 
         assert!(config.args.contains(&"--model".to_string()));
-        assert!(config.args.contains(&"claude-opus-4-7".to_string()));
+        assert!(config.args.contains(&"claude-opus-4-8".to_string()));
     }
 
     #[test]

--- a/crates/gwt-agent/src/session.rs
+++ b/crates/gwt-agent/src/session.rs
@@ -803,7 +803,7 @@ display_name = "Claude Code"
         );
         legacy.insert(
             "status".into(),
-            toml::Value::try_from(&session.status).unwrap(),
+            toml::Value::try_from(session.status).unwrap(),
         );
         legacy.insert("codex_fast_mode".into(), toml::Value::Boolean(true));
         legacy.insert(

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -3438,7 +3438,7 @@ fn default_launch_path(
     }
 }
 
-const CLAUDE_DEFAULT_MODEL_LABEL: &str = "Default (Opus 4.7)";
+const CLAUDE_DEFAULT_MODEL_LABEL: &str = "Default (Opus 4.8)";
 
 fn is_claude_opus_model(model: &str) -> bool {
     model == CLAUDE_DEFAULT_MODEL_LABEL || model == "opus"
@@ -3557,7 +3557,7 @@ const CLAUDE_OPUS_REASONING_OPTIONS: [ReasoningDisplayOption; 6] = [
     ReasoningDisplayOption {
         label: "xHigh",
         stored_value: "xhigh",
-        description: "Best results for most coding tasks (Opus 4.7 default)",
+        description: "Best results for most coding tasks (Opus 4.8 default)",
         is_default: true,
     },
     ReasoningDisplayOption {
@@ -4971,7 +4971,7 @@ mod tests {
     fn start_with_last_settings_runtime_confirmation_stays_enabled_without_quick_start_entry() {
         let previous = LaunchWizardPreviousProfile {
             agent_id: "claude".to_string(),
-            model: Some("Default (Opus 4.7)".to_string()),
+            model: Some("Default (Opus 4.8)".to_string()),
             reasoning: Some("max".to_string()),
             version: Some("latest".to_string()),
             session_mode: gwt_agent::SessionMode::Normal,
@@ -7585,6 +7585,7 @@ mod tests {
             .any(|option| option.value == "continue"));
 
         assert!(current_model_options("claude").contains(&"sonnet"));
+        assert!(current_model_options("claude").contains(&"Default (Opus 4.8)"));
         assert_eq!(
             current_model_options("codex"),
             vec![


### PR DESCRIPTION
## Summary

- Claude Code 本体の既定モデルが Opus 4.7 → Opus 4.8 に更新されたため、Launch Wizard が情報表示する既定モデルラベルと xHigh effort の説明文を Opus 4.8 に追従させる。
- `Default` 選択時は従来どおり `--model` を渡さず Claude Code CLI の既定に委ねるため、起動時の機能挙動は不変（表示文字列の追従のみ）。
- 併せて、Opus 4.8 対応とは独立した pre-existing な clippy lint（`needless_borrows_for_generic_args`, clippy 1.95.0 由来）を別 chore コミットで解消。

## Changes

- `crates/gwt/src/launch_wizard.rs`: `CLAUDE_DEFAULT_MODEL_LABEL` を `Default (Opus 4.8)` に更新。xHigh `ReasoningDisplayOption` の説明文を `(Opus 4.8 default)` に更新。前回 profile fixture の stale ラベルを追従。catalog テストに `current_model_options("claude")` が `Default (Opus 4.8)` を含む assertion を追加。
- `crates/gwt-agent/src/launch.rs`: `build_claude_with_model` テストの model ID を `claude-opus-4-8` に更新。
- `crates/gwt-agent/src/session.rs`: legacy session map 構築の `toml::Value::try_from(&session.status)` を所有値渡しへ変更（clippy lint 解消・別 chore）。
- SPEC-2014（Launch Wizard, US-3）の `spec` / `plan` / `tasks` に 2026-05-29 amendment と検証 evidence を追記（T186–T190）。

## Testing

- [x] `cargo test -p gwt-core -p gwt -p gwt-agent --all-features` — 2375 passed / 0 failed
- [x] `cargo test -p gwt --lib option_views_and_model_catalogs_expose_expected_labels` — RED（旧定数）→ GREEN（実装後）を確認
- [x] `cargo clippy -p gwt-core -p gwt --all-targets --all-features -- -D warnings` — clean（CI clippy scope）
- [x] `cargo clippy -p gwt-agent --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` / `git diff --check` — clean
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — PASS
- [x] `gwt-verify --mode pre-pr` — Overall: PASS

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — 表示ラベルの追従のみで単独配信可能。既存機能を壊さず、中途半端なユーザー可視挙動を出さない。
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- #2014 (SPEC-2014: Launch Wizard / US-3 — オーナー SPEC。本 PR では close せず amendment 追記のみ)

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated — N/A: README/設計ドキュメントに既定モデルラベルの記載は無く、UI 上の情報表示のみのため不要
- [ ] Migration/backfill plan — N/A: スキーマ/データ変更なし
- [x] CHANGELOG impact considered — `feat`（minor）として Conventional Commits で反映。CHANGELOG は release ワークフローが自動生成

## Context

- Claude Code のデフォルトモデルが Opus 4.8 に更新されたことへの追従。gwt の Launch Wizard はモデルドロップダウン先頭に現行既定を情報表示しており、`Default (Opus 4.7)` のままだと表示が実態と乖離する。過去の 4.5→4.6→4.7 と同種の version 追従。
- base=develop: CI の `check-source-branch` が `work/*` ブランチの main 宛 PR を拒否するため develop を対象にする。

## Screenshots

UI（Launch Wizard のモデルドロップダウン）変更のため、ビルド済みバイナリを隔離環境（本番 GWT.app とは別プロセス/別ポート）で起動し視覚確認済み:

| 項目 | Before | After |
|------|--------|-------|
| Model ドロップダウン先頭 | `Default (Opus 4.7)` | `Default (Opus 4.8)` |
| 選択肢一覧 | — | `[Default (Opus 4.8), opus, sonnet, haiku]` |
| ページ上の `4.7` 残存 | あり | なし |

ユーザーによる視覚確認: confirmed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default Claude model version from Opus 4.7 to Opus 4.8, including UI labels and descriptions that reflect the new default model.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akiojin/gwt/pull/2935?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->