### PR TITLE
docs(gwt-fix-issue): closure コメント必須化と gwt-verify 明示保証を追加

### DIFF
--- a/.claude/skills/gwt-fix-issue/SKILL.md
+++ b/.claude/skills/gwt-fix-issue/SKILL.md
@@ -35,8 +35,10 @@ Do not use this for new work intake. Use `gwt-register-issue` instead.
 1. Verify that `gwtd issue view` and `gwtd issue comments` can access the target issue.
 2. Gather facts with `gwtd issue view <number>`, `gwtd issue comments <number>`, `gwtd issue linked-prs <number>`, and `python3 ".claude/skills/gwt-fix-issue/scripts/inspect_issue.py" --repo "." --issue "<number or URL>"`.
 3. Decide direct-fix vs spec-needed. Prefer direct fix for clear corrective work; prefer `gwt-discussion` when behavior design or broader scope definition is required.
-4. If the change is a clear direct fix, continue through `gwt-build-spec` and finish verification.
-5. Post progress and closure comments through `gwtd issue comment`.
+4. If the change is a clear direct fix, implement it. Verification is mandatory and must run in the correct environment via `gwt-verify --mode full`:
+   - When routing through `gwt-build-spec`, its Phase 3 already runs `gwt-verify --mode full`.
+   - When fixing inline without `gwt-build-spec`, run `gwt-verify --mode full` yourself and require `Overall: PASS` before posting the closure comment or handing off. Do not skip verification because the fix looks small; `gwt-verify` self-selects the matrix (cargo / frontend / Playwright / docs) for the changed surfaces.
+5. Post progress and closure comments through `gwtd issue comment`. On direct-fix completion the closure comment is mandatory and must follow `.claude/skills/gwt-fix-issue/references/closure-comment.md` (root cause, changed files, commit/PR link, `gwt-verify` result, remaining work). When the work is handed off to the SPEC flow instead of completed, `gwt-build-spec` owns closure; post a short handoff comment only.
 6. Return the result in the current user's language.
 
 ## Guardrails

--- a/.claude/skills/gwt-fix-issue/references/closure-comment.md
+++ b/.claude/skills/gwt-fix-issue/references/closure-comment.md
@@ -1,0 +1,84 @@
+# Closure Comment Template
+
+Use this template for the closure comment posted on an Issue when a direct fix
+is completed through `gwt-fix-issue`. The closure comment is the durable record
+of what was fixed and how it was verified, so the issue history stays useful
+long after the conversation is gone.
+
+## When to use
+
+- Post the closure comment on **direct-fix completion**, after `gwt-verify
+  --mode full` returns `Overall: PASS`.
+- Do **not** use this template when the work is handed off to the SPEC flow
+  instead of completed. In that case `gwt-build-spec` owns closure; post a short
+  handoff comment only.
+
+## Required fields
+
+Every closure comment must fill all five fields. Do not omit a field; if a field
+is genuinely empty, state that explicitly (e.g. `Remaining Work: none`).
+
+### Root Cause
+
+The verified reason the issue occurred, stated as fact. Name the responsible
+code path or behavior. Do not speculate ("might be", "seems like"); if the cause
+is unproven, the fix is not ready to close.
+
+### Changed Files
+
+The concrete files touched, each with a one-line note on what changed. Use
+`path/to/file:line` form when a specific location matters.
+
+### Commit or PR
+
+The commit hash(es) or PR link that deliver the fix.
+
+### Verification
+
+The exact `gwt-verify --mode full` outcome (`Overall: PASS`) plus the runners it
+selected for the changed surfaces (cargo / frontend / Playwright / docs). Name
+any test or command run beyond the matrix.
+
+### Remaining Work
+
+Any follow-up that is intentionally out of scope, or `none`. Remaining items
+must not be delivery blockers for this fix.
+
+## Comment template
+
+```text
+## Fix Summary: #<number>
+
+**Root Cause:** <verified cause>
+
+**Changed Files:**
+- `path/to/file.ext` — <what changed>
+
+**Commit / PR:** <hash or PR link>
+
+**Verification:** `gwt-verify --mode full` → Overall: PASS
+- Runners: <cargo | frontend | Playwright | docs>
+- Additional: <any extra command/test, or none>
+
+**Remaining Work:** <follow-up items, or none>
+```
+
+## Posting
+
+Write the comment body to a file and post it with the canonical CLI:
+
+```text
+gwtd issue comment <number> -f <body-file>
+```
+
+Direct `gh issue comment ...` is not part of the normal path.
+
+## Anti-patterns
+
+- Omitting any of the five required fields.
+- Speculative root cause ("this might be caused by ...") instead of a verified
+  statement.
+- Claiming completion without the `gwt-verify --mode full` `Overall: PASS`
+  result in the Verification field.
+- Listing "various files" or "some changes" instead of concrete paths.
+- Using this template for a SPEC handoff instead of a completed direct fix.

