### PR TITLE
fix(gui): support Windows Ctrl+C terminal copy

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -235,8 +235,9 @@ Windows の Host 起動では、Launch Agent で Command Prompt、Windows PowerS
 PowerShell 7 を選択できます。Docker 起動では引き続きコンテナ内のシェルを使います。
 
 ターミナルウィンドウでは、テキストをドラッグ選択してマウスボタンを離すとコピー
-できます。Windows / Linux では `Ctrl+Shift+C` でも現在の選択をコピーできます。
-`Ctrl+C` は実行中のターミナルプロセス向けの割り込みのままです。
+できます。Windows では `Ctrl+C` で現在の選択をコピーして選択を解除します。
+選択がない場合、`Ctrl+C` は実行中のターミナルプロセス向けの割り込みのままです。
+Linux では `Ctrl+Shift+C` でも現在の選択をコピーできます。
 
 ## Knowledge、Search、Managed Skills
 

--- a/README.md
+++ b/README.md
@@ -244,8 +244,9 @@ PowerShell, or PowerShell 7. Docker launches continue to use the container
 shell.
 
 In terminal windows, drag to select text and release the mouse button to copy.
-On Windows and Linux, `Ctrl+Shift+C` also copies the current terminal
-selection. `Ctrl+C` stays mapped to the running terminal process.
+On Windows, `Ctrl+C` copies the current terminal selection and clears it; if no
+selection exists, `Ctrl+C` stays mapped to the running terminal process. On
+Linux, `Ctrl+Shift+C` also copies the current terminal selection.
 
 ## Knowledge, Search, and Managed Skills
 

--- a/crates/gwt/playwright/tests/_helpers/embedded-frontend.ts
+++ b/crates/gwt/playwright/tests/_helpers/embedded-frontend.ts
@@ -43,6 +43,7 @@ const ROOT_MODULES = new Set([
   // SPEC-2809 — Console window per-kind tab live tail.
   "console-window.js",
   "socket-receive-dispatcher.js",
+  "terminal-copy-shortcut.js",
   "terminal-context-menu.js",
   "terminal-wheel-scroll.js",
   "terminal-viewport-reflow.js",

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -62,6 +62,10 @@ pub fn terminal_context_menu_js() -> &'static str {
     include_str!("../web/terminal-context-menu.js")
 }
 
+pub fn terminal_copy_shortcut_js() -> &'static str {
+    include_str!("../web/terminal-copy-shortcut.js")
+}
+
 pub fn terminal_wheel_scroll_js() -> &'static str {
     include_str!("../web/terminal-wheel-scroll.js")
 }
