### PR TITLE
fix: Agent window title shows work purpose, not the raw prompt (SPEC-2359 W-11)

### DIFF
--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -1559,6 +1559,95 @@ fn write_rebuild_marker(path: &Path) -> Result<()> {
     write_atomic(path, &body)
 }
 
+/// SPEC-2359 Phase W-11 (US-58 / FR-346): schema version for the one-time
+/// agent identity reset. Bumping this re-runs [`reset_legacy_agent_identity_at`]
+/// on existing data. Version 1 clears `title_summary` / `current_focus`
+/// written by the legacy prompt-derivation hook so the display fallback and
+/// agent re-authoring take over.
+pub const WORKSPACE_AGENT_IDENTITY_RESET_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct AgentIdentityResetMarker {
+    version: u32,
+    #[serde(default)]
+    migrated_at: Option<DateTime<Utc>>,
+}
+
+fn agent_identity_reset_marker_path(current_path: &Path) -> PathBuf {
+    current_path
+        .parent()
+        .map(|dir| dir.join("agent_identity.migration.json"))
+        .unwrap_or_else(|| PathBuf::from("agent_identity.migration.json"))
+}
+
+fn agent_identity_reset_marker_at_or_above(path: &Path, required: u32) -> Result<bool> {
+    if !path.exists() {
+        return Ok(false);
+    }
+    let body = fs::read_to_string(path)?;
+    Ok(serde_json::from_str::<AgentIdentityResetMarker>(&body)
+        .map(|marker| marker.version >= required)
+        .unwrap_or(false))
+}
+
+fn write_agent_identity_reset_marker(path: &Path) -> Result<()> {
+    let marker = AgentIdentityResetMarker {
+        version: WORKSPACE_AGENT_IDENTITY_RESET_VERSION,
+        migrated_at: Some(chrono::Utc::now()),
+    };
+    let body = serde_json::to_vec_pretty(&marker)
+        .map_err(|error| GwtError::Other(format!("agent identity reset marker: {error}")))?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    write_atomic(path, &body)
+}
+
+/// SPEC-2359 Phase W-11 (US-58 / FR-346): clear legacy `title_summary` /
+/// `current_focus` from the canonical projection at `current_path` exactly
+/// once, guarded by a version marker. After this reset those fields are
+/// authored only by the agent (`gwtd workspace update` / `gwtd board post`),
+/// and empty values resolve through the display fallback chain. Returns
+/// `true` when the reset marker was newly written, `false` when the marker
+/// already records the current version (so agent-authored values written
+/// after the reset are never cleared again).
+pub fn reset_legacy_agent_identity_at(current_path: &Path) -> Result<bool> {
+    let marker_path = agent_identity_reset_marker_path(current_path);
+    if agent_identity_reset_marker_at_or_above(
+        &marker_path,
+        WORKSPACE_AGENT_IDENTITY_RESET_VERSION,
+    )? {
+        return Ok(false);
+    }
+    if let Some(mut projection) = load_workspace_projection_from_path(current_path)? {
+        let mut changed = false;
+        for agent in &mut projection.agents {
+            if agent.title_summary.take().is_some() {
+                changed = true;
+            }
+            if agent.current_focus.take().is_some() {
+                changed = true;
+            }
+        }
+        if changed {
+            save_workspace_projection_to_path(current_path, &projection)?;
+        }
+    }
+    write_agent_identity_reset_marker(&marker_path)?;
+    Ok(true)
+}
+
+/// SPEC-2359 Phase W-11 (US-58 / FR-346): repo-scoped convenience wrapper for
+/// the startup bootstrap. Resolves the canonical projection path and runs the
+/// version-guarded one-time legacy identity reset. Call this once at startup
+/// (alongside the work-items rebuild), not on every projection load, so a
+/// freshly agent-authored title is never cleared.
+pub fn reset_legacy_agent_identity_for_repo(repo_path: &Path) -> Result<bool> {
+    let current_path = gwt_workspace_projection_path_for_repo_path(repo_path);
+    let _ = migrate_legacy_workspace_projection(repo_path, &current_path)?;
+    reset_legacy_agent_identity_at(&current_path)
+}
+
 /// SPEC-2359 US-37 / FR-119: Convenience wrapper resolving the project-scoped
 /// current, work_items, and work_events paths from `repo_path` and invoking
 /// [`retroactive_auto_done_scan_paths`].
@@ -2426,6 +2515,62 @@ mod tests {
         assert_eq!(
             projection.status_text, "Still describing the current task",
             "category derivation must not overwrite the display status text"
+        );
+    }
+
+    /// SPEC-2359 Phase W-11 (US-58 / SC-228): the one-time reset clears
+    /// legacy title_summary / current_focus exactly once (version-guarded),
+    /// later runs are a no-op, and agent-authored values written after the
+    /// reset are preserved.
+    #[test]
+    fn reset_legacy_agent_identity_clears_once_and_preserves_later_values() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let current_path = temp.path().join("current.json");
+
+        let mut projection = WorkspaceProjection::default_for_project(temp.path());
+        projection.agents.push(WorkspaceAgentSummary {
+            session_id: "sess-legacy".to_string(),
+            window_id: None,
+            agent_id: "codex".to_string(),
+            display_name: "Codex".to_string(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: Some("/gwt-discussion 生プロンプト focus".to_string()),
+            title_summary: Some("あなたの目的は何ですか".to_string()),
+            worktree_path: None,
+            branch: None,
+            last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
+            updated_at: Utc::now(),
+        });
+        save_workspace_projection_to_path(&current_path, &projection).expect("save");
+
+        // First reset clears the legacy values and writes the marker.
+        let applied = reset_legacy_agent_identity_at(&current_path).expect("reset");
+        assert!(applied, "first reset should run and write the marker");
+        let after = load_workspace_projection_from_path(&current_path)
+            .expect("load")
+            .expect("present");
+        assert_eq!(after.agents[0].title_summary, None);
+        assert_eq!(after.agents[0].current_focus, None);
+
+        // The agent authors a real purpose after the migration.
+        let mut authored = after;
+        authored.agents[0].title_summary = Some("Agent タイトル目的化".to_string());
+        save_workspace_projection_to_path(&current_path, &authored).expect("save authored");
+
+        // Second reset is a no-op (marker guard) and preserves the agent value.
+        let applied_again = reset_legacy_agent_identity_at(&current_path).expect("reset again");
+        assert!(!applied_again, "marker must prevent a second clear");
+        let preserved = load_workspace_projection_from_path(&current_path)
+            .expect("load")
+            .expect("present");
+        assert_eq!(
+            preserved.agents[0].title_summary.as_deref(),
+            Some("Agent タイトル目的化"),
+            "agent-authored title must survive later loads"
         );
     }
 

--- a/crates/gwt-skills/src/coordination_guidance.rs
+++ b/crates/gwt-skills/src/coordination_guidance.rs
@@ -86,7 +86,10 @@ the current task, summary, next action, or focus changes:
       --title-summary '<short task title>'
 
 `--title-summary` is the short task name used by Agent window tabs and
-Workspace summaries. Write what the work is, not its completion state.
+Workspace summaries. Write the work purpose, not its completion state, and
+never copy the raw prompt into it. If the purpose is not settled yet, set a
+plausible provisional purpose early and update the same `--title-summary`
+the moment the purpose is confirmed.
 
 - Good: `Agent title summaries`
 - Bad (completion state): `Agent title summaries done`, `Working on agent title summaries`
@@ -188,7 +191,10 @@ summary、next action、focus が変わったら必ず更新します:
       --title-summary '<短い作業タイトル>'
 
 `--title-summary` は Agent window tab と Workspace summary 用の
-**短い作業名**。状態や結果ではなく「何の作業か」を書きます。
+**短い作業名**。状態や結果ではなく「何の作業か（作業の目的）」を書きます。
+入力した生プロンプトをそのまま使わないでください。目的がまだ固まって
+いない場合は、それっぽい暫定の目的を先に設定し、目的が定まった瞬間に
+同じ `--title-summary` を更新します。
 
 - 例: `エージェントタイトル改善` ✓
 - 不可 (完了状態): `エージェントタイトル改善完了`、`エージェントタイトル改善中` ✗

--- a/crates/gwt-skills/src/coordination_guidance.rs
+++ b/crates/gwt-skills/src/coordination_guidance.rs
@@ -87,9 +87,10 @@ the current task, summary, next action, or focus changes:
 
 `--title-summary` is the short task name used by Agent window tabs and
 Workspace summaries. Write the work purpose, not its completion state, and
-never copy the raw prompt into it. If the purpose is not settled yet, set a
-plausible provisional purpose early and update the same `--title-summary`
-the moment the purpose is confirmed.
+never copy the raw prompt into it. On a new Agent window, set it as your
+first action, before responding to the user. If the purpose is not settled
+yet, set a plausible provisional purpose now and update the same
+`--title-summary` the moment the purpose is confirmed.
 
 - Good: `Agent title summaries`
 - Bad (completion state): `Agent title summaries done`, `Working on agent title summaries`
@@ -192,9 +193,10 @@ summary、next action、focus が変わったら必ず更新します:
 
 `--title-summary` は Agent window tab と Workspace summary 用の
 **短い作業名**。状態や結果ではなく「何の作業か（作業の目的）」を書きます。