--- a/.codex/skills/gwt-fix-issue/SKILL.md
+++ b/.codex/skills/gwt-fix-issue/SKILL.md
@@ -35,8 +35,10 @@ Do not use this for new work intake. Use `gwt-register-issue` instead.
 1. Verify that `gwtd issue view` and `gwtd issue comments` can access the target issue.
 2. Gather facts with `gwtd issue view <number>`, `gwtd issue comments <number>`, `gwtd issue linked-prs <number>`, and `python3 ".codex/skills/gwt-fix-issue/scripts/inspect_issue.py" --repo "." --issue "<number or URL>"`.
 3. Decide direct-fix vs spec-needed. Prefer direct fix for clear corrective work; prefer `gwt-discussion` when behavior design or broader scope definition is required.
-4. If the change is a clear direct fix, continue through `gwt-build-spec` and finish verification.
-5. Post progress and closure comments through `gwtd issue comment`.
+4. If the change is a clear direct fix, implement it. Verification is mandatory and must run in the correct environment via `gwt-verify --mode full`:
+   - When routing through `gwt-build-spec`, its Phase 3 already runs `gwt-verify --mode full`.
+   - When fixing inline without `gwt-build-spec`, run `gwt-verify --mode full` yourself and require `Overall: PASS` before posting the closure comment or handing off. Do not skip verification because the fix looks small; `gwt-verify` self-selects the matrix (cargo / frontend / Playwright / docs) for the changed surfaces.
+5. Post progress and closure comments through `gwtd issue comment`. On direct-fix completion the closure comment is mandatory and must follow `.codex/skills/gwt-fix-issue/references/closure-comment.md` (root cause, changed files, commit/PR link, `gwt-verify` result, remaining work). When the work is handed off to the SPEC flow instead of completed, `gwt-build-spec` owns closure; post a short handoff comment only.
 6. Return the result in the current user's language.
 
 ## Guardrails

--- a/.codex/skills/gwt-fix-issue/references/closure-comment.md
+++ b/.codex/skills/gwt-fix-issue/references/closure-comment.md
@@ -1,0 +1,84 @@
+# Closure Comment Template
+
+Use this template for the closure comment posted on an Issue when a direct fix
+is completed through `gwt-fix-issue`. The closure comment is the durable record
+of what was fixed and how it was verified, so the issue history stays useful
+long after the conversation is gone.
+
+## When to use
+
+- Post the closure comment on **direct-fix completion**, after `gwt-verify
+  --mode full` returns `Overall: PASS`.
+- Do **not** use this template when the work is handed off to the SPEC flow
+  instead of completed. In that case `gwt-build-spec` owns closure; post a short
+  handoff comment only.
+
+## Required fields
+
+Every closure comment must fill all five fields. Do not omit a field; if a field
+is genuinely empty, state that explicitly (e.g. `Remaining Work: none`).
+
+### Root Cause
+
+The verified reason the issue occurred, stated as fact. Name the responsible
+code path or behavior. Do not speculate ("might be", "seems like"); if the cause
+is unproven, the fix is not ready to close.
+
+### Changed Files
+
+The concrete files touched, each with a one-line note on what changed. Use
+`path/to/file:line` form when a specific location matters.
+
+### Commit or PR
+
+The commit hash(es) or PR link that deliver the fix.
+
+### Verification
+
+The exact `gwt-verify --mode full` outcome (`Overall: PASS`) plus the runners it
+selected for the changed surfaces (cargo / frontend / Playwright / docs). Name
+any test or command run beyond the matrix.
+
+### Remaining Work
+
+Any follow-up that is intentionally out of scope, or `none`. Remaining items
+must not be delivery blockers for this fix.
+
+## Comment template
+
+```text
+## Fix Summary: #<number>
+
+**Root Cause:** <verified cause>
+
+**Changed Files:**
+- `path/to/file.ext` — <what changed>
+
+**Commit / PR:** <hash or PR link>
+
+**Verification:** `gwt-verify --mode full` → Overall: PASS
+- Runners: <cargo | frontend | Playwright | docs>
+- Additional: <any extra command/test, or none>
+
+**Remaining Work:** <follow-up items, or none>
+```
+
+## Posting
+
+Write the comment body to a file and post it with the canonical CLI:
+
+```text
+gwtd issue comment <number> -f <body-file>
+```
+
+Direct `gh issue comment ...` is not part of the normal path.
+
+## Anti-patterns
+
+- Omitting any of the five required fields.
+- Speculative root cause ("this might be caused by ...") instead of a verified
+  statement.
+- Claiming completion without the `gwt-verify --mode full` `Overall: PASS`
+  result in the Verification field.
+- Listing "various files" or "some changes" instead of concrete paths.
+- Using this template for a SPEC handoff instead of a completed direct fix.

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6522,3 +6522,10 @@ Type: lesson
 Context: SPEC-2920 tray/About verification used an isolated HOME. With an empty ~/.gwt/session.json, the app opened the Open Project picker instead of the intended checkout surface.
 Learning: Isolated GUI verification that must land on an in-project surface needs a seeded session.json pointing at the checkout under test; otherwise the verification can be blocked before the changed UI is reachable.
 Future Action: Before sharing a manual GUI verification URL from a temp HOME, seed ~/.gwt/session.json with the target checkout tab and verify the served URL reaches the intended screen.
