### PR TITLE
fix(gui): terminal layout — glyph clipping, resize reflow, and maximize zoom inset

### DIFF
--- a/crates/gwt/src/workspace.rs
+++ b/crates/gwt/src/workspace.rs
@@ -372,12 +372,13 @@ impl WorkspaceState {
         let group_id = self.persisted.windows[index].tab_group_id.clone();
         let was_maximized = self.persisted.windows[index].maximized;
         let pre_geometry = self.persisted.windows[index].geometry.clone();
-        let target_geometry = WindowGeometry {
-            x: bounds.x + ARRANGE_PADDING,
-            y: bounds.y + ARRANGE_PADDING,
-            width: (bounds.width - ARRANGE_PADDING * 2.0).max(0.0),
-            height: (bounds.height - ARRANGE_PADDING * 2.0).max(0.0),
-        };
+        // The frontend sends the FINAL maximized geometry (with a zoom-corrected
+        // screen-space inset already applied in `maximizedGeometry`), so store it
+        // verbatim. The previous code added a constant `ARRANGE_PADDING` in WORLD
+        // units here, which rendered as an `ARRANGE_PADDING * zoom` SCREEN inset
+        // under the canvas-stage `scale(zoom)` transform and drifted the maximized
+        // window off the visible viewport at any zoom != 1.
+        let target_geometry = bounds;
 
         // No-op fast path: already maximized at the exact target geometry.
         // Without this, repeated sync events from the frontend turn into a
@@ -1488,15 +1489,12 @@ mod tests {
         assert!(maximized.maximized);
         assert!(!maximized.minimized);
         assert_eq!(maximized.pre_maximize_geometry, Some(original.clone()));
-        assert_eq!(
-            maximized.geometry,
-            WindowGeometry {
-                x: 124.0,
-                y: 64.0,
-                width: 952.0,
-                height: 712.0,
-            }
-        );
+        // The backend now stores the received geometry VERBATIM — the frontend
+        // applies the zoom-corrected screen inset in `maximizedGeometry` before
+        // sending. (Previously the backend added ARRANGE_PADDING here, which
+        // became a zoom-scaled inset under the canvas-stage transform and drifted
+        // the maximized window off the viewport at any zoom != 1.)
+        assert_eq!(maximized.geometry, arrange_bounds());
 
         // Issue #2757 follow-up: repeated maximize_window with the same
         // bounds must be a no-op. The frontend's viewport-sync path used to
@@ -1520,6 +1518,28 @@ mod tests {
         assert!(!restored.minimized);
         assert_eq!(restored.pre_maximize_geometry, None);
         assert_eq!(restored.geometry, original);
+    }
+
+    #[test]
+    fn maximize_window_stores_received_geometry_verbatim_without_world_padding() {
+        // Regression: the zoom-correct maximize inset is applied on the frontend
+        // (`maximizedGeometry` divides the 24px screen inset by zoom). The backend
+        // must NOT re-pad in world units, otherwise the inset scales with zoom and
+        // the maximized window drifts off the visible viewport.
+        let mut workspace = WorkspaceState::from_persisted(default_workspace_state());
+        let geometry = WindowGeometry {
+            x: 312.5,
+            y: 88.0,
+            width: 640.0,
+            height: 360.0,
+        };
+        assert!(workspace.maximize_window("claude-1", geometry.clone()));
+        let maximized = workspace.window("claude-1").expect("claude");
+        assert!(maximized.maximized);
+        assert_eq!(
+            maximized.geometry, geometry,
+            "backend must store the frontend-computed maximize geometry unchanged",
+        );
     }
 
     #[test]

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1073,6 +1073,33 @@ test("xterm developer readability defaults use larger font metrics", () => {
   );
 });
 
+test("xterm fontFamily is resolved without CSS var() so OffscreenCanvas char measurement matches the rendered font", () => {
+  // xterm 6.0.0 measures the char cell via an OffscreenCanvas strategy
+  // (ctx.font = `${fontSize}px ${fontFamily}`). Canvas 2D `ctx.font` CANNOT
+  // resolve CSS custom properties, so a `var(--font-mono)` family token is
+  // dropped and the SHORTER system fallback (SF Mono / Menlo) is measured,
+  // while the rendered rows resolve var() to the TALLER JetBrains Mono — the
+  // permanent measure-vs-render mismatch that clips glyphs vertically.
+  const runtime = appSource.match(/new\s+Terminal\(\{\s*([\s\S]*?)\s*\}\);/);
+  assert.ok(runtime, "expected xterm Terminal constructor options");
+  assert.doesNotMatch(
+    runtime[1],
+    /var\(/,
+    "xterm Terminal options must not pass a CSS var() font family; OffscreenCanvas ctx.font cannot resolve it",
+  );
+  assert.match(
+    appSource,
+    /function\s+resolveTerminalFontFamily\s*\(/,
+    "expected a resolveTerminalFontFamily() helper that resolves --font-mono to a var()-free stack",
+  );
+  // The resolver's hardcoded fallback must still prefer JetBrains Mono.
+  assert.match(
+    appSource,
+    /resolveTerminalFontFamily[\s\S]{0,400}?JetBrains Mono/,
+    "resolveTerminalFontFamily fallback must reference JetBrains Mono",
+  );
+});
+
 test("operator-shell wires hover-reveal chrome and Mission Briefing early dismiss", () => {
   const operatorShell = readFileSync(resolve(here, "../operator-shell.js"), "utf8");
   // SPEC-2356 Phase 9 (FR-021/FR-022/FR-031): hover-reveal state machine sets

--- a/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
@@ -16,6 +16,7 @@ import { parseHTML } from "linkedom";
 
 import {
   applyVisibilityTransition,
+  attachContainerResizeReflow,
   attachHostResizeReflow,
   classifyProjectWindowVisibility,
   elementHasLayoutBox,
@@ -789,5 +790,152 @@ test("gateTerminalInputForReadiness forwards when isReady is missing (legacy run
   assert.deepEqual(
     gateTerminalInputForReadiness({ runtime: {}, data: "C" }),
     { forward: true },
+  );
+});
+
+// --- attachContainerResizeReflow: re-fit when the terminal CONTAINER size
+// actually changes (maximize/restore/tile/server-geometry/no-op-fit gaps that
+// the per-lifecycle-event wiring misses, leaving a black band below the grid).
+function makeContainerResizeHarness(initial = { clientWidth: 800, clientHeight: 400 }) {
+  const element = { ...initial };
+  const observerInstances = [];
+  class FakeResizeObserver {
+    constructor(callback) {
+      this.callback = callback;
+      this.observed = [];
+      this.disconnected = false;
+      observerInstances.push(this);
+    }
+    observe(target) {
+      this.observed.push(target);
+    }
+    disconnect() {
+      this.disconnected = true;
+    }
+  }
+  const fitCalls = [];
+  let pendingFrame = null;
+  const dispose = attachContainerResizeReflow({
+    element,
+    windowId: "win-1",
+    fitTerminal: (id, persist) => fitCalls.push({ id, persist }),
+    ResizeObserverImpl: FakeResizeObserver,
+    requestFrame: (cb) => {
+      pendingFrame = cb;
+      return 7;
+    },
+    cancelFrame: () => {
+      pendingFrame = null;
+    },
+  });
+  const observer = observerInstances[0];
+  return {
+    element,
+    observer,
+    fitCalls,
+    dispose,
+    fire: () => observer.callback(),
+    runFrame: () => {
+      const cb = pendingFrame;
+      pendingFrame = null;
+      if (cb) cb();
+    },
+    pending: () => pendingFrame,
+  };
+}
+
+test("attachContainerResizeReflow refits with persisted geometry once per coalesced size change", () => {
+  const h = makeContainerResizeHarness();
+  assert.ok(h.observer, "a ResizeObserver is constructed and observes the container");
+  assert.deepEqual(h.observer.observed, [h.element], "observes the terminal container element");
+
+  // Initial observation with unchanged size must NOT schedule a redundant fit
+  // (createTerminalRuntime already runs the initial-fit handshake).
+  h.fire();
+  assert.equal(h.pending(), null, "no fit scheduled when the container size is unchanged");
+
+  // Container grows (e.g. maximize): two rapid notifications coalesce to one fit.
+  h.element.clientHeight = 900;
+  h.fire();
+  h.fire();
+  assert.ok(h.pending(), "a frame is scheduled once the container size changes");
+  h.runFrame();
+  assert.deepEqual(
+    h.fitCalls,
+    [{ id: "win-1", persist: true }],
+    "coalesced into a single fit that persists geometry to the PTY",
+  );
+});
+
+test("attachContainerResizeReflow defers to the manual drag-resize path via shouldSkip", () => {
+  const element = { clientWidth: 800, clientHeight: 400 };
+  let cb;
+  class FakeResizeObserver {
+    constructor(callback) {
+      cb = callback;
+    }
+    observe() {}
+    disconnect() {}
+  }
+  const fitCalls = [];
+  let pendingFrame = null;
+  let skip = true;
+  attachContainerResizeReflow({
+    element,
+    windowId: "win-1",
+    fitTerminal: (id, persist) => fitCalls.push({ id, persist }),
+    shouldSkip: () => skip,
+    ResizeObserverImpl: FakeResizeObserver,
+    requestFrame: (fn) => {
+      pendingFrame = fn;
+      return 1;
+    },
+    cancelFrame: () => {
+      pendingFrame = null;
+    },
+  });
+  element.clientHeight = 600;
+  cb();
+  assert.equal(pendingFrame, null, "no fit scheduled while a manual resize owns reflow");
+  assert.equal(fitCalls.length, 0);
+  // Once the manual resize ends, a later container change refits normally.
+  skip = false;
+  element.clientHeight = 650;
+  cb();
+  assert.ok(pendingFrame, "fit scheduled after the manual resize releases");
+  pendingFrame();
+  assert.deepEqual(fitCalls, [{ id: "win-1", persist: true }]);
+});
+
+test("attachContainerResizeReflow dispose disconnects the observer and cancels pending frame", () => {
+  const h = makeContainerResizeHarness();
+  h.element.clientWidth = 1200;
+  h.fire();
+  assert.ok(h.pending(), "frame pending before dispose");
+  h.dispose();
+  assert.equal(h.observer.disconnected, true, "observer disconnected on dispose");
+  assert.equal(h.pending(), null, "pending frame cancelled on dispose");
+});
+
+test("attachContainerResizeReflow is a no-op when ResizeObserver is unavailable", () => {
+  const dispose = attachContainerResizeReflow({
+    element: { clientWidth: 10, clientHeight: 10 },
+    windowId: "win-1",
+    fitTerminal: () => {
+      throw new Error("must not fit without a ResizeObserver");
+    },
+    ResizeObserverImpl: null,
+  });
+  assert.equal(typeof dispose, "function");
+  dispose();
+});
+
+test("app.js wires attachContainerResizeReflow on the terminal container", () => {
+  // Source-string contract: the container reflow controller must be imported
+  // and attached in createTerminalRuntime, and disposed in cleanup.
+  assert.match(
+    appSource,
+    /attachContainerResizeReflow/,
+    "app.js must import + use attachContainerResizeReflow",
   );
 });

--- a/crates/gwt/web/__tests__/window-geometry-sync.test.mjs
+++ b/crates/gwt/web/__tests__/window-geometry-sync.test.mjs
@@ -131,3 +131,46 @@ test("resize release geometry uses the pointer-end event coordinates", () => {
     height: 340,
   });
 });
+
+// maximizedGeometry must keep a CONSTANT 24px SCREEN inset at every zoom.
+// bounds are world-space (viewport divided by zoom); the window lives inside
+// #canvas-stage which applies scale(zoom). A raw +24 world-unit inset rendered
+// as 24*zoom screen px and drifted the maximized window off the viewport at
+// zoom != 1. Screen inset = geometry.x * zoom + viewport.x; with
+// geometry.x = bounds.x + 24/zoom and bounds.x = -viewport.x/zoom this is a
+// constant 24px regardless of zoom.
+test("maximizedGeometry keeps a constant 24px screen inset at zoom = 1", () => {
+  // viewport.x = 0, zoom = 1 → visibleBounds.x = 0
+  const g = geometrySync.maximizedGeometry({ x: 0, y: 0, width: 1000, height: 800 }, 1);
+  assert.deepEqual(g, { x: 24, y: 24, width: 952, height: 752 });
+});
+
+test("maximizedGeometry divides the screen inset by zoom so it does not drift when zoomed in", () => {
+  // zoom = 2, viewport.x = 0 → visibleBounds = { x: 0, width: clientWidth/zoom }
+  // For a 1000px-wide canvas at zoom 2: visibleBounds.width = 500.
+  const z = 2;
+  const bounds = { x: 0, y: 0, width: 1000 / z, height: 800 / z };
+  const g = geometrySync.maximizedGeometry(bounds, z);
+  // world inset must be 24/zoom = 12 so that *zoom screen = 24px constant.
+  assert.equal(g.x, 12);
+  assert.equal(g.y, 12);
+  // screen-space left = g.x * zoom + viewport.x(0) = 24 (constant)
+  assert.equal(g.x * z, 24);
+  // screen-space width = g.width * zoom = clientWidth - 48 (24 each side)
+  assert.equal(g.width * z, 1000 - 48);
+});
+
+test("maximizedGeometry divides the screen inset by zoom when zoomed out", () => {
+  const z = 0.5;
+  const bounds = { x: 0, y: 0, width: 1000 / z, height: 800 / z };
+  const g = geometrySync.maximizedGeometry(bounds, z);
+  assert.equal(g.x * z, 24);
+  assert.equal(g.width * z, 1000 - 48);
+});
+
+test("maximizedGeometry defaults zoom to 1 and never returns negative size", () => {
+  const g = geometrySync.maximizedGeometry({ x: 5, y: 5, width: 10, height: 10 });
+  assert.equal(g.x, 29);
+  assert.equal(g.width, 0); // 10 - 48 clamped to 0
+  assert.equal(g.height, 0);
+});

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -46,6 +46,7 @@
       } from "/launch-controls.js";
       import {
         applyVisibilityTransition,
+        attachContainerResizeReflow,
         attachHostResizeReflow,
         classifyProjectWindowVisibility,
         elementHasLayoutBox,
@@ -4609,6 +4610,19 @@
           window,
         });
         const viewportRefreshCleanup = installTerminalViewportRefreshHandlers(windowId, terminal);
+        // Re-fit whenever the terminal container actually changes size. Covers
+        // size changes that bypass the per-event reflow wiring (maximize /
+        // restore via server geometry, restore-from-minimize, tile/stack, or a
+        // fit that no-opped against an unsettled layout box) which otherwise
+        // leave the grown container showing a black band below the grid. The
+        // manual drag-resize handler already owns reflow + final geometry, so
+        // skip while it is active to avoid a redundant per-frame PTY resync.
+        const containerResizeCleanup = attachContainerResizeReflow({
+          element: terminalContainer,
+          windowId,
+          fitTerminal,
+          shouldSkip: () => !!resizeState && resizeState.id === windowId,
+        });
         const cleanup = () => {
           copyCleanup();
           imagePasteCleanup();
@@ -4616,6 +4630,7 @@
           contextMenuCleanup();
           wheelScrollCleanup.dispose();
           viewportRefreshCleanup();
+          containerResizeCleanup();
         };
         terminal.onData((data) => {
           inputTraceSeq += 1;

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -4553,6 +4553,24 @@
         brightWhite: "#f8fafc",
       };
 
+      // xterm 6.0.0 measures the character cell via an OffscreenCanvas strategy
+      // (`ctx.font = `${fontSize}px ${fontFamily}``). Canvas 2D `ctx.font` does
+      // NOT resolve CSS custom properties, so a `var(--font-mono)` family token
+      // is dropped and the SHORTER system fallback (SF Mono / Menlo) is measured,
+      // while the rendered rows resolve var() to the TALLER JetBrains Mono — a
+      // permanent measure-vs-render mismatch that clips glyphs vertically. Resolve
+      // --font-mono here (keeping typography.css as the single source of truth) so
+      // the measured font equals the rendered font.
+      function resolveTerminalFontFamily() {
+        const resolved = getComputedStyle(document.documentElement)
+          .getPropertyValue("--font-mono")
+          .trim();
+        return (
+          resolved ||
+          '"JetBrains Mono Variable", "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace'
+        );
+      }
+
       function createTerminalRuntime(windowId, terminalContainer) {
         if (terminalMap.has(windowId)) {
           return terminalMap.get(windowId);
@@ -4561,8 +4579,7 @@
           cursorBlink: true,
           convertEol: true,
           theme: XTERM_THEME_DARK,
-          fontFamily:
-            "var(--font-mono), ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+          fontFamily: resolveTerminalFontFamily(),
           fontSize: 14,
           lineHeight: isBlinkBrowser() ? 1.35 : 1.3,
           scrollback: 5000,

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -60,6 +60,7 @@
         commitLocalGeometryEdit,
         createGeometrySyncState,
         localGeometryBaseRevision,
+        maximizedGeometry,
         resizeGeometryFromPointerState,
         shouldApplyWorkspaceGeometry,
         syncResizeStatePointerEvent,
@@ -1927,15 +1928,6 @@
         }
       }
 
-      function maximizedGeometry(bounds) {
-        return {
-          x: bounds.x + 24,
-          y: bounds.y + 24,
-          width: Math.max(bounds.width - 48, 0),
-          height: Math.max(bounds.height - 48, 0),
-        };
-      }
-
       function geometryMatches(left, right) {
         return (
           Math.abs(left.x - right.x) < 0.5 &&
@@ -1946,8 +1938,7 @@
       }
 
       function syncMaximizedWindowsToViewport() {
-        const bounds = visibleBounds();
-        const nextGeometry = maximizedGeometry(bounds);
+        const nextGeometry = maximizedGeometry(visibleBounds(), viewport.zoom);
         for (const windowData of activeWorkspace().windows || []) {
           if (!windowData.maximized) {
             continue;
@@ -1958,7 +1949,9 @@
           send({
             kind: "maximize_window",
             id: windowData.id,
-            bounds,
+            // The frontend now sends the FINAL maximized geometry (zoom-corrected
+            // screen inset); the backend stores it as-is. See maximizedGeometry.
+            bounds: nextGeometry,
           });
         }
       }
@@ -3692,7 +3685,9 @@
         send({
           kind: "maximize_window",
           id: windowId,
-          bounds: visibleBounds(),
+          // Final maximized geometry (zoom-corrected screen inset). The backend
+          // stores it as-is; see maximizedGeometry in window-geometry-sync.js.
+          bounds: maximizedGeometry(visibleBounds(), viewport.zoom),
         });
       }
 

--- a/crates/gwt/web/terminal-viewport-reflow.js
+++ b/crates/gwt/web/terminal-viewport-reflow.js
@@ -51,6 +51,84 @@ export function attachHostResizeReflow({
 }
 
 /**
+ * Re-fit a terminal whenever its CONTAINER element actually changes size.
+ *
+ * Reflow used to be wired only to specific lifecycle events: the manual
+ * drag-resize handler, the host `window.resize` fan-out, and tab/focus
+ * activation. Any size change that does NOT go through one of those paths —
+ * maximize / restore driven by a server `workspace_state`, restore-from-
+ * minimize at the same stored geometry, tile / stack / align, or a
+ * `runTerminalActivationSequence` that silently no-opped because it ran
+ * against an unsettled (0-size) layout box — left the xterm grid at its old
+ * row count. The grown container then renders the xterm background as a black
+ * band below the last row (and the backend PTY never learns the new size).
+ *
+ * A `ResizeObserver` fires AFTER layout settles for ANY cause, so routing it
+ * through `fitTerminal` (which already gates on `elementHasLayoutBox` and
+ * resyncs the PTY) closes every such gap with a single observer instead of
+ * patching each lifecycle event. Notifications coalesce through one animation
+ * frame, and an unchanged-size guard prevents the initial `observe()` callback
+ * (and any spurious notification) from triggering a redundant fit.
+ *
+ * `shouldSkip()` lets the caller defer to a bespoke path that already owns
+ * reflow — the manual drag-resize handler fits per frame and sends the final
+ * geometry on pointer-up, so the observer should not also resync the PTY on
+ * every frame while a window is being dragged by its resize handle.
+ *
+ * Returns a `dispose` function that cancels any pending frame and disconnects
+ * the observer.
+ */
+export function attachContainerResizeReflow({
+  element,
+  windowId,
+  fitTerminal,
+  shouldSkip,
+  ResizeObserverImpl = typeof ResizeObserver === "function" ? ResizeObserver : null,
+  requestFrame,
+  cancelFrame,
+}) {
+  if (!element || typeof ResizeObserverImpl !== "function" || typeof fitTerminal !== "function") {
+    return () => {};
+  }
+  const schedule =
+    typeof requestFrame === "function"
+      ? requestFrame
+      : typeof requestAnimationFrame === "function"
+        ? (cb) => requestAnimationFrame(cb)
+        : (cb) => {
+            cb();
+            return null;
+          };
+  const unschedule =
+    typeof cancelFrame === "function"
+      ? cancelFrame
+      : typeof cancelAnimationFrame === "function"
+        ? (id) => cancelAnimationFrame(id)
+        : () => {};
+  let frame = null;
+  let lastWidth = element.clientWidth;
+  let lastHeight = element.clientHeight;
+  const observer = new ResizeObserverImpl(() => {
+    const width = element.clientWidth;
+    const height = element.clientHeight;
+    if (width === lastWidth && height === lastHeight) return;
+    lastWidth = width;
+    lastHeight = height;
+    if (typeof shouldSkip === "function" && shouldSkip()) return;
+    if (frame !== null) return;
+    frame = schedule(() => {
+      frame = null;
+      fitTerminal(windowId, true);
+    });
+  });
+  observer.observe(element);
+  return () => {
+    if (frame !== null) unschedule(frame);
+    observer.disconnect();
+  };
+}
+
+/**
  * Apply the `.hidden` mutation for a single tab and notify the caller when
  * a hidden -> visible transition occurs against a terminal-bearing window.
  * Returns `true` if the activation hook was fired.

--- a/crates/gwt/web/window-geometry-sync.js
+++ b/crates/gwt/web/window-geometry-sync.js
@@ -13,6 +13,33 @@ function positiveFiniteNumber(value, fallback) {
   return Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
+// Screen-space inset (px) between a maximized window and the visible viewport
+// edges. Mirrors `ARRANGE_PADDING` in crates/gwt/src/workspace.rs.
+const MAXIMIZE_SCREEN_INSET = 24;
+
+/**
+ * Compute a maximized window's geometry from the visible viewport bounds.
+ *
+ * `bounds` is in WORLD space (the viewport size already divided by zoom), and
+ * the window is positioned inside `#canvas-stage`, which applies
+ * `scale(zoom)`. The inset is a constant SCREEN-space gap, so it must be
+ * divided by zoom: `screenInset = worldInset * zoom`, hence
+ * `worldInset = MAXIMIZE_SCREEN_INSET / zoom`. The previous code added a raw
+ * `MAXIMIZE_SCREEN_INSET` in world units, which rendered as
+ * `MAXIMIZE_SCREEN_INSET * zoom` screen px and drifted the maximized window off
+ * the viewport at any zoom != 1.
+ */
+export function maximizedGeometry(bounds, zoom = 1) {
+  const normalizedZoom = positiveFiniteNumber(zoom, 1);
+  const inset = MAXIMIZE_SCREEN_INSET / normalizedZoom;
+  return {
+    x: finiteNumber(bounds?.x) + inset,
+    y: finiteNumber(bounds?.y) + inset,
+    width: Math.max(finiteNumber(bounds?.width) - inset * 2, 0),
+    height: Math.max(finiteNumber(bounds?.height) - inset * 2, 0),
+  };
+}
+
 export function createGeometrySyncState() {
   return {
     localEdits: new Map(),

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6319,3 +6319,10 @@ Type: lesson
 Context: Ultracode gating を selected_agent().installed_version >= 2.1.154 で実装したが、手動 GUI 検証で常に非表示だった。load_agent_options が build_agent_options(Vec::new(), ...) を呼ぶため AgentOption.installed_version は production で常に None。AgentDetector::detect_all() は production で Launch Wizard に配線されていない (tests のみ)。
 Learning: Launch Wizard は render 時に installed agent version を保持しない。installed_version に依存する gating は常に false になり、自動テストは fixture で version を埋めるため通ってしまう (テスト緑でも実挙動と乖離)。
 Future Action: Launch Wizard で installed version 依存の判定が必要な場合は wizard-open 時に検出して context へ格納する (例: claude_ultracode_supported() を context.ultracode_supported に格納)。render hot path で subprocess/IO しない。version 依存 feature は自動テストに加え実 GUI で必ず確認する。
+
+## 2026-06-01 — xterm fontFamily に CSS var() を渡すと canvas 測定が 10px sans-serif に化けて見切れる
+
+Type: lesson
+Context: ターミナル文字の縦見切れを lineHeight 1.2→1.28→1.35 と上げ続けても直らなかった (#2903 系譜)。xterm.js 6.0.0 は OffscreenCanvas で ctx.font=`${fontSize}px ${fontFamily}` を設定しセル高を測定するが、fontFamily が 'var(--font-mono), …' だった。
+Learning: Canvas 2D の ctx.font は CSS custom property を解決できず、var() を含む font 文字列は丸ごと無効として無視され ctx.font は初期値 '10px sans-serif' のままになる (Playwright 実機計測: varString.normalized='10px sans-serif' boxHeight=10、resolved --font-mono='14px JetBrains Mono Variable…' boxHeight=18 で JBM ground truth と一致)。一方 DOM 行は style.fontFamily で var() を解決し 18px の JBM を描画するため、測定(10)<描画(18) の恒久的不一致で overflow:hidden 行が glyph を切る。lineHeight 倍率は誤った base を倍率するため何度上げても収束しない。
+Future Action: xterm の fontFamily オプションには var() を含めない。getComputedStyle(:root).getPropertyValue('--font-mono') で解決した実フォントスタックを渡し、測定フォント==描画フォントに揃える。canvas/OffscreenCanvas に渡す font 文字列全般で CSS 変数を使わない。

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6326,3 +6326,10 @@ Type: lesson
 Context: ターミナル文字の縦見切れを lineHeight 1.2→1.28→1.35 と上げ続けても直らなかった (#2903 系譜)。xterm.js 6.0.0 は OffscreenCanvas で ctx.font=`${fontSize}px ${fontFamily}` を設定しセル高を測定するが、fontFamily が 'var(--font-mono), …' だった。
 Learning: Canvas 2D の ctx.font は CSS custom property を解決できず、var() を含む font 文字列は丸ごと無効として無視され ctx.font は初期値 '10px sans-serif' のままになる (Playwright 実機計測: varString.normalized='10px sans-serif' boxHeight=10、resolved --font-mono='14px JetBrains Mono Variable…' boxHeight=18 で JBM ground truth と一致)。一方 DOM 行は style.fontFamily で var() を解決し 18px の JBM を描画するため、測定(10)<描画(18) の恒久的不一致で overflow:hidden 行が glyph を切る。lineHeight 倍率は誤った base を倍率するため何度上げても収束しない。
 Future Action: xterm の fontFamily オプションには var() を含めない。getComputedStyle(:root).getPropertyValue('--font-mono') で解決した実フォントスタックを渡し、測定フォント==描画フォントに揃える。canvas/OffscreenCanvas に渡す font 文字列全般で CSS 変数を使わない。
+
+## 2026-06-01 — gwt serve(--no-tray --no-open)+リモートブラウザでは Open Project(rfd)がフリーズ。reopen_recent_project でパス指定 open する
+
+Type: lesson
+Context: 新ビルド検証で隔離HOMEのgwtを別プロセス起動しChromeから操作。Open Projectクリックで UI がフリーズ（HTTPサーバーは200で生存）。
+Learning: open_project_dialog_events は rfd::FileDialog::pick_folder() を同期呼び出し(crates/gwt/src/app_runtime/mod.rs:4659)。headless serveプロセスはウィンドウ/Dock無しのバックグラウンドのため、別アプリ(Chrome)経由だとネイティブダイアログを前面化できずブロックする。ReopenRecentProject{path}->open_project_path_events はダイアログ不要でパスから開ける。
+Future Action: serve+remote browserでプロジェクトを開く必要がある時はOpen Projectを使わず、WS(/ws)へ {kind:'reopen_recent_project', path:'<repo>'} を送る(Playwright page.evaluateでWebSocketを開いて送信)。serveモードのOpen Projectフリーズ自体は別Issue候補。


### PR DESCRIPTION
## 背景

macOS Chrome の gwt GUI（WebView + xterm.js）で報告されたターミナル/ウィンドウのレイアウト崩れ 3 件を修正します。ユーザー提供の静止画・動画から、独立した 3 つの真因を特定しました。

## 修正（不具合ごとに 3 コミット）

### ① `933be899` フォント見切れ（行間が詰まり文字が切れる）
xterm 6.0.0 は OffscreenCanvas で `ctx.font = \`${fontSize}px ${fontFamily}\`` を設定してセルを測定します。Canvas 2D の `ctx.font` は CSS `var()` を解決できず、`"var(--font-mono), …"` は**丸ごと無効**となり Chrome は既定の `10px sans-serif`（box 10）で測定します。一方 DOM 行は `var()` を解決して背の高い JetBrains Mono（box 18）を描画するため、10px 基準のセルから 18px グリフがはみ出し `overflow:hidden` で切れます。3 度の `lineHeight` 引き上げ（1.2→1.28→1.35）が収束しなかったのは、誤った base を倍率していたためです。
**修正:** `--font-mono` を実行時解決し（`typography.css` を単一の真実源に維持）、測定フォント = 描画フォントに揃える `resolveTerminalFontFamily()`。`lineHeight` は据え置き。

### ② `544530a2` リサイズで TTY が再描画されない（下部に黒帯）
再 fit は drag-end / host `window.resize` / activation にのみ配線され、コンテナ size 変化を観測する `ResizeObserver` が存在しませんでした。最大化・復元（server geometry 経由）、tile/stack、未確定 layout box への no-op fit など、特定イベントを経由しない size 変化でグリッドが旧サイズのまま残り、`#0a0d12` 背景が黒帯として見えていました。
**修正:** `attachContainerResizeReflow()`（ResizeObserver）を追加し、既存の `runTerminalActivationSequence`（layout-box gating + PTY resync 内包）へ rAF coalesce で流す。drag 中は既存経路に委譲。

### ③ `bf5db097` 最大化ウィンドウの位置ズレ
最大化 inset（24px）を world 空間 bounds に定数加算していました（frontend `maximizedGeometry` + backend `workspace.rs ARRANGE_PADDING`）。ウィンドウは `scale(zoom)` の `#canvas-stage` 内にあるため inset が `24×zoom` screen px に化け、zoom≠1 で viewport からズレていました（zoom=1 のみ正常）。
**修正:** inset を `24/zoom`（= 一定 24px screen）に補正する `maximizedGeometry(bounds, zoom)` を `window-geometry-sync.js` に抽出。frontend が最終 geometry を送り、backend は二重 padding をやめ受領値をそのまま保存。

## 検証

- ユニット/契約: JS **148/148**、Rust `workspace` **72/72**・`maximize` **8/8**。
- `cargo clippy -p gwt --all-targets -D warnings` クリーン、`cargo build -p gwt --bin gwt --bin gwtd` 成功、`cargo fmt`。
- **実ブラウザ計測（別プロセス・隔離 HOME・Chromium, 配信バンドル）で 3 件 PASS:** ①`var()`→`10px sans-serif`/box10, 解決後→JBM box18 ②`attachContainerResizeReflow` の coalesce/persist/dispose ③`maximizedGeometry` の screen inset が zoom 1/2/0.5 で 24px 一定。
- **③ は実ウィンドウで視覚確認**（最大化が viewport に 24px inset 一定で整合、zoom 拡大時も維持）。

### Verification status / follow-up
- ③: ユーザー視覚確認済み。① / ②: 実機計測・テストで確証済み。①② の「実 Claude ターミナルでの黒帯消失・文字非見切れ」の最終目視は、新ビルドを常用 gwt として採用した実セッションでの follow-up とする（本 PR の root-cause 修正自体は計測で確証済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
