### PR TITLE
fix(branches): clarify branch detail status

### DIFF
--- a/crates/gwt/playwright/tests/branch-cleanup.spec.ts
+++ b/crates/gwt/playwright/tests/branch-cleanup.spec.ts
@@ -27,6 +27,9 @@ test.describe("Branch Cleanup E2E", () => {
 
     const branchSurface = branchesWindow.locator("[data-work-section='branches']");
     await expect(branchSurface).toBeVisible();
+    const notice = branchSurface.locator(".branch-notice");
+    await expect(notice).toBeHidden();
+    await expect(notice).toHaveCSS("display", "none");
 
     const firstBranch = branchSurface.locator(
       ".branch-row[data-branch-name='work/cleanup-one']",
@@ -144,6 +147,121 @@ test.describe("Branch Cleanup E2E", () => {
     await expect(modal).toContainText("Cleanup result");
     await expect(modal).toContainText("success 2 · partial 0 · failed 0");
     await expect(modal.getByRole("button", { name: "Close" })).toBeVisible();
+  });
+
+  test("explains branch detail checks and interrupted cleanup safety", async ({
+    page,
+  }) => {
+    await installEmbeddedRoutes(page);
+    await installBranchDetailCheckBackend(page);
+
+    await page.goto(APP_URL);
+
+    const branchesWindow = page.locator(".workspace-window.surface-work");
+    await expect(branchesWindow).toBeVisible({ timeout: 10_000 });
+    await branchesWindow.locator("[data-work-tab='branches']").click();
+
+    const branchSurface = branchesWindow.locator("[data-work-section='branches']");
+    const notice = branchSurface.locator(".branch-notice");
+    const branch = branchSurface.locator(
+      ".branch-row[data-branch-name='work/detail-pending']",
+    );
+
+    await expect(notice.locator(".branch-notice-title")).toHaveText(
+      "Checking branch details",
+    );
+    await expect(notice).toContainText(
+      "Cleanup selection unlocks after verification.",
+    );
+    await expect(branch.locator(".branch-cleanup-badge")).toHaveText("checking");
+    await expect(branch.locator(".branch-cleanup-toggle")).toHaveAttribute(
+      "title",
+      "Checking cleanup safety",
+    );
+    await expect
+      .poll(() =>
+        notice.evaluate(
+          (element) =>
+            window.getComputedStyle(element, "::before").animationName,
+        ),
+      )
+      .toContain("branch-detail-check-sweep");
+    await expect
+      .poll(() =>
+        branch
+          .locator(".branch-cleanup-badge")
+          .evaluate((element) => window.getComputedStyle(element).animationName),
+      )
+      .toContain("branch-cleanup-checking-pulse");
+
+    await page.evaluate(() => window.__branchDetailFixture.close());
+
+    await expect(notice.locator(".branch-notice-title")).toHaveText(
+      "Branch detail check interrupted",
+    );
+    await expect(notice).toContainText("Refresh to verify cleanup safety.");
+    await expect(branch.locator(".branch-cleanup-badge")).toHaveText(
+      "Safety unknown",
+    );
+    await expect(branch.locator(".branch-cleanup-toggle")).toHaveAttribute(
+      "title",
+      "Refresh to verify cleanup safety",
+    );
+    await expect
+      .poll(() =>
+        notice.evaluate(
+          (element) =>
+            window.getComputedStyle(element, "::before").animationName,
+        ),
+      )
+      .toBe("none");
+    await expect
+      .poll(() =>
+        branch
+          .locator(".branch-cleanup-badge")
+          .evaluate((element) => window.getComputedStyle(element).animationName),
+      )
+      .toBe("none");
+  });
+
+  test("honors reduced motion for branch detail check animations", async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    await installEmbeddedRoutes(page);
+    await installBranchDetailCheckBackend(page);
+
+    await page.goto(APP_URL);
+
+    const branchesWindow = page.locator(".workspace-window.surface-work");
+    await expect(branchesWindow).toBeVisible({ timeout: 10_000 });
+    await branchesWindow.locator("[data-work-tab='branches']").click();
+
+    const branchSurface = branchesWindow.locator("[data-work-section='branches']");
+    const notice = branchSurface.locator(".branch-notice");
+    const branch = branchSurface.locator(
+      ".branch-row[data-branch-name='work/detail-pending']",
+    );
+
+    await expect(notice.locator(".branch-notice-title")).toHaveText(
+      "Checking branch details",
+    );
+    await expect(branch.locator(".branch-cleanup-badge")).toHaveText("checking");
+    await expect
+      .poll(() =>
+        notice.evaluate(
+          (element) =>
+            window.getComputedStyle(element, "::before").animationName,
+        ),
+      )
+      .toBe("none");
+    await expect
+      .poll(() =>
+        branch
+          .locator(".branch-cleanup-badge")
+          .evaluate((element) => window.getComputedStyle(element).animationName),
+      )
+      .toBe("none");
   });
 });
 
