### PR TITLE
fix(autostart): macOS 13+ の Login Items 表示名を GWT にする

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,6 +1292,8 @@ dependencies = [
  "libc",
  "notify",
  "notify-debouncer-mini",
+ "objc2-foundation",
+ "objc2-service-management",
  "pulldown-cmark",
  "regex",
  "reqwest",
@@ -2521,6 +2523,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2546,6 +2549,30 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-service-management"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b213642d6959cc6023ceb1217aa595eaaf09b8094ce95127c103cab611fe65e8"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-security",
 ]
 
 [[package]]

--- a/crates/gwt/Cargo.toml
+++ b/crates/gwt/Cargo.toml
@@ -73,6 +73,16 @@ image.workspace = true
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 
+# SPEC #2920 Phase 12: macOS Login Items display-name fix. On macOS 13+ the
+# autostart entry is registered through the modern `SMAppService` API so the
+# System Settings background/login list attributes it to the app bundle and
+# shows "GWT" instead of the Developer ID team name. macOS 12 and earlier keep
+# the `auto-launch` LaunchAgent path. `NSError` is enabled so register /
+# unregister failures surface a real message instead of a silent fallback.
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-foundation = { version = "0.3", features = ["NSError"] }
+objc2-service-management = { version = "0.3", features = ["SMAppService", "objc2-foundation"] }
+
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winresource.workspace = true
 

--- a/crates/gwt/src/cli/tray/autostart.rs
+++ b/crates/gwt/src/cli/tray/autostart.rs
@@ -1,16 +1,22 @@
-//! SPEC #2920 FR-005 / Phase 7 — Autostart manager backed by the
-//! `auto-launch` crate.
+//! SPEC #2920 FR-005 / Phase 7 + Phase 12 — Autostart manager.
 //!
-//! Per-OS mechanism (handled internally by `auto-launch`):
-//! - macOS: LaunchAgent plist (`~/Library/LaunchAgents/<app>.plist`) when
-//!   `set_use_launch_agent(true)` is configured. Otherwise an AppleScript
-//!   Login Item is added via NSWorkspace. SPEC #2920 Q6 settled on the
-//!   LaunchAgent plist for predictability: it lives under the user's
-//!   home directory, can be inspected with `launchctl list`, and survives
-//!   `gwt` updates because the path resolves at runtime via
-//!   `std::env::current_exe()`.
-//! - Windows: `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`.
-//! - Linux: `~/.config/autostart/<app>.desktop` (XDG autostart).
+//! Per-OS mechanism:
+//! - macOS 13+ (Ventura, Darwin 22+): the modern `SMAppService` API
+//!   (`SMAppService.mainAppService`). Registering through SMAppService lets
+//!   macOS attribute the entry to the app bundle, so System Settings >
+//!   "Login Items & Extensions" shows the app name ("GWT") instead of the
+//!   Developer ID team name. A raw LaunchAgent plist cannot be associated
+//!   with a bundle, so Background Task Management falls back to the signing
+//!   team name (e.g. a personal Developer ID shows the developer's own
+//!   name) — that is the bug Phase 12 fixes.
+//! - macOS 12 and earlier: the `auto-launch` LaunchAgent plist
+//!   (`~/Library/LaunchAgents/<app>.plist`). These releases predate the
+//!   Background Task Management UI, so the display-name problem does not
+//!   exist there and the LaunchAgent path stays.
+//! - Windows: `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` via
+//!   `auto-launch`.
+//! - Linux: `~/.config/autostart/<app>.desktop` (XDG autostart) via
+//!   `auto-launch`.
 
 use std::path::PathBuf;
 
