### PR TITLE
fix(ui): remove status strip server url

### DIFF
--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -812,6 +812,23 @@ test("Status Strip is exposed as a live region with semantic value labels", () =
   assert.equal(clockCell.getAttribute("aria-hidden"), "true");
 });
 
+test("Status Strip omits the retired server URL cell", () => {
+  assert.equal(document.getElementById("op-strip-server-url"), null);
+  assert.equal(document.getElementById("op-strip-server-url-copy"), null);
+  assert.equal(document.querySelector(".op-status-strip__cell--server-url"), null);
+  assert.doesNotMatch(appSource, /op-strip-server-url/);
+  assert.doesNotMatch(appSource, /kind:\s*"open_server_url"/);
+});
+
+test("Status Strip labels the WebSocket connection state as ONLINE/OFFLINE", () => {
+  const strip = document.getElementById("op-status-strip");
+  const connectionLabel = strip?.querySelector("[data-role='connection-label']");
+  assert.ok(connectionLabel, "expected a connection label in the status strip");
+  assert.equal(connectionLabel.textContent?.trim(), "ONLINE");
+  assert.doesNotMatch(html, />\s*LIVE\s*</);
+  assert.match(appSource, /connectionStatusLabel\.textContent\s*=\s*connected\s*\?\s*"ONLINE"\s*:\s*"OFFLINE"/);
+});
+
 test("Sidebar Quick rows expose aria-keyshortcuts and kbd badges", () => {
   for (const [cmd, key] of [
     ["open-board", "B"],

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1185,81 +1185,6 @@
         });
       }
 
-      // SPEC-2785 US-1 / FR-A〜G: server URL cell in op-status-strip. URL is
-      // derived from `window.location` (frontend is always loaded from the
-      // bound URL, so this is the canonical source) and matches the backend
-      // `AppRuntime::server_url` exactly. Clicking the URL value forwards an
-      // `OpenServerUrl` event to the backend which performs an exact
-      // same-origin check before invoking the OS opener. Clicking the copy
-      // glyph writes the URL to the clipboard with a transient `Copied`
-      // affordance; clipboard rejection downgrades to an inline error state
-      // (no modal) and logs to console for diagnostics.
-      const serverUrlValue = document.getElementById("op-strip-server-url");
-      const serverUrlCopy = document.getElementById("op-strip-server-url-copy");
-      if (serverUrlValue && !serverUrlValue.dataset.serverUrlBound) {
-        serverUrlValue.dataset.serverUrlBound = "true";
-        const serverUrl = new URL("/", window.location.href).toString();
-        serverUrlValue.textContent = serverUrl;
-        serverUrlValue.title = serverUrl;
-        if (serverUrlCopy) {
-          serverUrlCopy.dataset.url = serverUrl;
-        }
-        const openServerUrlInBrowser = () => {
-          send({ kind: "open_server_url", url: serverUrl });
-        };
-        serverUrlValue.addEventListener("click", openServerUrlInBrowser);
-        serverUrlValue.addEventListener("keydown", (event) => {
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            openServerUrlInBrowser();
-          }
-        });
-
-        if (serverUrlCopy && !serverUrlCopy.dataset.serverUrlBound) {
-          serverUrlCopy.dataset.serverUrlBound = "true";
-          let copyResetTimer = 0;
-          const flashCopyState = (state, baseLabel) => {
-            serverUrlCopy.dataset.state = state;
-            serverUrlValue.dataset.state = state;
-            if (baseLabel) {
-              serverUrlCopy.setAttribute("aria-label", baseLabel);
-            }
-            if (copyResetTimer) {
-              window.clearTimeout(copyResetTimer);
-            }
-            copyResetTimer = window.setTimeout(() => {
-              serverUrlCopy.removeAttribute("data-state");
-              serverUrlValue.removeAttribute("data-state");
-              serverUrlCopy.setAttribute("aria-label", "Copy server URL");
-              copyResetTimer = 0;
-            }, 1500);
-          };
-          const copyServerUrl = () => {
-            if (!navigator.clipboard?.writeText) {
-              console.warn(
-                "navigator.clipboard.writeText unavailable; cannot copy server URL",
-              );
-              flashCopyState("error", "Copy failed; clipboard unavailable");
-              return;
-            }
-            navigator.clipboard
-              .writeText(serverUrl)
-              .then(() => flashCopyState("copied", "Copied server URL"))
-              .catch((error) => {
-                console.warn("clipboard.writeText rejected", error);
-                flashCopyState("error", "Copy failed; permission denied");
-              });
-          };
-          serverUrlCopy.addEventListener("click", copyServerUrl);
-          serverUrlCopy.addEventListener("keydown", (event) => {
-            if (event.key === "Enter" || event.key === " ") {
-              event.preventDefault();
-              copyServerUrl();
-            }
-          });
-        }
-      }
-
       const updateCtaController = createUpdateCtaController({
         document,
         send,
@@ -1273,9 +1198,15 @@
         connectionDot.classList.toggle("connected", connected);
         connectionLabel.textContent = connected ? "Connected" : "Reconnecting";
         // SPEC-2356 — propagate connection state to the Operator Status Strip
-        // so the LIVE cell visibly reflects whether the WebSocket bridge is
-        // up. The class is set on the strip element and consumed via CSS.
+        // so the bottom strip clearly reflects whether the WebSocket bridge is
+        // online. The class is set on the strip element and consumed via CSS.
         const strip = document.getElementById("op-status-strip");
+        const connectionStatusLabel = strip?.querySelector(
+          "[data-role='connection-label']",
+        );
+        if (connectionStatusLabel) {
+          connectionStatusLabel.textContent = connected ? "ONLINE" : "OFFLINE";
+        }
         if (strip) {
           strip.classList.toggle("op-status-strip--offline", !connected);
         }

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -288,25 +288,7 @@
         >
           <div class="op-status-strip__cell">
             <span class="op-status-strip__live-dot" aria-hidden="true"></span>
-            <span class="op-status-strip__label">LIVE</span>
-          </div>
-          <div class="op-status-strip__cell op-status-strip__cell--server-url">
-            <span class="op-status-strip__label">URL</span>
-            <span
-              class="op-status-strip__value op-status-strip__server-url-value"
-              id="op-strip-server-url"
-              role="button"
-              tabindex="0"
-              aria-label="Open server URL in browser"
-              title=""
-            >—</span>
-            <button
-              type="button"
-              class="op-status-strip__server-url-copy"
-              id="op-strip-server-url-copy"
-              aria-label="Copy server URL"
-              title="Copy URL"
-            >&#x29C9;</button>
+            <span class="op-status-strip__label" data-role="connection-label">ONLINE</span>
           </div>
           <div class="op-status-strip__cell op-status-strip__cell--active">
             <span class="op-status-strip__label">ACTIVE</span>

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1041,61 +1041,6 @@ body::after {
   color: var(--color-state-blocked);
 }
 
-/* SPEC-2785 FR-A / FR-B / FR-G: server URL cell sits immediately right of
-   the LIVE indicator with the full http://host:port/ URL. The value is
-   clickable (opens external browser via backend IPC) and a sibling copy
-   icon writes the URL to the clipboard. The value is constrained with
-   ellipsis so a long URL cannot crowd out the other status cells. */
-.op-status-strip__cell--server-url {
-  min-width: 0;
-}
-
-.op-status-strip__server-url-value {
-  color: var(--color-state-active);
-  cursor: pointer;
-  max-width: 28ch;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  outline: none;
-}
-
-.op-status-strip__server-url-value:hover,
-.op-status-strip__server-url-value:focus-visible {
-  text-decoration: underline;
-}
-
-.op-status-strip__server-url-value[data-state="copied"] {
-  color: var(--color-state-idle);
-}
-
-.op-status-strip__server-url-copy {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  margin-left: var(--space-1);
-  padding: 0 var(--space-1);
-  background: transparent;
-  border: 1px solid transparent;
-  border-radius: 4px;
-  color: color-mix(in oklab, var(--color-status-strip-fg) 75%, transparent);
-  cursor: pointer;
-  font: inherit;
-  line-height: 1;
-}
-
-.op-status-strip__server-url-copy:hover,
-.op-status-strip__server-url-copy:focus-visible {
-  border-color: color-mix(in oklab, var(--color-status-strip-fg) 40%, transparent);
-  color: var(--color-status-strip-fg);
-  outline: none;
-}
-
-.op-status-strip__server-url-copy[data-state="copied"] {
-  color: var(--color-state-active);
-  border-color: color-mix(in oklab, var(--color-state-active) 60%, transparent);
-}
-
 /* ============================================================
    Canvas area — Operator overrides on existing layout
    ============================================================ */
@@ -2863,7 +2808,7 @@ kbd.op-kbd {
 }
 
 /* SPEC-2356 — Status Strip "offline" state when WebSocket bridge is down.
-   The LIVE indicator dot shifts from active to blocked colour, the entire
+   The connection indicator dot shifts from active to blocked colour, the entire
    strip dim slightly, and counter values slide back to muted because they
    are no longer fresh. */
 :root[data-theme] .op-status-strip--offline .op-status-strip__live-dot {

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6396,3 +6396,10 @@ Type: failure-pattern
 Context: Agent TTY overlay had been intentionally disabled, but Launch completion errors before PTY spawn were only sent as TerminalStatus detail. The UI then showed an Error badge while xterm remained blank.
 Learning: When a process fails before a PTY exists, status/detail chrome is not enough. Emit a normal terminal_output diagnostic and replay it through terminal_snapshot on frontend reconnect; do not reintroduce foreground overlays.
 Future Action: For any future launch/startup failure path that can happen before PTY output, add tests for both immediate TerminalOutput and reconnect TerminalSnapshot visibility.
+
+## 2026-06-01 — Seed project tabs for isolated HOME visual verification
+
+Type: failure-pattern
+Context: SPEC-2785 status strip visual verification launched target/debug/gwt with a temporary HOME to avoid the user production GWT.app tray lock. The server was reachable, but the UI stopped at Open Project because the isolated HOME had an empty ~/.gwt/session.json.
+Learning: A reachable fresh gwt URL is not enough for visual verification when HOME is isolated. If the target UI surface requires an opened project, the isolated session.json must contain the current checkout project tab before asking the user to verify.
+Future Action: For headless-browser-check or fresh checkout UI verification with temporary HOME, pre-seed ~/.gwt/session.json with the current worktree project tab, then verify via browser automation that the page is past Open Project and the requested UI surface is visible before sharing the URL.


### PR DESCRIPTION
## Summary

- Remove the obsolete browser URL and Copy URL controls from the bottom status strip because the previous app-mode access path is no longer needed.
- Rename the bottom connection marker from `LIVE` to `ONLINE`/`OFFLINE` so it describes the WebSocket connection state directly.
- Keep the status strip counters and clock intact while updating regression coverage for the retired URL cell.

## Changes

- `crates/gwt/web/index.html`: removes the server URL status-strip cell and changes the default connection label to `ONLINE`.
- `crates/gwt/web/app.js`: removes URL-copy initialization from the boot path and updates connection state text to `ONLINE`/`OFFLINE`.
- `crates/gwt/web/styles/components.css`: removes the retired server URL cell styling while preserving status strip layout behavior.
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: adds assertions that the URL/copy controls are absent and the connection state no longer says `LIVE`.
- `tasks/memory.md`: records the isolated-HOME visual verification setup needed to avoid the Open Project blocker.

## Testing

- [x] `bash scripts/run-node-tests-with-linkedom.sh crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — PASS, 113 tests.
- [x] `bash scripts/check-frontend-bundle.sh` — PASS.
- [x] `bash scripts/run-frontend-unit-tests.sh` — PASS, 612 tests.
- [x] `cargo fmt --check` — PASS.
- [x] `cargo test -p gwt-core -p gwt --all-features` — PASS.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — PASS.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — PASS.
- [x] `bunx commitlint --from origin/develop --to HEAD` — PASS.
- [x] Headless browser DOM check against `target/debug/gwt --no-tray --no-open --port 0` — PASS: bottom strip shows `ONLINE`, has no server URL cell, has no `LIVE` label, and opens with a seeded project tab.
- [x] User visual verification — confirmed on 2026-06-01: bottom strip no longer shows the URL/Copy URL cell and shows `ONLINE` instead of `LIVE`.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes; this is a contained UI cleanup with regression tests and verified runtime behavior.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- #2785

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check` N/A: no Svelte surface)
- [x] Documentation updated (N/A: removes obsolete chrome affordance; README flow is unchanged)
- [x] Migration/backfill plan included (N/A: no schema or data migration)
- [x] CHANGELOG impact considered (patch-level UI fix; no breaking change)

## Context

- SPEC #2785 covers retiring the bottom status-strip browser URL from the current app UI while keeping the connection state visible.
- `LIVE` represented the browser WebSocket connection, but the label was ambiguous next to operator/agent status counters.

## Risk / Impact

- **Affected areas**: bottom status strip UI in the WebView/browser frontend.
- **Rollback plan**: revert `fix(ui): remove status strip server url` if the retired URL affordance is unexpectedly needed again.

## Screenshots

- User visual verification and the headless browser DOM check both confirmed the visible after-state: no URL/Copy URL cell, no `LIVE` label, and `ONLINE` displayed as the connection marker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * Server URL display removed from the status strip.

* **Changes**
  * Connection status label now displays "ONLINE" or "OFFLINE" instead of "LIVE".
  * Connection state updates dynamically based on current connection status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->