@@ -293,6 +411,120 @@ async function installBranchCleanupBackend(page) {
           risks,
         },
       };
+    }
+
+    Object.defineProperty(window, "WebSocket", {
+      configurable: true,
+      value: FixtureWebSocket,
+    });
+  });
+}
+
+async function installBranchDetailCheckBackend(page) {
+  await page.addInitScript(() => {
+    const branchEntries = [
+      {
+        name: "work/detail-pending",
+        scope: "local",
+        is_head: false,
+        upstream: null,
+        ahead: 0,
+        behind: 0,
+        last_commit_date: "2026-05-20",
+        cleanup_ready: false,
+        cleanup: null,
+      },
+    ];
+
+    const workspaceState = {
+      kind: "workspace_state",
+      workspace: {
+        app_version: "playwright",
+        tabs: [
+          {
+            id: "tab-1",
+            title: "Fixture",
+            project_root: "/fixture",
+            kind: "git",
+            workspace: {
+              viewport: { x: 0, y: 0, zoom: 1 },
+              windows: [
+                {
+                  id: "branches-1",
+                  title: "Branches",
+                  preset: "branches",
+                  geometry: { x: 96, y: 96, width: 760, height: 620 },
+                  z_index: 1,
+                  status: "running",
+                  minimized: false,
+                  maximized: false,
+                  pre_maximize_geometry: null,
+                  persist: true,
+                  purpose_title: null,
+                  dynamic_title: null,
+                  dynamic_title_detail: null,
+                  agent_id: null,
+                  agent_color: null,
+                  tab_group_id: null,
+                  tab_group_active: false,
+                },
+              ],
+            },
+          },
+        ],
+        active_tab_id: "tab-1",
+        recent_projects: [],
+      },
+    };
+
+    class FixtureWebSocket extends EventTarget {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+
+      constructor(url) {
+        super();
+        this.url = url;
+        this.readyState = FixtureWebSocket.CONNECTING;
+        window.__branchDetailFixture = this;
+        setTimeout(() => {
+          this.readyState = FixtureWebSocket.OPEN;
+          this.dispatchEvent(new Event("open"));
+        }, 0);
+      }
+
+      send(raw) {
+        const message = JSON.parse(raw);
+        switch (message.kind) {
+          case "frontend_ready":
+            this.emit(workspaceState);
+            break;
+          case "load_branches":
+            this.emit({
+              kind: "branch_entries",
+              id: message.id,
+              phase: "loading",
+              entries: branchEntries,
+            });
+            break;
+          default:
+            break;
+        }
+      }
+
+      close() {
+        this.readyState = FixtureWebSocket.CLOSED;
+        this.dispatchEvent(new CloseEvent("close"));
+      }
+
+      emit(payload) {
+        setTimeout(() => {
+          this.dispatchEvent(
+            new MessageEvent("message", { data: JSON.stringify(payload) }),
+          );
+        }, 0);
+      }
     }
 
     Object.defineProperty(window, "WebSocket", {

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -2281,6 +2281,49 @@ mod tests {
     }
 
     #[test]
+    fn embedded_web_branches_surface_explains_detail_check_state() {
+        let html = frontend_bundle_source();
+
+        assert!(
+            html.contains("branchLoadStatusSummary"),
+            "expected Branches bundle to derive a compact load status summary",
+        );
+        for expected in [
+            "Checking branch details",
+            "Branch detail check interrupted",
+            "Safety unknown",
+            "Refresh to verify cleanup safety",
+        ] {
+            assert!(
+                html.contains(expected),
+                "expected Branches bundle to include clarity copy: {expected}",
+            );
+        }
+        assert!(
+            !html.contains("Cleanup status unavailable"),
+            "expected Branches bundle to avoid ambiguous cleanup unavailable copy",
+        );
+    }
+
+    #[test]
+    fn embedded_web_branches_surface_animates_only_checking_detail_state() {
+        let html = frontend_bundle_source();
+
+        for expected in [
+            "@keyframes branch-detail-check-sweep",
+            "@keyframes branch-cleanup-checking-pulse",
+            r#".branch-notice[data-branch-status="checking"]::before"#,
+            ".branch-cleanup-badge.loading",
+            "prefers-reduced-motion: reduce",
+        ] {
+            assert!(
+                html.contains(expected),
+                "expected Branches bundle to include checking animation contract: {expected}",
+            );
+        }
+    }
+
+    #[test]
     fn embedded_web_branches_surface_keeps_inventory_failures_blocking_until_fresh_rows_arrive() {
         let html = frontend_bundle_source();
 

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -718,6 +718,79 @@ test("Branches loading state becomes recoverable when the WebSocket disconnects"
   );
 });
 
+test("Branches detail-check state explains checking and interrupted cleanup safety", () => {
+  assert.match(
+    appSource,
+    /function\s+branchLoadStatusSummary\(state\)/,
+    "expected Branches to derive a status summary from branch load state",
+  );
+  for (const copy of [
+    "Checking branch details",
+    "Branch detail check interrupted",
+    "Safety unknown",
+    "Refresh to verify cleanup safety",
+  ]) {
+    assert.ok(appSource.includes(copy), `expected Branches clarity copy: ${copy}`);
+  }
+  assert.doesNotMatch(
+    appSource,
+    /Cleanup status unavailable/,
+    "Branches rows should explain unknown safety instead of showing an unavailable cleanup placeholder",
+  );
+  assert.doesNotMatch(
+    appSource,
+    /state\.loading\s*\?\s*"loading"\s*:\s*"unknown"/,
+    "Branches cleanup badges should not collapse interrupted hydration into an ambiguous unknown label",
+  );
+  for (const selector of [
+    ".branch-notice-title",
+    ".branch-notice-detail",
+    ".branch-notice-hint",
+  ]) {
+    assert.ok(inlineStyle.includes(selector), `missing Branches status summary CSS: ${selector}`);
+  }
+  assert.match(
+    inlineStyle,
+    /\.branch-notice\[hidden\]\s*\{[\s\S]*display:\s*none/,
+    "hidden Branches notices must not leave an empty status band behind",
+  );
+});
+
+test("Branches detail-check checking state uses motion without animating static states", () => {
+  assert.match(
+    inlineStyle,
+    /@keyframes\s+branch-detail-check-sweep/,
+    "expected Branches checking summary to define a named sweep animation",
+  );
+  assert.match(
+    inlineStyle,
+    /@keyframes\s+branch-cleanup-checking-pulse/,
+    "expected Branches checking badge to define a named pulse animation",
+  );
+  assert.match(
+    inlineStyle,
+    /\.branch-notice\[data-branch-status="checking"\]::before[\s\S]+animation:\s*branch-detail-check-sweep/,
+    "expected only the checking summary notice to run the progress sweep",
+  );
+  assert.match(
+    inlineStyle,
+    /\.branch-cleanup-badge\.loading[\s\S]+animation:\s*branch-cleanup-checking-pulse/,
+    "expected only checking cleanup badges to pulse",
+  );
+
+  const reducedMotion = extractMediaBlocks(inlineStyle, "prefers-reduced-motion: reduce");
+  assert.match(
+    reducedMotion,
+    /branch-notice\[data-branch-status="checking"\]::before[\s\S]+animation:\s*none/,
+    "reduced-motion users must not get the checking summary sweep",
+  );
+  assert.match(
+    reducedMotion,
+    /branch-cleanup-badge\.loading[\s\S]+animation:\s*none/,
+    "reduced-motion users must not get the checking badge pulse",
+  );
+});
+
 test("hotkey overlay lists ⌘P/⌘B/⌘G/⌘L/⌘?/Esc (sidebar toggle hotkey is removed in Phase 9)", () => {
   const overlay = document.getElementById("op-hotkey-overlay");
   assert.ok(overlay, "hotkey overlay missing");

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -9124,11 +9124,7 @@
           cleanupButton.textContent =
             selectedCount === 0 ? "Clean Up" : `Clean Up (${selectedCount})`;
         }
-        if (notice) {
-          const noticeText = state.notice || branchLoadingNoticeText(state);
-          notice.hidden = !noticeText;
-          notice.textContent = noticeText || "";
-        }
+        renderBranchLoadStatusSummary(notice, branchLoadStatusSummary(state));
 
         if (state.error) {
           setBranchListPlaceholder(list, state.error);
@@ -9875,11 +9871,77 @@
         return target.reference ? `merged to ${target.reference}` : "";
       }
 
-      function branchLoadingNoticeText(state) {
-        if (!state.loading) {
-          return "";
+      const BRANCH_DETAIL_CHECK_INTERRUPTED_NOTICE = "Branch detail check interrupted";
+
+      function branchLoadStatusSummary(state) {
+        if (!state) {
+          return null;
         }
-        return state.entries.length === 0 ? "" : "Loading branch details";
+        if (state.error) {
+          return {
+            kind: "error",
+            title: "Branches unavailable",
+            detail: state.error,
+            hint: "Refresh to try again.",
+          };
+        }
+        if (state.loading && state.entries.length > 0) {
+          return {
+            kind: "checking",
+            title: "Checking branch details",
+            detail: "Loading branch details while cleanup safety is checked.",
+            hint: "Cleanup selection unlocks after verification.",
+          };
+        }
+        if (state.notice === BRANCH_DETAIL_CHECK_INTERRUPTED_NOTICE) {
+          return {
+            kind: "interrupted",
+            title: BRANCH_DETAIL_CHECK_INTERRUPTED_NOTICE,
+            detail: "Branch names are available, but cleanup safety was not verified.",
+            hint: "Refresh to verify cleanup safety.",
+          };
+        }
+        if (state.notice) {
+          return {
+            kind: "notice",
+            title: "Branch notice",
+            detail: state.notice,
+            hint: "",
+          };
+        }
+        return null;
+      }
+
+      function renderBranchLoadStatusSummary(notice, summary) {
+        if (!notice) {
+          return;
+        }
+        notice.textContent = "";
+        notice.hidden = !summary;
+        if (!summary) {
+          notice.removeAttribute("data-branch-status");
+          return;
+        }
+        notice.dataset.branchStatus = summary.kind;
+
+        const title = document.createElement("div");
+        title.className = "branch-notice-title";
+        title.textContent = summary.title;
+        notice.appendChild(title);
+
+        if (summary.detail) {
+          const detail = document.createElement("div");
+          detail.className = "branch-notice-detail";
+          detail.textContent = summary.detail;
+          notice.appendChild(detail);
+        }
+
+        if (summary.hint) {
+          const hint = document.createElement("div");
+          hint.className = "branch-notice-hint";
+          hint.textContent = summary.hint;
+          notice.appendChild(hint);
+        }
       }
 
       function failLoadingBranchesOnConnectionLoss(windowId, state) {
@@ -9893,22 +9955,28 @@
           state.notice = "";
         } else {
           state.error = "";
-          state.notice = "Connection lost while loading branch details";
+          state.notice = BRANCH_DETAIL_CHECK_INTERRUPTED_NOTICE;
         }
         syncBranchSelectionState(state);
         return true;
       }
 
       function branchCleanupPendingText(state) {
-        return state.loading ? "Loading cleanup status" : "Cleanup status unavailable";
+        return state.loading ? "Checking cleanup safety" : "Refresh to verify cleanup safety";
       }
 
       function cleanupAvailabilityForRender(entry, state) {
-        return entry.cleanup_ready ? entry.cleanup.availability : "loading";
+        if (entry.cleanup_ready) {
+          return entry.cleanup.availability;
+        }
+        if (state.loading) {
+          return "loading";
+        }
+        return "unknown";
       }
 
       function cleanupBadgeText(entry, state) {
-        return entry.cleanup_ready ? entry.cleanup.availability : state.loading ? "loading" : "unknown";
+        return entry.cleanup_ready ? entry.cleanup.availability : state.loading ? "checking" : "Safety unknown";
       }
 
       function toggleBranchCleanupSelection(windowId, branchName) {

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -3046,6 +3046,10 @@ body {
   color: var(--color-text-muted);
 }
 
+.branch-cleanup-toggle.unknown {
+  color: var(--color-text-muted);
+}
+
 .branch-cleanup-toggle.selected {
   background: var(--color-button-bg);
   border-color: var(--color-button-bg);
@@ -3237,6 +3241,12 @@ body {
 .branch-cleanup-badge.loading {
   background: color-mix(in oklab, var(--color-text-muted) 12%, transparent);
   color: var(--color-text-muted);
+  animation: branch-cleanup-checking-pulse 1400ms ease-in-out infinite;
+}
+
+.branch-cleanup-badge.unknown {
+  background: color-mix(in oklab, var(--agent-claude) 12%, transparent);
+  color: var(--agent-claude);
 }
 
 .branch-summary {
@@ -3247,13 +3257,100 @@ body {
 }
 
 .branch-notice {
+  position: relative;
+  display: grid;
+  gap: 3px;
   padding: 10px 12px;
   border-bottom: 1px solid var(--color-border);
-  font-family: var(--font-mono);
-  font-size: var(--type-xs);
-  letter-spacing: var(--tracking-mono);
   color: var(--agent-claude);
   background: color-mix(in oklab, var(--agent-claude) 10%, transparent);
+  overflow: hidden;
+}
+
+.branch-notice[hidden] {
+  display: none;
+}
+
+.branch-notice[data-branch-status="checking"] {
+  color: var(--color-state-active);
+  background: color-mix(in oklab, var(--color-state-active) 10%, transparent);
+}
+
+.branch-notice[data-branch-status="checking"]::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    100deg,
+    transparent 0%,
+    color-mix(in oklab, var(--color-state-active) 24%, transparent) 48%,
+    transparent 72%
+  );
+  transform: translateX(-100%);
+  animation: branch-detail-check-sweep 1800ms ease-in-out infinite;
+}
+
+.branch-notice > * {
+  position: relative;
+  z-index: 1;
+}
+
+.branch-notice-title {
+  font-family: var(--font-mono);
+  font-size: var(--type-xs);
+  font-weight: 700;
+  letter-spacing: var(--tracking-mono);
+  text-transform: uppercase;
+}
+
+.branch-notice-detail,
+.branch-notice-hint {
+  font-family: var(--font-body);
+  font-size: var(--type-xs);
+  letter-spacing: 0;
+}
+
+.branch-notice-detail {
+  color: var(--color-text);
+}
+
+.branch-notice-hint {
+  color: var(--color-text-muted);
+}
+
+@keyframes branch-detail-check-sweep {
+  0% {
+    opacity: 0;
+    transform: translateX(-100%);
+  }
+
+  35% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+}
+
+@keyframes branch-cleanup-checking-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in oklab, var(--color-text-muted) 0%, transparent);
+  }
+
+  50% {
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--color-state-active) 18%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .branch-notice[data-branch-status="checking"]::before,
+  .branch-cleanup-badge.loading {
+    animation: none;
+  }
 }
 
 .branch-cleanup-list {

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6403,3 +6403,10 @@ Type: lesson
 Context: SPEC-1919 added /terminal-copy-shortcut.js as a root module imported by crates/gwt/web/app.js. Frontend unit verification first failed at the Playwright embedded routes coverage because ROOT_MODULES did not include the new file.
 Learning: When adding a root-level web module imported by app.js, keep three contracts in sync: crates/gwt/src/embedded_web.rs asset registry, scripts/run-frontend-unit-tests.sh coverage, and crates/gwt/playwright/tests/_helpers/embedded-frontend.ts ROOT_MODULES.
 Future Action: Before final verification for app.js root imports, run scripts/run-frontend-unit-tests.sh and check the Playwright embedded route parity test instead of assuming the Rust embedded registry is sufficient.
+
+## 2026-06-01 — Hidden attribute can be overridden by component display rules
+
+Type: lesson
+Context: SPEC-2009 Branches notice hotfix: .branch-notice used display:grid, so a hidden notice still rendered as an empty red band after branch detail checking completed.
+Learning: When a component class sets display explicitly, hidden elements need an explicit selector such as .component[hidden] { display: none; } and a visual regression contract, because the class rule can override the UA hidden style.
+Future Action: For UI surfaces with reusable notice/banner components, add hidden-state display contracts in both static CSS tests and browser/UI tests whenever the component sets display.


### PR DESCRIPTION
## Summary

- Clarifies the Branches detail-check state so users can distinguish checking, interrupted, unavailable, and verified states.
- Adds checking-only animation for the detail notice and cleanup safety badges, while keeping interrupted and unknown states static.
- Fixes the hidden notice CSS cascade so an empty red notice band no longer remains after verification completes.

## Changes

- `crates/gwt/web/app.js`: renders structured branch status summaries and updates cleanup safety copy for checking and interrupted states.
- `crates/gwt/web/styles/app.css`: adds Branches notice styles, checking animations, reduced-motion handling, unknown badge styling, and `.branch-notice[hidden] { display: none; }`.
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: covers status summary copy, animation contracts, reduced-motion selectors, and hidden notice display behavior.
- `crates/gwt/src/embedded_web.rs`: pins the embedded bundle contract for branch detail clarity and checking-only animation assets.
- `crates/gwt/playwright/tests/branch-cleanup.spec.ts`: covers checking/interrupted cleanup safety UI, animation behavior, reduced motion, and the hidden notice regression.
- `tasks/memory.md`: records the hidden-attribute cascade lesson for future UI components that set explicit display rules.

## Testing

- [x] `bash scripts/run-node-tests-with-linkedom.sh crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` — passed, 113 tests.
- [x] `cargo test -p gwt embedded_web_branches_surface_explains_detail_check_state --all-features` — passed.
- [x] `cargo test -p gwt embedded_web_branches_surface_animates_only_checking_detail_state --all-features` — passed.
- [x] `bash scripts/run-visual-tests.sh --project=chromium-dark crates/gwt/playwright/tests/branch-cleanup.spec.ts` — passed, 3 tests.
- [x] `bash scripts/check-frontend-bundle.sh` — passed.
- [x] `bash scripts/run-frontend-unit-tests.sh` — passed, 612 tests.
- [x] `cargo fmt -- --check` — passed.
- [x] `git diff --check` — passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed.
- [x] Live UI smoke at `http://127.0.0.1:64242/` — HTTP 200; Branches rows rendered; checking notice transitioned to `hidden` / `display: none` / `height: 0`; user confirmed the refreshed UI on 2026-06-01.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes, this is scoped to Branches status clarity and hidden notice rendering without schema or migration changes.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- #2009

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check` N/A)
- [x] Documentation updated (memory note added; README unchanged because user-facing usage docs are unaffected)
- [x] Migration/backfill plan included (N/A: no schema/data migration)
- [x] CHANGELOG impact considered (patch-level `fix:` commit, no breaking change)

## Context

- SPEC-2009 Branches UI already had a top notice for detail-check state, but the state was not understandable enough from the band alone and a hidden notice could remain visible as an empty red band.

## Risk / Impact

- **Affected areas**: Branches work surface notice rendering, cleanup safety badge text, and Branches-specific tests.
- **Rollback plan**: Revert the two commits on this branch if the Branches notice behavior regresses.

## Screenshots

- Not attached; live visual verification was completed by the user against the fresh local URL `http://127.0.0.1:64242/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced branch detail status messaging with clear checking and safety indicators
  * Added animations for branch status updates with accessibility support for reduced-motion preferences

* **Bug Fixes**
  * Fixed branch notice visibility when using specific display rules

* **Tests**
  * Expanded test coverage for branch detail checking states and UI behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->