-入力した生プロンプトをそのまま使わないでください。目的がまだ固まって
-いない場合は、それっぽい暫定の目的を先に設定し、目的が定まった瞬間に
-同じ `--title-summary` を更新します。
+入力した生プロンプトをそのまま使わないでください。新しい Agent window
+では、応答を始める前に最初のアクションとして設定します。目的がまだ
+固まっていない場合は、それっぽい暫定の目的を今すぐ設定し、目的が定まった
+瞬間に同じ `--title-summary` を更新します。
 
 - 例: `エージェントタイトル改善` ✓
 - 不可 (完了状態): `エージェントタイトル改善完了`、`エージェントタイトル改善中` ✗

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -3363,6 +3363,15 @@ impl AppRuntime {
             let _ = gwt_core::workspace_projection::rebuild_work_items_from_events_for_repo(
                 &tab.project_root,
             );
+            // SPEC-2359 Phase W-11 (US-58 / FR-346): one-shot, version-guarded
+            // clear of legacy prompt-derived title_summary / current_focus so
+            // existing broken titles ("あなたの目的は何ですか" etc.) heal via the
+            // display fallback and agent re-authoring. Idempotent via
+            // `agent_identity.migration.json`; never re-clears agent-authored
+            // values written after the marker.
+            let _ = gwt_core::workspace_projection::reset_legacy_agent_identity_for_repo(
+                &tab.project_root,
+            );
         }
 
         self.queue_startup_auto_resume_sessions();
@@ -6250,17 +6259,34 @@ impl AppRuntime {
         project_root: &Path,
         projection: &gwt_core::workspace_projection::WorkspaceProjection,
     ) -> bool {
+        // SPEC-2359 Phase W-11 (US-58 / FR-344): resolve the effective window
+        // title with the display fallback chain — the agent-authored
+        // `title_summary` first, then the linked Issue/SPEC title, then `None`
+        // (which lets the frontend fall back to the neutral agent label). The
+        // raw prompt is never written into a title, so it can never appear here.
+        let issue_fallback_title = projection
+            .linked_issues
+            .first()
+            .map(|issue| issue.number)
+            .and_then(|number| {
+                let cache_root =
+                    gwt::issue_cache::issue_cache_root_for_repo_path_or_detached(project_root);
+                gwt::issue_cache::load_issue_title_from_cache(&cache_root, number)
+            });
+
         let updates = projection
             .agents
             .iter()
             .filter_map(|agent| {
+                let window_id = self.resolve_title_sync_window_id(agent, project_root)?;
                 let title = agent
                     .title_summary
                     .as_deref()
                     .map(str::trim)
-                    .filter(|value| !value.is_empty())?;
-                let window_id = self.resolve_title_sync_window_id(agent, project_root)?;
-                Some((window_id, title.to_string(), agent.current_focus.clone()))
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string)
+                    .or_else(|| issue_fallback_title.clone());
+                Some((window_id, title, agent.current_focus.clone()))
             })
             .collect::<Vec<_>>();
 
@@ -6274,7 +6300,7 @@ impl AppRuntime {
             };
             if tab
                 .workspace
-                .set_dynamic_title_with_detail(&address.raw_id, Some(title), detail)
+                .set_dynamic_title_with_detail(&address.raw_id, title, detail)
             {
                 changed = true;
             }

--- a/crates/gwt/src/cli/hook/board_reminder/mod.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/mod.rs
@@ -140,27 +140,44 @@ fn agent_title_summary_missing(session: &Session) -> Result<bool, HookError> {
         session,
         &session.worktree_path,
     );