+
+## 2026-06-02 — gwt-managed skill ファイル編集は dual-mirror + force-add
+
+Type: workflow
+Context: gwt-fix-issue SKILL.md 強化で新規 references/closure-comment.md を追加した際、git status に出ず原因調査した。
+Learning: `.claude/skills/gwt-*` と `.codex/skills/gwt-*` は .git/info/exclude で除外されており、新規ファイルは untracked 扱い。既存 tracked ファイル(SKILL.md 等)の編集は通常反映される。.codex は distribute.rs が embedded .claude を逐語コピーするが tracked-path 保護で上書きされない手動ミラーで、参照パスのみ .codex/ に書き換える。
+Future Action: skill 編集時は .claude と .codex の両ミラーを同一コミットで更新し、新規 managed skill ファイルは git add -f で tracked 化する。SKILL.md 内の自己参照パスは mirror 側で .codex/ prefix にする。


### PR DESCRIPTION
## Summary

- `gwt-fix-issue` skill のガイダンスにあった 2 つのギャップを埋める: direct-fix を inline 完結する経路で `gwt-verify` が走らない問題と、closure コメントの内容が無定義で修正根拠が Issue 履歴に残らない問題。
- step 4 に inline でも `gwt-verify --mode full` / `Overall: PASS` 必須を明記し、step 5 を新規 `references/closure-comment.md` 必須参照に強化（`.claude` / `.codex` 両ミラー）。

## Changes

- `.claude/skills/gwt-fix-issue/SKILL.md` / `.codex/skills/gwt-fix-issue/SKILL.md`: step 4 を「inline direct-fix でも `gwt-verify --mode full` を実行し `Overall: PASS` を closure/handoff 前に必須」に強化、step 5 を closure コメント必須 + reference 参照に強化（`.codex` 側は参照パスを `.codex/` prefix に）
- `.claude/skills/gwt-fix-issue/references/closure-comment.md` / `.codex/...`（新規）: Root Cause / Changed Files / Commit or PR / Verification / Remaining Work の必須フィールドを英語テンプレ化、`gwtd issue comment` 投稿手順と anti-patterns を含む
- `tasks/memory.md`: gwt-managed skill ファイル編集の dual-mirror + `git add -f` 規約を再発防止 memory として記録

## Testing

- [x] `bunx --bun markdownlint-cli <5 changed md> --config .markdownlint.json` — exit 0 / 警告 0
- [x] `cargo test -p gwt-skills` — 193 passed / 0 failed（include_dir! が新 reference を自動取込し distribution/preserve テスト green）
- [x] `bunx commitlint --from origin/develop --to HEAD` — exit 0（`docs(gwt-fix-issue)` + `docs(memory)`）
- [x] `gwt-verify --mode pre-pr` — Overall: PASS（UI surface 無し → User Verification: n/a）

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — skill ガイダンスの自己完結した強化で、既存挙動を壊さず単独で配信可能
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- Closes #2972

## Related Issues / Links

- None

## Checklist

- [x] Tests added/updated — N/A（guidance markdown。embedded asset は既存 gwt-skills distribution テストが網羅、include_dir! 自動取込）
- [x] Lint/format passed — markdownlint exit 0。Rust/Svelte 変更なしのため `cargo clippy` / `cargo fmt` / `svelte-check` は N/A
- [x] Documentation updated — 本変更自体が skill guidance ドキュメントの更新
- [x] Migration/backfill plan included — N/A（schema/data 変更なし）
- [x] CHANGELOG impact considered — `docs` type のためリリース対象外（バージョン bump なし）

## Context

- ユーザー監査質問「gwt-fix-issue は修正内容のコメント追加を行うか、適切な環境で gwt-verify を呼ぶか」を起点に調査。いずれも「建前はあるが弱い／曖昧」と判明した。
- `gwt-fix-issue` は FR-014s で意図的に Stop-check hook を持たない short-lived skill のため、SKILL.md prose が唯一の挙動レバー。強制ゲート化（hook 追加）は short-lived 設計と矛盾するため Out of Scope とした。
