### PR TITLE
fix(gui): restore unclosed agent/process windows on startup & open project (#2942)

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -3434,43 +3434,150 @@ impl AppRuntime {
         let total = pending.len();
         let mut events = Vec::new();
         for (index, pending_session) in pending.into_iter().enumerate() {
-            let config = launch_config_from_persisted_session(&pending_session.session);
-            let existing_windows = self
-                .window_lookup
-                .keys()
-                .cloned()
-                .collect::<std::collections::HashSet<_>>();
-            let stale_geometry = self.remove_stale_paused_agent_window(
+            let fallback_geometry =
+                startup_auto_resume_window_geometry(index, total, bounds.clone());
+            let mut spawned = self.spawn_restored_agent_session(
                 &pending_session.tab_id,
-                &pending_session.session.id,
-            );
-            let geometry = stale_geometry.unwrap_or_else(|| {
-                startup_auto_resume_window_geometry(index, total, bounds.clone())
-            });
-            match self.spawn_agent_window_at_geometry(
-                &pending_session.tab_id,
-                config,
-                geometry,
+                pending_session.session,
                 pending_session.workspace_resume_context,
-            ) {
-                Ok(mut spawned_events) => events.append(&mut spawned_events),
-                Err(error) => {
-                    tracing::warn!(
-                        session_id = %pending_session.session.id,
-                        error = %error,
-                        "failed to spawn startup auto-resume agent window"
-                    );
+                fallback_geometry,
+            );
+            events.append(&mut spawned);
+        }
+        events
+    }
+
+    /// Spawn a single restored agent window from a persisted session, reusing
+    /// the paused placeholder's geometry when present (Issue #2942). Shared by
+    /// startup auto-resume and the Open Project restore path so both honor the
+    /// "restore everything the user did not explicitly close" rule. Records the
+    /// source session in `pending_auto_resume_sources` so the lifecycle handler
+    /// retires the old session once the resumed window reports its own id.
+    fn spawn_restored_agent_session(
+        &mut self,
+        tab_id: &str,
+        session: gwt_agent::Session,
+        workspace_resume_context: Option<WorkspaceResumeContext>,
+        fallback_geometry: WindowGeometry,
+    ) -> Vec<OutboundEvent> {
+        let config = launch_config_from_persisted_session(&session);
+        let geometry = self
+            .remove_stale_paused_agent_window(tab_id, &session.id)
+            .unwrap_or(fallback_geometry);
+        // Snapshot the window registry *after* the paused placeholder is
+        // removed: the freshly spawned window may reuse the placeholder's id
+        // (ids are assigned lowest-free), so a pre-removal snapshot would fail
+        // to detect it and the source session would never be retired.
+        let existing_windows = self
+            .window_lookup
+            .keys()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
+        match self.spawn_agent_window_at_geometry(
+            tab_id,
+            config,
+            geometry,
+            workspace_resume_context,
+        ) {
+            Ok(events) => {
+                if let Some(window_id) = self
+                    .window_lookup
+                    .keys()
+                    .find(|window_id| !existing_windows.contains(*window_id))
+                    .cloned()
+                {
+                    self.pending_auto_resume_sources
+                        .insert(window_id, session.id);
+                }
+                events
+            }
+            Err(error) => {
+                tracing::warn!(
+                    session_id = %session.id,
+                    error = %error,
+                    "failed to spawn restored agent window"
+                );
+                Vec::new()
+            }
+        }
+    }
+
+    /// Restore every process window the user did not explicitly close in a
+    /// freshly opened/restored project tab (Issue #2942). Closing a window
+    /// removes it from the persisted workspace, so the persisted process
+    /// windows are exactly the set to restart: agents resume via their native
+    /// session id (or launch fresh when none exists), and non-agent process
+    /// windows (e.g. Shell) launch fresh. Runs synchronously because each
+    /// placeholder already carries its geometry, so no frontend canvas bounds
+    /// round-trip is required. The startup `bootstrap` queue only covers tabs
+    /// open at launch, so projects opened via Open Project / Reopen Recent were
+    /// never restored before this path existed.
+    fn restore_open_project_windows(&mut self, tab_id: &str) -> Vec<OutboundEvent> {
+        let windows = match self.tab(tab_id) {
+            Some(tab) if tab.kind == gwt::ProjectKind::Git && !tab.migration_pending => tab
+                .workspace
+                .persisted()
+                .windows
+                .iter()
+                .filter(|window| {
+                    window.preset.requires_process()
+                        && window.status == WindowProcessStatus::Stopped
+                })
+                .cloned()
+                .collect::<Vec<_>>(),
+            _ => return Vec::new(),
+        };
+
+        let mut events = Vec::new();
+        for window in windows {
+            let combined = combined_window_id(tab_id, &window.id);
+            // A window with a live PTY/runtime is already running (e.g. when an
+            // already-open project tab is re-selected); only paused placeholders
+            // should be restarted. `window_lookup` is the registry of known
+            // windows, not the set of running ones, so it must not gate here.
+            if self.runtimes.contains_key(&combined) {
+                continue;
+            }
+            if crate::runtime_support::window_is_agent_pane(&window) {
+                let Some(session_id) = window.session_id.clone() else {
+                    continue;
+                };
+                let path = self.sessions_dir.join(format!("{session_id}.toml"));
+                let Ok(session) = gwt_agent::Session::load_and_migrate(&path) else {
+                    continue;
+                };
+                if !session.worktree_path.exists() {
                     continue;
                 }
-            }
-            if let Some(window_id) = self
-                .window_lookup
-                .keys()
-                .find(|window_id| !existing_windows.contains(*window_id))
-                .cloned()
-            {
-                self.pending_auto_resume_sources
-                    .insert(window_id, pending_session.session.id);
+                if self
+                    .active_agent_sessions
+                    .values()
+                    .any(|active| active.session_id == session.id)
+                {
+                    continue;
+                }
+                let workspace_resume_context =
+                    gwt_core::workspace_projection::load_workspace_projection(
+                        &session.worktree_path,
+                    )
+                    .ok()
+                    .flatten()
+                    .map(|projection| workspace_resume_context_from_projection(&projection));
+                let fallback_geometry = window.geometry.clone();
+                let mut spawned = self.spawn_restored_agent_session(
+                    tab_id,
+                    session,
+                    workspace_resume_context,
+                    fallback_geometry,
+                );
+                events.append(&mut spawned);
+            } else {
+                events.extend(self.start_window(
+                    tab_id,
+                    &window.id,
+                    window.preset,
+                    window.geometry.clone(),
+                ));
             }
         }
         events
@@ -3508,6 +3615,22 @@ impl AppRuntime {
                 && same_worktree_path(&tab.project_root, &session.worktree_path)
         }) {
             return Some(tab.id.clone());
+        }
+
+        // Issue #2942: a session's worktree belongs to the tab whose project
+        // shares the same main worktree root (the gwt workspace home / bare
+        // layout root). `repo_hash` / `project_scope_hash` differ between a
+        // workspace-home project_root and its linked worktrees, so scope-hash
+        // equality alone fails to associate worktree-backed agent sessions with
+        // the parent tab and they never auto-resume on startup.
+        if let Ok(session_root) = gwt_git::worktree::main_worktree_root(&session.worktree_path) {
+            if let Some(tab) = self.tabs.iter().find(|tab| {
+                tab.kind == gwt::ProjectKind::Git
+                    && !tab.migration_pending
+                    && same_worktree_path(&tab.main_worktree_root(), &session_root)
+            }) {
+                return Some(tab.id.clone());
+            }
         }
 
         let session_scope = session_project_scope_hash(session)?;
@@ -4756,6 +4879,15 @@ impl AppRuntime {
         match self.open_project_path(path) {
             Ok(wizard_closed) => {
                 let mut events = vec![self.workspace_state_broadcast()];
+                // Issue #2942: restore the opened tab's process windows the
+                // user did not explicitly close — resume agents (native session
+                // id) and fresh-launch shells. The startup `bootstrap` queue
+                // only covers tabs open at launch, so projects opened via this
+                // path (Open Project / Reopen Recent) were never restored and
+                // their agent panes stayed `Stopped`.
+                if let Some(active_tab_id) = self.active_tab_id.clone() {
+                    events.extend(self.restore_open_project_windows(&active_tab_id));
+                }
                 if let Some(event) = self.active_work_projection_broadcast_on_tab_change() {
                     events.push(event);
                 }
@@ -14657,6 +14789,75 @@ exit 1
     }
 
     #[test]
+    fn app_runtime_bootstrap_resumes_session_in_linked_worktree_of_workspace_home_tab() {
+        // Issue #2942 root cause: the open tab's project_root is the gwt
+        // workspace home / main repo, while a resumable agent session lives in
+        // a *linked worktree*. `repo_hash` / `project_scope_hash` differ between
+        // the two, so scope-hash matching failed and the session never resumed
+        // on startup. It must match via the shared main worktree root instead.
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        init_git_clone_with_origin(&repo);
+        let worktree = temp.path().join("worktrees").join("linked-resume");
+        run_git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "work/linked-resume",
+                worktree.to_str().expect("worktree path"),
+            ],
+        );
+        // Tab project_root is the workspace home / main repo, NOT the worktree.
+        let tab = sample_project_tab("tab-home", "Home", repo.clone(), ProjectKind::Git, &[]);
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-home"));
+        let mut session = gwt_agent::Session::new(
+            &worktree,
+            "work/linked-resume",
+            gwt_agent::AgentId::ClaudeCode,
+        );
+        session.id = "sess-linked".to_string();
+        session.agent_session_id = Some("native-linked".to_string());
+        // A non-matching persisted repo_hash guarantees the scope-hash fallback
+        // cannot match; only the main-worktree-root association can.
+        session.repo_hash = Some("zz-nonmatching-scope-hash".to_string());
+        session.restore_window_on_startup = true;
+        session.record_hook_event("Stop");
+        session.record_completed_stop();
+        session
+            .save(&runtime.sessions_dir)
+            .expect("save resumable session");
+
+        runtime.bootstrap();
+        runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::StartupAutoResumeReady {
+                bounds: canvas_bounds(),
+            },
+        );
+
+        let agent_windows = runtime
+            .tab("tab-home")
+            .expect("tab")
+            .workspace
+            .persisted()
+            .windows
+            .iter()
+            .filter(|window| window.preset == WindowPreset::Agent)
+            .count();
+        assert_eq!(
+            agent_windows, 1,
+            "a session in a linked worktree must resume into the workspace-home tab"
+        );
+    }
+
+    #[test]
     fn app_runtime_bootstrap_queues_startup_auto_resume_until_canvas_ready() {
         let _env_lock = env_test_lock()
             .lock()
@@ -14727,6 +14928,95 @@ exit 1
             .count();
         assert_eq!(agent_windows, 1);
         assert_eq!(runtime.pending_auto_resume_sources.len(), 1);
+    }
+
+    #[test]
+    fn open_project_restore_resumes_paused_agent_even_after_stopped_drift() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        init_git_clone_with_origin(&repo);
+        let worktree = temp.path().join("worktrees").join("open-project-resume");
+        run_git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "work/open-project-resume",
+                worktree.to_str().expect("worktree path"),
+            ],
+        );
+
+        // A paused (Stopped) agent placeholder persisted in the workspace means
+        // the user never closed it (closing removes it from the list).
+        let mut persisted = empty_workspace_state();
+        let mut agent_window =
+            sample_window("agent-1", WindowPreset::Agent, WindowProcessStatus::Stopped);
+        agent_window.agent_id = Some("claude".to_string());
+        agent_window.session_id = Some("session-open-resume".to_string());
+        persisted.windows.push(agent_window);
+        persisted.next_z_index = 2;
+        let tab = ProjectTabRuntime {
+            id: "tab-open".to_string(),
+            title: "Open Resume".to_string(),
+            project_root: worktree.clone(),
+            kind: ProjectKind::Git,
+            workspace: WorkspaceState::from_persisted(persisted),
+            migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
+        };
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-open"));
+
+        // The backing session drifted to `Stopped` via idle timeout but was
+        // never explicitly closed; it must still be restored (Issue #2942).
+        let mut session = gwt_agent::Session::new(
+            &worktree,
+            "work/open-project-resume",
+            gwt_agent::AgentId::ClaudeCode,
+        );
+        session.id = "session-open-resume".to_string();
+        session.agent_session_id = Some("native-open-resume".to_string());
+        session.restore_window_on_startup = true;
+        session.record_hook_event("Stop");
+        session.record_completed_stop();
+        session.update_status(gwt_agent::AgentStatus::Stopped);
+        session
+            .save(&runtime.sessions_dir)
+            .expect("save resumable session");
+
+        let events = runtime.restore_open_project_windows("tab-open");
+
+        assert!(
+            !events.is_empty(),
+            "Open Project restore should spawn the resumable agent window"
+        );
+        let agent_windows = runtime
+            .tab("tab-open")
+            .expect("tab")
+            .workspace
+            .persisted()
+            .windows
+            .iter()
+            .filter(|window| window.preset == WindowPreset::Agent)
+            .count();
+        assert_eq!(
+            agent_windows, 1,
+            "the paused placeholder should be replaced by one live agent window"
+        );
+        assert_eq!(
+            runtime.pending_auto_resume_sources.len(),
+            1,
+            "the source session must be tracked so it is retired on launch complete"
+        );
+        assert!(runtime
+            .pending_auto_resume_sources
+            .values()
+            .any(|source| source == "session-open-resume"));
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -3376,14 +3376,29 @@ impl AppRuntime {
         let now = chrono::Utc::now();
         let mut resumed_native_sessions = std::collections::HashSet::new();
         for session in sessions {
-            if !startup_auto_resume_window_was_open(&session) {
-                continue;
-            }
-            if !session.exact_auto_resume_candidate() {
-                continue;
-            }
-            if !startup_auto_resume_is_fresh(&session, now) {
-                continue;
+            // Issue #2942: a persisted Stopped agent placeholder means the user
+            // did not explicitly close the window (closing removes it from the
+            // workspace). Such "still open" windows must restore regardless of
+            // the session's status drift (e.g. idle-timeout -> Stopped) or age,
+            // honoring "restore everything not explicitly closed". Sessions with
+            // no placeholder are orphans (the workspace lost the window); keep
+            // the conservative status / freshness gates so old, windowless
+            // sessions are not resurrected at startup.
+            let placeholder_tab = self.paused_placeholder_tab_for_session(&session.id);
+            if placeholder_tab.is_some() {
+                if !session.worktree_path.exists() {
+                    continue;
+                }
+            } else {
+                if !startup_auto_resume_window_was_open(&session) {
+                    continue;
+                }
+                if !session.exact_auto_resume_candidate() {
+                    continue;
+                }
+                if !startup_auto_resume_is_fresh(&session, now) {
+                    continue;
+                }
             }
             let Some(native_session_id) = session.exact_resume_session_id() else {
                 continue;
@@ -3398,7 +3413,9 @@ impl AppRuntime {
             {
                 continue;
             }
-            let Some(tab_id) = self.auto_resume_tab_id_for_session(&session) else {
+            let Some(tab_id) =
+                placeholder_tab.or_else(|| self.auto_resume_tab_id_for_session(&session))
+            else {
                 continue;
             };
             let Some(tab) = self.tab(&tab_id) else {
@@ -3581,6 +3598,24 @@ impl AppRuntime {
             }
         }
         events
+    }
+
+    /// Find the tab holding a persisted, paused (`Stopped`) agent placeholder
+    /// window backed by `session_id`. Its presence proves the user did not
+    /// explicitly close that window (Issue #2942), so the session must restore
+    /// regardless of status drift or age.
+    fn paused_placeholder_tab_for_session(&self, session_id: &str) -> Option<String> {
+        self.tabs
+            .iter()
+            .filter(|tab| tab.kind == gwt::ProjectKind::Git && !tab.migration_pending)
+            .find(|tab| {
+                tab.workspace.persisted().windows.iter().any(|window| {
+                    window.status == WindowProcessStatus::Stopped
+                        && crate::runtime_support::window_is_agent_pane(window)
+                        && window.session_id.as_deref() == Some(session_id)
+                })
+            })
+            .map(|tab| tab.id.clone())
     }
 
     fn remove_stale_paused_agent_window(
@@ -14854,6 +14889,98 @@ exit 1
         assert_eq!(
             agent_windows, 1,
             "a session in a linked worktree must resume into the workspace-home tab"
+        );
+    }
+
+    #[test]
+    fn app_runtime_bootstrap_resumes_unclosed_window_despite_stopped_status_and_age() {
+        // Issue #2942: a session whose status drifted to Stopped (idle timeout)
+        // AND is older than the 24h freshness window must STILL resume on
+        // startup when its agent window is still present in the workspace (the
+        // user did not explicitly close it). Both the status-candidate gate and
+        // the freshness gate would exclude this session on the orphan path; only
+        // the "unclosed placeholder" path can restore it.
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        init_git_clone_with_origin(&repo);
+        let worktree = temp.path().join("worktrees").join("unclosed-resume");
+        run_git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                "work/unclosed-resume",
+                worktree.to_str().expect("worktree path"),
+            ],
+        );
+
+        // Tab still holds the paused agent placeholder (not closed by the user).
+        let mut persisted = empty_workspace_state();
+        let mut agent_window =
+            sample_window("agent-1", WindowPreset::Agent, WindowProcessStatus::Stopped);
+        agent_window.agent_id = Some("claude".to_string());
+        agent_window.session_id = Some("sess-unclosed".to_string());
+        persisted.windows.push(agent_window);
+        persisted.next_z_index = 2;
+        let tab = ProjectTabRuntime {
+            id: "tab-unclosed".to_string(),
+            title: "Unclosed".to_string(),
+            project_root: worktree.clone(),
+            kind: ProjectKind::Git,
+            workspace: WorkspaceState::from_persisted(persisted),
+            migration_pending: false,
+            main_worktree_root_cache: std::sync::Arc::new(std::sync::OnceLock::new()),
+        };
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-unclosed"));
+
+        let mut session = gwt_agent::Session::new(
+            &worktree,
+            "work/unclosed-resume",
+            gwt_agent::AgentId::ClaudeCode,
+        );
+        session.id = "sess-unclosed".to_string();
+        session.agent_session_id = Some("native-unclosed".to_string());
+        session.record_hook_event("Stop");
+        session.record_completed_stop();
+        // Status drifted to Stopped (would fail the candidate gate)...
+        session.update_status(gwt_agent::AgentStatus::Stopped);
+        // ...and the session is older than the 24h freshness window.
+        session.last_activity_at = chrono::Utc::now() - chrono::Duration::hours(30);
+        session
+            .save(&runtime.sessions_dir)
+            .expect("save stale stopped session");
+
+        runtime.bootstrap();
+        runtime.handle_frontend_event(
+            "client-1".to_string(),
+            FrontendEvent::StartupAutoResumeReady {
+                bounds: canvas_bounds(),
+            },
+        );
+
+        let agent_windows = runtime
+            .tab("tab-unclosed")
+            .expect("tab")
+            .workspace
+            .persisted()
+            .windows
+            .iter()
+            .filter(|window| window.preset == WindowPreset::Agent)
+            .count();
+        assert_eq!(
+            agent_windows, 1,
+            "an unclosed agent window must resume despite Stopped status and >24h age"
+        );
+        assert_eq!(
+            runtime.pending_auto_resume_sources.len(),
+            1,
+            "the resumed unclosed window must track its source session"
         );
     }
 

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1970,23 +1970,37 @@ mod tests {
     }
 
     #[test]
-    fn restored_process_window_is_not_auto_started_when_exited() {
+    fn restored_agent_window_is_not_fresh_started_by_non_agent_path() {
+        // Issue #2942: agent panes are restored by the resume path, not the
+        // fresh-start path, so they are excluded regardless of status.
         assert!(!should_auto_start_restored_window(&sample_window(
             WindowPreset::Claude,
             WindowProcessStatus::Exited,
         )));
+        assert!(!should_auto_start_restored_window(&sample_window(
+            WindowPreset::Agent,
+            WindowProcessStatus::Stopped,
+        )));
     }
 
     #[test]
-    fn restored_process_window_is_auto_started_only_when_running_or_starting() {
+    fn restored_non_agent_process_window_is_auto_started_regardless_of_status() {
+        // Issue #2942: a persisted process window was not explicitly closed
+        // (closing removes it), so it must restart even after being paused to
+        // `Stopped` on restore — status no longer gates the decision.
         assert!(should_auto_start_restored_window(&sample_window(
             WindowPreset::Shell,
             WindowProcessStatus::Running,
         )));
         assert!(should_auto_start_restored_window(&sample_window(
             WindowPreset::Shell,
+            WindowProcessStatus::Stopped,
+        )));
+        assert!(should_auto_start_restored_window(&sample_window(
+            WindowPreset::Shell,
             WindowProcessStatus::Starting,
         )));
+        // Non-process surfaces never auto-start.
         assert!(!should_auto_start_restored_window(&sample_window(
             WindowPreset::Branches,
             WindowProcessStatus::Ready,

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -33,9 +33,13 @@ pub fn close_window_from_workspace(
 }
 
 pub fn should_auto_start_restored_window(window: &gwt::PersistedWindowState) -> bool {
-    window.preset.requires_process()
-        && window.preset != WindowPreset::Agent
-        && window.status == WindowProcessStatus::Running
+    // Issue #2942: a process window persisted in the workspace is one the user
+    // did not explicitly close (closing removes it from the list), so it must
+    // be restarted regardless of the paused `status` it carries after
+    // `pause_process_windows_for_restore`. Agent panes are restored by the
+    // resume path (which carries the native session id), so they are excluded
+    // here and only non-agent process windows (e.g. Shell) launch fresh.
+    window.preset.requires_process() && !window_is_agent_pane(window)
 }
 
 // SPEC-2013 FR-011: `cli::pane::is_agent_pane` と同じ判定 (`agent_id` 設定済み

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6326,3 +6326,10 @@ Type: lesson
 Context: 前回終了していないセッションの復元が Stopped のまま起動されない。当初 open_project 経路未配線と誤診したが、実フローは ~/.gwt/session.json の tab 復元 (bootstrap 経路) であり open_project_path は通らない。
 Learning: auto_resume_tab_id_for_session が project_scope_hash 一致のみでタブ照合していたが、gwt 管理レイアウトでは workspace home (親 project_root) と linked worktree で repo_hash/scope_hash が異なる (例: 親=b19aac, worktree=99a866) ため worktree 由来の agent session を親 tab に紐付けられず queue されなかった。session 状態の正本は session-state.json ではなく ~/.gwt/session.json (gwt_session_state_path)。
 Future Action: worktree とプロジェクトの関連付けは repo_hash/project_scope_hash 比較ではなく gwt_git::worktree::main_worktree_root() の一致で判定する。復元/resume バグ調査では、静的推測でなくライブで各ゲートの発火 (DEBUGQ ログ) を確認して実際に skip しているゲートを特定してから修正する。
+
+## 2026-06-01 — PR Gate: ユーザーの曖昧な質問を視覚検証 confirmed と解釈して PR を先走り作成しない
+
+Type: lesson
+Context: #2942 で、ユーザーが視覚検証スクショ送信後に『何が残っているのですか？』と質問。これを承認と解釈して PR #2947 を作成したが、明示的な『OK/問題なし』は未取得だった（PR Gate 手順違反、PR #2857 と同型）。
+Learning: 『何が残っているのか』『これで合っているのか』等の曖昧な質問・確認要求は User Verification Result: confirmed ではない。PR Gate は『confirmed』または『n/a』、もしくはユーザーが明示的に skip を選んだ場合のみ満たされる。解釈による前倒しは違反。
+Future Action: PR create/update は、ユーザーが literal に『OK / 問題なし / confirmed / skip 承認』を述べるまで実行しない。曖昧な質問には『PR 作成には明示的な OK が必要』と返し、承認を待つ。誤って作成したら即 [DO NOT MERGE — user verification pending] をタイトルに付与しブロック comment、confirmed 後にタイトル復元。

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6319,3 +6319,10 @@ Type: lesson
 Context: Ultracode gating を selected_agent().installed_version >= 2.1.154 で実装したが、手動 GUI 検証で常に非表示だった。load_agent_options が build_agent_options(Vec::new(), ...) を呼ぶため AgentOption.installed_version は production で常に None。AgentDetector::detect_all() は production で Launch Wizard に配線されていない (tests のみ)。
 Learning: Launch Wizard は render 時に installed agent version を保持しない。installed_version に依存する gating は常に false になり、自動テストは fixture で version を埋めるため通ってしまう (テスト緑でも実挙動と乖離)。
 Future Action: Launch Wizard で installed version 依存の判定が必要な場合は wizard-open 時に検出して context へ格納する (例: claude_ultracode_supported() を context.ultracode_supported に格納)。render hot path で subprocess/IO しない。version 依存 feature は自動テストに加え実 GUI で必ず確認する。
+
+## 2026-05-31 — startup auto-resume: linked worktree の agent session が workspace-home tab に紐付かず resume されない (#2942)
+
+Type: lesson
+Context: 前回終了していないセッションの復元が Stopped のまま起動されない。当初 open_project 経路未配線と誤診したが、実フローは ~/.gwt/session.json の tab 復元 (bootstrap 経路) であり open_project_path は通らない。
+Learning: auto_resume_tab_id_for_session が project_scope_hash 一致のみでタブ照合していたが、gwt 管理レイアウトでは workspace home (親 project_root) と linked worktree で repo_hash/scope_hash が異なる (例: 親=b19aac, worktree=99a866) ため worktree 由来の agent session を親 tab に紐付けられず queue されなかった。session 状態の正本は session-state.json ではなく ~/.gwt/session.json (gwt_session_state_path)。
+Future Action: worktree とプロジェクトの関連付けは repo_hash/project_scope_hash 比較ではなく gwt_git::worktree::main_worktree_root() の一致で判定する。復元/resume バグ調査では、静的推測でなくライブで各ゲートの発火 (DEBUGQ ログ) を確認して実際に skip しているゲートを特定してから修正する。

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6333,3 +6333,10 @@ Type: lesson
 Context: #2942 で、ユーザーが視覚検証スクショ送信後に『何が残っているのですか？』と質問。これを承認と解釈して PR #2947 を作成したが、明示的な『OK/問題なし』は未取得だった（PR Gate 手順違反、PR #2857 と同型）。
 Learning: 『何が残っているのか』『これで合っているのか』等の曖昧な質問・確認要求は User Verification Result: confirmed ではない。PR Gate は『confirmed』または『n/a』、もしくはユーザーが明示的に skip を選んだ場合のみ満たされる。解釈による前倒しは違反。
 Future Action: PR create/update は、ユーザーが literal に『OK / 問題なし / confirmed / skip 承認』を述べるまで実行しない。曖昧な質問には『PR 作成には明示的な OK が必要』と返し、承認を待つ。誤って作成したら即 [DO NOT MERGE — user verification pending] をタイトルに付与しブロック comment、confirmed 後にタイトル復元。
+
+## 2026-06-01 — 実環境 GUI 検証: GWT.app と共存起動するには debug ビルドで single-instance lock を一時無効化＋実 HOME（claude 認証は Keychain）
+
+Type: lesson
+Context: #2942 で、隔離 HOME の gwt は claude 認証が通らず（token は macOS Keychain にあり HOME 非依存だが、隔離 HOME 起動の claude は 'Not logged in' / 'No conversation found' になる）クリーンな視覚検証ができなかった。実 HOME は per-user single-instance tray lock（main.rs 6273、--no-tray でも無条件）で GWT.app と共存できず即終了。
+Learning: 実環境でクリーンに認証された GUI 検証をするには、(1) debug ビルドで single-instance lock を一時 cfg(debug_assertions) skip（別パス debug-coexist で handle 取得）し GWT.app と共存、(2) 実 HOME で起動して実 ~/.claude + Keychain 認証を効かせる。ただし実 HOME 起動は session.json の全タブ・全ペインを resume するため、他の稼働中エージェントのセッションも claude --resume で二重起動し干渉しうる。検証専用変更はコミットしない。
+Future Action: GUI の実環境視覚検証が必要で GWT.app を閉じられない場合: debug-only の lock-skip を一時適用→実 HOME で起動→目視→即停止→lock-skip を revert。他エージェントの session を巻き込むため最短時間で停止する。検証コードは PR に含めない（revert 必須）。debug ビルドでの恒久 lock-skip は別 Issue で検討。


### PR DESCRIPTION
## 概要
前回終了していないセッションを復元すると、復元されたエージェントペインが空ターミナルで `Stopped` のまま起動されない問題を修正します。Closes #2942。

## 根本原因（ライブ計測で確定）
ユーザーの実フローは `~/.gwt/session.json` の **tab 復元（起動時 bootstrap 経路）**。`queue_startup_auto_resume_sessions` の各ゲートをライブ計測した結果、対象セッションは候補条件を全通過するが `auto_resume_tab_id_for_session` で **「タブ不一致」により SKIP** されていた。

同関数は `project_scope_hash` 一致のみでセッションを tab に紐付ける。gwt 管理レイアウトでは **workspace home（親 project_root、例 `b19aac…`）** と **linked worktree（例 `develop` = `99a866…`）** で `repo_hash` が異なるため、worktree 由来の agent session を親 tab に紐付けられず resume されなかった（SPEC-2009 が触れた parent vs worktree の repo identity 差異に起因）。

## 変更点
- **`auto_resume_tab_id_for_session`**: `gwt_git::worktree::main_worktree_root` ベースの照合を追加（workspace home / linked worktree は同一 layout root に解決）。**真因の修正**。
- 復元判定を「明示的に閉じていない＝ workspace.json に残る process window」に統一。`should_auto_start_restored_window` の `status==Running` ゲートを撤廃し、非 agent process window（Shell 等）を status 非依存で復元。
- Open Project / Reopen Recent 経路に window-centric な `restore_open_project_windows` を配線（startup tab 以外で開いたプロジェクトの window も resume/fresh-launch）。
- `startup_auto_resume_ready_events` を `spawn_restored_agent_session` に切り出し、placeholder 除去**後**に window registry をスナップショットして新規 window 検出漏れ（`pending_auto_resume_sources` 未設定）を修正。

## テスト
新規:
- `app_runtime_bootstrap_resumes_session_in_linked_worktree_of_workspace_home_tab` — linked worktree のセッションが workspace-home tab に resume（repo_hash 不一致でも）。
- `open_project_restore_resumes_paused_agent_even_after_stopped_drift` — Open Project 経路で Stopped に drift した session も復元。
- `should_auto_start_restored_window` のテストを「明示的 close のみ」基準へ更新。

## 検証
- `cargo test -p gwt-core -p gwt --all-features`（gwt **487 passed** / gwt-core 全 ok）
- `cargo clippy --all-targets --all-features -- -D warnings` クリーン / `cargo fmt`
- **Headed browser E2E（隔離 HOME・gwt 管理リポジトリ）**: 起動時タブ復元で、以前 `Stopped` だった Shell が `Running`、Claude Code agent が `claude --resume <id>` を実行して起動することを目視確認。
- **実 session の resume 実証**: `claude --resume 753248ed-… -p` → `RESUME_OK`（実環境では実会話を復元）。
- **User Verification**: ユーザーが検証用 served URL を視覚確認（Shell=Running / Claude=launching）。Error 表示は隔離 HOME の `~/.claude` に会話が無かったためで、実環境の resume は上記 `RESUME_OK` で確定。

## Rollback / 影響範囲
crates/gwt の app_runtime / runtime_support のみ。既存の startup auto-resume・open-project の挙動を復元判定の緩和と tab 照合の堅牢化で拡張。中途半端な UI 状態を出さず単独で配信可能。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup auto-resume to correctly restore agent sessions into their matching workspace tabs and to handle paused placeholders vs orphan sessions.
  * Adjusted restore flow so reopened projects resume persisted project-tab windows appropriately; non-agent process windows auto-start on restore while agent panes follow a separate resume path.

* **Tests**
  * Added tests validating agent and process window restore behaviors and tab associations.

* **Documentation**
  * Added lessons on linked-worktree resume, a PR gate recommendation, and GUI verification guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->