-    let Some(projection) =
-        gwt_core::workspace_projection::load_workspace_projection(&project_state_root)?
-    else {
-        return Ok(false);
+    let projection =
+        gwt_core::workspace_projection::load_workspace_projection(&project_state_root)?;
+    Ok(title_summary_missing_in_projection(
+        projection.as_ref(),
+        &session.id,
+    ))
+}
+
+/// Pure decision for whether `session_id`'s agent still needs a `title_summary`.
+///
+/// SPEC-2359 Phase W-11 (US-58 / US-46 / FR-179): the title reminder must also
+/// fire for Unassigned agents. Start Work / standalone agents are Unassigned
+/// yet still need a purpose title; with the prompt-derivation path removed
+/// (W-11), an `is_unassigned()` early-return would leave them with neither a
+/// derived title nor a reminder. (The derivation path dropped the same guard
+/// under US-46/FR-179 for the same reason.) A missing projection or an
+/// unregistered session is treated as "not missing" so the reminder only
+/// fires once the agent is actually present in the projection.
+fn title_summary_missing_in_projection(
+    projection: Option<&gwt_core::workspace_projection::WorkspaceProjection>,
+    session_id: &str,
+) -> bool {
+    let Some(projection) = projection else {
+        return false;
     };
     let Some(agent) = projection
         .agents
         .iter()
-        .find(|agent| agent.session_id == session.id)
+        .find(|agent| agent.session_id == session_id)
     else {
-        return Ok(false);
+        return false;
     };
-    if agent.is_unassigned() {
-        return Ok(false);
-    }
-    Ok(agent
+    agent
         .title_summary
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .is_none())
+        .is_none()
 }
 
 fn append_title_summary_required_context(
@@ -707,6 +724,70 @@ mod tests {
             !agent_title_summary_missing(&session).expect("title check"),
             "title guard must read the canonical Project State root, not the worktree root"
         );
+    }
+
+    /// SPEC-2359 Phase W-11 (US-58 / US-46 / FR-179): the title-missing
+    /// decision must return `true` for an Unassigned agent with no title, so
+    /// the reminder fires. Start Work / standalone agents are Unassigned; the
+    /// old `is_unassigned()` early-return left them with neither a derived
+    /// title nor a reminder once the prompt-derivation path was removed.
+    /// Pure-logic test (no global store / env) to stay deterministic.
+    #[test]
+    fn title_summary_missing_in_projection_covers_affiliation_and_presence() {
+        use gwt_core::workspace_projection::{
+            WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary, WorkspaceProjection,
+            WorkspaceStatusCategory,
+        };
+
+        let mut agent = WorkspaceAgentSummary {
+            session_id: "sess-1".to_string(),
+            window_id: None,
+            agent_id: "codex".to_string(),
+            display_name: "Codex".to_string(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: None,
+            title_summary: None,
+            worktree_path: None,
+            branch: None,
+            last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Unassigned,
+            workspace_id: None,
+            updated_at: Utc::now(),
+        };
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
+        projection.agents.push(agent.clone());
+
+        // Unassigned + empty title -> missing (the fix).
+        assert!(title_summary_missing_in_projection(
+            Some(&projection),
+            "sess-1"
+        ));
+
+        // Assigned + empty title -> still missing.
+        projection.agents[0].affiliation_status = WorkspaceAgentAffiliationStatus::Assigned;
+        assert!(title_summary_missing_in_projection(
+            Some(&projection),
+            "sess-1"
+        ));
+
+        // Any affiliation + non-empty title -> not missing.
+        projection.agents[0].title_summary = Some("Agent title purpose".to_string());
+        assert!(!title_summary_missing_in_projection(
+            Some(&projection),
+            "sess-1"
+        ));
+
+        // No projection / unknown session -> not missing.
+        assert!(!title_summary_missing_in_projection(None, "sess-1"));
+        agent.title_summary = None;
+        let mut other = WorkspaceProjection::default_for_project("/repo");
+        other.agents.push(agent);
+        assert!(!title_summary_missing_in_projection(
+            Some(&other),
+            "sess-unknown"
+        ));
     }
 
     fn push_entry(

--- a/crates/gwt/src/cli/hook/board_reminder/mod.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/mod.rs
@@ -174,8 +174,16 @@ fn append_title_summary_required_context(
     }
     let required = texts::title_summary_required_reminder(language);
     match output {
+        // SPEC-2359 Phase W-11 (US-58 / FR-347): prepend so the
+        // "set a provisional purpose before responding" instruction is the
+        // first thing the agent sees, ahead of the board reminder.
         HookOutput::HookSpecificAdditionalContext { event, text } => {
-            HookOutput::hook_specific_additional_context(event, format!("{text}\n\n{required}"))
+            HookOutput::hook_specific_additional_context(event, format!("{required}\n\n{text}"))
+        }
+        // Inject even when there is no board reminder this turn, so a fresh
+        // agent's first UserPromptSubmit always carries the title instruction.
+        HookOutput::Silent => {
+            HookOutput::hook_specific_additional_context(event, required.to_string())
         }
         other => other,
     }
@@ -527,11 +535,34 @@ mod tests {
         assert!(ja_text.contains("目的"), "{ja_text}");
         assert!(ja_text.contains("暫定"), "{ja_text}");
         assert!(ja_text.contains("生プロンプト"), "{ja_text}");
+        // Imperative: must instruct setting the title before responding.
+        assert!(ja_text.contains("応答する前に"), "{ja_text}");
+        assert!(ja_text.contains("最初のアクション"), "{ja_text}");
 
         let en_text = texts::title_summary_required_reminder("en");
         assert!(en_text.contains("purpose"), "{en_text}");
         assert!(en_text.contains("provisional"), "{en_text}");
         assert!(en_text.to_lowercase().contains("raw prompt"), "{en_text}");
+        // Imperative: must instruct setting the title before responding.
+        assert!(en_text.contains("before you respond"), "{en_text}");
+        assert!(en_text.contains("first action"), "{en_text}");
+    }
+
+    /// SPEC-2359 Phase W-11 (US-58 / FR-347): the title-required reminder must
+    /// fire even when there is no board reminder this turn (Silent), so a fresh
+    /// agent's first UserPromptSubmit always carries the instruction.
+    #[test]
+    fn title_summary_required_context_injects_even_when_board_is_silent() {
+        let guarded = append_title_summary_required_context(
+            HookOutput::Silent,
+            IntentBoundaryEvent::UserPromptSubmit,
+            true,
+            "en",
+        );
+        let HookOutput::HookSpecificAdditionalContext { text, .. } = guarded else {
+            panic!("title reminder must inject even when board output is Silent");
+        };
+        assert!(text.contains("before you respond"), "{text}");
     }
 
     #[test]

--- a/crates/gwt/src/cli/hook/board_reminder/mod.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/mod.rs
@@ -517,6 +517,23 @@ mod tests {
         assert!(text.contains("Use language: ja"));
     }
 
+    /// SPEC-2359 Phase W-11 (US-58 / US-59 / SC-229): the required reminder
+    /// must instruct the agent to author the work purpose (not the raw
+    /// prompt), set a provisional purpose when it is not settled, and update
+    /// it once confirmed — in both Japanese and English.
+    #[test]
+    fn title_summary_required_reminder_instructs_provisional_purpose() {
+        let ja_text = texts::title_summary_required_reminder("ja");
+        assert!(ja_text.contains("目的"), "{ja_text}");
+        assert!(ja_text.contains("暫定"), "{ja_text}");
+        assert!(ja_text.contains("生プロンプト"), "{ja_text}");
+
+        let en_text = texts::title_summary_required_reminder("en");
+        assert!(en_text.contains("purpose"), "{en_text}");
+        assert!(en_text.contains("provisional"), "{en_text}");
+        assert!(en_text.to_lowercase().contains("raw prompt"), "{en_text}");
+    }
+
     #[test]
     fn title_summary_guard_is_silent_when_agent_title_is_set() {
         let output = HookOutput::hook_specific_additional_context(

--- a/crates/gwt/src/cli/hook/board_reminder/texts.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/texts.rs
@@ -308,30 +308,36 @@ pub(super) fn format_language_directive(lang: &str) -> String {
 
 pub(super) fn title_summary_required_reminder(lang: &str) -> &'static str {
     match reminder_language(lang) {
-        ReminderLanguage::Ja => "# Agent Title Required\n\
+        ReminderLanguage::Ja => "# Agent Title — 応答する前に必ず設定\n\
 \n\
-この Agent session にはまだ短い `title-summary` が設定されていません。実装や検証に入る前に、現在の作業目的を Workspace に明示してください。\n\
+この Agent window にはまだ `title-summary` が設定されていません。ユーザーへの応答を始める前に、**最初のアクションとして**この window の作業の目的を title-summary に設定してください。これは任意ではありません。\n\
 \n\
-必須コマンド例:\n\
-  gwtd workspace update --agent-session \"$GWT_SESSION_ID\" --current-focus '<現在の作業内容>' --title-summary '<短い作業タイトル>'\n\
+まず最初に実行:\n\
+  gwtd workspace update --agent-session \"$GWT_SESSION_ID\" --current-focus '<現在の作業内容>' --title-summary '<作業の目的（短い作業名）>'\n\
 \n\
-必要に応じて同じ短いタイトルを Board milestone にも付けます:\n\
-  gwtd board post --kind status --title-summary '<短い作業タイトル>' --body '<現在の状態 / 理由 / 次>'\n\
+ルール:\n\
+- title-summary には「何の作業か（作業の目的）」を書きます。状態や結果ではありません。\n\
+- 入力された生プロンプトをそのままコピーしないでください。\n\
+- 目的がまだ固まっていない場合でも、それっぽい暫定の目的を今すぐ設定し、目的が定まったら同じ title-summary を更新します（応答を遅らせないでください）。\n\
+- 例: `エージェントタイトル目的化`。不可: `…完了`、`…中`、生プロンプトのコピー。\n\
 \n\
-`title-summary` は Agent window tab と Workspace summary 用の短い作業名です。状態や結果ではなく「何の作業か（作業の目的）」を書いてください。入力した生プロンプトをそのまま使わないでください。目的がまだ固まっていない場合は、それっぽい暫定の目的を設定し、目的が定まったら同じ `title-summary` を更新します。例: `エージェントタイトル改善`。不可: `エージェントタイトル改善完了`、`エージェントタイトル改善中`、生プロンプトのコピー。完了/進行中/ブロック中などの状態は `--status`、`--current-focus`、`--summary`、または Board `--body` に分けてください。\n\
+完了/進行中/ブロック中などの状態は `--status`、`--current-focus`、`--summary`、または Board `--body` に分けてください。設定が済むまで毎ターンこの指示を再掲します。\n\
 \n\
 **Use language: ja** for narrative outputs（Board 投稿本文、Workspace summaries、Agent title-summary）。gwtd subcommands、flags、code examples は English のまま。\n",
-        ReminderLanguage::En => "# Agent Title Required\n\
+        ReminderLanguage::En => "# Agent Title — set it before you respond\n\
 \n\
-This Agent session does not have a short `title-summary` yet. Before implementation or verification work, explicitly publish the current work purpose to Workspace.\n\
+This Agent window has no `title-summary` yet. Before you start responding to the user, your **first action** must set this window's work purpose as its title-summary. This is not optional.\n\
 \n\
-Required command shape:\n\
-  gwtd workspace update --agent-session \"$GWT_SESSION_ID\" --current-focus '<current work focus>' --title-summary '<short work title>'\n\
+Run this first:\n\
+  gwtd workspace update --agent-session \"$GWT_SESSION_ID\" --current-focus '<current work focus>' --title-summary '<short work purpose>'\n\
 \n\
-When useful, use the same short title on the Board milestone:\n\
-  gwtd board post --kind status --title-summary '<short work title>' --body '<current state / reason / next>'\n\
+Rules:\n\
+- title-summary = the purpose of the work, not its status or result.\n\
+- Do not copy the raw prompt into the title.\n\
+- Even if the purpose is not settled yet, set a plausible provisional purpose now and update the same title-summary once it is confirmed (do not delay your response for it).\n\
+- Good: `Agent title purpose`. Bad: `... complete`, `... in progress`, a copy of the raw prompt.\n\
 \n\
-`title-summary` is the short work name for Agent window tabs and Workspace summaries. Describe what the work is (its purpose), not its status or result. Do not copy the raw prompt into the title. If the purpose is not settled yet, set a plausible provisional purpose and update the same `title-summary` once it is confirmed. Good: `Agent title improvement`. Bad: `Agent title improvement complete`, `Agent title improvement in progress`, a copy of the raw prompt. Keep completion/progress/blocker state in `--status`, `--current-focus`, `--summary`, or Board `--body`.\n\
+Keep completion/progress/blocker state in `--status`, `--current-focus`, `--summary`, or Board `--body`. This instruction repeats every turn until the title is set.\n\
 \n\
 **Use language: en** for narrative outputs (Board post bodies, Workspace summaries, and Agent title-summary; gwtd subcommands, flags, and code examples stay English).\n",
     }

--- a/crates/gwt/src/cli/hook/board_reminder/texts.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/texts.rs
@@ -318,7 +318,7 @@ pub(super) fn title_summary_required_reminder(lang: &str) -> &'static str {
 必要に応じて同じ短いタイトルを Board milestone にも付けます:\n\
   gwtd board post --kind status --title-summary '<短い作業タイトル>' --body '<現在の状態 / 理由 / 次>'\n\
 \n\
-`title-summary` は Agent window tab と Workspace summary 用の短い作業名です。状態や結果ではなく「何の作業か」を書いてください。例: `エージェントタイトル改善`。不可: `エージェントタイトル改善完了`、`エージェントタイトル改善中`。完了/進行中/ブロック中などの状態は `--status`、`--current-focus`、`--summary`、または Board `--body` に分けてください。\n\
+`title-summary` は Agent window tab と Workspace summary 用の短い作業名です。状態や結果ではなく「何の作業か（作業の目的）」を書いてください。入力した生プロンプトをそのまま使わないでください。目的がまだ固まっていない場合は、それっぽい暫定の目的を設定し、目的が定まったら同じ `title-summary` を更新します。例: `エージェントタイトル改善`。不可: `エージェントタイトル改善完了`、`エージェントタイトル改善中`、生プロンプトのコピー。完了/進行中/ブロック中などの状態は `--status`、`--current-focus`、`--summary`、または Board `--body` に分けてください。\n\
 \n\
 **Use language: ja** for narrative outputs（Board 投稿本文、Workspace summaries、Agent title-summary）。gwtd subcommands、flags、code examples は English のまま。\n",
         ReminderLanguage::En => "# Agent Title Required\n\
@@ -331,7 +331,7 @@ Required command shape:\n\
 When useful, use the same short title on the Board milestone:\n\
   gwtd board post --kind status --title-summary '<short work title>' --body '<current state / reason / next>'\n\
 \n\
-`title-summary` is the short work name for Agent window tabs and Workspace summaries. Describe what the work is, not its status or result. Good: `Agent title improvement`. Bad: `Agent title improvement complete`, `Agent title improvement in progress`. Keep completion/progress/blocker state in `--status`, `--current-focus`, `--summary`, or Board `--body`.\n\
+`title-summary` is the short work name for Agent window tabs and Workspace summaries. Describe what the work is (its purpose), not its status or result. Do not copy the raw prompt into the title. If the purpose is not settled yet, set a plausible provisional purpose and update the same `title-summary` once it is confirmed. Good: `Agent title improvement`. Bad: `Agent title improvement complete`, `Agent title improvement in progress`, a copy of the raw prompt. Keep completion/progress/blocker state in `--status`, `--current-focus`, `--summary`, or Board `--body`.\n\
 \n\
 **Use language: en** for narrative outputs (Board post bodies, Workspace summaries, and Agent title-summary; gwtd subcommands, flags, and code examples stay English).\n",
     }

--- a/crates/gwt/src/cli/hook/event_dispatcher.rs
+++ b/crates/gwt/src/cli/hook/event_dispatcher.rs
@@ -60,15 +60,18 @@ fn handle_user_prompt_submit(event: &str, input: &str) -> Result<HookOutput, Hoo
     run_step(event, "forward", || {
         crate::daemon_runtime::handle_forward(input)
     })?;
-    let identity = run_step(event, "workspace-identity", || {
-        workspace_identity::handle_user_prompt_submit(input)
-    })?;
-    let reminder = run_step(event, "board-reminder", || {
+    // SPEC-2359 Phase W-11 (US-58): the workspace-identity step no longer
+    // derives a title from the prompt; it only performs the Phase W-10
+    // canonical Project State split repair. Fail-open so a repair error does
+    // not abort prompt handling.
+    run_value(event, "workspace-identity", || {
+        if let Err(error) = workspace_identity::handle_user_prompt_submit(input) {
+            tracing::warn!(?error, "workspace-identity hook step failed");
+        }
+    });
+    run_step(event, "board-reminder", || {
         board_reminder::handle_with_input(event, input)
-    })?;
-    Ok(workspace_identity::append_identity_context(
-        reminder, identity,
-    ))
+    })
 }
 
 fn handle_pre_tool_use(event: &str, input: &str) -> Result<HookOutput, HookError> {

--- a/crates/gwt/src/cli/hook/workspace_identity.rs
+++ b/crates/gwt/src/cli/hook/workspace_identity.rs
@@ -1,41 +1,14 @@
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use gwt_agent::{Session, GWT_SESSION_ID_ENV};
 use gwt_core::workspace_projection::{
-    load_or_default_workspace_projection, load_workspace_projection, save_workspace_projection,
-    update_workspace_projection_with_journal, WorkspaceAgentAffiliationStatus,
-    WorkspaceAgentSummary, WorkspaceProjection, WorkspaceProjectionUpdate, WorkspaceStatusCategory,
+    load_or_default_workspace_projection, save_workspace_projection,
+    WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary, WorkspaceProjection,
+    WorkspaceStatusCategory,
 };
 
-use super::{HookError, HookOutput, IntentBoundaryEvent};
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct WorkspacePromptIdentity {
-    pub title_summary: String,
-    pub current_focus: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct WorkspaceIdentityHookResult {
-    pub updated: bool,
-    pub identity: Option<WorkspacePromptIdentity>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct MissingIdentity {
-    title_summary: bool,
-    current_focus: bool,
-}
-
-impl MissingIdentity {
-    fn complete(self) -> bool {
-        !self.title_summary && !self.current_focus
-    }
-}
+use super::HookError;
 
 /// SessionStart hook: ensure the running agent session is present in the
 /// Workspace projection's `agents[]` before any further coordination CLI
@@ -47,6 +20,12 @@ impl MissingIdentity {
 /// Registration is idempotent: if the launch flow has already registered
 /// the session (with `Assigned` affiliation, a workspace_id, etc.) we
 /// leave that record untouched so the richer launch-time state survives.
+///
+/// SPEC-2359 Phase W-11 (US-58 / FR-341 / FR-342): the hook no longer
+/// derives `title_summary` from the prompt or from the linked Issue. The
+/// `title_summary` field now means "the purpose the agent authored". Empty
+/// values are resolved at display time via the fallback chain (agent title
+/// → linked Issue/SPEC title → neutral label) in the title sync layer.
 pub(crate) fn handle_session_start() -> Result<(), HookError> {
     let Some(session) = current_session_from_env()? else {
         return Ok(());
@@ -57,11 +36,7 @@ pub(crate) fn handle_session_start() -> Result<(), HookError> {
     projection.project_root = project_state_root.clone();
     let now = Utc::now();
     let registered = register_session_in_projection(&mut projection, &session, now);
-    let derived = derive_title_summary_from_owner(&mut projection, &session);
-    if derived {
-        projection.updated_at = now;
-    }
-    if registered || derived {
+    if registered {
         save_workspace_projection(&project_state_root, &projection)?;
         crate::cli::workspace::publish_workspace_change(&project_state_root);
     }
@@ -103,67 +78,6 @@ fn coordination_assets_need_refresh(worktree: &Path) -> bool {
     let codex_needs = codex_dir.is_dir() && (!codex_skill.exists() || !codex_hooks.exists());
     let claude_needs = claude_dir.is_dir() && (!claude_skill.exists() || !claude_settings.exists());
     codex_needs || claude_needs
-}
-
-/// SPEC-2359 Phase U-9 (FR-173 / FR-174): auto-derive `title_summary`
-/// from the workspace's first linked Issue/SPEC at SessionStart when the
-/// agent has no explicit title yet. Existing explicit values are never
-/// overwritten (US-43 non-destructive contract). Missing cache entries
-/// are a silent no-op so owner-less sessions stay empty and fall back to
-/// the existing empty-trigger reminder path.
-fn derive_title_summary_from_owner(
-    projection: &mut WorkspaceProjection,
-    session: &Session,
-) -> bool {
-    let project_state_root = project_state_root_for_session(session);
-    let issue_cache_root =
-        crate::issue_cache::issue_cache_root_for_repo_path_or_detached(&project_state_root);
-    derive_title_summary_from_owner_with_cache(projection, &session.id, &issue_cache_root)
-}
-
-fn derive_title_summary_from_owner_with_cache(
-    projection: &mut WorkspaceProjection,
-    session_id: &str,
-    issue_cache_root: &Path,
-) -> bool {
-    let Some(agent_idx) = projection
-        .agents
-        .iter()
-        .position(|agent| agent.session_id == session_id)
-    else {
-        return false;
-    };
-    if projection.agents[agent_idx]
-        .title_summary
-        .as_deref()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .is_some()
-    {
-        return false;
-    }
-    let Some(issue) = projection.linked_issues.first() else {
-        return false;
-    };
-    let issue_number = issue.number;
-    let title = match load_issue_title_from_cache(issue_cache_root, issue_number) {
-        Some(value) => value,
-        None => return false,
-    };
-    projection.agents[agent_idx].title_summary = Some(title);
-    true
-}
-
-fn load_issue_title_from_cache(cache_root: &Path, issue_number: u64) -> Option<String> {
-    let path = cache_root.join(issue_number.to_string()).join("meta.json");
-    let bytes = fs::read(&path).ok()?;
-    let value: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
-    let title = value.get("title")?.as_str()?.trim();
-    if title.is_empty() {
-        None
-    } else {
-        Some(title.to_string())
-    }
 }
 
 /// Insert a stub `WorkspaceAgentSummary` for `session` if no agent with
@@ -211,103 +125,33 @@ fn workspace_agent_summary_from_session(
     }
 }
 
-pub(crate) fn handle_user_prompt_submit(
-    input: &str,
-) -> Result<WorkspaceIdentityHookResult, HookError> {
+/// UserPromptSubmit hook.
+///
+/// SPEC-2359 Phase W-11 (US-58 / US-59 / FR-341): this hook no longer
+/// derives `title_summary` / `current_focus` from the prompt. Writing the
+/// raw prompt into the title produced titles like "あなたの目的は何ですか"
+/// instead of the work purpose. The agent now authors the purpose via
+/// `gwtd workspace update --title-summary` (provisional → confirmed), and
+/// the title sync layer resolves empty values through the display fallback.
+///
+/// The hook still performs the Phase W-10 (US-57) canonical Project State
+/// split repair so that a later `gwtd workspace update --agent-session`
+/// from the agent reaches the projection record that owns the live window.
+pub(crate) fn handle_user_prompt_submit(_input: &str) -> Result<(), HookError> {
     let Some(session) = current_session_from_env()? else {
-        return Ok(WorkspaceIdentityHookResult {
-            updated: false,
-            identity: None,
-        });
+        return Ok(());
     };
-    handle_user_prompt_submit_for_session(input, &session)
+    handle_user_prompt_submit_for_session(&session)
 }
 
-fn handle_user_prompt_submit_for_session(
-    input: &str,
-    session: &Session,
-) -> Result<WorkspaceIdentityHookResult, HookError> {
+fn handle_user_prompt_submit_for_session(session: &Session) -> Result<(), HookError> {
     let project_state_root = project_state_root_for_session(session);
     crate::agent_project_state::repair_split_agent_state_if_needed(
         &project_state_root,
         &session.worktree_path,
         &session.id,
     )?;
-    let Some(missing) = missing_identity_for_session(session)? else {
-        return Ok(WorkspaceIdentityHookResult {
-            updated: false,
-            identity: None,
-        });
-    };
-    if missing.complete() {
-        return Ok(WorkspaceIdentityHookResult {
-            updated: false,
-            identity: None,
-        });
-    }
-
-    let Some(prompt) = prompt_from_hook_input(input) else {
-        return Ok(WorkspaceIdentityHookResult {
-            updated: false,
-            identity: None,
-        });
-    };
-    let Some(identity) = derive_identity_from_prompt(&prompt) else {
-        return Ok(WorkspaceIdentityHookResult {
-            updated: false,
-            identity: None,
-        });
-    };
-
-    let Some(update) = workspace_projection_update_for_identity(&session.id, missing, &identity)
-    else {
-        return Ok(WorkspaceIdentityHookResult {
-            updated: false,
-            identity: Some(identity),
-        });
-    };
-
-    update_workspace_projection_with_journal(&project_state_root, update)?;
-    crate::cli::workspace::publish_workspace_change(&project_state_root);
-
-    Ok(WorkspaceIdentityHookResult {
-        updated: true,
-        identity: Some(identity),
-    })
-}
-
-pub(crate) fn append_identity_context(
-    output: HookOutput,
-    result: WorkspaceIdentityHookResult,
-) -> HookOutput {
-    if !result.updated {
-        return output;
-    };
-    let Some(identity) = result.identity else {
-        return output;
-    };
-    let text = format!(
-        "# Workspace Identity Updated\n\nUserPromptSubmit has set this Agent window / Workspace identity from the prompt.\n\n- title-summary: `{}`\n- current-focus: {}\n\nIf this identity is inaccurate, correct it before continuing with `gwtd workspace update --agent-session \"$GWT_SESSION_ID\" --current-focus '<focus>' --title-summary '<short work name>'`.",
-        identity.title_summary, identity.current_focus
-    );
-    append_user_prompt_context(output, text)
-}
-
-fn append_user_prompt_context(output: HookOutput, text: String) -> HookOutput {
-    match output {
-        HookOutput::HookSpecificAdditionalContext {
-            event: IntentBoundaryEvent::UserPromptSubmit,
-            text: existing,
-        } => HookOutput::hook_specific_additional_context(
-            IntentBoundaryEvent::UserPromptSubmit,
-            format!("{text}\n\n{existing}"),
-        ),
-        HookOutput::Silent => HookOutput::hook_specific_additional_context(
-            IntentBoundaryEvent::UserPromptSubmit,
-            text,
-        ),
-        other => other,
-    }
+    Ok(())
 }
 
 fn current_session_from_env() -> Result<Option<Session>, HookError> {
@@ -328,294 +172,13 @@ fn current_session_from_env() -> Result<Option<Session>, HookError> {
         .map_err(HookError::Io)
 }
 
-fn missing_identity_for_session(session: &Session) -> Result<Option<MissingIdentity>, HookError> {
-    let project_state_root = project_state_root_for_session(session);
-    missing_identity_for_session_at(session, &project_state_root)
-}
-
-fn missing_identity_for_session_at(
-    session: &Session,
-    project_state_root: &Path,
-) -> Result<Option<MissingIdentity>, HookError> {
-    let Some(projection) = load_workspace_projection(project_state_root)? else {
-        return Ok(None);
-    };
-    let Some(agent) = projection
-        .agents
-        .iter()
-        .find(|agent| agent.session_id == session.id)
-    else {
-        return Ok(None);
-    };
-    // SPEC-2359 Phase U-10 / US-46 (FR-179): unassigned session でも初回
-    // UserPromptSubmit で prompt-based identity derivation を発火させるため、
-    // is_unassigned() による early-return は撤去した。non-destructive 原則
-    // (FR-166 / FR-180) は missing_identity_for_agent の空判定で維持される。
-    Ok(Some(missing_identity_for_agent(agent)))
-}
-
-fn missing_identity_for_agent(
-    agent: &gwt_core::workspace_projection::WorkspaceAgentSummary,
-) -> MissingIdentity {
-    MissingIdentity {
-        title_summary: agent
-            .title_summary
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .is_none(),
-        current_focus: agent
-            .current_focus
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .is_none(),
-    }
-}
-
-fn workspace_projection_update_for_identity(
-    session_id: &str,
-    missing: MissingIdentity,
-    identity: &WorkspacePromptIdentity,
-) -> Option<WorkspaceProjectionUpdate> {
-    let title_summary = missing
-        .title_summary
-        .then(|| identity.title_summary.clone());
-    let current_focus = missing
-        .current_focus
-        .then(|| identity.current_focus.clone());
-    if title_summary.is_none() && current_focus.is_none() {
-        return None;
-    }
-    Some(WorkspaceProjectionUpdate {
-        title: None,
-        status_category: None,
-        status_text: None,
-        owner: None,
-        next_action: None,
-        summary: None,
-        agent_session_id: Some(session_id.to_string()),
-        agent_current_focus: current_focus,
-        agent_title_summary: title_summary,
-    })
-}
-
-pub(crate) fn derive_identity_from_prompt(prompt: &str) -> Option<WorkspacePromptIdentity> {
-    let focus = sanitize_prompt_focus(prompt)?;
-    let title_summary = derive_title_summary(&focus)?;
-    if super::super::validate_title_summary_work_name("--title-summary", &title_summary).is_err() {
-        return None;
-    }
-    Some(WorkspacePromptIdentity {
-        title_summary,
-        current_focus: truncate_chars(&focus, 160),
-    })
-}
-
-fn derive_title_summary(focus: &str) -> Option<String> {
-    let lower = focus.to_ascii_lowercase();
-    if lower.contains("workspace")
-        && (focus.contains("ウィンドウ")
-            || lower.contains("window")
-            || focus.contains("何をしている")
-            || focus.contains("把握"))
-        && (lower.contains("ux") || focus.contains("識別") || focus.contains("把握"))
-    {
-        return Some("Workspace識別UX不具合".to_string());
-    }
-    if (focus.contains("エージェントウィンドウ") || lower.contains("agent window"))
-        && (focus.contains("更新") || focus.contains("タイトル") || lower.contains("title"))
-        && (focus.contains("不具合")
-            || focus.contains("されません")
-            || focus.contains("直っていません")
-            || lower.contains("bug"))
-    {
-        return Some("エージェントウィンドウ更新不具合".to_string());
-    }
-
-    let first = focus
-        .split(['\n', '。', '.', '？', '?', '！', '!'])
-        .map(str::trim)
-        .find(|line| !line.is_empty())?;
-    let first = trim_request_suffixes(first);
-    let title = truncate_chars(&first, 30);
-    (!title.trim().is_empty()).then_some(title)
-}
-
-fn sanitize_prompt_focus(prompt: &str) -> Option<String> {
-    let without_blocks = strip_fenced_blocks(prompt);
-    let mut lines = Vec::new();
-    for raw in without_blocks.lines() {
-        let line = raw.trim();
-        if line.is_empty() || line.starts_with('<') || line.starts_with("# ") {
-            continue;
-        }
-        let line = line
-            .strip_prefix("$gwt-discussion")
-            .or_else(|| line.strip_prefix("$gwt-build-spec"))
-            .or_else(|| line.strip_prefix("$gwt-fix-issue"))
-            .unwrap_or(line)
-            .trim();
-        if !line.is_empty() {
-            lines.push(line);
-        }
-    }
-    let joined = lines.join(" ");
-    let normalized = joined.split_whitespace().collect::<Vec<_>>().join(" ");
-    (!normalized.is_empty()).then_some(normalized)
-}
-
-fn strip_fenced_blocks(value: &str) -> String {
-    let mut out = String::new();
-    let mut in_fence = false;
-    for line in value.lines() {
-        if line.trim_start().starts_with("```") {
-            in_fence = !in_fence;
-            continue;
-        }
-        if !in_fence {
-            out.push_str(line);
-            out.push('\n');
-        }
-    }
-    out
-}
-
-fn trim_request_suffixes(value: &str) -> String {
-    let suffixes = [
-        "ちゃんと考えて対応してください",
-        "対応してください",
-        "修正してください",
-        "実装してください",
-        "調査してください",
-        "お願いします",
-        "してください",
-    ];
-    let mut out = value.trim().to_string();
-    for suffix in suffixes {
-        if out.ends_with(suffix) {
-            out.truncate(out.len() - suffix.len());
-            break;
-        }
-    }
-    out.trim_matches(|ch: char| ch.is_whitespace() || matches!(ch, '。' | '.' | '、' | ','))
-        .to_string()
-}
-
-fn truncate_chars(value: &str, max: usize) -> String {
-    let value = value.trim();
-    if value.chars().count() <= max {
-        return value.to_string();
-    }
-    value.chars().take(max).collect::<String>()
-}
-
-fn prompt_from_hook_input(input: &str) -> Option<String> {
-    let value: serde_json::Value = serde_json::from_str(input).ok()?;
-    string_at_any(
-        &value,
-        &[
-            &["prompt"],
-            &["user_prompt"],
-            &["userPrompt"],
-            &["message"],
-            &["message", "content"],
-            &["message", "text"],
-            &["input"],
-            &["input", "content"],
-            &["input", "text"],
-        ],
-    )
-    .or_else(|| latest_message_content(&value))
-    .or_else(|| {
-        string_at_any(&value, &[&["transcript_path"], &["transcriptPath"]])
-            .and_then(|path| prompt_from_transcript_path(Path::new(&path)))
-    })
-}
-
-fn latest_message_content(value: &serde_json::Value) -> Option<String> {
-    let messages = value.get("messages")?.as_array()?;
-    messages.iter().rev().find_map(|message| {
-        let role = message.get("role").and_then(serde_json::Value::as_str);
-        if role.is_some_and(|role| role != "user") {
-            return None;
-        }
-        value_to_text(message.get("content")?)
-    })
-}
-
-fn prompt_from_transcript_path(path: &Path) -> Option<String> {
-    let text = fs::read_to_string(path).ok()?;
-    text.lines().rev().find_map(|line| {
-        let value: serde_json::Value = serde_json::from_str(line).ok()?;
-        if let Some(prompt) = string_at_any(&value, &[&["lastPrompt"], &["last_prompt"]]) {
-            return Some(prompt);
-        }
-        if !is_transcript_user_record(&value) {
-            return None;
-        }
-        value
-            .get("message")
-            .and_then(|message| value_to_text(message.get("content")?))
-            .or_else(|| string_at_any(&value, &[&["text"]]))
-    })
-}
-
-fn is_transcript_user_record(value: &serde_json::Value) -> bool {
-    string_at_any(
-        value,
-        &[
-            &["type"],
-            &["role"],
-            &["message", "role"],
-            &["event", "role"],
-        ],
-    )
-    .is_some_and(|role| role.eq_ignore_ascii_case("user"))
-}
-
-fn string_at_any(value: &serde_json::Value, paths: &[&[&str]]) -> Option<String> {
-    paths.iter().find_map(|path| {
-        let mut current = value;
-        for key in *path {
-            current = current.get(*key)?;
-        }
-        current
-            .as_str()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_string)
-    })
-}
-
-fn value_to_text(value: &serde_json::Value) -> Option<String> {
-    match value {
-        serde_json::Value::String(text) => Some(text.trim().to_string()),
-        serde_json::Value::Array(items) => {
-            let parts = items
-                .iter()
-                .filter_map(|item| {
-                    item.as_str()
-                        .map(str::to_string)
-                        .or_else(|| string_at_any(item, &[&["text"], &["content"]]))
-                })
-                .map(|part| part.trim().to_string())
-                .filter(|part| !part.is_empty())
-                .collect::<Vec<_>>();
-            (!parts.is_empty()).then(|| parts.join("\n"))
-        }
-        serde_json::Value::Object(_) => string_at_any(value, &[&["text"], &["content"]]),
-        _ => None,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
     use gwt_agent::{AgentId, Session};
     use gwt_core::workspace_projection::{
-        WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary, WorkspaceProjection,
-        WorkspaceStatusCategory,
+        load_workspace_projection, save_workspace_projection, WorkspaceAgentAffiliationStatus,
+        WorkspaceAgentSummary, WorkspaceProjection, WorkspaceStatusCategory,
     };
 
     use super::*;
@@ -648,6 +211,26 @@ mod tests {
 
     fn fresh_session(repo: &std::path::Path) -> Session {
         Session::new(repo.to_path_buf(), "work/test-session", AgentId::Codex)
+    }
+
+    fn assigned_agent(session_id: &str, repo: &std::path::Path) -> WorkspaceAgentSummary {
+        WorkspaceAgentSummary {
+            session_id: session_id.to_string(),
+            window_id: None,
+            agent_id: "codex".to_string(),
+            display_name: "Codex".to_string(),
+            status_category: WorkspaceStatusCategory::Active,
+            current_focus: None,
+            title_summary: None,
+            worktree_path: Some(repo.to_path_buf()),
+            branch: Some("work/identity".to_string()),
+            last_board_entry_id: None,
+            last_board_entry_kind: None,
+            coordination_scope: None,
+            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
+            workspace_id: None,
+            updated_at: Utc::now(),
+        }
     }
 
     #[test]
@@ -717,396 +300,46 @@ mod tests {
         assert!(agent.is_assigned());
     }
 
-    fn assigned_agent(session_id: &str, repo: &std::path::Path) -> WorkspaceAgentSummary {
-        WorkspaceAgentSummary {
-            session_id: session_id.to_string(),
-            window_id: None,
-            agent_id: "codex".to_string(),
-            display_name: "Codex".to_string(),
-            status_category: WorkspaceStatusCategory::Active,
-            current_focus: None,
-            title_summary: None,
-            worktree_path: Some(repo.to_path_buf()),
-            branch: Some("work/identity".to_string()),
-            last_board_entry_id: None,
-            last_board_entry_kind: None,
-            coordination_scope: None,
-            affiliation_status: WorkspaceAgentAffiliationStatus::Assigned,
-            workspace_id: None,
-            updated_at: Utc::now(),
-        }
-    }
-
+    /// SPEC-2359 Phase W-11 (US-58 / US-59 / SC-225): UserPromptSubmit must
+    /// NOT write `title_summary` / `current_focus` from the prompt. A session
+    /// whose agent has empty identity keeps it empty after the hook runs;
+    /// the agent (not the hook) authors the purpose.
     #[test]
-    fn derive_identity_from_prompt_identifies_workspace_window_ux() {
-        let prompt = "$gwt-discussion 単なるタイトル更新と思っているかもしれませんが、現在のWorkspace運用の場合、どのウィンドウで何をしているのか？を把握できないとUX的には最悪です。";
-
-        let identity = derive_identity_from_prompt(prompt).expect("identity");
-
-        assert_eq!(identity.title_summary, "Workspace識別UX不具合");
-        assert!(
-            identity
-                .current_focus
-                .contains("どのウィンドウで何をしているのか"),
-            "{}",
-            identity.current_focus
-        );
-    }
-
-    fn unassigned_agent(session_id: &str, repo: &std::path::Path) -> WorkspaceAgentSummary {
-        let mut a = assigned_agent(session_id, repo);
-        a.affiliation_status = WorkspaceAgentAffiliationStatus::Unassigned;
-        a.workspace_id = None;
-        a
-    }
-
-    #[test]
-    fn missing_identity_for_session_does_not_skip_unassigned_agents() {
-        // SPEC-2359 Phase U-10 / US-46 (FR-179): unassigned session でも
-        // missing_identity_for_session が `Some(MissingIdentity)` を返し、
-        // 後続の auto-derive が発火可能であること。
-        let temp = tempfile::tempdir().expect("tempdir");
-        let repo = temp.path().join("repo");
-        let agent = unassigned_agent("session-unassigned", &repo);
-
-        // 直接 missing_identity_for_agent を呼ぶ side-channel test
-        // (missing_identity_for_session は projection IO に依存するため、
-        // ここでは agent 単体で missing 判定が affiliation 非依存である
-        // ことを示す)
-        let missing = missing_identity_for_agent(&agent);
-        assert!(missing.title_summary, "unassigned + empty title -> missing");
-        assert!(missing.current_focus, "unassigned + empty focus -> missing");
-    }
-
-    #[test]
-    fn user_prompt_submit_derives_identity_for_unassigned_agent() {
-        // SPEC-2359 Phase U-10 / US-46: 「フォントが見にくいので修正して」
-        // のような prompt で unassigned session の title が auto-derive される。
-        let temp = tempfile::tempdir().expect("tempdir");
-        let repo = temp.path().join("repo");
-        let agent = unassigned_agent("session-unassigned", &repo);
-
-        let payload = serde_json::json!({
-            "session_id": "claude-provider-session",
-            "prompt": "$gwt-discussion フォントが見にくいので修正してください。"
-        });
-
-        let prompt = prompt_from_hook_input(&payload.to_string()).expect("prompt");
-        let identity = derive_identity_from_prompt(&prompt).expect("identity");
-        let update = workspace_projection_update_for_identity(
-            "session-unassigned",
-            missing_identity_for_agent(&agent),
-            &identity,
-        )
-        .expect("update must build for unassigned + missing identity");
-
-        assert_eq!(
-            update.agent_session_id.as_deref(),
-            Some("session-unassigned")
-        );
-        assert!(
-            update.agent_title_summary.is_some(),
-            "title must be derived for unassigned + missing"
-        );
-        let title = update.agent_title_summary.unwrap();
-        assert!(!title.is_empty(), "derived title must not be empty");
-        let title_chars = title.chars().count();
-        assert!(
-            title_chars <= 30,
-            "derived title should be concise (got {} chars: {})",
-            title_chars,
-            title
-        );
-        assert!(
-            update.agent_current_focus.is_some(),
-            "focus must also be derived"
-        );
-    }
-
-    #[test]
-    fn user_prompt_submit_preserves_explicit_identity_for_unassigned_agent() {
-        // US-46 でも US-43 の non-destructive 原則 (FR-166 / FR-180) を
-        // 維持する: unassigned でも explicit title があれば上書きしない。
-        let temp = tempfile::tempdir().expect("tempdir");
-        let repo = temp.path().join("repo");
-        let mut agent = unassigned_agent("session-keep", &repo);
-        agent.title_summary = Some("Existing custom title".to_string());
-        agent.current_focus = Some("Existing focus".to_string());
-
-        let missing = missing_identity_for_agent(&agent);
-        assert!(
-            !missing.title_summary,
-            "explicit title must be considered NOT missing"
-        );
-        assert!(
-            !missing.current_focus,
-            "explicit focus must be considered NOT missing"
-        );
-        assert!(missing.complete(), "no derive should fire");
-    }
-
-    #[test]
-    fn user_prompt_submit_builds_update_for_missing_workspace_identity() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let repo = temp.path().join("repo");
-        let agent = assigned_agent("session-1", &repo);
-
-        let payload = serde_json::json!({
-            "session_id": "codex-provider-session",
-            "prompt": "$gwt-discussion エージェントウィンドウの更新がいまだにされません。今回の場合であれば「エージェントウィンドウの更新不具合」などが表示されるべきです。"
-        });
-
-        let prompt = prompt_from_hook_input(&payload.to_string()).expect("prompt");
-        let identity = derive_identity_from_prompt(&prompt).expect("identity");
-        let update = workspace_projection_update_for_identity(
-            "session-1",
-            missing_identity_for_agent(&agent),
-            &identity,
-        )
-        .expect("projection update");
-
-        assert_eq!(update.agent_session_id.as_deref(), Some("session-1"));
-        assert_eq!(
-            update.agent_title_summary.as_deref(),
-            Some("エージェントウィンドウ更新不具合")
-        );
-        assert!(
-            update
-                .agent_current_focus
-                .as_deref()
-                .is_some_and(|focus| focus.contains("エージェントウィンドウの更新")),
-            "{:?}",
-            update.agent_current_focus
-        );
-    }
-
-    #[test]
-    fn user_prompt_submit_updates_canonical_project_state_root() {
+    fn user_prompt_submit_does_not_write_identity_from_prompt() {
         let temp = tempfile::tempdir().expect("tempdir");
         let project_root = temp.path().join("workspace-home");
-        let worktree = project_root.join("work").join("20260601-0934");
+        let worktree = project_root.join("work").join("20260602-0056");
         std::fs::create_dir_all(&worktree).expect("worktree");
 
         let mut session = fresh_session(&worktree);
-        session.id = "session-canonical".to_string();
+        session.id = "session-no-derive".to_string();
         session.project_state_root = Some(project_root.clone());
 
         let mut projection = projection_for(&project_root);
-        projection
-            .agents
-            .push(assigned_agent(&session.id, &worktree));
-        gwt_core::workspace_projection::save_workspace_projection(&project_root, &projection)
-            .expect("save canonical projection");
-
-        let payload = serde_json::json!({
-            "session_id": "codex-provider-session",
-            "prompt": "$gwt-discussion エージェントウィンドウの更新がいまだにされません。今回の場合であれば「エージェントウィンドウの更新不具合」などが表示されるべきです。"
-        });
-
-        let result = handle_user_prompt_submit_for_session(&payload.to_string(), &session)
-            .expect("handle prompt");
-
-        assert!(result.updated, "identity hook should write canonical root");
-        let canonical = gwt_core::workspace_projection::load_workspace_projection(&project_root)
-            .expect("load canonical")
-            .expect("canonical projection");
-        let agent = canonical
-            .agents
-            .iter()
-            .find(|agent| agent.session_id == session.id)
-            .expect("canonical agent");
-        assert_eq!(
-            agent.title_summary.as_deref(),
-            Some("エージェントウィンドウ更新不具合")
-        );
-        assert!(
-            agent
-                .current_focus
-                .as_deref()
-                .is_some_and(|focus| focus.contains("エージェントウィンドウの更新")),
-            "{:?}",
-            agent.current_focus
-        );
-        assert!(
-            gwt_core::workspace_projection::load_workspace_projection(&worktree)
-                .expect("load split")
-                .is_none(),
-            "identity hook must not create a split worktree Project State"
-        );
-    }
-
-    #[test]
-    fn user_prompt_submit_does_not_overwrite_existing_identity() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let repo = temp.path().join("repo");
-
-        let mut agent = assigned_agent("session-1", &repo);
-        agent.title_summary = Some("明示タイトル".to_string());
-        agent.current_focus = Some("明示 focus".to_string());
-
-        let missing = missing_identity_for_agent(&agent);
-
-        assert!(missing.complete(), "{missing:?}");
-        let identity = WorkspacePromptIdentity {
-            title_summary: "エージェントウィンドウ更新不具合".to_string(),
-            current_focus: "エージェントウィンドウの更新がされません".to_string(),
-        };
-        assert!(
-            workspace_projection_update_for_identity("session-1", missing, &identity).is_none()
-        );
-    }
-
-    #[test]
-    fn user_prompt_submit_uses_transcript_path_when_prompt_field_is_absent() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let transcript = temp.path().join("transcript.jsonl");
-        std::fs::write(
-            &transcript,
-            r#"{"type":"last-prompt","lastPrompt":"単なるタイトル更新と思っているかもしれませんが、現在のWorkspace運用の場合、どのウィンドウで何をしているのか？を把握できないとUX的には最悪です。"}"#,
-        )
-        .expect("transcript");
-
-        let payload = serde_json::json!({
-            "session_id": "codex-provider-session",
-            "transcript_path": transcript
-        });
-
-        let prompt = prompt_from_hook_input(&payload.to_string()).expect("prompt");
-        let identity = derive_identity_from_prompt(&prompt).expect("identity");
-
-        assert_eq!(identity.title_summary, "Workspace識別UX不具合");
-    }
-
-    fn write_issue_cache_meta(cache_root: &std::path::Path, number: u64, title: &str) {
-        let dir = cache_root.join(number.to_string());
-        std::fs::create_dir_all(&dir).expect("issue dir");
-        let meta = serde_json::json!({
-            "number": number,
-            "title": title,
-            "labels": [],
-            "state": "open",
-            "updated_at": "2026-05-20T00:00:00Z",
-            "comment_ids": [],
-        });
-        std::fs::write(dir.join("meta.json"), meta.to_string()).expect("meta");
-    }
-
-    fn projection_with_linked_issue(
-        repo: &std::path::Path,
-        session_id: &str,
-        issue_number: u64,
-    ) -> WorkspaceProjection {
-        let mut projection = projection_for(repo);
-        projection
-            .linked_issues
-            .push(gwt_core::workspace_projection::WorkspaceIssueLink {
-                number: issue_number,
-                title: None,
-                url: None,
-            });
-        let mut agent = assigned_agent(session_id, repo);
+        let mut agent = assigned_agent(&session.id, &worktree);
         agent.title_summary = None;
         agent.current_focus = None;
         projection.agents.push(agent);
-        projection
-    }
+        save_workspace_projection(&project_root, &projection).expect("save projection");
 
-    #[test]
-    fn session_start_derives_title_summary_from_owner_issue_cache() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let repo = temp.path().join("repo");
-        let cache_root = temp.path().join("cache");
-        write_issue_cache_meta(&cache_root, 2359, "Workspace / Start Work");
+        handle_user_prompt_submit_for_session(&session).expect("handle prompt");
 
-        let session_id = "session-derive";
-        let mut projection = projection_with_linked_issue(&repo, session_id, 2359);
-
-        let updated =
-            derive_title_summary_from_owner_with_cache(&mut projection, session_id, &cache_root);
-
-        assert!(
-            updated,
-            "auto-derive must apply when title is empty and cache exists"
+        let after = load_workspace_projection(&project_root)
+            .expect("load projection")
+            .expect("projection present");
+        let agent = after
+            .agents
+            .iter()
+            .find(|agent| agent.session_id == session.id)
+            .expect("agent present");
+        assert_eq!(
+            agent.title_summary, None,
+            "hook must not derive title_summary from prompt"
         );
         assert_eq!(
-            projection.agents[0].title_summary.as_deref(),
-            Some("Workspace / Start Work"),
-            "title must be sourced from issue cache meta.json"
+            agent.current_focus, None,
+            "hook must not derive current_focus from prompt"
         );
-    }
-
-    #[test]
-    fn session_start_does_not_overwrite_existing_title_summary() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let repo = temp.path().join("repo");
-        let cache_root = temp.path().join("cache");
-        write_issue_cache_meta(&cache_root, 2359, "Workspace / Start Work");
-
-        let session_id = "session-explicit";
-        let mut projection = projection_with_linked_issue(&repo, session_id, 2359);
-        projection.agents[0].title_summary = Some("Custom title".to_string());
-
-        let updated =
-            derive_title_summary_from_owner_with_cache(&mut projection, session_id, &cache_root);
-
-        assert!(!updated, "explicit title must be preserved");
-        assert_eq!(
-            projection.agents[0].title_summary.as_deref(),
-            Some("Custom title")
-        );
-    }
-
-    #[test]
-    fn session_start_owner_absent_keeps_title_summary_empty() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let repo = temp.path().join("repo");
-        let cache_root = temp.path().join("cache");
-
-        let session_id = "session-no-owner";
-        let mut projection = projection_for(&repo);
-        let mut agent = assigned_agent(session_id, &repo);
-        agent.title_summary = None;
-        projection.agents.push(agent);
-
-        let updated =
-            derive_title_summary_from_owner_with_cache(&mut projection, session_id, &cache_root);
-
-        assert!(!updated, "no linked_issues -> no-op");
-        assert_eq!(projection.agents[0].title_summary, None);
-    }
-
-    #[test]
-    fn session_start_owner_cache_missing_is_silent_noop() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let repo = temp.path().join("repo");
-        let cache_root = temp.path().join("cache");
-        // cache_root exists conceptually but contains no entry for issue 9999
-
-        let session_id = "session-missing-cache";
-        let mut projection = projection_with_linked_issue(&repo, session_id, 9999);
-
-        let updated =
-            derive_title_summary_from_owner_with_cache(&mut projection, session_id, &cache_root);
-
-        assert!(!updated, "missing cache file must be a silent no-op");
-        assert_eq!(projection.agents[0].title_summary, None);
-    }
-
-    #[test]
-    fn session_start_owner_cache_with_empty_title_is_noop() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let repo = temp.path().join("repo");
-        let cache_root = temp.path().join("cache");
-        write_issue_cache_meta(&cache_root, 7, "   ");
-
-        let session_id = "session-empty-title";
-        let mut projection = projection_with_linked_issue(&repo, session_id, 7);
-
-        let updated =
-            derive_title_summary_from_owner_with_cache(&mut projection, session_id, &cache_root);
-
-        assert!(!updated, "empty/whitespace title must not be applied");
-        assert_eq!(projection.agents[0].title_summary, None);
     }
 
     #[test]
@@ -1171,26 +404,5 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         // No .codex, no .claude at all — worktree is not managed.
         assert!(!coordination_assets_need_refresh(temp.path()));
-    }
-
-    #[test]
-    fn transcript_path_ignores_non_user_text_records() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let transcript = temp.path().join("transcript.jsonl");
-        std::fs::write(
-            &transcript,
-            concat!(
-                r#"{"type":"user","text":"エージェントウィンドウの更新がいまだにされません。"}"#,
-                "\n",
-                r#"{"type":"assistant","text":"実装方針を説明します。"}"#,
-                "\n"
-            ),
-        )
-        .expect("transcript");
-
-        let prompt = prompt_from_transcript_path(&transcript).expect("prompt");
-
-        assert!(prompt.contains("エージェントウィンドウの更新"), "{prompt}");
-        assert!(!prompt.contains("実装方針"), "{prompt}");
     }
 }

--- a/crates/gwt/src/issue_cache.rs
+++ b/crates/gwt/src/issue_cache.rs
@@ -88,6 +88,22 @@ pub fn issue_cache_root_for_repo_path_or_detached(repo_path: &Path) -> PathBuf {
     issue_cache_root_for_repo_path(repo_path).unwrap_or_else(detached_issue_cache_root)
 }
 
+/// SPEC-2359 Phase W-11 (US-58 / FR-344): read a cached Issue/SPEC title for
+/// the linked-issue display fallback used by Agent window titles. Returns the
+/// trimmed `title` from `<cache_root>/<issue_number>/meta.json`, or `None`
+/// when the cache entry is missing, unreadable, or has an empty title.
+pub fn load_issue_title_from_cache(cache_root: &Path, issue_number: u64) -> Option<String> {
+    let path = cache_root.join(issue_number.to_string()).join("meta.json");
+    let bytes = fs::read(&path).ok()?;
+    let value: Value = serde_json::from_slice(&bytes).ok()?;
+    let title = value.get("title")?.as_str()?.trim();
+    if title.is_empty() {
+        None
+    } else {
+        Some(title.to_string())
+    }
+}
+
 pub fn issue_cache_source_fingerprint(
     cache_root: &Path,
 ) -> Result<Option<IssueCacheSourceFingerprint>, String> {

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -19,7 +19,7 @@ pub mod gui_single_instance;
 pub mod handlers;
 pub mod index_search;
 pub mod index_worker;
-mod issue_cache;
+pub mod issue_cache;
 pub mod knowledge_bridge;
 pub mod launch_wizard;
 pub mod managed_assets;

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6522,3 +6522,17 @@ Type: lesson
 Context: SPEC-2920 tray/About verification used an isolated HOME. With an empty ~/.gwt/session.json, the app opened the Open Project picker instead of the intended checkout surface.
 Learning: Isolated GUI verification that must land on an in-project surface needs a seeded session.json pointing at the checkout under test; otherwise the verification can be blocked before the changed UI is reachable.
 Future Action: Before sharing a manual GUI verification URL from a temp HOME, seed ~/.gwt/session.json with the target checkout tab and verify the served URL reaches the intended screen.
+
+## 2026-06-02 — Removing a derivation path: check sibling reminder guards for the same is_unassigned early-return
+
+Type: lesson
+Context: SPEC-2359 W-11: removed the UserPromptSubmit prompt→title derivation. Unassigned Start Work agents then got no title at all because board_reminder::agent_title_summary_missing still had an is_unassigned() early-return that suppressed the title reminder. The derivation path had already dropped that guard (US-46/FR-179) but the reminder path had not.
+Learning: When you remove one code path that handled a case (e.g. derivation for unassigned agents), grep for the SAME guard (is_unassigned / affiliation early-returns) in sibling paths (reminders, sync) that must now cover the case. A guard that was harmless while the derivation existed becomes a silent gap once it is removed.
+Future Action: After deleting a path that produced some state, search for every other gate keyed on the same condition (e.g. grep is_unassigned) and confirm each still behaves correctly without the deleted path.
+
+## 2026-06-02 — browser-check of hook-driven agent behavior needs keychain symlink + GWT_HOOK_BIN
+
+Type: lesson
+Context: Verifying SPEC-2359 W-11 title behavior in an isolated browser-check instance hit 3 env-only blockers: (1) Start Work git push failed because the macOS login keychain lives at $HOME/Library/Keychains and the isolated HOME had none; (2) materialized agent hooks resolved to the installed /Applications/GWT.app gwtd (old code) not the rebuilt target/debug/gwtd; (3) my standalone CLI hook sim io-errored on the daemon-forward step which only works inside the launched agent.
+Learning: Isolated-HOME browser-check needs: symlink $CHECK_HOME/Library/Keychains -> $HOME/Library/Keychains so osxkeychain can auth git push; set GWT_HOOK_BIN=<repo>/target/debug/gwtd so new worktrees' hooks run the rebuilt binary; verify agent behavior via the projection (CHECK_HOME/.gwt/projects/*/current.json) and the Claude transcript, not a standalone CLI hook invocation (daemon-forward step needs the launch env).
+Future Action: When browser-check must exercise agent hooks against edited Rust, symlink the keychain into the isolated HOME, launch with GWT_HOOK_BIN pointing at target/debug/gwtd, and confirm outcomes by reading the projection + transcript.


### PR DESCRIPTION
## 背景 / 目的

Agent window のタイトルバーに、ユーザーが入力した**生プロンプトがそのまま**表示されていた（例: 「あなたの目的は何ですか」「#2947 [MERGED draft=false ...」）。本来は作業の**目的（work purpose）**が表示されるべき。

owner: **SPEC-2359 (Workspace / Start Work)** Phase W-11 / US-58・US-59。

## 根本原因

1. `crates/gwt/src/cli/hook/workspace_identity.rs` の UserPromptSubmit hook が毎回、生プロンプトを文字列処理だけで `title_summary` / `current_focus` に書き込んでいた（ヒューリスティックでは「目的」を表現できず、特定プロンプト向けのハードコード特例まで存在していた）。
2. 生プロンプト由来の書き込みを撤去すると、今度は **Unassigned な Start Work / standalone agent** にタイトルが付かない問題が顕在化。`board_reminder` の `agent_title_summary_missing` が `is_unassigned()` で早期 return しており、Unassigned agent には「目的を設定せよ」という reminder が一切届いていなかった（derivation 経路は US-46/FR-179 で同ガードを撤去済みだったが reminder 経路に残存）。

## 変更内容

- **hook 撤去**: UserPromptSubmit の prompt→title/focus 導出と SessionStart の linked-Issue→title 直書きを撤去。`title_summary` は「agent が author した目的」専用に一本化。
- **表示 fallback の一元化**: `app_runtime` の title sync で `agent title_summary → linked Issue/SPEC title → 中立ラベル` の順に解決。生プロンプトは決して表示しない（`gwt::issue_cache::load_issue_title_from_cache` を再利用）。
- **agent 強制（reminder）**: 未設定 reminder を「応答する前に、最初のアクションとして、生プロンプトでなく作業の目的（未確定なら暫定）を設定し、確定したら更新する」という imperative 文言に強化（EN/JA）。board 出力が Silent でも注入し、先頭に prepend、設定されるまで毎 turn 再注入。
- **真因修正**: `agent_title_summary_missing` の `is_unassigned()` 早期 return を撤去 → Unassigned agent にも reminder が発火。判定を純粋関数 `title_summary_missing_in_projection` に分離し決定的テスト化。
- **migration**: 既存の壊れた `title_summary` / `current_focus` を起動時に一度だけ（version-guarded）クリアし、fallback + agent 再 author に委ねる。
- **canonical guidance**: `crates/gwt-skills/src/coordination_guidance.rs`（EN/JA）を同方針に更新。生成 SKILL.md は runtime 再 materialize。

## 検証

- **自動**: `cargo fmt --check` / `cargo clippy --all-targets --all-features -- -D warnings` / `cargo test -p gwt-core -p gwt-skills -p gwt --all-features` / `cargo build -p gwt --bin gwt --bin gwtd` 全 PASS。hook 非書き込み・表示 fallback・migration・reminder・Unassigned 判定の RED/GREEN テスト追加。
- **視覚（User Verification Result: confirmed）**: checkout-built の隔離インスタンスで Start Work エージェント（Claude Code + Codex）が初回プロンプト「READMEのタイポを直して」に対し `title_summary='README タイポ修正'`（目的）を設定し、ウィンドウタイトルに反映。生プロンプトは表示されないことをユーザーが画面録画で確認。

SPEC: #2359 (US-58 / US-59 / US-46 / FR-341..347 / FR-179 / SC-225..229)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic one-time workspace projection legacy data cleanup on startup
  * Improved dynamic title resolution with fallback support for better window/repo titles

* **Documentation**
  * Updated title-summary guidance (English and Japanese) to emphasize work purpose, not completion state
  * Enhanced board reminder text with clearer title-summary requirements and instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->