@@ -265,6 +269,11 @@ pub const ROOT_JS_MODULE_ASSETS: &[RootJsModuleAsset] = &[
         path: "/terminal-context-menu.js",
         source: terminal_context_menu_js,
         marker: "createTerminalContextMenuController",
+    },
+    RootJsModuleAsset {
+        path: "/terminal-copy-shortcut.js",
+        source: terminal_copy_shortcut_js,
+        marker: "classifyTerminalCopyKeyEvent",
     },
     RootJsModuleAsset {
         path: "/terminal-wheel-scroll.js",
@@ -622,6 +631,40 @@ mod tests {
         assert!(
             html.contains("event.shiftKey"),
             "expected Shift modifier handling in embedded html",
+        );
+    }
+
+    #[test]
+    fn embedded_web_terminal_copy_shortcut_module_is_registered() {
+        let paths: Vec<&str> = root_js_module_assets()
+            .iter()
+            .map(|asset| asset.path)
+            .collect();
+        assert!(
+            paths.contains(&"/terminal-copy-shortcut.js"),
+            "expected terminal copy shortcut helper to be served as a root JS module",
+        );
+    }
+
+    #[test]
+    fn embedded_web_terminal_windows_ctrl_c_copy_clears_selection() {
+        let html = frontend_bundle_source();
+
+        assert!(
+            html.contains("from \"/terminal-copy-shortcut.js\""),
+            "expected app.js to import the terminal copy shortcut classifier",
+        );
+        assert!(
+            html.contains("classifyTerminalCopyKeyEvent"),
+            "expected app.js to classify Windows Ctrl+C terminal copy before xterm handles input",
+        );
+        assert!(
+            html.contains("clearSelectionAfterCopy"),
+            "expected Windows Ctrl+C terminal copy to carry a selection-clear decision",
+        );
+        assert!(
+            html.contains("terminal.clearSelection"),
+            "expected Windows Ctrl+C terminal copy to clear the terminal selection after copying",
         );
     }
 
@@ -2204,6 +2247,7 @@ mod tests {
             "/operator-shell.js",
             "/focus-trap.js",
             "/terminal-context-menu.js",
+            "/terminal-copy-shortcut.js",
             "/terminal-wheel-scroll.js",
             "/custom-agent-env-editor.js",
         ] {

--- a/crates/gwt/web/__tests__/terminal-copy-shortcut.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-copy-shortcut.test.mjs
@@ -1,0 +1,80 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { classifyTerminalCopyKeyEvent } from "../terminal-copy-shortcut.js";
+
+test("Windows Ctrl+C copies only when a terminal selection exists", () => {
+  assert.deepEqual(
+    classifyTerminalCopyKeyEvent(keyEvent({ ctrlKey: true, key: "c" }), {
+      platform: "Windows",
+      hasSelection: true,
+    }),
+    { copy: true, clearSelectionAfterCopy: true },
+  );
+
+  assert.deepEqual(
+    classifyTerminalCopyKeyEvent(keyEvent({ ctrlKey: true, key: "c" }), {
+      platform: "Windows",
+      hasSelection: false,
+    }),
+    { copy: false, clearSelectionAfterCopy: false },
+  );
+});
+
+test("Windows Ctrl+C copy ignores keyup so it cannot copy twice", () => {
+  assert.deepEqual(
+    classifyTerminalCopyKeyEvent(keyEvent({ type: "keyup", ctrlKey: true, key: "c" }), {
+      platform: "Win32",
+      hasSelection: true,
+    }),
+    { copy: false, clearSelectionAfterCopy: false },
+  );
+});
+
+test("Linux keeps Ctrl+C on the PTY path even when a selection exists", () => {
+  assert.deepEqual(
+    classifyTerminalCopyKeyEvent(keyEvent({ ctrlKey: true, key: "c" }), {
+      platform: "Linux x86_64",
+      hasSelection: true,
+    }),
+    { copy: false, clearSelectionAfterCopy: false },
+  );
+});
+
+test("non-macOS Ctrl+Shift+C remains the explicit copy shortcut", () => {
+  assert.deepEqual(
+    classifyTerminalCopyKeyEvent(keyEvent({ ctrlKey: true, shiftKey: true, key: "C" }), {
+      platform: "Windows",
+      hasSelection: true,
+    }),
+    { copy: true, clearSelectionAfterCopy: false },
+  );
+
+  assert.deepEqual(
+    classifyTerminalCopyKeyEvent(keyEvent({ ctrlKey: true, shiftKey: true, key: "c" }), {
+      platform: "Linux",
+      hasSelection: true,
+    }),
+    { copy: true, clearSelectionAfterCopy: false },
+  );
+});
+
+test("macOS keeps terminal copy shortcuts out of the Ctrl-based handler", () => {
+  assert.deepEqual(
+    classifyTerminalCopyKeyEvent(keyEvent({ ctrlKey: true, shiftKey: true, key: "c" }), {
+      platform: "MacIntel",
+      hasSelection: true,
+    }),
+    { copy: false, clearSelectionAfterCopy: false },
+  );
+});
+
+function keyEvent({
+  type = "keydown",
+  ctrlKey = false,
+  shiftKey = false,
+  altKey = false,
+  metaKey = false,
+  key = "",
+} = {}) {
+  return { type, ctrlKey, shiftKey, altKey, metaKey, key };
+}

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -30,6 +30,7 @@
       import { createReleaseNotesWindow } from "/release-notes-window.js";
       import { createConsoleWindow } from "/console-window.js";
       import { createTerminalContextMenuController } from "/terminal-context-menu.js";
+      import { classifyTerminalCopyKeyEvent } from "/terminal-copy-shortcut.js";
       import { createTerminalWheelScrollController } from "/terminal-wheel-scroll.js";
       import { aggregateProjectTabDotState } from "/index-status-controller.js";
       import {
@@ -3782,28 +3783,9 @@
         return Uint8Array.from(atob(base64), (value) => value.charCodeAt(0));
       }
 
-      function isMacPlatform() {
-        const platform = navigator.userAgentData?.platform || navigator.platform || "";
-        return /mac|iphone|ipad|ipod/i.test(platform);
-      }
-
       function isBlinkBrowser() {
         const ua = navigator.userAgent || "";
         return /Chrome\//.test(ua);
-      }
-
-      function isTerminalCopyShortcut(event) {
-        if (isMacPlatform()) {
-          return false;
-        }
-        const key = typeof event.key === "string" ? event.key.toLowerCase() : "";
-        return (
-          event.ctrlKey &&
-          event.shiftKey &&
-          !event.altKey &&
-          !event.metaKey &&
-          key === "c"
-        );
       }
 
       const SUPPORTED_IMAGE_PASTE_MIME_TYPES = new Set([
@@ -4154,7 +4136,7 @@
         }
       }
 
-      async function copyTerminalSelection(windowId) {
+      async function copyTerminalSelection(windowId, { clearSelectionAfterCopy = false } = {}) {
         const runtime = terminalMap.get(windowId);
         if (!runtime || !runtime.terminal.hasSelection()) {
           return false;
@@ -4163,7 +4145,11 @@
         if (!selection) {
           return false;
         }
-        return writeClipboardText(selection, () => runtime.terminal.focus());
+        const copied = await writeClipboardText(selection, () => runtime.terminal.focus());
+        if (copied && clearSelectionAfterCopy) {
+          runtime.terminal.clearSelection();
+        }
+        return copied;
       }
 
       async function copyTerminalOverlayMessage(windowId) {
@@ -4249,7 +4235,10 @@
         };
 
         terminal.attachCustomKeyEventHandler((event) => {
-          if (!isTerminalCopyShortcut(event)) {
+          const copyDecision = classifyTerminalCopyKeyEvent(event, {
+            hasSelection: terminal.hasSelection(),
+          });
+          if (!copyDecision.copy) {
             return true;
           }
           event.preventDefault();
@@ -4257,7 +4246,9 @@
           if (!terminal.hasSelection()) {
             return false;
           }
-          void copyTerminalSelection(windowId);
+          void copyTerminalSelection(windowId, {
+            clearSelectionAfterCopy: copyDecision.clearSelectionAfterCopy,
+          });
           return false;
         });
 

--- a/crates/gwt/web/terminal-copy-shortcut.js
+++ b/crates/gwt/web/terminal-copy-shortcut.js
@@ -1,0 +1,46 @@
+export function classifyTerminalCopyKeyEvent(event, {
+  platform = detectTerminalShortcutPlatform(),
+  hasSelection = false,
+} = {}) {
+  const empty = { copy: false, clearSelectionAfterCopy: false };
+  if (event?.type && event.type !== "keydown") {
+    return empty;
+  }
+  if (!isCopyKey(event)) {
+    return empty;
+  }
+  if (event.altKey || event.metaKey || !event.ctrlKey) {
+    return empty;
+  }
+
+  const family = platformFamily(platform);
+  if (family === "mac") {
+    return empty;
+  }
+  if (event.shiftKey) {
+    return { copy: true, clearSelectionAfterCopy: false };
+  }
+  if (family === "windows" && hasSelection) {
+    return { copy: true, clearSelectionAfterCopy: true };
+  }
+  return empty;
+}
+
+export function detectTerminalShortcutPlatform(navigatorLike = globalThis.navigator) {
+  return navigatorLike?.userAgentData?.platform || navigatorLike?.platform || "";
+}
+
+function isCopyKey(event) {
+  return String(event?.key ?? "").toLowerCase() === "c";
+}
+
+function platformFamily(platform) {
+  const value = String(platform || "");
+  if (/mac|iphone|ipad|ipod/i.test(value)) {
+    return "mac";
+  }
+  if (/win/i.test(value)) {
+    return "windows";
+  }
+  return "other";
+}

--- a/scripts/run-frontend-unit-tests.sh
+++ b/scripts/run-frontend-unit-tests.sh
@@ -21,6 +21,7 @@ bash scripts/run-node-tests-with-linkedom.sh \
   crates/gwt/web/__tests__/update-button.test.mjs \
   crates/gwt/web/__tests__/window-docking.test.mjs \
   crates/gwt/web/__tests__/terminal-context-menu.test.mjs \
+  crates/gwt/web/__tests__/terminal-copy-shortcut.test.mjs \
   crates/gwt/web/__tests__/terminal-wheel-scroll.test.mjs \
   crates/gwt/web/__tests__/canvas-wheel-gesture.test.mjs \
   crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs \

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6396,3 +6396,10 @@ Type: failure-pattern
 Context: Agent TTY overlay had been intentionally disabled, but Launch completion errors before PTY spawn were only sent as TerminalStatus detail. The UI then showed an Error badge while xterm remained blank.
 Learning: When a process fails before a PTY exists, status/detail chrome is not enough. Emit a normal terminal_output diagnostic and replay it through terminal_snapshot on frontend reconnect; do not reintroduce foreground overlays.
 Future Action: For any future launch/startup failure path that can happen before PTY output, add tests for both immediate TerminalOutput and reconnect TerminalSnapshot visibility.
+
+## 2026-06-01 — frontend root module route parity
+
+Type: lesson
+Context: SPEC-1919 added /terminal-copy-shortcut.js as a root module imported by crates/gwt/web/app.js. Frontend unit verification first failed at the Playwright embedded routes coverage because ROOT_MODULES did not include the new file.
+Learning: When adding a root-level web module imported by app.js, keep three contracts in sync: crates/gwt/src/embedded_web.rs asset registry, scripts/run-frontend-unit-tests.sh coverage, and crates/gwt/playwright/tests/_helpers/embedded-frontend.ts ROOT_MODULES.
+Future Action: Before final verification for app.js root imports, run scripts/run-frontend-unit-tests.sh and check the Playwright embedded route parity test instead of assuming the Rust embedded registry is sufficient.


### PR DESCRIPTION
## Summary

- Support the Windows terminal convention where `Ctrl+C` copies selected terminal text without stealing `Ctrl+C` from the running process when there is no selection.
- Keep Linux and macOS terminal shortcut behavior unchanged.

## Changes

- `crates/gwt/web/terminal-copy-shortcut.js`: Adds a platform-aware terminal copy shortcut classifier for Windows `Ctrl+C` and non-macOS `Ctrl+Shift+C`.
- `crates/gwt/web/app.js`: Wires the classifier into the xterm custom key handler and clears Windows selections after a successful `Ctrl+C` copy.
- `crates/gwt/src/embedded_web.rs`: Registers the new root web module and adds embedded asset contract tests.
- `crates/gwt/playwright/tests/_helpers/embedded-frontend.ts`: Keeps Playwright embedded route coverage in sync with the new root module.
- `README.md` / `README.ja.md`: Documents the Windows `Ctrl+C` terminal selection behavior.

## Testing

- [x] `bash scripts/run-node-tests-with-linkedom.sh crates/gwt/web/__tests__/terminal-copy-shortcut.test.mjs` — RED first with missing module, then PASS after implementation.
- [x] `bash scripts/run-frontend-unit-tests.sh` — PASS, 610 tests.
- [x] `bash scripts/check-frontend-bundle.sh` — PASS.
- [x] `cargo fmt --check` — PASS.
- [x] `cargo test -p gwt-core -p gwt --all-features` — PASS.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — PASS.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — PASS.
- [x] `bunx markdownlint-cli README.md README.ja.md tasks/memory.md` — PASS.
- [x] `git diff --check` — PASS.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — PASS.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — the shortcut change is isolated to terminal copy handling and packaged web asset registration.
- Known blockers: None
- Remaining acceptance: None; User Verification Result: skipped(macOS environment cannot verify Windows behavior, and the user explicitly requested PR creation on 2026-06-01).

## Closing Issues

- None

## Related Issues / Links

- #1919

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, frontend unit, markdownlint)
- [x] Documentation updated (if user-facing change)
- [x] Migration/backfill plan included (N/A: no schema or data migration)
- [x] CHANGELOG impact considered (patch-level GUI behavior fix, no breaking change)

## Context

- Windows users expect `Ctrl+C` to copy selected terminal text, but gwt previously forwarded `Ctrl+C` to the running agent/process even when text was selected.

## Risk / Impact

- **Affected areas**: terminal keyboard handling, clipboard copy behavior, embedded web asset packaging.
- **Rollback plan**: revert this PR to restore the previous `Ctrl+Shift+C`-only copy behavior on Windows/Linux.