@@ -35,27 +41,57 @@ pub struct AutostartStatus {
 pub enum AutostartMechanism {
     LoginItems,
     LaunchAgent,
+    /// macOS 13+ modern Service Management registration (`SMAppService`).
+    AppService,
     Registry,
     XdgAutostart,
     Unsupported,
 }
 
 impl AutostartMechanism {
-    /// Resolve the canonical mechanism for the host OS at compile time.
-    pub const fn for_host_os() -> Self {
-        if cfg!(target_os = "macos") {
-            // SPEC #2920 Q6: prefer the LaunchAgent plist on macOS so the
-            // toggle is reversible from the file system without prompting
-            // for AppleScript automation permissions.
-            Self::LaunchAgent
-        } else if cfg!(target_os = "windows") {
+    /// Resolve the mechanism for the host OS. On macOS the choice depends on
+    /// the runtime OS version (SMAppService exists only on macOS 13+), so this
+    /// is no longer a `const fn`.
+    pub fn for_host_os() -> Self {
+        #[cfg(target_os = "macos")]
+        {
+            mechanism_for_macos(current_darwin_major())
+        }
+        #[cfg(target_os = "windows")]
+        {
             Self::Registry
-        } else if cfg!(target_os = "linux") {
+        }
+        #[cfg(target_os = "linux")]
+        {
             Self::XdgAutostart
-        } else {
+        }
+        #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+        {
             Self::Unsupported
         }
     }
+}
+
+/// Map a Darwin kernel major version to the macOS autostart mechanism.
+///
+/// SMAppService first shipped in macOS 13 Ventura, which is Darwin kernel 22.
+/// The Darwin↔macOS *product* number map is no longer linear after the macOS
+/// 26 renumber, so gate strictly on the Darwin major (the SMAppService floor),
+/// never on a computed macOS product number.
+#[cfg(any(target_os = "macos", test))]
+const fn mechanism_for_macos(darwin_major: u32) -> AutostartMechanism {
+    if macos_supports_app_service(darwin_major) {
+        AutostartMechanism::AppService
+    } else {
+        AutostartMechanism::LaunchAgent
+    }
+}
+
+/// `true` when the Darwin kernel is 22 (macOS 13 Ventura) or newer, i.e. when
+/// `SMAppService` is available.
+#[cfg(any(target_os = "macos", test))]
+const fn macos_supports_app_service(darwin_major: u32) -> bool {
+    darwin_major >= 22
 }
 
 /// Errors surfaced from autostart install / uninstall / status.
@@ -65,14 +101,17 @@ pub enum AutostartError {
     ExecutablePathUnavailable(std::io::Error),
     #[error("auto-launch backend error: {0}")]
     Backend(#[from] auto_launch::Error),
+    #[cfg(target_os = "macos")]
+    #[error("SMAppService error: {0}")]
+    AppService(String),
     #[error("autostart is not supported on this OS")]
     UnsupportedOs,
 }
 
-/// Stateless wrapper around the `auto-launch` crate. Construction lives in
-/// `build_auto_launch` so the install / uninstall / status paths share the
-/// exact same `(app_name, app_path, use_launch_agent)` triple — a mismatch
-/// here would silently leak orphan entries across calls.
+/// Stateless wrapper around the per-OS autostart mechanism. macOS 13+ routes
+/// through `SMAppService`; every other target shares the exact same
+/// `(app_name, app_path, use_launch_agent)` triple via `build_auto_launch` so a
+/// mismatch here cannot silently leak orphan entries across calls.
 pub struct AutostartManager;
 
 impl AutostartManager {
@@ -80,11 +119,13 @@ impl AutostartManager {
     /// `install()` after a successful first call returns `Ok(())` instead
     /// of erroring out.
     pub fn install() -> Result<(), AutostartError> {
-        if matches!(
-            AutostartMechanism::for_host_os(),
-            AutostartMechanism::Unsupported
-        ) {
+        let mechanism = AutostartMechanism::for_host_os();
+        if matches!(mechanism, AutostartMechanism::Unsupported) {
             return Err(AutostartError::UnsupportedOs);
+        }
+        #[cfg(target_os = "macos")]
+        if matches!(mechanism, AutostartMechanism::AppService) {
+            return macos_app_service::install();
         }
         let auto = build_auto_launch()?;
         auto.enable()?;
@@ -94,11 +135,13 @@ impl AutostartManager {
     /// Remove the autostart entry. Idempotent: a second `uninstall()`
     /// after the entry has already been removed returns `Ok(())`.
     pub fn uninstall() -> Result<(), AutostartError> {
-        if matches!(
-            AutostartMechanism::for_host_os(),
-            AutostartMechanism::Unsupported
-        ) {
+        let mechanism = AutostartMechanism::for_host_os();
+        if matches!(mechanism, AutostartMechanism::Unsupported) {
             return Err(AutostartError::UnsupportedOs);
+        }
+        #[cfg(target_os = "macos")]
+        if matches!(mechanism, AutostartMechanism::AppService) {
+            return macos_app_service::uninstall();
         }
         let auto = build_auto_launch()?;
         auto.disable()?;
@@ -107,10 +150,18 @@ impl AutostartManager {
 
     /// Inspect the OS to determine whether autostart is currently enabled
     /// for `gwt`, the resolved install path, and the mechanism in use.
+    ///
+    /// Read-only: this never writes to the user's autostart state. The legacy
+    /// LaunchAgent migration cleanup happens only on the explicit `install` /
+    /// `uninstall` mutations.
     pub fn status() -> Result<AutostartStatus, AutostartError> {
         let mechanism = AutostartMechanism::for_host_os();
         if matches!(mechanism, AutostartMechanism::Unsupported) {
             return Err(AutostartError::UnsupportedOs);
+        }
+        #[cfg(target_os = "macos")]
+        if matches!(mechanism, AutostartMechanism::AppService) {
+            return macos_app_service::status();
         }
         let auto = build_auto_launch()?;
         let enabled = auto.is_enabled()?;
@@ -128,17 +179,17 @@ fn build_auto_launch() -> Result<auto_launch::AutoLaunch, AutostartError> {
     let mut builder = AutoLaunchBuilder::new();
     builder.set_app_name(APP_NAME);
     builder.set_app_path(&exe_str);
-    // SPEC #2920 Q6: pin the macOS strategy to the LaunchAgent plist so
-    // the toggle remains reversible from the file system. The flag is a
-    // no-op on Linux / Windows.
+    // macOS 12 and earlier: pin the LaunchAgent plist so the toggle remains
+    // reversible from the file system. The flag is a no-op on Linux / Windows.
     builder.set_use_launch_agent(true);
     Ok(builder.build()?)
 }
 
 /// Compute the path the OS-native autostart entry would live at without
-/// touching the file system. Mirrors the `auto-launch` crate's per-OS
-/// path resolution so the Settings page can preview the location before
-/// `install()` is called.
+/// touching the file system. Mirrors the per-OS path resolution so the
+/// Settings page can preview the location before `install()` is called.
+/// macOS 13+ uses SMAppService, which has no on-disk entry, so it returns
+/// `None`.
 fn install_path_for_app(app_name: &str) -> Option<PathBuf> {
     let home = home_dir()?;
     match AutostartMechanism::for_host_os() {
@@ -159,7 +210,9 @@ fn install_path_for_app(app_name: &str) -> Option<PathBuf> {
                 "HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run\\{app_name}"
             )))
         }
-        AutostartMechanism::LoginItems | AutostartMechanism::Unsupported => None,
+        AutostartMechanism::AppService
+        | AutostartMechanism::LoginItems
+        | AutostartMechanism::Unsupported => None,
     }
 }
 
@@ -174,6 +227,157 @@ fn home_dir() -> Option<PathBuf> {
     }
 }
 
+/// Parse the Darwin kernel major version from a `kern.osrelease` string such
+/// as `"22.6.0"`.
+#[cfg(any(target_os = "macos", test))]
+fn parse_darwin_major(osrelease: &str) -> Option<u32> {
+    osrelease.split('.').next()?.trim().parse::<u32>().ok()
+}
+
+// SMAppServiceStatus values from `<ServiceManagement/SMAppService.h>`:
+// NotRegistered = 0, Enabled = 1, RequiresApproval = 2, NotFound = 3.
+#[cfg(any(target_os = "macos", test))]
+const SM_STATUS_ENABLED: isize = 1;
+#[cfg(any(target_os = "macos", test))]
+const SM_STATUS_REQUIRES_APPROVAL: isize = 2;
+
+/// `true` when the SMAppService status means the login item is actively
+/// enabled.
+#[cfg(any(target_os = "macos", test))]
+fn sm_status_is_enabled(raw: isize) -> bool {
+    raw == SM_STATUS_ENABLED
+}
+
+/// `true` when the SMAppService status means an entry exists (enabled or
+/// awaiting the user's approval) and therefore can be unregistered.
+#[cfg(any(target_os = "macos", test))]
+fn sm_status_is_registered(raw: isize) -> bool {
+    raw == SM_STATUS_ENABLED || raw == SM_STATUS_REQUIRES_APPROVAL
+}
+
+/// Path of the legacy `auto-launch` LaunchAgent plist for `APP_NAME`.
+#[cfg(any(target_os = "macos", test))]
+fn legacy_launch_agent_path(home: &std::path::Path) -> PathBuf {
+    home.join("Library")
+        .join("LaunchAgents")
+        .join(format!("{APP_NAME}.plist"))
+}
+
+/// Remove `path` if it exists; treat an already-absent file as success so the
+/// migration cleanup is idempotent.
+#[cfg(any(target_os = "macos", test))]
+fn remove_file_if_present(path: &std::path::Path) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+/// Read the Darwin kernel major version via `sysctl kern.osrelease`. Returns 0
+/// on failure, which makes [`mechanism_for_macos`] fall back to the LaunchAgent
+/// path rather than risk calling an unavailable SMAppService.
+#[cfg(target_os = "macos")]
+fn current_darwin_major() -> u32 {
+    let name = c"kern.osrelease";
+    let mut size: libc::size_t = 0;
+    // First call: query the required buffer size.
+    let rc = unsafe {
+        libc::sysctlbyname(
+            name.as_ptr(),
+            std::ptr::null_mut(),
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if rc != 0 || size == 0 {
+        return 0;
+    }
+    let mut buf = vec![0u8; size];
+    let rc = unsafe {
+        libc::sysctlbyname(
+            name.as_ptr(),
+            buf.as_mut_ptr().cast(),
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        )
+    };
+    if rc != 0 {
+        return 0;
+    }
+    // `size` now counts the trailing NUL written by sysctl.
+    let end = size.saturating_sub(1);
+    let text = String::from_utf8_lossy(&buf[..end.min(buf.len())]);
+    parse_darwin_major(&text).unwrap_or(0)
+}
+
+/// Remove the legacy LaunchAgent plist left by older gwt versions so the
+/// SMAppService entry is the only one Background Task Management lists. Older
+/// builds dropped a raw plist that BTM attributes to the signing team name;
+/// dropping it prevents a stale "<developer name>" entry from lingering under
+/// "Allow in the Background".
+#[cfg(target_os = "macos")]
+fn remove_legacy_launch_agent() {
+    if let Some(home) = home_dir() {
+        // Best effort: an absent file is the desired end state.
+        let _ = remove_file_if_present(&legacy_launch_agent_path(&home));
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos_app_service {
+    use super::{
+        home_dir, legacy_launch_agent_path, remove_legacy_launch_agent, sm_status_is_enabled,
+        sm_status_is_registered, AutostartError, AutostartMechanism, AutostartStatus,
+    };
+    use objc2_service_management::SMAppService;
+
+    /// Register the main app as a login item and clear any legacy plist.
+    /// Idempotent: skips `register` when already enabled.
+    pub(super) fn install() -> Result<(), AutostartError> {
+        let service = unsafe { SMAppService::mainAppService() };
+        let raw = unsafe { service.status() }.0;
+        if !sm_status_is_enabled(raw) {
+            unsafe { service.registerAndReturnError() }
+                .map_err(|err| AutostartError::AppService(format!("{err:?}")))?;
+        }
+        remove_legacy_launch_agent();
+        Ok(())
+    }
+
+    /// Unregister the main-app login item and clear any legacy plist.
+    /// Idempotent: skips `unregister` when nothing is registered.
+    pub(super) fn uninstall() -> Result<(), AutostartError> {
+        let service = unsafe { SMAppService::mainAppService() };
+        let raw = unsafe { service.status() }.0;
+        if sm_status_is_registered(raw) {
+            unsafe { service.unregisterAndReturnError() }
+                .map_err(|err| AutostartError::AppService(format!("{err:?}")))?;
+        }
+        remove_legacy_launch_agent();
+        Ok(())
+    }
+
+    /// Read-only status. Reports enabled when SMAppService is registered or a
+    /// legacy LaunchAgent plist still exists (so an upgraded user who enabled
+    /// autostart via the old mechanism still sees the toggle ON until they
+    /// re-toggle, which migrates them onto SMAppService).
+    pub(super) fn status() -> Result<AutostartStatus, AutostartError> {
+        let service = unsafe { SMAppService::mainAppService() };
+        let raw = unsafe { service.status() }.0;
+        let legacy_present = home_dir()
+            .map(|home| legacy_launch_agent_path(&home).exists())
+            .unwrap_or(false);
+        Ok(AutostartStatus {
+            enabled: sm_status_is_enabled(raw) || legacy_present,
+            install_path: None,
+            mechanism: AutostartMechanism::AppService,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -182,7 +386,13 @@ mod tests {
     fn mechanism_for_host_os_matches_compile_target() {
         let mechanism = AutostartMechanism::for_host_os();
         #[cfg(target_os = "macos")]
-        assert_eq!(mechanism, AutostartMechanism::LaunchAgent);
+        assert!(
+            matches!(
+                mechanism,
+                AutostartMechanism::AppService | AutostartMechanism::LaunchAgent
+            ),
+            "macOS resolves to SMAppService (13+) or the LaunchAgent fallback, got {mechanism:?}"
+        );
         #[cfg(target_os = "windows")]
         assert_eq!(mechanism, AutostartMechanism::Registry);
         #[cfg(target_os = "linux")]
@@ -192,54 +402,102 @@ mod tests {
     }
 
     #[test]
-    fn install_path_for_app_is_user_scoped() {
-        let path = install_path_for_app("GWT");
-        let Some(path) = path else {
-            // Unsupported OS — no install path is also acceptable.
-            return;
-        };
-        let path_str = path.to_string_lossy().into_owned();
-        #[cfg(target_os = "macos")]
+    fn macos_mechanism_switches_on_darwin_floor() {
+        // Darwin 22 == macOS 13 Ventura, the SMAppService floor.
+        assert_eq!(mechanism_for_macos(21), AutostartMechanism::LaunchAgent); // macOS 12
+        assert_eq!(mechanism_for_macos(22), AutostartMechanism::AppService); // macOS 13
+        assert_eq!(mechanism_for_macos(25), AutostartMechanism::AppService); // macOS 26
+        assert!(!macos_supports_app_service(21));
+        assert!(macos_supports_app_service(22));
+        assert!(macos_supports_app_service(25));
+    }
+
+    #[test]
+    fn parse_darwin_major_reads_first_component() {
+        assert_eq!(parse_darwin_major("22.6.0"), Some(22));
+        assert_eq!(parse_darwin_major("25.5.0"), Some(25));
+        assert_eq!(parse_darwin_major("13"), Some(13));
+        assert_eq!(parse_darwin_major(""), None);
+        assert_eq!(parse_darwin_major("notanumber"), None);
+    }
+
+    #[test]
+    fn sm_status_mapping_matches_apple_enum() {
+        // NotRegistered = 0, Enabled = 1, RequiresApproval = 2, NotFound = 3.
+        assert!(!sm_status_is_enabled(0));
+        assert!(sm_status_is_enabled(1));
+        assert!(!sm_status_is_enabled(2));
+        assert!(!sm_status_is_enabled(3));
+
+        assert!(!sm_status_is_registered(0));
+        assert!(sm_status_is_registered(1));
+        assert!(sm_status_is_registered(2));
+        assert!(!sm_status_is_registered(3));
+    }
+
+    #[test]
+    fn remove_file_if_present_is_idempotent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("GWT.plist");
+        std::fs::write(&path, b"<plist/>").expect("write");
+        assert!(path.exists());
+
+        remove_file_if_present(&path).expect("first remove");
+        assert!(!path.exists());
+        // A second call on an absent file is a no-op success.
+        remove_file_if_present(&path).expect("second remove");
+    }
+
+    #[test]
+    fn legacy_launch_agent_path_is_user_scoped() {
+        let home = std::path::Path::new("/Users/example");
+        let path = legacy_launch_agent_path(home);
         assert!(
-            path_str.ends_with("Library/LaunchAgents/GWT.plist"),
-            "macOS install path must be a user LaunchAgent plist, got {path_str}"
-        );
-        #[cfg(target_os = "linux")]
-        assert!(
-            path_str.ends_with(".config/autostart/GWT.desktop"),
-            "Linux install path must be the XDG autostart entry, got {path_str}"
-        );
-        #[cfg(target_os = "windows")]
-        assert!(
-            path_str.contains("HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"),
-            "Windows install path must point at the user Run registry key, got {path_str}"
+            path.to_string_lossy()
+                .ends_with("Library/LaunchAgents/GWT.plist"),
+            "got {path:?}"
         );
     }
 
     #[test]
-    fn status_returns_a_consistent_snapshot() {
-        // SPEC #2920 Phase 7 — `status()` must work without writing to
-        // the user's autostart entry. The auto-launch crate inspects the
-        // OS-native state and never installs anything on `is_enabled()`.
-        let result = AutostartManager::status();
-        match result {
-            Ok(status) => {
-                assert_eq!(status.mechanism, AutostartMechanism::for_host_os());
-                // `install_path` is only `None` on truly unsupported OS;
-                // every CI target we support returns Some(_) here.
-                #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
-                assert!(status.install_path.is_some());
+    fn install_path_for_app_is_user_scoped() {
+        let path = install_path_for_app("GWT");
+        #[cfg(target_os = "macos")]
+        {
+            // macOS 13+ (SMAppService) has no on-disk entry; macOS 12 uses a
+            // LaunchAgent plist.
+            match AutostartMechanism::for_host_os() {
+                AutostartMechanism::AppService => {
+                    assert!(path.is_none(), "SMAppService has no fs path, got {path:?}")
+                }
+                AutostartMechanism::LaunchAgent => {
+                    let path = path.expect("LaunchAgent path");
+                    assert!(
+                        path.to_string_lossy()
+                            .ends_with("Library/LaunchAgents/GWT.plist"),
+                        "got {path:?}"
+                    );
+                }
+                other => panic!("unexpected macOS mechanism {other:?}"),
             }
-            Err(AutostartError::ExecutablePathUnavailable(_)) => {
-                // The test runner may execute the binary without a
-                // resolvable current_exe() (rare in CI). Accept the
-                // graceful error rather than panicking.
-            }
-            Err(AutostartError::UnsupportedOs) => {
-                #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
-                panic!("AutostartManager::status returned UnsupportedOs on a supported target");
-            }
-            Err(other) => panic!("AutostartManager::status returned unexpected error: {other}"),
+        }
+        #[cfg(target_os = "linux")]
+        {
+            let path = path.expect("xdg autostart path");
+            assert!(
+                path.to_string_lossy()
+                    .ends_with(".config/autostart/GWT.desktop"),
+                "got {path:?}"
+            );
+        }
+        #[cfg(target_os = "windows")]
+        {
+            let path = path.expect("registry hint");
+            assert!(
+                path.to_string_lossy()
+                    .contains("HKCU\\Software\\Microsoft\\Windows\\CurrentVersion\\Run"),
+                "got {path:?}"
+            );
         }
     }
 
@@ -253,5 +511,37 @@ mod tests {
         let json = serde_json::to_string(&status).expect("serialize");
         let round: AutostartStatus = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(round, status);
+    }
+
+    #[test]
+    fn app_service_mechanism_serializes_to_pascal_case() {
+        let json = serde_json::to_string(&AutostartMechanism::AppService).expect("serialize");
+        assert_eq!(json, "\"AppService\"");
+        let round: AutostartMechanism = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(round, AutostartMechanism::AppService);
+    }
+
+    // macOS 13+ routes `status()` through the SMAppService FFI, which we do not
+    // exercise from unit tests, so this lives on the non-macOS targets where
+    // the auto-launch backend reads OS-native state without writing anything.
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn status_returns_a_consistent_snapshot() {
+        match AutostartManager::status() {
+            Ok(status) => {
+                assert_eq!(status.mechanism, AutostartMechanism::for_host_os());
+                #[cfg(any(target_os = "linux", target_os = "windows"))]
+                assert!(status.install_path.is_some());
+            }
+            Err(AutostartError::ExecutablePathUnavailable(_)) => {
+                // The test runner may execute without a resolvable
+                // current_exe(); accept the graceful error.
+            }
+            Err(AutostartError::UnsupportedOs) => {
+                #[cfg(any(target_os = "linux", target_os = "windows"))]
+                panic!("AutostartManager::status returned UnsupportedOs on a supported target");
+            }
+            Err(other) => panic!("AutostartManager::status returned unexpected error: {other}"),
+        }
     }
 }

--- a/crates/gwt/tests/tray_module_present_test.rs
+++ b/crates/gwt/tests/tray_module_present_test.rs
@@ -100,7 +100,13 @@ fn tray_autostart_pins_status_surface() {
     // Mechanism variants are part of the WebSocket protocol surface; pin
     // them so a casual rename does not break the Settings page contract
     // before Phase 8 ships.
-    for mechanism in ["LoginItems", "LaunchAgent", "Registry", "XdgAutostart"] {
+    for mechanism in [
+        "LoginItems",
+        "LaunchAgent",
+        "AppService",
+        "Registry",
+        "XdgAutostart",
+    ] {
         assert!(
             TRAY_AUTOSTART.contains(mechanism),
             "AutostartMechanism must include {mechanism}"


### PR DESCRIPTION
## Summary

- macOS の System Settings >「ログイン項目と機能拡張」一覧で gwt が署名チーム名「Akio Jinsenji」と表示される問題を修正し、アプリ名「GWT」で表示されるようにする。
- 原因は autostart が raw な LaunchAgent plist を直置きしていたこと。Background Task Management は直置き plist をアプリバンドルに紐付けられず、署名 identity (個人 Developer ID では開発者名) で表示するため。
- macOS 13+ (Darwin 22+) を `SMAppService.mainApp` 経由へ移行し、macOS 12 以下は従来の `auto-launch` LaunchAgent へ fallback する。

## Context

- SPEC #2920 Phase 12 (T-120〜T-127)。SPEC #2920 は autostart 機構として raw LaunchAgent plist を採用していたが、本変更でその受け入れシナリオ #5/#6・成功基準・FR-005 を SMAppService dual-path へ改訂済み (新規受け入れシナリオ #10 を追加)。
- macOS 12 以前には Ventura の「バックグラウンドでのアクティビティ」UI が存在せず、旧 UI はアプリ名表示のため本問題は発生しない。よって「13+ は SMAppService / 旧 OS は LaunchAgent」の dual-path で過不足ない。

## Changes

- `crates/gwt/src/cli/tray/autostart.rs`: `AutostartMechanism::AppService` を追加。`for_host_os()` を runtime 版本依存に変更し、macOS は Darwin major (libc `sysctl kern.osrelease`) で 13+ 判定。`#[cfg(target_os = "macos")] mod macos_app_service` で `SMAppService.mainApp` の register / unregister / status を実装。install / uninstall 時に legacy `~/Library/LaunchAgents/GWT.plist` を migration cleanup。status() は read-only (legacy plist 存在も enabled として報告し移行期の整合を維持)。公開 API (`AutostartManager::{install,uninstall,status}`) は不変。
- `crates/gwt/Cargo.toml`: `[target.'cfg(target_os = "macos")'.dependencies]` に `objc2-service-management` (features `SMAppService`, `objc2-foundation`) と `objc2-foundation` (feature `NSError`) を追加 (objc2 は既存 transitive 0.6.x と整合)。
- `crates/gwt/tests/tray_module_present_test.rs`: `AutostartMechanism` の pin リストに `AppService` を追加。
- `Cargo.lock`: 上記依存を反映。

## Testing

- [x] `cargo build -p gwt --bin gwt --bin gwtd` — 成功
- [x] `cargo test -p gwt -p gwt-core --all-features` — 60 suites PASS / 0 failed (autostart 純ロジック: 版本→mechanism、SMAppService status マッピング、legacy plist cleanup、PascalCase serde を新規カバー)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — 警告ゼロ
- [x] `cargo fmt -p gwt -- --check` — 差分なし
- [ ] (実機 / user-skipped) Developer ID 署名 build を `/Applications/GWT.app` に install → Settings>System で `Launch GWT at login` を ON → System Settings に「GWT」表示・旧「Akio Jinsenji」消失を目視

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — macOS 13+ の表示名修正で完結。macOS 12 以下・Windows・Linux は既存挙動を維持し、公開 API も不変のため既存機能を壊さない。
- Known blockers: None
- Remaining acceptance: 実機視覚検証 (T-127) は **ユーザーが `AskUserQuestion` で「視覚検証はスキップして PR」を明示選択**したため `skipped`。自動検証は全 PASS。マージ前に確認したい場合は Testing の最後の手順で目視可能。

## Closing Issues

- None

## Related Issues / Links

- #2920 (SPEC: Tray-only Browser Front Door / autostart — Phase 12)

## Risk / Impact

- **Affected areas**: macOS の autostart (Login Items) のみ。Windows / Linux / macOS 12 以下は `auto-launch` 経路を維持。
- **Rollback plan**: 本 commit を revert すれば従来の LaunchAgent plist 方式に戻る (機能的には autostart は引き続き動作)。

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (if user-facing change) — SPEC #2920 の spec/tasks を更新。README は autostart の内部機構変更のみで利用者向け操作 (Settings>System の toggle) は不変のため変更不要
- [x] Migration/backfill plan included — 旧 LaunchAgent plist は install/uninstall 時に自動 cleanup
- [x] CHANGELOG impact considered — `fix:` (patch)。破壊的変更なし

## Notes

- 実機視覚検証はユーザー明示選択で skip。調査で「SMAppService でも稀に署名名が残る実機報告」があるため、可能なら署名 build で一度目視確認すると確実。
- OS バージョン判定は Darwin major (kern.osrelease) で行う。macOS 26 への renumber で Darwin↔macOS product 番号が非線形になったため、SMAppService 下限の Darwin 22 で安定判定している。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for modern macOS 13+ autostart mechanism with automatic runtime selection based on system version.

* **Bug Fixes**
  * Improved error reporting for autostart registration and unregistration failures on macOS.

* **Tests**
  * Updated test coverage for autostart mechanism validation across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->