### PR TITLE
fix(gui): preserve terminal snapshot boundary scrollback

### DIFF
--- a/crates/gwt-terminal/src/pane.rs
+++ b/crates/gwt-terminal/src/pane.rs
@@ -145,8 +145,8 @@ impl Pane {
     pub fn snapshot_bytes(&self) -> Vec<u8> {
         let mut snapshot = Vec::new();
         let scrollback_len = self.scrollback.len();
-        let visible_rows = usize::from(self.parser.screen().size().0);
-        let replayable_len = scrollback_len.saturating_sub(visible_rows);
+        let visible_completed_lines = usize::from(self.parser.screen().cursor_position().0);
+        let replayable_len = scrollback_len.saturating_sub(visible_completed_lines);
         let start = replayable_len.saturating_sub(SNAPSHOT_SCROLLBACK_REPLAY_LIMIT);
 
         for line in self.scrollback.get_lines(start, replayable_len - start) {
@@ -334,6 +334,19 @@ mod tests {
         .expect("Pane creation failed")
     }
 
+    fn test_pane_with_rows(id: &str, rows: u16, command: TestCommand) -> Pane {
+        Pane::new(
+            id.to_string(),
+            command.command,
+            command.args,
+            80,
+            rows,
+            HashMap::new(),
+            None,
+        )
+        .expect("Pane creation failed")
+    }
+
     #[test]
     fn test_pane_creation() {
         let _pty_guard = lock_pty_test();
@@ -372,6 +385,23 @@ mod tests {
             String::from_utf8_lossy(&output),
             "\x1b[31;1mALERT\x1b[0m",
             "scrollback replay must keep styling but not cursor moves or clears"
+        );
+    }
+
+    #[test]
+    fn test_snapshot_bytes_preserves_boundary_scrollback_line() {
+        let _pty_guard = lock_pty_test();
+        let mut pane = test_pane_with_rows("test-boundary", 6, sleep_command("60"));
+
+        for line in 1..=18 {
+            pane.process_bytes(format!("line-{line:02}\r\n").as_bytes());
+        }
+
+        let snapshot = String::from_utf8_lossy(&pane.snapshot_bytes()).into_owned();
+
+        assert!(
+            snapshot.contains("line-13"),
+            "snapshot should include the boundary scrollback line; got: {snapshot:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Preserve the scrollback boundary line when reconnect snapshots replay terminal history.
- Add a regression test for the `\r\n` case where the visible grid has completed lines plus a blank cursor row.

## Changes

- `crates/gwt-terminal/src/pane.rs`: compute scrollback overlap from the cursor row instead of the raw terminal height.
- `crates/gwt-terminal/src/pane.rs`: add a focused RED/GREEN regression covering the missing `line-13` boundary case.

## Testing

- `cargo test -p gwt-terminal test_snapshot_bytes_preserves_boundary_scrollback_line --all-features -- --nocapture`
- `cargo test -p gwt-terminal --all-features`
- `cargo test -p gwt app_runtime_frontend_ready_replays_terminal_snapshot_with_scrollback_history --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check`
- `bunx --bun markdownlint-cli . --config .markdownlint.json --ignore target --ignore CHANGELOG.md --ignore tasks/todo.md`
- `cargo build -p gwt --bin gwt --bin gwtd`
- `bunx commitlint --from origin/develop --to HEAD`

## PR Readiness

- State: Ready for review
- Releaseable slice: yes
- Known blockers: none
- Remaining acceptance: none
- User verification: SPEC-2008 scroll UX was confirmed on 2026-06-01; this follow-up is covered by the new automated boundary regression.

## Closing Issues

None

## Related Issues

- #2008
- Follow-up to #2965

## Checklist

- [x] Tests added or updated
- [x] Lint and format checks passed
- [x] User verification status documented
- [x] CHANGELOG impact considered: patch fix
- [x] Documentation update not required for this boundary-condition fix
