### PR TITLE
fix(launch-wizard): preserve open errors on reconnect

### DIFF
--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -2964,9 +2964,10 @@ mod tests {
         // Issue #2698 PR 1 (B7) — the launch_wizard_state case now
         // also defers via `wizardInteractionGuard.defer(...)` before
         // mutating launchWizard, so the regex permits an optional
-        // guard preamble between the case label and the assignment.
+        // guard preamble between the case label and the assignment. A
+        // null tombstone must not clear an open-error modal during reconnect.
         let wizard_state = regex::Regex::new(
-            r#"case\s*"launch_wizard_state":[\s\S]*?launchWizard\s*=\s*event\.wizard;\s*launchWizardOpenError\s*=\s*null;\s*(?:renderLaunchWizard|frontendUnits\.launchWizardSurface\.render)\(\);\s*break;"#,
+            r#"case\s*"launch_wizard_state":[\s\S]*?clearLaunchWizardPendingAction\(\);\s*if\s*\(event\.wizard\)\s*\{[\s\S]*?launchWizardOpenError\s*=\s*null;[\s\S]*?\}\s*launchWizard\s*=\s*event\.wizard;\s*(?:renderLaunchWizard|frontendUnits\.launchWizardSurface\.render)\(\);\s*break;"#,
         )
         .expect("valid regex");
         assert!(
@@ -3161,9 +3162,10 @@ mod tests {
         // Issue #2698 PR 1 (B7) — wizard_state / wizard_open_error
         // now defer through `wizardInteractionGuard.defer(...)` before
         // mutating module state, so the regex tolerates an optional
-        // guard preamble between the case label and the mutation.
+        // guard preamble between the case label and the mutation. A
+        // null tombstone must not clear an open-error modal during reconnect.
         let wizard_event = regex::Regex::new(
-            r#"case\s*"launch_wizard_state":[\s\S]*?launchWizard\s*=\s*event\.wizard;\s*launchWizardOpenError\s*=\s*null;\s*frontendUnits\.launchWizardSurface\.render\(\);\s*break;"#,
+            r#"case\s*"launch_wizard_state":[\s\S]*?clearLaunchWizardPendingAction\(\);\s*if\s*\(event\.wizard\)\s*\{[\s\S]*?launchWizardOpenError\s*=\s*null;[\s\S]*?\}\s*launchWizard\s*=\s*event\.wizard;\s*frontendUnits\.launchWizardSurface\.render\(\);\s*break;"#,
         )
         .expect("valid regex");
         let wizard_open_error_event = regex::Regex::new(

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1530,6 +1530,19 @@ test("Launch wizard open errors render in wizard modal and close locally", () =>
   );
 });
 
+test("Launch wizard tombstone does not dismiss open-error modal state", () => {
+  assert.match(
+    appSource,
+    /if\s*\(deferred\.kind\s*===\s*"launch_wizard_state"\)[\s\S]{0,500}?if\s*\(deferred\.wizard\)\s*\{[\s\S]{0,160}?launchWizardOpenError\s*=\s*null[\s\S]{0,160}?\}[\s\S]{0,240}?launchWizard\s*=\s*deferred\.wizard/,
+    "expected deferred launch_wizard_state tombstones to preserve launchWizardOpenError",
+  );
+  assert.match(
+    appSource,
+    /case\s+"launch_wizard_state":[\s\S]{0,900}?if\s*\(event\.wizard\)\s*\{[\s\S]{0,160}?launchWizardOpenError\s*=\s*null[\s\S]{0,160}?\}[\s\S]{0,240}?launchWizard\s*=\s*event\.wizard/,
+    "expected launch_wizard_state tombstones to clear stale wizard state without clearing launchWizardOpenError",
+  );
+});
+
 test("Launch wizard removes duplicate header close button", () => {
   assert.equal(
     document.getElementById("wizard-close-button"),

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -369,8 +369,10 @@
           }
           if (deferred.kind === "launch_wizard_state") {
             clearLaunchWizardPendingAction();
+            if (deferred.wizard) {
+              launchWizardOpenError = null;
+            }
             launchWizard = deferred.wizard;
-            launchWizardOpenError = null;
           } else if (deferred.kind === "launch_wizard_open_error") {
             clearLaunchWizardPendingAction();
             launchWizard = null;
@@ -12822,8 +12824,10 @@
               break;
             }
             clearLaunchWizardPendingAction();
+            if (event.wizard) {
+              launchWizardOpenError = null;
+            }
             launchWizard = event.wizard;
-            launchWizardOpenError = null;
             frontendUnits.launchWizardSurface.render();
             break;
           case "runtime_hook_event":


### PR DESCRIPTION
## Summary

- Preserve Launch Wizard open-error modal state when reconnect tombstones arrive after a backend-side launch has already succeeded.
- Add frontend and embedded-bundle regression contracts so `launch_wizard_state` null tombstones cannot dismiss the recovery/error modal again.

## Changes

- `crates/gwt/web/app.js`: clear `launchWizardOpenError` only when a non-null wizard payload arrives; null tombstones still clear stale wizard state.
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: cover both deferred and direct `launch_wizard_state` handlers for tombstone preservation.
- `crates/gwt/src/embedded_web.rs`: align embedded frontend contract tests with the new non-null wizard clear rule.

## Testing

- [x] `bash scripts/run-node-tests-with-linkedom.sh crates/gwt/web/__tests__/operator-chrome-structure.test.mjs --test-name-pattern "Launch wizard tombstone"` - PASS, 116 tests after merging latest `origin/develop`.
- [x] `bash scripts/run-frontend-unit-tests.sh` - PASS, 616 tests after merging latest `origin/develop`.
- [x] `cargo test -p gwt embedded_web::tests::embedded_web --all-features -- --nocapture` - PASS, 103 embedded tests after merging latest `origin/develop`.
- [x] `cargo fmt -- --check` - PASS.
- [x] `git diff --check origin/develop...HEAD` - PASS.
- [x] `bunx commitlint --from origin/develop --to HEAD` - PASS.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes; this is a focused frontend state-handling fix with regression coverage and no partial feature exposure.
- Known blockers: None
- Remaining acceptance: None
- User Verification Result: confirmed by user; the heavy-terminal reproduction path is hard to trigger manually and the user explicitly accepted the check as complete.

## Closing Issues

- None

## Related Issues / Links

- #2956

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo fmt -- --check`, `git diff --check origin/develop...HEAD`, frontend/Rust focused tests)
- [x] Documentation updated (N/A: no user-facing docs change)
- [x] Migration/backfill plan included (N/A: no schema or data migration)
- [x] CHANGELOG impact considered (`fix:` patch-level behavior fix)

## Context

- Follow-up to the post-merge review on #2956: reconnect `LaunchWizardState(wizard: null)` should close stale wizard state but must not clear `launchWizardOpenError`, otherwise an error-only recovery modal can disappear during reconnect.

## Risk / Impact

- **Affected areas**: Launch Wizard frontend state reconciliation for reconnect and interaction-guard deferred event paths.
- **Rollback plan**: Revert this PR if the state-preservation behavior regresses adjacent wizard rendering.
