### PR TITLE
fix(launch-wizard): recover close on reconnect

### DIFF
--- a/crates/gwt/playwright/tests/launch-wizard-reconnect-live.spec.ts
+++ b/crates/gwt/playwright/tests/launch-wizard-reconnect-live.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * SPEC-2012/SPEC-2014 2026-06-01 - Launch Wizard reconnect recovery.
+ *
+ * Runs against a real gwt browser-server backend. The test injects a stale
+ * Launch Wizard state into the frontend, then sends `frontend_ready` over the
+ * live WebSocket. The backend must reply with the authoritative
+ * `launch_wizard_state` tombstone (`wizard: null`) so the stale modal closes.
+ */
+import { expect, test, type Page } from "@playwright/test";
+import { gotoLiveGwt, sendLiveGwtEvent } from "./_helpers/live-gwt";
+
+const BASE = process.env.GWT_PLAYWRIGHT_BASE_URL ?? "";
+
+test.describe.serial("Launch Wizard reconnect recovery (live backend)", () => {
+  test.skip(!BASE, "GWT_PLAYWRIGHT_BASE_URL is not set; live E2E skipped");
+
+  test.beforeEach(async ({ page }, testInfo) => {
+    test.skip(
+      testInfo.project.name !== "chromium-dark",
+      "live Launch Wizard reconnect E2E runs once against the shared backend",
+    );
+    await gotoLiveGwt(page, BASE, { enableTestBridge: true });
+    await keepLaunchWizardModalVisibilityDeterministic(page);
+  });
+
+  test("FrontendReady tombstone closes a stale Launch Wizard after reconnect", async ({
+    page,
+  }) => {
+    await injectStaleLaunchWizard(page);
+
+    const wizard = page.locator("#wizard-modal");
+    await expect(wizard).toBeVisible();
+    await expect(wizard).toContainText("Stale Launch Wizard");
+
+    await sendLiveGwtEvent(page, { kind: "frontend_ready" });
+
+    await expect(wizard).toHaveAttribute("aria-hidden", "true");
+    await expect(wizard).toBeHidden();
+  });
+});
+
+async function keepLaunchWizardModalVisibilityDeterministic(page: Page): Promise<void> {
+  await page.addStyleTag({
+    content: `
+      #wizard-modal[aria-hidden="false"],
+      #wizard-modal.open {
+        display: flex !important;
+        pointer-events: auto !important;
+      }
+      #wizard-modal[aria-hidden="true"] {
+        display: none !important;
+        pointer-events: none !important;
+      }
+    `,
+  });
+}
+
+async function injectStaleLaunchWizard(page: Page): Promise<void> {
+  await page.evaluate((wizard) => {
+    window.dispatchEvent(
+      new CustomEvent("__gwt_test_inject", {
+        detail: {
+          kind: "launch_wizard_state",
+          wizard,
+        },
+      }),
+    );
+  }, {
+    title: "Launch Agent",
+    branch_name: "work/reconnect-stale",
+    selected_branch_name: "work/reconnect-stale",
+    show_branch_controls: false,
+    show_start_methods: false,
+    show_manual_setup: false,
+    show_runtime_confirmation: false,
+    runtime_context_resolved: true,
+    runtime_resolution_pending: false,
+    is_hydrating: false,
+    show_back_button: false,
+    primary_action_label: "Launch",
+    primary_action_enabled: true,
+    launch_summary: [
+      { label: "Recovery", value: "Stale Launch Wizard" },
+      { label: "Target", value: "Agent" },
+    ],
+    progress_steps: [
+      { label: "Launch requested", state: "done" },
+      {
+        label: "Reconnect sync",
+        state: "current",
+        detail: "Waiting for authoritative backend state",
+      },
+    ],
+    start_methods: [],
+  });
+}

