### PR TITLE
fix(gui): avoid duplicate terminal snapshot visible rows

### DIFF
--- a/crates/gwt-terminal/src/pane.rs
+++ b/crates/gwt-terminal/src/pane.rs
@@ -145,8 +145,9 @@ impl Pane {
     pub fn snapshot_bytes(&self) -> Vec<u8> {
         let mut snapshot = Vec::new();
         let scrollback_len = self.scrollback.len();
-        let visible_completed_lines = usize::from(self.parser.screen().cursor_position().0);
-        let replayable_len = scrollback_len.saturating_sub(visible_completed_lines);
+        let visible_overlap =
+            visible_scrollback_overlap_len(&self.scrollback, self.parser.screen());
+        let replayable_len = scrollback_len.saturating_sub(visible_overlap);
         let start = replayable_len.saturating_sub(SNAPSHOT_SCROLLBACK_REPLAY_LIMIT);
 
         for line in self.scrollback.get_lines(start, replayable_len - start) {
@@ -232,6 +233,38 @@ impl Pane {
     pub fn reader(&self) -> Result<Box<dyn std::io::Read + Send>, TerminalError> {
         self.pty.reader()
     }
+}
+
+fn visible_scrollback_overlap_len(scrollback: &ScrollbackStorage, screen: &vt100::Screen) -> usize {
+    let scrollback_len = scrollback.len();
+    if scrollback_len == 0 {
+        return 0;
+    }
+
+    let (_, cols) = screen.size();
+    let visible_rows: Vec<String> = screen.rows(0, cols).collect();
+    let max_overlap = scrollback_len.min(visible_rows.len());
+    let scrollback_tail: Vec<String> = scrollback
+        .get_lines(scrollback_len - max_overlap, max_overlap)
+        .into_iter()
+        .map(normalized_scrollback_text)
+        .collect();
+
+    for overlap in (1..=max_overlap).rev() {
+        let scrollback_suffix = &scrollback_tail[max_overlap - overlap..];
+        if visible_rows
+            .windows(overlap)
+            .any(|window| window == scrollback_suffix)
+        {
+            return overlap;
+        }
+    }
+
+    0
+}
+
+fn normalized_scrollback_text(line: &ScrollbackLine) -> String {
+    line.text.trim_end_matches('\r').to_string()
 }
 
 fn append_snapshot_scrollback_line(snapshot: &mut Vec<u8>, line: &ScrollbackLine) {
@@ -402,6 +435,25 @@ mod tests {
         assert!(
             snapshot.contains("line-13"),
             "snapshot should include the boundary scrollback line; got: {snapshot:?}"
+        );
+    }
+
+    #[test]
+    fn test_snapshot_bytes_uses_visible_rows_for_scrollback_overlap() {
+        let _pty_guard = lock_pty_test();
+        let mut pane = test_pane_with_rows("test-visible-overlap", 6, sleep_command("60"));
+
+        for line in 1..=18 {
+            pane.process_bytes(format!("line-{line:02}\r\n").as_bytes());
+        }
+        pane.process_bytes(b"\x1b[2;1H");
+
+        let snapshot = String::from_utf8_lossy(&pane.snapshot_bytes()).into_owned();
+        let repeated_visible_line = snapshot.matches("line-14").count();
+
+        assert_eq!(
+            repeated_visible_line, 1,
+            "snapshot should not replay visible scrollback lines when cursor moves; got: {snapshot:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Avoid duplicate reconnect snapshot history when terminal apps move the cursor above the bottom row.
- Keep the prior blank-cursor-row fix by computing overlap from visible rows that actually match the scrollback tail.

## Changes

- `crates/gwt-terminal/src/pane.rs`: calculate scrollback replay overlap by matching current visible rows against the scrollback suffix.
- `crates/gwt-terminal/src/pane.rs`: add a regression where CSI cursor movement previously caused `line-14` to appear twice in the snapshot.

## Testing

- `cargo test -p gwt-terminal test_snapshot_bytes_preserves_boundary_scrollback_line --all-features -- --nocapture`
- `cargo test -p gwt-terminal test_snapshot_bytes_uses_visible_rows_for_scrollback_overlap --all-features -- --nocapture`
- `cargo test -p gwt-terminal --all-features`
- `cargo test -p gwt app_runtime_frontend_ready_replays_terminal_snapshot_with_scrollback_history --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt -- --check`
- `git diff --check`
- `bunx --bun markdownlint-cli . --config .markdownlint.json --ignore target --ignore CHANGELOG.md --ignore tasks/todo.md`
- `cargo build -p gwt --bin gwt --bin gwtd`
- `bunx commitlint --from origin/develop --to HEAD`

## PR Readiness

- State: Ready for review
- Releaseable slice: yes
- Known blockers: none
- Remaining acceptance: none
- User verification: SPEC-2008 scroll UX was confirmed on 2026-06-01; this follow-up is covered by the automated visible-overlap regression.

## Closing Issues

None

## Related Issues

- #2008
- Follow-up to #2966

## Checklist

- [x] Tests added or updated
- [x] Lint and format checks passed
- [x] User verification status documented
- [x] CHANGELOG impact considered: patch fix
- [x] Documentation update not required for this boundary-condition fix