--- a/crates/gwt/playwright/tests/launch-wizard-reconnect-live.spec.ts
+++ b/crates/gwt/playwright/tests/launch-wizard-reconnect-live.spec.ts
@@ -19,8 +19,10 @@ test.describe.serial("Launch Wizard reconnect recovery (live backend)", () => {
       testInfo.project.name !== "chromium-dark",
       "live Launch Wizard reconnect E2E runs once against the shared backend",
     );
+    await suppressInitialFrontendReady(page);
     await gotoLiveGwt(page, BASE, { enableTestBridge: true });
     await keepLaunchWizardModalVisibilityDeterministic(page);
+    await clearBackendLaunchWizard(page);
   });
 
   test("FrontendReady tombstone closes a stale Launch Wizard after reconnect", async ({
@@ -53,6 +55,39 @@ async function keepLaunchWizardModalVisibilityDeterministic(page: Page): Promise
       }
     `,
   });
+}
+
+async function suppressInitialFrontendReady(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const originalSend = WebSocket.prototype.send;
+    WebSocket.prototype.send = function sendWithInitialReadySuppressed(data) {
+      try {
+        const payload = typeof data === "string" ? JSON.parse(data) : null;
+        if (
+          payload?.kind === "frontend_ready" &&
+          (window as any).__gwtDropInitialFrontendReady !== false
+        ) {
+          (window as any).__gwtDropInitialFrontendReady = false;
+          return;
+        }
+      } catch {
+        /* no-op */
+      }
+      return originalSend.call(this, data);
+    };
+  });
+}
+
+async function clearBackendLaunchWizard(page: Page): Promise<void> {
+  const wizard = page.locator("#wizard-modal");
+  await sendLiveGwtEvent(page, {
+    kind: "launch_wizard_action",
+    action: { kind: "cancel" },
+    bounds: null,
+  });
+  await expect(wizard).toBeHidden();
+  await expect(wizard.locator(".wizard-summary-item")).toHaveCount(0);
+  await expect(wizard).not.toContainText("Work launch");
 }
 
 async function injectStaleLaunchWizard(page: Page): Promise<void> {

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1667,14 +1667,12 @@ pub fn build_frontend_sync_events(
         ));
     }
 
-    if let Some(wizard) = launch_wizard {
-        events.push(OutboundEvent::reply(
-            client_id,
-            BackendEvent::LaunchWizardState {
-                wizard: Some(Box::new(wizard)),
-            },
-        ));
-    }
+    events.push(OutboundEvent::reply(
+        client_id,
+        BackendEvent::LaunchWizardState {
+            wizard: launch_wizard.map(Box::new),
+        },
+    ));
 
     if let Some(state) = pending_update {
         events.push(OutboundEvent::reply(
@@ -11265,6 +11263,35 @@ exit 1
             event.event,
             BackendEvent::UpdateState(gwt_core::update::UpdateState::UpToDate { .. })
         )));
+    }
+
+    #[test]
+    fn app_runtime_frontend_ready_replies_launch_wizard_tombstone_when_closed() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab_with_window(
+            "tab-1",
+            "shell-1",
+            WindowPreset::Shell,
+            WindowProcessStatus::Ready,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+
+        let events =
+            runtime.handle_frontend_event("client-1".to_string(), FrontendEvent::FrontendReady);
+
+        let tombstone = events
+            .iter()
+            .find(|event| {
+                matches!(
+                    event.event,
+                    BackendEvent::LaunchWizardState { wizard: None }
+                )
+            })
+            .expect("FrontendReady must clear stale Launch Wizard state after reconnect");
+        assert!(
+            matches!(&tombstone.target, DispatchTarget::Client(client_id) if client_id == "client-1"),
+            "Launch Wizard tombstone must be scoped to the reconnecting client"
+        );
     }
 
     #[test]

--- a/crates/gwt/src/embedded_server.rs
+++ b/crates/gwt/src/embedded_server.rs
@@ -156,6 +156,15 @@ impl ClientHub {
         }
 
         if !stale_clients.is_empty() {
+            stale_clients.sort();
+            stale_clients.dedup();
+            tracing::warn!(
+                target: "gwt::client_hub",
+                queue_capacity = CLIENT_QUEUE_CAPACITY,
+                stale_client_count = stale_clients.len(),
+                stale_clients = ?stale_clients,
+                "evicting lagging websocket clients after outbound queue overflow; reconnect will replay latest state"
+            );
             let mut clients = self
                 .clients
                 .lock()

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -1775,7 +1775,7 @@ mod tests {
             Some(UpdateState::UpToDate { checked_at: None }),
         );
 
-        assert_eq!(events.len(), 4);
+        assert_eq!(events.len(), 5);
         assert!(events.iter().all(|event| {
             matches!(&event.target, DispatchTarget::Client(client_id) if client_id == "browser-1")
         }));
@@ -1794,6 +1794,10 @@ mod tests {
             &event.event,
             gwt::BackendEvent::TerminalSnapshot { id, data_base64 }
                 if id == "tab-1::shell-1" && data_base64 == &expected_snapshot
+        )));
+        assert!(events.iter().any(|event| matches!(
+            &event.event,
+            gwt::BackendEvent::LaunchWizardState { wizard: None }
         )));
         assert!(events.iter().any(|event| matches!(
             &event.event,
@@ -1826,11 +1830,14 @@ mod tests {
         let primary_payloads = drain_client_payloads(&mut primary);
         let secondary_payloads = drain_client_payloads(&mut secondary);
 
-        assert_eq!(primary_payloads.len(), 2);
+        assert_eq!(primary_payloads.len(), 3);
         assert_eq!(secondary_payloads.len(), 1);
         assert!(primary_payloads
             .iter()
             .any(|payload| payload.contains("\"kind\":\"workspace_state\"")));
+        assert!(primary_payloads
+            .iter()
+            .any(|payload| payload.contains("\"kind\":\"launch_wizard_state\"")));
         assert!(primary_payloads
             .iter()
             .any(|payload| payload.contains("\"kind\":\"project_open_error\"")));

--- a/crates/gwt/web/__tests__/socket-receive-dispatcher.test.mjs
+++ b/crates/gwt/web/__tests__/socket-receive-dispatcher.test.mjs
@@ -89,6 +89,22 @@ test("default coalescing policy mirrors backend latest-wins event policy", () =>
   }
 });
 
+test("launch_wizard_state null tombstone wins during coalescing", () => {
+  const coalesced = coalesceEvents(
+    [
+      { kind: "launch_wizard_state", wizard: { id: "wizard-1" } },
+      { kind: "terminal_output", id: "agent", data: "ready" },
+      { kind: "launch_wizard_state", wizard: null },
+    ],
+    DEFAULT_COALESCE_KINDS,
+  );
+
+  assert.deepEqual(coalesced, [
+    { kind: "terminal_output", id: "agent", data: "ready" },
+    { kind: "launch_wizard_state", wizard: null },
+  ]);
+});
+
 test("dispatcher flushes once per frame and renders only the latest workspace_state", () => {
   const received = [];
   const scheduler = manualScheduler();

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6403,3 +6403,10 @@ Type: lesson
 Context: SPEC-1919 added /terminal-copy-shortcut.js as a root module imported by crates/gwt/web/app.js. Frontend unit verification first failed at the Playwright embedded routes coverage because ROOT_MODULES did not include the new file.
 Learning: When adding a root-level web module imported by app.js, keep three contracts in sync: crates/gwt/src/embedded_web.rs asset registry, scripts/run-frontend-unit-tests.sh coverage, and crates/gwt/playwright/tests/_helpers/embedded-frontend.ts ROOT_MODULES.
 Future Action: Before final verification for app.js root imports, run scripts/run-frontend-unit-tests.sh and check the Playwright embedded route parity test instead of assuming the Rust embedded registry is sufficient.
+
+## 2026-06-01 — FrontendReady must replay nullable singleton tombstones
+
+Type: lesson
+Context: Launch Wizard close recovery after heavy Launch Agent processing / Event Hub queue overflow investigation on 2026-06-01.
+Learning: A successful mutation can emit a close event, but bounded ClientHub overflow may disconnect a slow WebView before it receives the frame. Reconnect recovery must be authoritative for latest-wins nullable singleton state; omitting None/tombstone payloads leaves stale frontend UI.
+Future Action: When adding nullable latest-wins frontend state, make FrontendReady reply with both Some(current state) and None(tombstone), and add RED reconnect-sync coverage before relying on one-shot broadcast close events.

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6410,3 +6410,10 @@ Type: lesson
 Context: Launch Wizard close recovery after heavy Launch Agent processing / Event Hub queue overflow investigation on 2026-06-01.
 Learning: A successful mutation can emit a close event, but bounded ClientHub overflow may disconnect a slow WebView before it receives the frame. Reconnect recovery must be authoritative for latest-wins nullable singleton state; omitting None/tombstone payloads leaves stale frontend UI.
 Future Action: When adding nullable latest-wins frontend state, make FrontendReady reply with both Some(current state) and None(tombstone), and add RED reconnect-sync coverage before relying on one-shot broadcast close events.
+
+## 2026-06-01 — User-accepted visual verification for rare load-only UI failures
+
+Type: lesson
+Context: Launch Wizard close recovery after reconnect depended on an extreme terminal load condition that was hard for the user to reproduce manually after live E2E RED/GREEN coverage existed.
+Learning: When a UI failure is rare and load-dependent, deterministic E2E evidence can be the strongest practical proof; if the user explicitly accepts that evidence, record the acceptance in the SPEC instead of keeping the work blocked on manual reproduction.
+Future Action: For future rare load-only UI bugs, add a deterministic E2E that models the lost or delayed event path, record RED/GREEN evidence, then ask the user whether that evidence is sufficient when manual reproduction is impractical.


### PR DESCRIPTION
## Summary

- Recover Launch Wizard close behavior after a slow client misses the one-shot close frame by replaying an authoritative nullable wizard state on reconnect.
- Add live Playwright E2E coverage that injects stale frontend wizard state and verifies `frontend_ready` clears it through a real backend.
- Add ClientHub overflow diagnostics so future slow-client drops are visible without changing queue semantics.

## Changes

- `crates/gwt/src/app_runtime/mod.rs`: always includes `LaunchWizardState { wizard: null }` in `FrontendReady` sync when no wizard is active.
- `crates/gwt/src/embedded_server.rs`: logs bounded client-queue overflow drops with client id and capacity context.
- `crates/gwt/src/main.rs`: extends backend contract tests for Launch Wizard reconnect tombstone behavior.
- `crates/gwt/web/__tests__/socket-receive-dispatcher.test.mjs`: covers latest-wins coalescing for `launch_wizard_state` tombstones.
- `crates/gwt/playwright/tests/launch-wizard-reconnect-live.spec.ts`: adds live backend E2E for stale Launch Wizard recovery after reconnect.
- `tasks/memory.md`: records reusable lessons for nullable singleton reconnect recovery and rare load-only verification.

## Testing

- [x] `cargo fmt -- --check` — passed.
- [x] `git diff --check` — passed.
- [x] `node --test crates/gwt/web/__tests__/socket-receive-dispatcher.test.mjs` — passed, 13 tests.
- [x] `bash scripts/run-frontend-unit-tests.sh` — passed, 613 tests.
- [x] `cargo test -p gwt frontend_sync_events --all-features -- --nocapture` — passed, 4 focused tests.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed.
- [x] `GWT_PLAYWRIGHT_BASE_URL=http://127.0.0.1:49176/ bash scripts/run-visual-tests.sh --project=chromium-dark crates/gwt/playwright/tests/launch-wizard-reconnect-live.spec.ts --reporter=list` — passed, 1 live E2E.
- [x] `bunx commitlint --from origin/develop --to HEAD` — passed.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — reconnect sync is backward-compatible and only makes the latest Launch Wizard state authoritative for reconnecting clients.
- Known blockers: None
- Remaining acceptance: None; user accepted visual verification as complete on 2026-06-01 because the exact stuck-window condition only occurs under very heavy terminal load and is difficult to reproduce manually, and the deterministic live E2E RED/GREEN evidence covers the lost-close-frame path.

## Closing Issues

- None

## Related Issues / Links

- #2012
- #2014

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, frontend checks)
- [x] Documentation updated (N/A — no user-facing docs change; SPEC tasks and memory were updated)
- [x] Migration/backfill plan included (N/A — no schema/data migration)
- [x] CHANGELOG impact considered (patch fix; no breaking change)

## Context

- The reported failure was that Launch Agent could start successfully while the browser-side Launch Wizard remained visible when the client was under heavy load. The root cause was that a slow WebView could miss the close frame, while reconnect sync omitted the nullable `None` state needed to clear stale frontend UI.

## Risk / Impact

- **Affected areas**: Launch Wizard reconnect state sync and WebSocket client-drop observability.
- **Rollback plan**: revert this PR; no data migration or persisted format change is involved.
