### PR TITLE
feat(usage): Codex/Claude の使用量・レートリミット・消費をステータスバーに表示

### DIFF
--- a/crates/gwt-config/src/lib.rs
+++ b/crates/gwt-config/src/lib.rs
@@ -10,6 +10,7 @@ pub mod error;
 pub mod locale;
 pub mod profile;
 pub mod settings;
+pub mod usage_config;
 pub mod voice_config;
 
 pub use agent_config::AgentConfig;
@@ -20,4 +21,5 @@ pub use locale::{
 };
 pub use profile::{Profile, ProfilesConfig};
 pub use settings::Settings;
+pub use usage_config::UsageConfig;
 pub use voice_config::VoiceConfig;

--- a/crates/gwt-config/src/settings.rs
+++ b/crates/gwt-config/src/settings.rs
@@ -14,6 +14,7 @@ use crate::{
     atomic::write_atomic,
     error::{ConfigError, Result},
     profile::ProfilesConfig,
+    usage_config::UsageConfig,
     voice_config::VoiceConfig,
 };
 
@@ -44,6 +45,8 @@ pub struct Settings {
     /// Currently the only reader is [`AISettings::effective_language`] for
     /// narrative output language resolution (SPEC-1933 FR-009 / FR-010).
     pub ai: AISettings,
+    /// Provider usage display configuration (SPEC-2970).
+    pub usage: UsageConfig,
 }
 
 impl Default for Settings {
@@ -62,6 +65,7 @@ impl Default for Settings {
             voice: VoiceConfig::default(),
             agent: AgentConfig::default(),
             ai: AISettings::default(),
+            usage: UsageConfig::default(),
         }
     }
 }
@@ -151,6 +155,16 @@ mod tests {
         assert!(s.protected_branches.contains(&"main".to_string()));
         assert!(!s.debug);
         assert!(!s.profiling);
+    }
+
+    #[test]
+    fn legacy_config_without_usage_section_defaults() {
+        // A config written before SPEC-2970 has no [usage] table; both
+        // providers default on (FR-013 migration).
+        let s: Settings =
+            toml::from_str("default_base_branch = \"main\"\ndebug = false\n").unwrap();
+        assert!(s.usage.codex_enabled);
+        assert!(s.usage.claude_account_enabled);
     }
 
     #[test]

--- a/crates/gwt-config/src/usage_config.rs
+++ b/crates/gwt-config/src/usage_config.rs
@@ -1,0 +1,74 @@
+//! Provider usage display configuration (SPEC-2970 FR-008/FR-009/FR-013).
+//!
+//! Controls which provider usage axes gwt collects. Both providers default on.
+//! Claude **account** usage reads OAuth credentials (Keychain) and contacts
+//! Anthropic; it can be turned off in Settings. Claude per-session usage
+//! (local transcript) is not gated here.
+
+use serde::{Deserialize, Serialize};
+
+fn default_enabled() -> bool {
+    true
+}
+
+/// Usage display configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct UsageConfig {
+    /// Collect Codex usage (local rollout files). Defaults on.
+    #[serde(default = "default_enabled")]
+    pub codex_enabled: bool,
+    /// Collect Claude account usage (Keychain + Anthropic request). Defaults
+    /// on; can be disabled in Settings.
+    #[serde(default = "default_enabled")]
+    pub claude_account_enabled: bool,
+}
+
+impl Default for UsageConfig {
+    fn default() -> Self {
+        Self {
+            codex_enabled: true,
+            claude_account_enabled: true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_both_on() {
+        let c = UsageConfig::default();
+        assert!(c.codex_enabled);
+        assert!(c.claude_account_enabled);
+    }
+
+    #[test]
+    fn missing_table_uses_defaults() {
+        // No [usage] table at all → both default on.
+        let c: UsageConfig = toml::from_str("").unwrap();
+        assert!(c.codex_enabled);
+        assert!(c.claude_account_enabled);
+    }
+
+    #[test]
+    fn partial_table_keeps_other_default_on() {
+        // Only one flag is set; the missing one must stay defaulted on.
+        let c: UsageConfig = toml::from_str("claude_account_enabled = false\n").unwrap();
+        assert!(c.codex_enabled);
+        assert!(!c.claude_account_enabled);
+    }
+
+    #[test]
+    fn roundtrip() {
+        let c = UsageConfig {
+            codex_enabled: false,
+            claude_account_enabled: true,
+        };
+        let s = toml::to_string(&c).unwrap();
+        let back: UsageConfig = toml::from_str(&s).unwrap();
+        assert_eq!(back.codex_enabled, c.codex_enabled);
+        assert_eq!(back.claude_account_enabled, c.claude_account_enabled);
+    }
+}

--- a/crates/gwt-core/src/lib.rs
+++ b/crates/gwt-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod skill_state;
 #[cfg(test)]
 pub(crate) mod test_support;
 pub mod update;
+pub mod usage;
 pub mod workspace_projection;
 pub mod workspace_projection_migration;
 pub mod worktree_hash;

--- a/crates/gwt-core/src/usage/claude.rs
+++ b/crates/gwt-core/src/usage/claude.rs
@@ -1,0 +1,517 @@
+//! Claude Code usage readers (SPEC-2970 FR-004/FR-005/FR-006/FR-017).
+//!
+//! Two sources, asymmetric:
+//! - account-level: undocumented `GET /api/oauth/usage` with the OAuth token
+//!   from `~/.claude/.credentials.json` (or macOS Keychain). Opt-in only.
+//! - per-session: local transcript JSONL under
+//!   `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`. No network / no
+//!   credentials, so always available.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+
+use super::model_context;
+use super::types::{
+    ProviderUsage, SessionUsage, UsageProvider, UsageState, UsageWindow, WindowKind,
+};
+
+const OAUTH_USAGE_URL: &str = "https://api.anthropic.com/api/oauth/usage";
+
+/// Account windows parsed from the `/api/oauth/usage` response body.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClaudeAccount {
+    pub windows: Vec<UsageWindow>,
+    pub limit_reached: bool,
+}
+
+/// OAuth credentials resolved from disk or Keychain.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClaudeCreds {
+    pub access_token: String,
+    pub subscription_type: Option<String>,
+}
+
+fn claude_window(obj: &Value, kind: WindowKind, _now: DateTime<Utc>) -> Option<UsageWindow> {
+    if obj.is_null() {
+        return None;
+    }
+    let util = obj.get("utilization").and_then(Value::as_f64)? as f32;
+    let reset = obj
+        .get("resets_at")
+        .and_then(Value::as_str)
+        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+        .map(|d| d.with_timezone(&Utc));
+    Some(UsageWindow::new(kind, util, reset))
+}
+
+/// Parse the `/api/oauth/usage` JSON body into account windows. Missing/`null`
+/// sub-windows (e.g. `seven_day_opus`) are skipped.
+pub fn parse_oauth_usage(body: &str, now: DateTime<Utc>) -> Option<ClaudeAccount> {
+    let v: Value = serde_json::from_str(body).ok()?;
+    let mut windows = Vec::new();
+    for (key, kind) in [
+        ("five_hour", WindowKind::FiveHour),
+        ("seven_day", WindowKind::Weekly),
+        ("seven_day_opus", WindowKind::OpusWeekly),
+        ("seven_day_sonnet", WindowKind::SonnetWeekly),
+    ] {
+        if let Some(obj) = v.get(key) {
+            if let Some(w) = claude_window(obj, kind, now) {
+                windows.push(w);
+            }
+        }
+    }
+    if windows.is_empty() {
+        return None;
+    }
+    let limit_reached = windows.iter().any(|w| w.used_percent >= 100.0);
+    Some(ClaudeAccount {
+        windows,
+        limit_reached,
+    })
+}
+
+/// Parse OAuth credentials JSON (`{ claudeAiOauth: { accessToken, ... } }`).
+pub fn parse_creds_json(body: &str) -> Option<ClaudeCreds> {
+    let v: Value = serde_json::from_str(body).ok()?;
+    let oauth = v.get("claudeAiOauth").unwrap_or(&v);
+    let access_token = oauth
+        .get("accessToken")
+        .and_then(Value::as_str)?
+        .to_string();
+    if access_token.is_empty() {
+        return None;
+    }
+    let subscription_type = oauth
+        .get("subscriptionType")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    Some(ClaudeCreds {
+        access_token,
+        subscription_type,
+    })
+}
+
+fn creds_from_file(home: &Path) -> Option<ClaudeCreds> {
+    let text = fs::read_to_string(home.join(".credentials.json")).ok()?;
+    parse_creds_json(&text)
+}
+
+#[cfg(target_os = "macos")]
+fn creds_from_keychain() -> Option<ClaudeCreds> {
+    let out = Command::new("security")
+        .args([
+            "find-generic-password",
+            "-s",
+            "Claude Code-credentials",
+            "-w",
+        ])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8(out.stdout).ok()?;
+    parse_creds_json(text.trim())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn creds_from_keychain() -> Option<ClaudeCreds> {
+    None
+}
+
+/// Resolve Claude OAuth credentials. On macOS the Keychain holds the live
+/// (refreshed) token while `~/.claude/.credentials.json` can be stale and
+/// expired — yielding 401s — so the Keychain is preferred and the file is the
+/// fallback. On other platforms the Keychain reader is a no-op and the file is
+/// authoritative.
+pub fn resolve_claude_creds(home: &Path) -> Option<ClaudeCreds> {
+    creds_from_keychain().or_else(|| creds_from_file(home))
+}
+
+/// Build the `User-Agent` from the installed `claude --version`
+/// (`"2.1.159 (Claude Code)"` → `claude-code/2.1.159`).
+pub fn claude_user_agent() -> String {
+    let version = Command::new("claude")
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .and_then(|s| s.split_whitespace().next().map(str::to_string));
+    match version {
+        Some(v) if !v.is_empty() => format!("claude-code/{v}"),
+        _ => "claude-code/unknown".to_string(),
+    }
+}
+
+/// Map a non-success HTTP status to a degraded [`UsageState`].
+pub fn map_status_to_state(status: u16) -> UsageState {
+    let reason = match status {
+        401 | 403 => "auth expired".to_string(),
+        429 => "rate limited (429)".to_string(),
+        other => format!("http {other}"),
+    };
+    UsageState::Unavailable { reason }
+}
+
+/// Fetch account usage from the undocumented OAuth usage endpoint.
+pub async fn fetch_claude_account(
+    creds: &ClaudeCreds,
+    user_agent: &str,
+    now: DateTime<Utc>,
+) -> ProviderUsage {
+    let plan = creds.subscription_type.clone();
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(OAUTH_USAGE_URL)
+        .header(
+            reqwest::header::AUTHORIZATION,
+            format!("Bearer {}", creds.access_token),
+        )
+        .header("anthropic-beta", "oauth-2025-04-20")
+        .header(reqwest::header::USER_AGENT, user_agent)
+        .header(reqwest::header::CONTENT_TYPE, "application/json")
+        .send()
+        .await;
+
+    match resp {
+        Ok(r) if r.status().is_success() => {
+            let body = r.text().await.unwrap_or_default();
+            match parse_oauth_usage(&body, now) {
+                Some(acc) => ProviderUsage {
+                    provider: UsageProvider::ClaudeCode,
+                    plan,
+                    windows: acc.windows,
+                    limit_reached: acc.limit_reached,
+                    state: UsageState::Ok,
+                    fetched_at: Some(now),
+                },
+                None => ProviderUsage {
+                    provider: UsageProvider::ClaudeCode,
+                    plan,
+                    windows: Vec::new(),
+                    limit_reached: false,
+                    state: UsageState::Unavailable {
+                        reason: "unparseable usage".to_string(),
+                    },
+                    fetched_at: Some(now),
+                },
+            }
+        }
+        Ok(r) => ProviderUsage {
+            provider: UsageProvider::ClaudeCode,
+            plan,
+            windows: Vec::new(),
+            limit_reached: false,
+            state: map_status_to_state(r.status().as_u16()),
+            fetched_at: Some(now),
+        },
+        Err(_) => ProviderUsage::degraded(
+            UsageProvider::ClaudeCode,
+            UsageState::Unavailable {
+                reason: "request failed".to_string(),
+            },
+        ),
+    }
+}
+
+/// Parse per-session usage from Claude transcript JSONL text.
+pub fn parse_claude_transcript(session_id: &str, jsonl: &str) -> SessionUsage {
+    let mut input = 0u64;
+    let mut output = 0u64;
+    let mut cache_create = 0u64;
+    let mut cache_read = 0u64;
+    let mut model: Option<String> = None;
+    let mut context_used: Option<u64> = None;
+    let mut saw_assistant = false;
+
+    for line in jsonl.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(obj) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if obj.get("type").and_then(Value::as_str) != Some("assistant") {
+            continue;
+        }
+        let Some(msg) = obj.get("message") else {
+            continue;
+        };
+        saw_assistant = true;
+        if let Some(m) = msg.get("model").and_then(Value::as_str) {
+            model = Some(m.to_string());
+        }
+        let Some(usage) = msg.get("usage") else {
+            continue;
+        };
+        let inp = usage
+            .get("input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let outp = usage
+            .get("output_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let cc = usage
+            .get("cache_creation_input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let cr = usage
+            .get("cache_read_input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        input += inp;
+        output += outp;
+        cache_create += cc;
+        cache_read += cr;
+        // The latest assistant turn's prompt footprint approximates the
+        // current context occupancy.
+        context_used = Some(inp + cc + cr);
+    }
+
+    let total_tokens = input + output + cache_create + cache_read;
+    let context_limit = model.as_deref().and_then(model_context::context_limit);
+    let context_left_pct = SessionUsage::context_left_from(context_used, context_limit);
+
+    SessionUsage {
+        session_id: session_id.to_string(),
+        provider: UsageProvider::ClaudeCode,
+        model,
+        input_tokens: input,
+        output_tokens: output,
+        total_tokens,
+        context_used_tokens: context_used,
+        context_limit_tokens: context_limit,
+        context_left_pct,
+        limit_reached: false,
+        eligible: true,
+        state: if saw_assistant {
+            UsageState::Ok
+        } else {
+            UsageState::NoData
+        },
+    }
+}
+
+/// Resolve the Claude home directory. Honors `CLAUDE_CONFIG_DIR` (Claude
+/// Code's own override) before falling back to `~/.claude`, mirroring how
+/// [`super::codex::codex_home`] honors `CODEX_HOME`.
+pub fn claude_home() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("CLAUDE_CONFIG_DIR") {
+        if !dir.is_empty() {
+            return Some(PathBuf::from(dir));
+        }
+    }
+    dirs::home_dir().map(|h| h.join(".claude"))
+}
+
+/// Locate the transcript file for a session id under `~/.claude/projects/*`.
+pub fn transcript_for_session(home: &Path, session_id: &str) -> Option<PathBuf> {
+    let projects = home.join("projects");
+    let entries = fs::read_dir(projects).ok()?;
+    for entry in entries.flatten() {
+        if entry.path().is_dir() {
+            let candidate = entry.path().join(format!("{session_id}.jsonl"));
+            if candidate.exists() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
+/// Transcript paths under `~/.claude/projects/*` modified at/after `cutoff`,
+/// newest first, capped at `limit`. Used by daily/weekly consumption.
+pub fn transcripts_modified_since(
+    home: &Path,
+    cutoff: std::time::SystemTime,
+    limit: usize,
+) -> Vec<PathBuf> {
+    let projects = home.join("projects");
+    let mut all: Vec<(std::time::SystemTime, PathBuf)> = Vec::new();
+    if let Ok(dirs) = fs::read_dir(&projects) {
+        for dir in dirs.flatten() {
+            if !dir.path().is_dir() {
+                continue;
+            }
+            let Ok(files) = fs::read_dir(dir.path()) else {
+                continue;
+            };
+            for file in files.flatten() {
+                let path = file.path();
+                if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                    continue;
+                }
+                if let Ok(mtime) = file.metadata().and_then(|m| m.modified()) {
+                    if mtime >= cutoff {
+                        all.push((mtime, path));
+                    }
+                }
+            }
+        }
+    }
+    all.sort_by_key(|(mtime, _)| std::cmp::Reverse(*mtime));
+    all.into_iter().take(limit).map(|(_, p)| p).collect()
+}
+
+/// Read per-session usage for a Claude session id from its transcript.
+pub fn read_claude_session(home: &Path, session_id: &str) -> Option<SessionUsage> {
+    let path = transcript_for_session(home, session_id)?;
+    let text = fs::read_to_string(&path).ok()?;
+    Some(parse_claude_transcript(session_id, &text))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Verbatim shape returned by the live `/api/oauth/usage` endpoint
+    // (2026-06-02): RFC3339 `+00:00` offsets, many null sub-windows, and a
+    // sonnet window whose `resets_at` is null.
+    #[test]
+    fn parses_live_endpoint_shape() {
+        let body = r#"{"five_hour":{"utilization":28.0,"resets_at":"2026-06-02T05:00:00.497878+00:00"},"seven_day":{"utilization":6.0,"resets_at":"2026-06-03T21:00:00.497905+00:00"},"seven_day_oauth_apps":null,"seven_day_opus":null,"seven_day_sonnet":{"utilization":0.0,"resets_at":null},"seven_day_cowork":null,"tangelo":null,"extra_usage":{"is_enabled":false}}"#;
+        let acc = parse_oauth_usage(body, now()).unwrap();
+        // five_hour + seven_day + seven_day_sonnet (opus is null → skipped).
+        assert_eq!(acc.windows.len(), 3);
+        let five = acc
+            .windows
+            .iter()
+            .find(|w| w.kind == WindowKind::FiveHour)
+            .unwrap();
+        assert_eq!(five.used_percent, 28.0);
+        assert!(five.resets_at.is_some());
+        let week = acc
+            .windows
+            .iter()
+            .find(|w| w.kind == WindowKind::Weekly)
+            .unwrap();
+        assert_eq!(week.used_percent, 6.0);
+        let sonnet = acc
+            .windows
+            .iter()
+            .find(|w| w.kind == WindowKind::SonnetWeekly)
+            .unwrap();
+        assert_eq!(sonnet.used_percent, 0.0);
+        assert!(sonnet.resets_at.is_none());
+        assert!(!acc.limit_reached);
+    }
+
+    fn now() -> DateTime<Utc> {
+        DateTime::from_timestamp(1_780_000_000, 0).unwrap()
+    }
+
+    #[test]
+    fn parses_all_windows_with_iso_reset() {
+        let body = r#"{
+            "five_hour": {"utilization": 48, "resets_at": "2026-06-02T16:10:00Z"},
+            "seven_day": {"utilization": 18, "resets_at": "2026-06-05T09:00:00Z"},
+            "seven_day_opus": {"utilization": 31, "resets_at": "2026-06-05T09:00:00Z"},
+            "seven_day_sonnet": null
+        }"#;
+        let acc = parse_oauth_usage(body, now()).unwrap();
+        assert_eq!(acc.windows.len(), 3);
+        assert_eq!(acc.windows[0].kind, WindowKind::FiveHour);
+        assert_eq!(acc.windows[0].used_percent, 48.0);
+        assert!(acc.windows[0].resets_at.is_some());
+        assert_eq!(acc.windows[2].kind, WindowKind::OpusWeekly);
+        assert!(!acc.limit_reached);
+    }
+
+    #[test]
+    fn limit_reached_when_window_full() {
+        let body = r#"{"five_hour": {"utilization": 100}, "seven_day": {"utilization": 50}}"#;
+        let acc = parse_oauth_usage(body, now()).unwrap();
+        assert!(acc.limit_reached);
+    }
+
+    #[test]
+    fn empty_or_bad_body_is_none() {
+        assert!(parse_oauth_usage("{}", now()).is_none());
+        assert!(parse_oauth_usage("not json", now()).is_none());
+    }
+
+    #[test]
+    fn creds_parsed_from_oauth_shape() {
+        let body = r#"{"claudeAiOauth":{"accessToken":"tok123","refreshToken":"r","expiresAt":1,"subscriptionType":"max"}}"#;
+        let c = parse_creds_json(body).unwrap();
+        assert_eq!(c.access_token, "tok123");
+        assert_eq!(c.subscription_type.as_deref(), Some("max"));
+    }
+
+    #[test]
+    fn creds_empty_token_rejected() {
+        assert!(parse_creds_json(r#"{"claudeAiOauth":{"accessToken":""}}"#).is_none());
+        assert!(parse_creds_json("{}").is_none());
+    }
+
+    #[test]
+    fn status_mapping() {
+        assert_eq!(
+            map_status_to_state(429),
+            UsageState::Unavailable {
+                reason: "rate limited (429)".into()
+            }
+        );
+        assert_eq!(
+            map_status_to_state(401),
+            UsageState::Unavailable {
+                reason: "auth expired".into()
+            }
+        );
+        assert_eq!(
+            map_status_to_state(500),
+            UsageState::Unavailable {
+                reason: "http 500".into()
+            }
+        );
+    }
+
+    #[test]
+    fn transcript_aggregates_usage_and_context() {
+        let jsonl = concat!(
+            r#"{"type":"user","message":{"role":"user"}}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"model":"claude-opus-4-7","usage":{"input_tokens":100,"output_tokens":20,"cache_creation_input_tokens":30,"cache_read_input_tokens":10}}}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"model":"claude-opus-4-7","usage":{"input_tokens":5,"output_tokens":40,"cache_creation_input_tokens":0,"cache_read_input_tokens":140}}}"#,
+            "\n",
+        );
+        let s = parse_claude_transcript("sid", jsonl);
+        assert_eq!(s.input_tokens, 105);
+        assert_eq!(s.output_tokens, 60);
+        assert_eq!(s.total_tokens, 105 + 60 + 30 + 150);
+        assert_eq!(s.model.as_deref(), Some("claude-opus-4-7"));
+        // last turn context = 5 + 0 + 140
+        assert_eq!(s.context_used_tokens, Some(145));
+        assert_eq!(s.context_limit_tokens, Some(200_000));
+        assert!(s.context_left_pct.is_some());
+        assert_eq!(s.state, UsageState::Ok);
+    }
+
+    #[test]
+    fn transcript_without_assistant_is_nodata() {
+        let s = parse_claude_transcript("sid", r#"{"type":"user","message":{}}"#);
+        assert_eq!(s.state, UsageState::NoData);
+        assert_eq!(s.total_tokens, 0);
+    }
+
+    #[test]
+    fn transcript_path_resolution() {
+        let dir = tempfile::tempdir().unwrap();
+        let proj = dir.path().join("projects/-Users-akiojin-x");
+        fs::create_dir_all(&proj).unwrap();
+        let file = proj.join("sid-123.jsonl");
+        fs::write(&file, r#"{"type":"assistant","message":{"model":"claude-opus-4-7","usage":{"input_tokens":1,"output_tokens":1}}}"#).unwrap();
+        let found = transcript_for_session(dir.path(), "sid-123").unwrap();
+        assert_eq!(found, file);
+        let s = read_claude_session(dir.path(), "sid-123").unwrap();
+        assert_eq!(s.input_tokens, 1);
+    }
+}

--- a/crates/gwt-core/src/usage/codex.rs
+++ b/crates/gwt-core/src/usage/codex.rs
@@ -1,0 +1,478 @@
+//! Codex usage readers (SPEC-2970 FR-002/FR-003/FR-008/FR-016).
+//!
+//! Source of truth is the per-session rollout JSONL under
+//! `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`. Each
+//! `token_count` event embeds:
+//! - `rate_limits` — account-level 5h (`primary`) / weekly (`secondary`) +
+//!   optional `code_review`, with `plan_type` and `rate_limit_reached_type`.
+//! - `info.total_token_usage` — cumulative per-session tokens.
+//! - `info.model_context_window` — the model's context size (so no static
+//!   table lookup is needed for Codex).
+//!
+//! Reset instants come as `resets_at` (unix epoch seconds, observed) and we
+//! also accept `resets_at` RFC3339 strings and relative `resets_in_seconds`
+//! for forward/backward compatibility.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Duration, Utc};
+use serde_json::Value;
+
+use super::types::{
+    ProviderUsage, SessionUsage, UsageProvider, UsageState, UsageWindow, WindowKind,
+};
+
+/// Parsed account-level fields from a `rate_limits` object.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CodexAccount {
+    pub windows: Vec<UsageWindow>,
+    pub plan: Option<String>,
+    pub limit_reached: bool,
+}
+
+fn parse_reset(window: &Value, now: DateTime<Utc>) -> Option<DateTime<Utc>> {
+    if let Some(epoch) = window.get("resets_at").and_then(Value::as_i64) {
+        return DateTime::from_timestamp(epoch, 0);
+    }
+    if let Some(text) = window.get("resets_at").and_then(Value::as_str) {
+        if let Ok(dt) = DateTime::parse_from_rfc3339(text) {
+            return Some(dt.with_timezone(&Utc));
+        }
+    }
+    if let Some(rel) = window.get("resets_in_seconds").and_then(Value::as_i64) {
+        return Some(now + Duration::seconds(rel));
+    }
+    None
+}
+
+fn window_from(kind: WindowKind, obj: &Value, now: DateTime<Utc>) -> Option<UsageWindow> {
+    let used = obj.get("used_percent").and_then(Value::as_f64)? as f32;
+    Some(UsageWindow::new(kind, used, parse_reset(obj, now)))
+}
+
+/// Parse a `rate_limits` JSON object into account windows. Returns `None` when
+/// the value is `null` (Codex exec mode) or has no recognized windows.
+pub fn parse_rate_limits(rate_limits: &Value, now: DateTime<Utc>) -> Option<CodexAccount> {
+    if rate_limits.is_null() {
+        return None;
+    }
+    let mut windows = Vec::new();
+    if let Some(primary) = rate_limits.get("primary") {
+        if let Some(w) = window_from(WindowKind::FiveHour, primary, now) {
+            windows.push(w);
+        }
+    }
+    if let Some(secondary) = rate_limits.get("secondary") {
+        if let Some(w) = window_from(WindowKind::Weekly, secondary, now) {
+            windows.push(w);
+        }
+    }
+    if let Some(review) = rate_limits.get("code_review") {
+        if let Some(w) = window_from(WindowKind::CodeReviewWeekly, review, now) {
+            windows.push(w);
+        }
+    }
+    if windows.is_empty() {
+        return None;
+    }
+    let plan = rate_limits
+        .get("plan_type")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let limit_reached = rate_limits
+        .get("rate_limit_reached_type")
+        .map(|v| !v.is_null())
+        .unwrap_or(false)
+        || windows.iter().any(|w| w.used_percent >= 100.0);
+    Some(CodexAccount {
+        windows,
+        plan,
+        limit_reached,
+    })
+}
+
+/// Scan rollout JSONL text and return the last `token_count` payload value.
+fn last_token_count(jsonl: &str) -> Option<Value> {
+    let mut last = None;
+    for line in jsonl.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(obj) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        let payload = obj.get("payload").unwrap_or(&obj);
+        if payload.get("type").and_then(Value::as_str) == Some("token_count") {
+            last = Some(payload.clone());
+        }
+    }
+    last
+}
+
+/// Extract the last `model`/`cli` model name seen in the rollout (session_meta
+/// or token_count payloads).
+fn last_model(jsonl: &str) -> Option<String> {
+    let mut model = None;
+    for line in jsonl.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(obj) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        let payload = obj.get("payload").unwrap_or(&obj);
+        if let Some(m) = payload.get("model").and_then(Value::as_str) {
+            model = Some(m.to_string());
+        }
+        if let Some(m) = obj.get("model").and_then(Value::as_str) {
+            model = Some(m.to_string());
+        }
+    }
+    model
+}
+
+/// Parse account usage from full rollout JSONL text.
+pub fn parse_codex_account(jsonl: &str, now: DateTime<Utc>) -> Option<CodexAccount> {
+    let tc = last_token_count(jsonl)?;
+    let rl = tc.get("rate_limits")?;
+    parse_rate_limits(rl, now)
+}
+
+/// Parse per-session usage from full rollout JSONL text.
+pub fn parse_codex_session(session_id: &str, jsonl: &str) -> SessionUsage {
+    let tc = last_token_count(jsonl);
+    let info = tc.as_ref().and_then(|t| t.get("info"));
+    let total = info.and_then(|i| i.get("total_token_usage"));
+    let input = total
+        .and_then(|t| t.get("input_tokens"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let output = total
+        .and_then(|t| t.get("output_tokens"))
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let total_tokens = total
+        .and_then(|t| t.get("total_tokens"))
+        .and_then(Value::as_u64)
+        .unwrap_or(input + output);
+
+    let context_limit = info
+        .and_then(|i| i.get("model_context_window"))
+        .and_then(Value::as_u64);
+    // Approximate current context occupancy from the last turn's prompt size.
+    // `input_tokens` already includes the cached portion, so it must NOT be
+    // summed with `cached_input_tokens` (that double-counts and pins ctx to 0%).
+    let last = info.and_then(|i| i.get("last_token_usage"));
+    let context_used = last.and_then(|l| l.get("input_tokens").and_then(Value::as_u64));
+    let context_left_pct = SessionUsage::context_left_from(context_used, context_limit);
+
+    let limit_reached = tc
+        .as_ref()
+        .and_then(|t| t.get("rate_limits"))
+        .and_then(|rl| rl.get("rate_limit_reached_type"))
+        .map(|v| !v.is_null())
+        .unwrap_or(false);
+
+    let state = if tc.is_some() {
+        UsageState::Ok
+    } else {
+        UsageState::NoData
+    };
+
+    SessionUsage {
+        session_id: session_id.to_string(),
+        provider: UsageProvider::Codex,
+        model: last_model(jsonl),
+        input_tokens: input,
+        output_tokens: output,
+        total_tokens,
+        context_used_tokens: context_used,
+        context_limit_tokens: context_limit,
+        context_left_pct,
+        limit_reached,
+        eligible: true,
+        state,
+    }
+}
+
+/// Resolve the effective Codex home directory.
+pub fn codex_home() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("CODEX_HOME") {
+        if !dir.is_empty() {
+            return Some(PathBuf::from(dir));
+        }
+    }
+    dirs::home_dir().map(|h| h.join(".codex"))
+}
+
+/// Find the most recently modified `rollout-*.jsonl` under `<home>/sessions`.
+pub fn newest_rollout(home: &Path) -> Option<PathBuf> {
+    let sessions = home.join("sessions");
+    let mut newest: Option<(std::time::SystemTime, PathBuf)> = None;
+    visit_rollouts(&sessions, &mut |path, mtime| match &newest {
+        Some((best, _)) if *best >= mtime => {}
+        _ => newest = Some((mtime, path)),
+    });
+    newest.map(|(_, p)| p)
+}
+
+/// Rollout paths under `<home>/sessions` modified at/after `cutoff`, newest
+/// first, capped at `limit`. Used by daily/weekly consumption aggregation to
+/// bound how many files are scanned.
+pub fn rollouts_modified_since(
+    home: &Path,
+    cutoff: std::time::SystemTime,
+    limit: usize,
+) -> Vec<PathBuf> {
+    let sessions = home.join("sessions");
+    let mut all: Vec<(std::time::SystemTime, PathBuf)> = Vec::new();
+    visit_rollouts(&sessions, &mut |path, mtime| {
+        if mtime >= cutoff {
+            all.push((mtime, path));
+        }
+    });
+    all.sort_by_key(|(mtime, _)| std::cmp::Reverse(*mtime));
+    all.into_iter().take(limit).map(|(_, p)| p).collect()
+}
+
+/// Collect rollout paths under `<home>/sessions`, newest first, capped at
+/// `limit`.
+pub fn recent_rollouts(home: &Path, limit: usize) -> Vec<PathBuf> {
+    let sessions = home.join("sessions");
+    let mut all: Vec<(std::time::SystemTime, PathBuf)> = Vec::new();
+    visit_rollouts(&sessions, &mut |path, mtime| all.push((mtime, path)));
+    all.sort_by_key(|(mtime, _)| std::cmp::Reverse(*mtime));
+    all.into_iter().take(limit).map(|(_, p)| p).collect()
+}
+
+fn visit_rollouts(dir: &Path, f: &mut impl FnMut(PathBuf, std::time::SystemTime)) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            visit_rollouts(&path, f);
+        } else if path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n.starts_with("rollout-") && n.ends_with(".jsonl"))
+            .unwrap_or(false)
+        {
+            if let Ok(mtime) = entry.metadata().and_then(|m| m.modified()) {
+                f(path, mtime);
+            }
+        }
+    }
+}
+
+/// Locate a rollout file whose name contains the given session id (uuid).
+pub fn rollout_for_session(home: &Path, session_id: &str) -> Option<PathBuf> {
+    let sessions = home.join("sessions");
+    let mut found = None;
+    visit_rollouts(&sessions, &mut |path, _| {
+        if found.is_none()
+            && path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n.contains(session_id))
+                .unwrap_or(false)
+        {
+            found = Some(path);
+        }
+    });
+    found
+}
+
+/// Read account usage from recent rollouts under `home` (newest first), using
+/// the freshest one that carries a usable `rate_limits` block. A brand-new
+/// session's rollout may not have emitted `rate_limits` yet, so scanning a few
+/// recent files avoids a spurious `NoData`. `rate_limits` is account-global, so
+/// the most recent one is the freshest account state. Returns degraded
+/// `NoData` when none have account data.
+pub fn read_codex_account(home: &Path, now: DateTime<Utc>) -> ProviderUsage {
+    for path in recent_rollouts(home, 8) {
+        let Ok(text) = fs::read_to_string(&path) else {
+            continue;
+        };
+        if let Some(acc) = parse_codex_account(&text, now) {
+            return ProviderUsage {
+                provider: UsageProvider::Codex,
+                plan: acc.plan,
+                windows: acc.windows,
+                limit_reached: acc.limit_reached,
+                state: UsageState::Ok,
+                fetched_at: Some(now),
+            };
+        }
+    }
+    ProviderUsage::degraded(UsageProvider::Codex, UsageState::NoData)
+}
+
+/// Read per-session usage for the given session id from its rollout file.
+pub fn read_codex_session(home: &Path, session_id: &str) -> Option<SessionUsage> {
+    let path = rollout_for_session(home, session_id)?;
+    let text = fs::read_to_string(&path).ok()?;
+    Some(parse_codex_session(session_id, &text))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now() -> DateTime<Utc> {
+        DateTime::from_timestamp(1_780_000_000, 0).unwrap()
+    }
+
+    #[test]
+    fn parses_epoch_resets_at_schema() {
+        let rl = serde_json::json!({
+            "limit_id": "codex",
+            "primary": {"used_percent": 0.0, "window_minutes": 300, "resets_at": 1780376627},
+            "secondary": {"used_percent": 23.0, "window_minutes": 10080, "resets_at": 1780899120},
+            "plan_type": "pro",
+            "rate_limit_reached_type": null
+        });
+        let acc = parse_rate_limits(&rl, now()).unwrap();
+        assert_eq!(acc.plan.as_deref(), Some("pro"));
+        assert!(!acc.limit_reached);
+        assert_eq!(acc.windows.len(), 2);
+        assert_eq!(acc.windows[0].kind, WindowKind::FiveHour);
+        assert_eq!(acc.windows[1].kind, WindowKind::Weekly);
+        assert_eq!(acc.windows[1].used_percent, 23.0);
+        assert_eq!(
+            acc.windows[0].resets_at,
+            DateTime::from_timestamp(1780376627, 0)
+        );
+    }
+
+    #[test]
+    fn parses_relative_resets_in_seconds_schema() {
+        let rl = serde_json::json!({
+            "primary": {"used_percent": 10.0, "window_minutes": 299, "resets_in_seconds": 600},
+            "secondary": {"used_percent": 5.0, "window_minutes": 10079, "resets_in_seconds": 3600}
+        });
+        let acc = parse_rate_limits(&rl, now()).unwrap();
+        assert_eq!(
+            acc.windows[0].resets_at,
+            Some(now() + Duration::seconds(600))
+        );
+        assert_eq!(acc.plan, None);
+    }
+
+    #[test]
+    fn includes_code_review_when_present() {
+        let rl = serde_json::json!({
+            "primary": {"used_percent": 1.0},
+            "secondary": {"used_percent": 2.0},
+            "code_review": {"used_percent": 6.0}
+        });
+        let acc = parse_rate_limits(&rl, now()).unwrap();
+        assert_eq!(acc.windows.len(), 3);
+        assert_eq!(acc.windows[2].kind, WindowKind::CodeReviewWeekly);
+    }
+
+    #[test]
+    fn null_rate_limits_is_none() {
+        assert!(parse_rate_limits(&Value::Null, now()).is_none());
+    }
+
+    #[test]
+    fn limit_reached_from_reached_type() {
+        let rl = serde_json::json!({
+            "primary": {"used_percent": 100.0},
+            "rate_limit_reached_type": "primary"
+        });
+        let acc = parse_rate_limits(&rl, now()).unwrap();
+        assert!(acc.limit_reached);
+    }
+
+    #[test]
+    fn account_from_jsonl_uses_last_token_count() {
+        let jsonl = concat!(
+            r#"{"type":"session_meta","payload":{"id":"abc","model":"gpt-5.5"}}"#,
+            "\n",
+            r#"{"timestamp":"t","type":"event_msg","payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":1.0}},"info":{}}}"#,
+            "\n",
+            r#"{"timestamp":"t","type":"event_msg","payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":42.0}},"info":{}}}"#,
+            "\n",
+        );
+        let acc = parse_codex_account(jsonl, now()).unwrap();
+        assert_eq!(acc.windows[0].used_percent, 42.0);
+    }
+
+    #[test]
+    fn session_usage_aggregates_totals_and_context() {
+        let jsonl = concat!(
+            r#"{"type":"session_meta","payload":{"id":"abc","model":"gpt-5.5"}}"#,
+            "\n",
+            r#"{"payload":{"type":"token_count","rate_limits":null,"info":{"total_token_usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":20,"total_tokens":160},"last_token_usage":{"input_tokens":80,"cached_input_tokens":10},"model_context_window":400000}}}"#,
+            "\n",
+        );
+        let s = parse_codex_session("abc", jsonl);
+        assert_eq!(s.input_tokens, 100);
+        assert_eq!(s.output_tokens, 20);
+        assert_eq!(s.total_tokens, 160);
+        assert_eq!(s.context_limit_tokens, Some(400000));
+        // input_tokens already includes the cached portion; no double-count.
+        assert_eq!(s.context_used_tokens, Some(80));
+        assert_eq!(s.model.as_deref(), Some("gpt-5.5"));
+        assert_eq!(s.state, UsageState::Ok);
+        assert!(s.eligible);
+    }
+
+    #[test]
+    fn read_account_handles_missing_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let acc = read_codex_account(dir.path(), now());
+        assert_eq!(acc.state, UsageState::NoData);
+        assert_eq!(acc.provider, UsageProvider::Codex);
+    }
+
+    #[test]
+    fn newest_rollout_picks_latest_by_mtime() {
+        let dir = tempfile::tempdir().unwrap();
+        let day = dir.path().join("sessions/2026/06/02");
+        fs::create_dir_all(&day).unwrap();
+        let older = day.join("rollout-2026-06-02T08-00-00-aaaa.jsonl");
+        let newer = day.join("rollout-2026-06-02T09-00-00-bbbb.jsonl");
+        fs::write(&older, r#"{"payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":1.0}},"info":{}}}"#).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        fs::write(&newer, r#"{"payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":2.0}},"info":{}}}"#).unwrap();
+        let picked = newest_rollout(dir.path()).unwrap();
+        assert_eq!(picked, newer);
+        let acc = read_codex_account(dir.path(), now());
+        assert_eq!(acc.windows[0].used_percent, 2.0);
+
+        // session lookup by uuid fragment
+        let found = rollout_for_session(dir.path(), "bbbb").unwrap();
+        assert_eq!(found, newer);
+    }
+
+    #[test]
+    fn account_skips_newest_rollout_without_rate_limits() {
+        let dir = tempfile::tempdir().unwrap();
+        let day = dir.path().join("sessions/2026/06/02");
+        fs::create_dir_all(&day).unwrap();
+        let older = day.join("rollout-2026-06-02T08-00-00-aaaa.jsonl");
+        let newer = day.join("rollout-2026-06-02T09-00-00-bbbb.jsonl");
+        // Older has rate_limits; the newer (fresh session) has none yet.
+        fs::write(
+            &older,
+            r#"{"payload":{"type":"token_count","rate_limits":{"primary":{"used_percent":7.0}},"info":{}}}"#,
+        )
+        .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        fs::write(
+            &newer,
+            r#"{"payload":{"type":"session_meta","payload":{"id":"bbbb"}}}"#,
+        )
+        .unwrap();
+        let acc = read_codex_account(dir.path(), now());
+        assert_eq!(acc.state, UsageState::Ok);
+        assert_eq!(acc.windows[0].used_percent, 7.0);
+    }
+}

--- a/crates/gwt-core/src/usage/consumption.rs
+++ b/crates/gwt-core/src/usage/consumption.rs
@@ -1,0 +1,354 @@
+//! Daily / weekly token-consumption aggregation (SPEC-2970 extension).
+//!
+//! Separate axis from the rate-limit windows: this reads local session history
+//! (Codex rollouts, Claude transcripts) and sums **actual token consumption**
+//! per local day. Each provider rollup carries a Today total, a This-week total
+//! (aligned to the weekly rate-limit window via `week_start`), and a 7-day
+//! series for a mini bar chart. Token counts are split into
+//! `input` (uncached) / `output` / `cached` so the cache re-read volume does
+//! not drown out the real new-work numbers.
+//!
+//! Per-event timestamps make day bucketing accurate:
+//! - Codex `token_count` events carry a top-level `timestamp` and
+//!   `info.last_token_usage` (the per-turn delta).
+//! - Claude `assistant` lines carry a `timestamp` and `message.usage`.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::time::{Duration as StdDuration, SystemTime};
+
+use chrono::{DateTime, Duration, Local, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::claude;
+use super::codex;
+use super::types::UsageProvider;
+
+/// How many days of files to scan / chart.
+pub const RANGE_DAYS: i64 = 8;
+/// Number of days shown in the mini bar chart (including today).
+pub const CHART_DAYS: i64 = 7;
+/// Upper bound on files scanned per provider (cost guard). When hit, the caller
+/// should log that older history was skipped.
+pub const MAX_FILES: usize = 400;
+
+/// Token consumption split so cache re-reads don't dominate the real numbers.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConsumptionBreakdown {
+    pub input: u64,
+    pub output: u64,
+    pub cached: u64,
+}
+
+impl ConsumptionBreakdown {
+    pub fn add(&mut self, other: &ConsumptionBreakdown) {
+        self.input += other.input;
+        self.output += other.output;
+        self.cached += other.cached;
+    }
+
+    /// Grand total across all three buckets (used for the chart bar height).
+    pub fn total(&self) -> u64 {
+        self.input + self.output + self.cached
+    }
+}
+
+/// One day's consumption bucket for the chart series.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DayConsumption {
+    /// Local date, `YYYY-MM-DD`.
+    pub date: String,
+    pub breakdown: ConsumptionBreakdown,
+}
+
+/// Per-provider consumption rollup.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderConsumption {
+    pub provider: UsageProvider,
+    pub today: ConsumptionBreakdown,
+    pub this_week: ConsumptionBreakdown,
+    /// Oldest-first series of the last [`CHART_DAYS`] local days (today last).
+    pub days: Vec<DayConsumption>,
+}
+
+impl ProviderConsumption {
+    pub fn empty(provider: UsageProvider, now: DateTime<Utc>) -> Self {
+        aggregate(provider, Vec::new(), now, now)
+    }
+}
+
+/// A single timestamped consumption delta.
+pub type ConsumptionEvent = (DateTime<Utc>, ConsumptionBreakdown);
+
+fn parse_ts(value: Option<&Value>) -> Option<DateTime<Utc>> {
+    let text = value?.as_str()?;
+    DateTime::parse_from_rfc3339(text)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+/// Extract consumption events from Codex rollout JSONL. `input` excludes the
+/// cached portion (`input_tokens - cached_input_tokens`).
+pub fn parse_codex_events(jsonl: &str) -> Vec<ConsumptionEvent> {
+    let mut events = Vec::new();
+    for line in jsonl.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(obj) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        let payload = obj.get("payload").unwrap_or(&obj);
+        if payload.get("type").and_then(Value::as_str) != Some("token_count") {
+            continue;
+        }
+        let Some(ts) = parse_ts(obj.get("timestamp")) else {
+            continue;
+        };
+        let last = payload.get("info").and_then(|i| i.get("last_token_usage"));
+        let Some(last) = last else { continue };
+        let input_total = last
+            .get("input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let cached = last
+            .get("cached_input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let output = last
+            .get("output_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        events.push((
+            ts,
+            ConsumptionBreakdown {
+                input: input_total.saturating_sub(cached),
+                output,
+                cached,
+            },
+        ));
+    }
+    events
+}
+
+/// Extract consumption events from a Claude transcript JSONL. Claude's
+/// `input_tokens` is already the uncached input; cache fields are separate.
+pub fn parse_claude_events(jsonl: &str) -> Vec<ConsumptionEvent> {
+    let mut events = Vec::new();
+    for line in jsonl.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(obj) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if obj.get("type").and_then(Value::as_str) != Some("assistant") {
+            continue;
+        }
+        let Some(ts) = parse_ts(obj.get("timestamp")) else {
+            continue;
+        };
+        let Some(usage) = obj.get("message").and_then(|m| m.get("usage")) else {
+            continue;
+        };
+        let input = usage
+            .get("input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let output = usage
+            .get("output_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let cache_read = usage
+            .get("cache_read_input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let cache_create = usage
+            .get("cache_creation_input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        events.push((
+            ts,
+            ConsumptionBreakdown {
+                input,
+                output,
+                cached: cache_read + cache_create,
+            },
+        ));
+    }
+    events
+}
+
+/// Aggregate events into Today / This-week / 7-day-series, bucketing by the
+/// **local** date of each event. `week_start` is the weekly rate-limit window
+/// start (sum events at/after it); `now` defines "today".
+pub fn aggregate(
+    provider: UsageProvider,
+    events: Vec<ConsumptionEvent>,
+    week_start: DateTime<Utc>,
+    now: DateTime<Utc>,
+) -> ProviderConsumption {
+    let today_date = now.with_timezone(&Local).date_naive();
+    let mut today = ConsumptionBreakdown::default();
+    let mut this_week = ConsumptionBreakdown::default();
+    let mut by_day: HashMap<NaiveDate, ConsumptionBreakdown> = HashMap::new();
+
+    for (ts, breakdown) in &events {
+        let local_date = ts.with_timezone(&Local).date_naive();
+        if local_date == today_date {
+            today.add(breakdown);
+        }
+        if *ts >= week_start {
+            this_week.add(breakdown);
+        }
+        by_day.entry(local_date).or_default().add(breakdown);
+    }
+
+    let mut days = Vec::with_capacity(CHART_DAYS as usize);
+    for offset in (0..CHART_DAYS).rev() {
+        let date = today_date - Duration::days(offset);
+        days.push(DayConsumption {
+            date: date.format("%Y-%m-%d").to_string(),
+            breakdown: by_day.get(&date).copied().unwrap_or_default(),
+        });
+    }
+
+    ProviderConsumption {
+        provider,
+        today,
+        this_week,
+        days,
+    }
+}
+
+fn scan_cutoff(now: DateTime<Utc>) -> SystemTime {
+    let secs = (RANGE_DAYS as u64) * 24 * 60 * 60;
+    // Anchor to wall-clock SystemTime; `now` is only used for date math.
+    let _ = now;
+    SystemTime::now()
+        .checked_sub(StdDuration::from_secs(secs))
+        .unwrap_or(SystemTime::UNIX_EPOCH)
+}
+
+/// Read Codex consumption from recent rollouts under `home`.
+pub fn read_codex_consumption(
+    home: &Path,
+    week_start: DateTime<Utc>,
+    now: DateTime<Utc>,
+) -> ProviderConsumption {
+    let paths = codex::rollouts_modified_since(home, scan_cutoff(now), MAX_FILES);
+    let mut events = Vec::new();
+    for path in &paths {
+        if let Ok(text) = fs::read_to_string(path) {
+            events.extend(parse_codex_events(&text));
+        }
+    }
+    aggregate(UsageProvider::Codex, events, week_start, now)
+}
+
+/// Read Claude consumption from recent transcripts under `home`.
+pub fn read_claude_consumption(
+    home: &Path,
+    week_start: DateTime<Utc>,
+    now: DateTime<Utc>,
+) -> ProviderConsumption {
+    let paths = claude::transcripts_modified_since(home, scan_cutoff(now), MAX_FILES);
+    let mut events = Vec::new();
+    for path in &paths {
+        if let Ok(text) = fs::read_to_string(path) {
+            events.extend(parse_claude_events(&text));
+        }
+    }
+    aggregate(UsageProvider::ClaudeCode, events, week_start, now)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ts(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    #[test]
+    fn codex_events_subtract_cached_from_input() {
+        let jsonl = concat!(
+            r#"{"timestamp":"2026-06-02T09:52:15.989Z","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":25228,"cached_input_tokens":9600,"output_tokens":78}}}}"#,
+            "\n",
+            r#"{"timestamp":"x","payload":{"type":"event_msg"}}"#,
+        );
+        let ev = parse_codex_events(jsonl);
+        assert_eq!(ev.len(), 1);
+        assert_eq!(ev[0].1.input, 25228 - 9600);
+        assert_eq!(ev[0].1.cached, 9600);
+        assert_eq!(ev[0].1.output, 78);
+    }
+
+    #[test]
+    fn claude_events_sum_cache_fields() {
+        let jsonl = r#"{"type":"assistant","timestamp":"2026-06-02T09:00:00Z","message":{"usage":{"input_tokens":100,"output_tokens":20,"cache_read_input_tokens":140,"cache_creation_input_tokens":30}}}"#;
+        let ev = parse_claude_events(jsonl);
+        assert_eq!(ev.len(), 1);
+        assert_eq!(ev[0].1.input, 100);
+        assert_eq!(ev[0].1.output, 20);
+        assert_eq!(ev[0].1.cached, 170);
+    }
+
+    #[test]
+    fn aggregate_buckets_today_week_and_series() {
+        // now = today 12:00Z. Use a wide week_start so all events count weekly.
+        let now = ts("2026-06-02T12:00:00Z");
+        let week_start = ts("2026-05-30T00:00:00Z");
+        let b = |i, o, c| ConsumptionBreakdown {
+            input: i,
+            output: o,
+            cached: c,
+        };
+        let events = vec![
+            (ts("2026-06-02T01:00:00Z"), b(10, 1, 100)), // maybe today (tz dependent)
+            (ts("2026-06-01T10:00:00Z"), b(20, 2, 200)), // yesterday-ish
+            (ts("2026-05-20T10:00:00Z"), b(99, 9, 900)), // before week_start
+        ];
+        let pc = aggregate(UsageProvider::Codex, events, week_start, now);
+        assert_eq!(pc.provider, UsageProvider::Codex);
+        // 7-day series present, oldest first, ending today.
+        assert_eq!(pc.days.len(), CHART_DAYS as usize);
+        let today_local = now.with_timezone(&Local).date_naive();
+        assert_eq!(
+            pc.days.last().unwrap().date,
+            today_local.format("%Y-%m-%d").to_string()
+        );
+        // The pre-week event must not be in this_week.
+        assert!(pc.this_week.total() < b(99, 9, 900).total() + 1000);
+        assert_eq!(pc.this_week.input, 30); // 10 + 20 (both >= week_start)
+    }
+
+    #[test]
+    fn week_start_boundary_excludes_older() {
+        let now = ts("2026-06-02T12:00:00Z");
+        let week_start = ts("2026-06-02T00:00:00Z");
+        let b = ConsumptionBreakdown {
+            input: 5,
+            output: 0,
+            cached: 0,
+        };
+        let events = vec![
+            (ts("2026-06-02T01:00:00Z"), b), // after week_start
+            (ts("2026-06-01T23:00:00Z"), b), // before week_start
+        ];
+        let pc = aggregate(UsageProvider::ClaudeCode, events, week_start, now);
+        assert_eq!(pc.this_week.input, 5);
+    }
+
+    #[test]
+    fn empty_has_seven_zero_days() {
+        let pc = ProviderConsumption::empty(UsageProvider::Codex, ts("2026-06-02T12:00:00Z"));
+        assert_eq!(pc.days.len(), CHART_DAYS as usize);
+        assert_eq!(pc.today, ConsumptionBreakdown::default());
+        assert!(pc.days.iter().all(|d| d.breakdown.total() == 0));
+    }
+}

--- a/crates/gwt-core/src/usage/mod.rs
+++ b/crates/gwt-core/src/usage/mod.rs
@@ -1,0 +1,21 @@
+//! Provider usage & rate-limit domain (SPEC-2970).
+//!
+//! Models two axes of usage for the Codex and Claude Code CLIs:
+//! - account-level rate-limit windows (shared per provider account)
+//! - per-session token / context occupancy
+//!
+//! Pure parsers are separated from filesystem / network I/O so the parsing
+//! logic is deterministic under test. The GUI process owns the polling loop
+//! and converts [`UsageSnapshot`] into frontend protocol views.
+
+pub mod claude;
+pub mod codex;
+pub mod consumption;
+pub mod model_context;
+pub mod state;
+pub mod types;
+
+pub use consumption::{ConsumptionBreakdown, DayConsumption, ProviderConsumption};
+pub use types::{
+    ProviderUsage, SessionUsage, UsageProvider, UsageSnapshot, UsageState, UsageWindow, WindowKind,
+};

--- a/crates/gwt-core/src/usage/model_context.rs
+++ b/crates/gwt-core/src/usage/model_context.rs
@@ -1,0 +1,61 @@
+//! Model → context-window-size lookup (SPEC-2970 FR-018).
+//!
+//! Used to estimate per-session "context left" when the source does not embed
+//! the window size. Codex rollouts carry `info.model_context_window` directly,
+//! so this table is primarily for Claude transcripts. Unknown models return
+//! `None`, which the UI renders as "tokens only, no remaining %".
+
+/// Return the approximate context window size (in tokens) for a model name,
+/// or `None` when the model is unknown. Matching is case-insensitive and
+/// substring-based so versioned names (`claude-opus-4-7`) resolve correctly.
+pub fn context_limit(model: &str) -> Option<u64> {
+    let m = model.to_ascii_lowercase();
+
+    // Explicit 1M-context beta variants take priority.
+    if m.contains("[1m]") || m.contains("-1m") || m.contains("1m-context") {
+        return Some(1_000_000);
+    }
+
+    // Anthropic Claude family: standard 200k context.
+    if m.contains("claude") || m.contains("opus") || m.contains("sonnet") || m.contains("haiku") {
+        return Some(200_000);
+    }
+
+    // OpenAI gpt-5 / codex family fallback. Codex normally provides the real
+    // window via the rollout payload; this is only a defensive default.
+    if m.contains("gpt-5") || m.contains("codex") {
+        return Some(400_000);
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_claude_models_resolve_to_200k() {
+        assert_eq!(context_limit("claude-opus-4-7"), Some(200_000));
+        assert_eq!(context_limit("claude-sonnet-4-6"), Some(200_000));
+        assert_eq!(context_limit("Claude-Haiku-4-5"), Some(200_000));
+    }
+
+    #[test]
+    fn one_million_variant_detected() {
+        assert_eq!(context_limit("claude-opus-4-8[1m]"), Some(1_000_000));
+        assert_eq!(context_limit("claude-sonnet-1m-context"), Some(1_000_000));
+    }
+
+    #[test]
+    fn gpt5_codex_fallback() {
+        assert_eq!(context_limit("gpt-5.5"), Some(400_000));
+        assert_eq!(context_limit("gpt-5-codex"), Some(400_000));
+    }
+
+    #[test]
+    fn unknown_model_is_none() {
+        assert_eq!(context_limit("some-future-model"), None);
+        assert_eq!(context_limit(""), None);
+    }
+}

--- a/crates/gwt-core/src/usage/state.rs
+++ b/crates/gwt-core/src/usage/state.rs
@@ -1,0 +1,103 @@
+//! Usage freshness and polling-cadence helpers (SPEC-2970 FR-006/FR-007/FR-012).
+//!
+//! Pure functions with injected `now` so the state machine is deterministic
+//! under test.
+
+use chrono::{DateTime, Duration, Utc};
+
+use super::types::UsageState;
+
+/// Minimum interval between Claude account-usage fetches. The undocumented
+/// `/api/oauth/usage` endpoint 429s aggressively below ~180s, so this is a
+/// hard floor.
+pub const CLAUDE_MIN_FETCH_SECS: i64 = 180;
+
+/// Data older than this is rendered as [`UsageState::Stale`]. Chosen well above
+/// the Claude floor so a single skipped poll does not flap the UI.
+pub const DEFAULT_STALE_AFTER_SECS: i64 = 600;
+
+/// Whether a Claude account fetch is allowed now given the last fetch instant.
+/// Returns `true` when never fetched or when at least [`CLAUDE_MIN_FETCH_SECS`]
+/// have elapsed.
+pub fn should_fetch_claude(last_fetch: Option<DateTime<Utc>>, now: DateTime<Utc>) -> bool {
+    match last_fetch {
+        None => true,
+        Some(last) => now.signed_duration_since(last) >= Duration::seconds(CLAUDE_MIN_FETCH_SECS),
+    }
+}
+
+/// Age in whole seconds since `fetched_at`, clamped to `0`.
+pub fn age_secs(fetched_at: DateTime<Utc>, now: DateTime<Utc>) -> u64 {
+    now.signed_duration_since(fetched_at).num_seconds().max(0) as u64
+}
+
+/// True when `fetched_at` is older than `stale_after_secs`.
+pub fn is_stale(fetched_at: DateTime<Utc>, now: DateTime<Utc>, stale_after_secs: i64) -> bool {
+    now.signed_duration_since(fetched_at) > Duration::seconds(stale_after_secs)
+}
+
+/// Promote an `Ok` state to `Stale` when its data has aged past the threshold.
+/// Non-`Ok` states pass through unchanged.
+pub fn apply_staleness(
+    state: UsageState,
+    fetched_at: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+    stale_after_secs: i64,
+) -> UsageState {
+    match (&state, fetched_at) {
+        (UsageState::Ok, Some(at)) if is_stale(at, now, stale_after_secs) => UsageState::Stale {
+            age_secs: age_secs(at, now),
+        },
+        _ => state,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t(secs: i64) -> DateTime<Utc> {
+        DateTime::from_timestamp(1_780_000_000 + secs, 0).unwrap()
+    }
+
+    #[test]
+    fn first_fetch_always_allowed() {
+        assert!(should_fetch_claude(None, t(0)));
+    }
+
+    #[test]
+    fn fetch_blocked_within_floor() {
+        assert!(!should_fetch_claude(Some(t(0)), t(120)));
+        assert!(should_fetch_claude(Some(t(0)), t(180)));
+        assert!(should_fetch_claude(Some(t(0)), t(500)));
+    }
+
+    #[test]
+    fn age_never_negative() {
+        assert_eq!(age_secs(t(100), t(50)), 0);
+        assert_eq!(age_secs(t(0), t(42)), 42);
+    }
+
+    #[test]
+    fn ok_becomes_stale_after_threshold() {
+        let out = apply_staleness(UsageState::Ok, Some(t(0)), t(700), DEFAULT_STALE_AFTER_SECS);
+        assert_eq!(out, UsageState::Stale { age_secs: 700 });
+    }
+
+    #[test]
+    fn fresh_ok_unchanged() {
+        let out = apply_staleness(UsageState::Ok, Some(t(0)), t(120), DEFAULT_STALE_AFTER_SECS);
+        assert_eq!(out, UsageState::Ok);
+    }
+
+    #[test]
+    fn non_ok_states_pass_through() {
+        let out = apply_staleness(
+            UsageState::Disabled,
+            Some(t(0)),
+            t(10_000),
+            DEFAULT_STALE_AFTER_SECS,
+        );
+        assert_eq!(out, UsageState::Disabled);
+    }
+}

--- a/crates/gwt-core/src/usage/types.rs
+++ b/crates/gwt-core/src/usage/types.rs
@@ -1,0 +1,266 @@
+//! Core domain types for provider usage and rate-limit display (SPEC-2970).
+//!
+//! Two axes are modeled here:
+//! - account-level usage ([`ProviderUsage`]): a shared pool per provider
+//!   account (Codex / Claude Code), holding rolling/weekly/sub windows.
+//! - per-session usage ([`SessionUsage`]): tokens and context occupancy for a
+//!   single agent session.
+//!
+//! All percentages are clamped to `[0, 100]`. Reset instants are optional
+//! because upstream payloads do not always include them.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A usage pool owner. Each variant maps to one CLI account.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UsageProvider {
+    Codex,
+    ClaudeCode,
+}
+
+impl UsageProvider {
+    /// Stable wire identifier used in the frontend protocol.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            UsageProvider::Codex => "codex",
+            UsageProvider::ClaudeCode => "claude_code",
+        }
+    }
+}
+
+/// The kind of rate-limit window an account exposes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WindowKind {
+    /// 5-hour rolling window (Codex `primary` / Claude `five_hour`).
+    FiveHour,
+    /// 7-day window (Codex `secondary` / Claude `seven_day`).
+    Weekly,
+    /// Claude Opus-specific weekly sub-limit (`seven_day_opus`).
+    OpusWeekly,
+    /// Claude Sonnet-specific weekly sub-limit (`seven_day_sonnet`).
+    SonnetWeekly,
+    /// Codex code-review weekly sub-limit.
+    CodeReviewWeekly,
+}
+
+impl WindowKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            WindowKind::FiveHour => "five_hour",
+            WindowKind::Weekly => "weekly",
+            WindowKind::OpusWeekly => "opus_weekly",
+            WindowKind::SonnetWeekly => "sonnet_weekly",
+            WindowKind::CodeReviewWeekly => "code_review_weekly",
+        }
+    }
+}
+
+/// Clamp a raw utilization percentage into the valid `[0, 100]` range.
+pub fn clamp_percent(value: f32) -> f32 {
+    if value.is_nan() {
+        0.0
+    } else {
+        value.clamp(0.0, 100.0)
+    }
+}
+
+/// One rate-limit window with current utilization and optional reset instant.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UsageWindow {
+    pub kind: WindowKind,
+    pub used_percent: f32,
+    pub resets_at: Option<DateTime<Utc>>,
+}
+
+impl UsageWindow {
+    /// Build a window, clamping `used_percent` into `[0, 100]`.
+    pub fn new(kind: WindowKind, used_percent: f32, resets_at: Option<DateTime<Utc>>) -> Self {
+        Self {
+            kind,
+            used_percent: clamp_percent(used_percent),
+            resets_at,
+        }
+    }
+}
+
+/// Display state for a usage row. This is the single source of truth for
+/// graceful-degradation rendering.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum UsageState {
+    /// Fresh data is available.
+    Ok,
+    /// Collection is intentionally disabled (e.g. Claude account not opted in).
+    Disabled,
+    /// Enabled but no source data yet (e.g. no Codex session created).
+    NoData,
+    /// A fetch attempt failed; carries a short human reason.
+    Unavailable { reason: String },
+    /// Data exists but is older than the freshness threshold.
+    Stale { age_secs: u64 },
+}
+
+/// Account-level usage for one provider (shared pool).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ProviderUsage {
+    pub provider: UsageProvider,
+    pub plan: Option<String>,
+    pub windows: Vec<UsageWindow>,
+    pub limit_reached: bool,
+    pub state: UsageState,
+    pub fetched_at: Option<DateTime<Utc>>,
+}
+
+impl ProviderUsage {
+    /// A non-Ok placeholder carrying only provider + state.
+    pub fn degraded(provider: UsageProvider, state: UsageState) -> Self {
+        Self {
+            provider,
+            plan: None,
+            windows: Vec::new(),
+            limit_reached: false,
+            state,
+            fetched_at: None,
+        }
+    }
+}
+
+/// Per-session usage for a single agent session.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionUsage {
+    pub session_id: String,
+    pub provider: UsageProvider,
+    pub model: Option<String>,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub total_tokens: u64,
+    /// Tokens currently occupying the context window, when derivable.
+    pub context_used_tokens: Option<u64>,
+    /// Model context window size, when known.
+    pub context_limit_tokens: Option<u64>,
+    /// Remaining context as a percentage `[0, 100]`, when both above are known.
+    pub context_left_pct: Option<f32>,
+    pub limit_reached: bool,
+    /// Whether this session participates in subscription usage display.
+    /// API-key backends and non-target agents are `eligible == false`.
+    pub eligible: bool,
+    pub state: UsageState,
+}
+
+impl SessionUsage {
+    /// Compute `context_left_pct` from used/limit, returning `None` when the
+    /// limit is unknown or zero. Result is clamped to `[0, 100]`.
+    pub fn context_left_from(used: Option<u64>, limit: Option<u64>) -> Option<f32> {
+        match (used, limit) {
+            (Some(used), Some(limit)) if limit > 0 => {
+                let remaining = limit.saturating_sub(used) as f32 / limit as f32 * 100.0;
+                Some(clamp_percent(remaining))
+            }
+            _ => None,
+        }
+    }
+}
+
+/// A complete usage poll result: all account rows + all session rows + the
+/// daily/weekly consumption rollups.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct UsageSnapshot {
+    pub accounts: Vec<ProviderUsage>,
+    pub sessions: Vec<SessionUsage>,
+    #[serde(default)]
+    pub consumption: Vec<super::consumption::ProviderConsumption>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percent_is_clamped() {
+        assert_eq!(clamp_percent(-5.0), 0.0);
+        assert_eq!(clamp_percent(150.0), 100.0);
+        assert_eq!(clamp_percent(42.5), 42.5);
+        assert_eq!(clamp_percent(f32::NAN), 0.0);
+    }
+
+    #[test]
+    fn window_new_clamps_percent() {
+        let w = UsageWindow::new(WindowKind::Weekly, 250.0, None);
+        assert_eq!(w.used_percent, 100.0);
+        assert_eq!(w.kind, WindowKind::Weekly);
+    }
+
+    #[test]
+    fn context_left_handles_unknown_and_zero_limit() {
+        assert_eq!(SessionUsage::context_left_from(Some(10), None), None);
+        assert_eq!(SessionUsage::context_left_from(None, Some(100)), None);
+        assert_eq!(SessionUsage::context_left_from(Some(10), Some(0)), None);
+        assert_eq!(
+            SessionUsage::context_left_from(Some(25), Some(100)),
+            Some(75.0)
+        );
+        // Over-budget context never goes negative.
+        assert_eq!(
+            SessionUsage::context_left_from(Some(200), Some(100)),
+            Some(0.0)
+        );
+    }
+
+    #[test]
+    fn provider_wire_ids_are_stable() {
+        assert_eq!(UsageProvider::Codex.as_str(), "codex");
+        assert_eq!(UsageProvider::ClaudeCode.as_str(), "claude_code");
+    }
+
+    #[test]
+    fn state_serializes_with_tag() {
+        let json = serde_json::to_string(&UsageState::Unavailable {
+            reason: "http 429".into(),
+        })
+        .unwrap();
+        assert!(json.contains("\"kind\":\"unavailable\""));
+        assert!(json.contains("\"reason\":\"http 429\""));
+        let round: UsageState = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            round,
+            UsageState::Unavailable {
+                reason: "http 429".into()
+            }
+        );
+    }
+
+    #[test]
+    fn snapshot_roundtrips() {
+        let snap = UsageSnapshot {
+            accounts: vec![ProviderUsage {
+                provider: UsageProvider::Codex,
+                plan: Some("pro".into()),
+                windows: vec![UsageWindow::new(WindowKind::FiveHour, 12.0, None)],
+                limit_reached: false,
+                state: UsageState::Ok,
+                fetched_at: None,
+            }],
+            sessions: vec![SessionUsage {
+                session_id: "s1".into(),
+                provider: UsageProvider::ClaudeCode,
+                model: Some("claude-opus-4-7".into()),
+                input_tokens: 10,
+                output_tokens: 5,
+                total_tokens: 15,
+                context_used_tokens: Some(50),
+                context_limit_tokens: Some(200),
+                context_left_pct: Some(75.0),
+                limit_reached: false,
+                eligible: true,
+                state: UsageState::Ok,
+            }],
+            consumption: Vec::new(),
+        };
+        let json = serde_json::to_string(&snap).unwrap();
+        let round: UsageSnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(snap, round);
+    }
+}

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -438,6 +438,11 @@ fn summarize_ui_action_values<'a>(values: impl IntoIterator<Item = &'a str>) -> 
 fn frontend_user_action_log(event: &FrontendEvent) -> Option<FrontendUserActionLog> {
     let log = match event {
         FrontendEvent::FrontendReady => FrontendUserActionLog::new("frontend_ready", "app"),
+        FrontendEvent::SetClaudeAccountUsageEnabled { enabled } => {
+            FrontendUserActionLog::new("set_claude_account_usage_enabled", "usage")
+                .mode(if *enabled { "on" } else { "off" })
+        }
+        FrontendEvent::RefreshUsage => FrontendUserActionLog::new("refresh_usage", "usage"),
         FrontendEvent::OpenProjectDialog => {
             FrontendUserActionLog::new("open_project_dialog", "project")
         }
@@ -3236,6 +3241,10 @@ pub struct AppRuntime {
     /// AppRuntime construction or unit tests that never call
     /// `set_server_url`).
     pub(crate) server_url: Option<String>,
+    /// SPEC-2970: notifies the background usage poller to refresh immediately
+    /// (e.g. after the Claude opt-in toggle changes). `None` in unit tests and
+    /// before `set_usage_refresh` is called during startup wiring.
+    pub(crate) usage_refresh: Option<std::sync::Arc<tokio::sync::Notify>>,
 }
 
 impl ProjectTabRuntime {
@@ -3325,6 +3334,7 @@ impl AppRuntime {
             persist_dispatcher,
             file_tree_worktree_roots: HashMap::new(),
             server_url: None,
+            usage_refresh: None,
         };
         app.rebuild_window_lookup();
         app.seed_window_pty_statuses();
@@ -3738,6 +3748,32 @@ impl AppRuntime {
         self.server_url = Some(url);
     }
 
+    /// SPEC-2970: wire the usage poller's refresh handle so frontend toggles
+    /// can request an immediate re-poll.
+    pub(crate) fn set_usage_refresh(&mut self, refresh: std::sync::Arc<tokio::sync::Notify>) {
+        self.usage_refresh = Some(refresh);
+    }
+
+    /// SPEC-2970 FR-009/FR-013: persist the Claude account-usage opt-in and
+    /// request an immediate refresh.
+    fn set_claude_account_usage_enabled_events(&self, enabled: bool) -> Vec<OutboundEvent> {
+        if let Err(error) = gwt_config::Settings::update_global(|settings| {
+            settings.usage.claude_account_enabled = enabled;
+            Ok(())
+        }) {
+            tracing::warn!(%error, "failed to persist Claude usage opt-in");
+        }
+        self.request_usage_refresh_events()
+    }
+
+    /// SPEC-2970 FR-022: nudge the background poller to refresh now.
+    fn request_usage_refresh_events(&self) -> Vec<OutboundEvent> {
+        if let Some(refresh) = &self.usage_refresh {
+            refresh.notify_one();
+        }
+        Vec::new()
+    }
+
     pub(crate) fn handle_frontend_event(
         &mut self,
         client_id: ClientId,
@@ -3745,7 +3781,20 @@ impl AppRuntime {
     ) -> Vec<OutboundEvent> {
         log_frontend_user_action(&client_id, &event);
         match event {
-            FrontendEvent::FrontendReady => self.frontend_sync_events(&client_id),
+            FrontendEvent::FrontendReady => {
+                // SPEC-2970: kick an immediate usage poll on connect so the
+                // status-bar pill populates right away instead of waiting for
+                // the next 30s poller tick (otherwise a freshly loaded page
+                // shows an empty usage cell).
+                if let Some(refresh) = &self.usage_refresh {
+                    refresh.notify_one();
+                }
+                self.frontend_sync_events(&client_id)
+            }
+            FrontendEvent::SetClaudeAccountUsageEnabled { enabled } => {
+                self.set_claude_account_usage_enabled_events(enabled)
+            }
+            FrontendEvent::RefreshUsage => self.request_usage_refresh_events(),
             FrontendEvent::StartupAutoResumeReady { bounds } => {
                 self.startup_auto_resume_ready_events(bounds)
             }
@@ -10860,6 +10909,7 @@ exit 1
             persist_dispatcher,
             file_tree_worktree_roots: HashMap::new(),
             server_url: None,
+            usage_refresh: None,
         };
         runtime.rebuild_window_lookup();
         runtime.seed_window_pty_statuses();

--- a/crates/gwt/src/embedded_server.rs
+++ b/crates/gwt/src/embedded_server.rs
@@ -118,6 +118,16 @@ impl ClientHub {
             .remove(client_id);
     }
 
+    /// SPEC-2970 FR-007: whether any GUI client is currently connected. The
+    /// usage poller skips work entirely when no one is watching.
+    pub fn has_clients(&self) -> bool {
+        !self
+            .clients
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_empty()
+    }
+
     pub(super) fn dispatch(&self, events: Vec<OutboundEvent>) {
         // Snapshot sender clones under a short-lived lock so that serialization
         // and per-client try_send work happen outside the registry mutex. This

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -46,6 +46,7 @@ mod project_index_bootstrap;
 mod repo_browser;
 mod runtime_support;
 mod update_front_door;
+mod usage_poller;
 
 #[cfg(test)]
 pub(crate) fn env_test_lock() -> &'static std::sync::Mutex<()> {
@@ -2130,6 +2131,7 @@ mod tests {
             persist_dispatcher,
             file_tree_worktree_roots: HashMap::new(),
             server_url: None,
+            usage_refresh: None,
         };
         runtime.rebuild_window_lookup();
         runtime.seed_window_pty_statuses();
@@ -6408,6 +6410,11 @@ fn main() -> std::io::Result<()> {
     // SPEC-2785 FR-E: hand the bound URL to AppRuntime so
     // `open_server_url_events` can gate `OpenServerUrl` requests against it.
     app.set_server_url(browser_url.clone());
+    // SPEC-2970: background provider-usage poller. The shared Notify lets the
+    // Claude opt-in toggle request an immediate refresh.
+    let usage_refresh = std::sync::Arc::new(tokio::sync::Notify::new());
+    app.set_usage_refresh(usage_refresh.clone());
+    usage_poller::spawn_usage_poller(&runtime, clients.clone(), usage_refresh);
     eprintln!("gwt browser URL: {browser_url}");
     // SPEC-1939 T-IDX-109/110 / Issue #2584 — Playwright e2e seam.
     // When `GWT_BROWSER_URL_FILE` is set, the embedded server URL is also

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -182,6 +182,12 @@ pub enum FileAttachment {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum FrontendEvent {
     FrontendReady,
+    /// Toggle Claude account-usage collection (SPEC-2970 FR-009).
+    SetClaudeAccountUsageEnabled {
+        enabled: bool,
+    },
+    /// Request an immediate usage refresh (SPEC-2970 FR-022).
+    RefreshUsage,
     StartupAutoResumeReady {
         bounds: WindowGeometry,
     },
@@ -1004,6 +1010,14 @@ pub enum BackendEvent {
     WindowList {
         windows: Vec<PersistedWindowState>,
     },
+    /// Provider usage snapshot: account-level windows + per-session usage +
+    /// daily/weekly consumption (SPEC-2970 FR-010). Reuses the gwt-core domain
+    /// types directly.
+    ProviderUsage {
+        accounts: Vec<gwt_core::usage::ProviderUsage>,
+        sessions: Vec<gwt_core::usage::SessionUsage>,
+        consumption: Vec<gwt_core::usage::ProviderConsumption>,
+    },
     TerminalOutput {
         id: String,
         data_base64: String,
@@ -1569,6 +1583,11 @@ pub const BACKEND_EVENT_POLICIES: &[BackendEventPolicy] = &[
         BackendEventBackpressurePolicy::LatestWins,
     ),
     BackendEventPolicy::new(
+        "provider_usage",
+        BackendEventDeliveryClass::IdempotentLatest,
+        BackendEventBackpressurePolicy::LatestWins,
+    ),
+    BackendEventPolicy::new(
         "terminal_output",
         BackendEventDeliveryClass::Streamed,
         BackendEventBackpressurePolicy::PreserveOrder,
@@ -1968,6 +1987,7 @@ impl BackendEvent {
             BackendEvent::WorkspaceState { .. } => "workspace_state",
             BackendEvent::ActiveWorkProjection { .. } => "active_work_projection",
             BackendEvent::WindowList { .. } => "window_list",
+            BackendEvent::ProviderUsage { .. } => "provider_usage",
             BackendEvent::TerminalOutput { .. } => "terminal_output",
             BackendEvent::TerminalSnapshot { .. } => "terminal_snapshot",
             BackendEvent::TerminalStatus { .. } => "terminal_status",

--- a/crates/gwt/src/usage_poller.rs
+++ b/crates/gwt/src/usage_poller.rs
@@ -1,0 +1,407 @@
+//! Background provider-usage poller (SPEC-2970).
+//!
+//! Runs as a tokio task for the lifetime of the GUI process but only does work
+//! while at least one WebSocket client is connected (FR-007). Each tick it
+//! builds a [`UsageSnapshot`] and broadcasts it as
+//! [`BackendEvent::ProviderUsage`].
+//!
+//! Account-level usage is sourced here:
+//! - Codex: local rollout files (always allowed when enabled).
+//! - Claude: undocumented `/api/oauth/usage`, opt-in, rate-limited to
+//!   `CLAUDE_MIN_FETCH_SECS`; the last successful result is cached between
+//!   fetch windows so the UI keeps showing the value (with staleness applied).
+//!
+//! Per-session rows are gathered by [`collect_sessions`], which enumerates the
+//! gwt session store and reads each session's local rollout / transcript.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use gwt_agent::{AgentId, AgentStatus, Session};
+use gwt_config::{usage_config::UsageConfig, Settings};
+use gwt_core::usage::{
+    claude, codex, consumption,
+    state::{apply_staleness, should_fetch_claude, DEFAULT_STALE_AFTER_SECS},
+    ProviderConsumption, ProviderUsage, SessionUsage, UsageProvider, UsageSnapshot, UsageState,
+    WindowKind,
+};
+use tokio::sync::Notify;
+use tokio::time::{interval, MissedTickBehavior};
+
+use crate::embedded_server::ClientHub;
+use crate::OutboundEvent;
+use gwt::BackendEvent;
+
+/// Base polling cadence. Codex (local) refreshes every tick; Claude is further
+/// gated by [`should_fetch_claude`].
+const TICK_SECS: u64 = 30;
+
+/// Consumption aggregation scans many local files, so it is recomputed at most
+/// this often (or immediately on a forced refresh).
+const CONSUMPTION_CACHE_SECS: i64 = 300;
+
+/// Spawn the usage poller onto the shared tokio runtime.
+pub fn spawn_usage_poller(
+    runtime: &tokio::runtime::Runtime,
+    clients: ClientHub,
+    refresh: Arc<Notify>,
+) {
+    drop(runtime.handle().spawn(run(clients, refresh)));
+}
+
+async fn run(clients: ClientHub, refresh: Arc<Notify>) {
+    let mut poller = Poller::default();
+    let mut ticker = interval(Duration::from_secs(TICK_SECS));
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    loop {
+        // A refresh request forces an immediate Claude re-fetch (bypassing the
+        // 180s cadence gate); a normal tick respects it.
+        let forced = tokio::select! {
+            _ = ticker.tick() => false,
+            _ = refresh.notified() => true,
+        };
+        // FR-007: do nothing (no network, no credential access) when the GUI
+        // is closed.
+        if !clients.has_clients() {
+            continue;
+        }
+        let snapshot = poller.poll_once(Utc::now(), forced).await;
+        clients.dispatch(vec![OutboundEvent::broadcast(
+            BackendEvent::ProviderUsage {
+                accounts: snapshot.accounts,
+                sessions: snapshot.sessions,
+                consumption: snapshot.consumption,
+            },
+        )]);
+    }
+}
+
+/// Mutable state carried across polls (Claude cache + cadence + UA +
+/// consumption cache).
+#[derive(Default)]
+struct Poller {
+    cached_claude: Option<ProviderUsage>,
+    last_claude_fetch: Option<DateTime<Utc>>,
+    cached_user_agent: Option<String>,
+    cached_consumption: Vec<ProviderConsumption>,
+    last_consumption_at: Option<DateTime<Utc>>,
+}
+
+impl Poller {
+    async fn poll_once(&mut self, now: DateTime<Utc>, force: bool) -> UsageSnapshot {
+        let config = Settings::load().unwrap_or_default().usage;
+        let accounts = vec![
+            self.codex_account(&config, now),
+            self.claude_account(&config, now, force).await,
+        ];
+        let consumption = self.consumption(&config, &accounts, now, force);
+        UsageSnapshot {
+            accounts,
+            sessions: collect_sessions(&config),
+            consumption,
+        }
+    }
+
+    /// Daily/weekly consumption rollups. Heavy (scans many files), so it is
+    /// cached for [`CONSUMPTION_CACHE_SECS`] unless `force` is set. The weekly
+    /// window start per provider comes from the account snapshot's weekly
+    /// `resets_at` (FR: "this week" aligned to the rate-limit window).
+    fn consumption(
+        &mut self,
+        config: &UsageConfig,
+        accounts: &[ProviderUsage],
+        now: DateTime<Utc>,
+        force: bool,
+    ) -> Vec<ProviderConsumption> {
+        let due = force
+            || match self.last_consumption_at {
+                None => true,
+                Some(at) => {
+                    now.signed_duration_since(at)
+                        >= chrono::Duration::seconds(CONSUMPTION_CACHE_SECS)
+                }
+            };
+        if !due {
+            return self.cached_consumption.clone();
+        }
+        let mut out = Vec::new();
+        if config.codex_enabled {
+            if let Some(home) = codex::codex_home() {
+                let week_start = week_start_for(accounts, UsageProvider::Codex, now);
+                out.push(consumption::read_codex_consumption(&home, week_start, now));
+            }
+        }
+        // Claude consumption is read from local transcripts only, so it does not
+        // require the account opt-in (mirrors Claude per-session usage).
+        if let Some(home) = claude::claude_home() {
+            let week_start = week_start_for(accounts, UsageProvider::ClaudeCode, now);
+            out.push(consumption::read_claude_consumption(&home, week_start, now));
+        }
+        self.cached_consumption = out.clone();
+        self.last_consumption_at = Some(now);
+        out
+    }
+
+    fn codex_account(&self, config: &UsageConfig, now: DateTime<Utc>) -> ProviderUsage {
+        if !config.codex_enabled {
+            return ProviderUsage::degraded(UsageProvider::Codex, UsageState::Disabled);
+        }
+        let Some(home) = codex::codex_home() else {
+            return ProviderUsage::degraded(UsageProvider::Codex, UsageState::NoData);
+        };
+        let mut account = codex::read_codex_account(&home, now);
+        account.state = apply_staleness(
+            account.state,
+            account.fetched_at,
+            now,
+            DEFAULT_STALE_AFTER_SECS,
+        );
+        account
+    }
+
+    async fn claude_account(
+        &mut self,
+        config: &UsageConfig,
+        now: DateTime<Utc>,
+        force: bool,
+    ) -> ProviderUsage {
+        if !config.claude_account_enabled {
+            return ProviderUsage::degraded(UsageProvider::ClaudeCode, UsageState::Disabled);
+        }
+        let Some(home) = claude::claude_home() else {
+            return ProviderUsage::degraded(UsageProvider::ClaudeCode, UsageState::NoData);
+        };
+
+        if force || should_fetch_claude(self.last_claude_fetch, now) {
+            let Some(creds) = claude::resolve_claude_creds(&home) else {
+                return serve_cached_or(
+                    &self.cached_claude,
+                    now,
+                    ProviderUsage::degraded(
+                        UsageProvider::ClaudeCode,
+                        UsageState::Unavailable {
+                            reason: "no credentials".to_string(),
+                        },
+                    ),
+                );
+            };
+            let user_agent = self
+                .cached_user_agent
+                .get_or_insert_with(claude::claude_user_agent)
+                .clone();
+            let fresh = claude::fetch_claude_account(&creds, &user_agent, now).await;
+            self.last_claude_fetch = Some(now);
+            // Only a successful fetch (has windows) replaces the cache. A
+            // transient failure (429 / auth / network) keeps the last good
+            // value shown as stale instead of wiping the display.
+            if !fresh.windows.is_empty() {
+                self.cached_claude = Some(fresh.clone());
+                return fresh;
+            }
+            return serve_cached_or(&self.cached_claude, now, fresh);
+        }
+
+        // Within the cooldown window: reuse the cached value with staleness.
+        serve_cached_or(
+            &self.cached_claude,
+            now,
+            ProviderUsage::degraded(UsageProvider::ClaudeCode, UsageState::NoData),
+        )
+    }
+}
+
+/// Serve the last good cached account (as stale) when present, else the given
+/// fallback. Keeps a transient fetch failure (e.g. 429) from wiping a usable
+/// display. "Good" = the cached value carries windows.
+fn serve_cached_or(
+    cached: &Option<ProviderUsage>,
+    now: DateTime<Utc>,
+    fallback: ProviderUsage,
+) -> ProviderUsage {
+    match cached {
+        Some(c) if !c.windows.is_empty() => {
+            let mut c = c.clone();
+            c.state = apply_staleness(c.state, c.fetched_at, now, DEFAULT_STALE_AFTER_SECS);
+            c
+        }
+        _ => fallback,
+    }
+}
+
+/// Start instant of the weekly consumption window: the provider's weekly
+/// rate-limit `resets_at` minus 7 days, or a rolling 7-day fallback.
+fn week_start_for(
+    accounts: &[ProviderUsage],
+    provider: UsageProvider,
+    now: DateTime<Utc>,
+) -> DateTime<Utc> {
+    accounts
+        .iter()
+        .find(|a| a.provider == provider)
+        .and_then(|a| a.windows.iter().find(|w| w.kind == WindowKind::Weekly))
+        .and_then(|w| w.resets_at)
+        .map(|reset| reset - chrono::Duration::days(7))
+        .unwrap_or_else(|| now - chrono::Duration::days(7))
+}
+
+/// Map a gwt agent id to a usage provider (only Codex / Claude Code are in
+/// scope; FR-014).
+fn session_provider(agent_id: &AgentId) -> Option<UsageProvider> {
+    match agent_id {
+        AgentId::Codex => Some(UsageProvider::Codex),
+        AgentId::ClaudeCode => Some(UsageProvider::ClaudeCode),
+        _ => None,
+    }
+}
+
+/// Whether a session is currently active enough to show per-session usage.
+fn is_active_status(status: AgentStatus) -> bool {
+    matches!(
+        status,
+        AgentStatus::Running
+            | AgentStatus::Idle
+            | AgentStatus::WaitingInput
+            | AgentStatus::Interrupted
+    )
+}
+
+/// SPEC-2970 FR-015..FR-020: enumerate active gwt sessions and build their
+/// per-session usage from local rollout / transcript files. Keyed by the gwt
+/// session id so the frontend can match it to agent cards. Per-session reads
+/// are local-only; Claude does not require the account opt-in here.
+fn collect_sessions(config: &UsageConfig) -> Vec<SessionUsage> {
+    let mut out = Vec::new();
+    let dir = gwt_core::paths::gwt_sessions_dir();
+    let codex_home = codex::codex_home();
+    let claude_home = claude::claude_home();
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("toml") {
+            continue;
+        }
+        let Ok(session) = Session::load_and_migrate(&path) else {
+            continue;
+        };
+        if !is_active_status(session.status) {
+            continue;
+        }
+        let Some(provider) = session_provider(&session.agent_id) else {
+            continue;
+        };
+        let Some(agent_sid) = session.agent_session_id.clone() else {
+            continue;
+        };
+        let usage = match provider {
+            UsageProvider::Codex => {
+                if !config.codex_enabled {
+                    continue;
+                }
+                codex_home
+                    .as_ref()
+                    .and_then(|home| codex::read_codex_session(home, &agent_sid))
+            }
+            UsageProvider::ClaudeCode => claude_home
+                .as_ref()
+                .and_then(|home| claude::read_claude_session(home, &agent_sid)),
+        };
+        if let Some(mut usage) = usage {
+            // Re-key to the gwt session id (frontend agent cards use it) and
+            // mark API-key backend sessions ineligible for subscription frames.
+            usage.session_id = session.id.clone();
+            usage.eligible = session.backend_id.is_none();
+            out.push(usage);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now() -> DateTime<Utc> {
+        DateTime::from_timestamp(1_780_000_000, 0).unwrap()
+    }
+
+    #[test]
+    fn serve_cached_keeps_last_good_on_failure() {
+        let when = now();
+        let good = ProviderUsage {
+            provider: UsageProvider::ClaudeCode,
+            plan: Some("max".into()),
+            windows: vec![gwt_core::usage::UsageWindow::new(
+                WindowKind::FiveHour,
+                19.0,
+                None,
+            )],
+            limit_reached: false,
+            state: UsageState::Ok,
+            fetched_at: Some(when),
+        };
+        let fail = ProviderUsage::degraded(
+            UsageProvider::ClaudeCode,
+            UsageState::Unavailable {
+                reason: "rate limited (429)".into(),
+            },
+        );
+        // A transient failure must not wipe a usable cached value.
+        let served = serve_cached_or(&Some(good), when, fail.clone());
+        assert!(!served.windows.is_empty());
+        assert_eq!(served.plan.as_deref(), Some("max"));
+        // No cache → fallback is returned.
+        let served2 = serve_cached_or(&None, when, fail);
+        assert!(served2.windows.is_empty());
+        assert!(matches!(served2.state, UsageState::Unavailable { .. }));
+    }
+
+    #[test]
+    fn provider_mapping_scopes_to_codex_and_claude() {
+        assert_eq!(
+            session_provider(&AgentId::Codex),
+            Some(UsageProvider::Codex)
+        );
+        assert_eq!(
+            session_provider(&AgentId::ClaudeCode),
+            Some(UsageProvider::ClaudeCode)
+        );
+        assert_eq!(session_provider(&AgentId::Custom("foo".into())), None);
+    }
+
+    #[test]
+    fn active_status_excludes_stopped_and_unknown() {
+        assert!(is_active_status(AgentStatus::Running));
+        assert!(is_active_status(AgentStatus::WaitingInput));
+        assert!(!is_active_status(AgentStatus::Stopped));
+        assert!(!is_active_status(AgentStatus::Unknown));
+    }
+
+    #[test]
+    fn codex_disabled_yields_disabled_state() {
+        let poller = Poller::default();
+        let config = UsageConfig {
+            codex_enabled: false,
+            claude_account_enabled: false,
+        };
+        let account = poller.codex_account(&config, now());
+        assert_eq!(account.provider, UsageProvider::Codex);
+        assert_eq!(account.state, UsageState::Disabled);
+    }
+
+    #[tokio::test]
+    async fn claude_disabled_yields_disabled_state() {
+        let mut poller = Poller::default();
+        let config = UsageConfig {
+            codex_enabled: true,
+            claude_account_enabled: false,
+        };
+        let account = poller.claude_account(&config, now(), false).await;
+        assert_eq!(account.provider, UsageProvider::ClaudeCode);
+        assert_eq!(account.state, UsageState::Disabled);
+        // No fetch should have happened.
+        assert!(poller.last_claude_fetch.is_none());
+    }
+}

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -3,7 +3,7 @@
       import { renderBranchCleanupModal as renderBranchCleanupModalView } from "/branch-cleanup-modal.js";
       import { renderMigrationModal as renderMigrationModalView } from "/migration-modal.js";
       import { renderProjectCloneModal as renderProjectCloneModalView } from "/project-clone-modal.js";
-      import { initOperatorShell, applyTelemetryCounts } from "/operator-shell.js";
+      import { initOperatorShell, applyTelemetryCounts, applyProviderUsage } from "/operator-shell.js";
       import { createFocusTrap } from "/focus-trap.js";
       import {
         TITLEBAR_DOCK_HIT_HEIGHT,
@@ -97,6 +97,7 @@
         hotkey: __op.hotkey,
         palette: __op.palette,
         applyTelemetryCounts: (counts) => applyTelemetryCounts(document, counts),
+        applyProviderUsage: (snapshot) => applyProviderUsage(document, snapshot),
       };
 
       const uiTraceProfiler = createUiTraceProfiler();
@@ -3168,6 +3169,506 @@
         }
       }
 
+      // ---- Provider usage & rate limits (SPEC-2970) ----
+      let latestProviderUsage = { accounts: [], sessions: [], consumption: [] };
+
+      const USAGE_PROVIDER_NAME = { codex: "Codex", claude_code: "Claude Code" };
+      const USAGE_WINDOW_LABEL = {
+        five_hour: "5-hour",
+        weekly: "Weekly",
+        opus_weekly: "Opus weekly",
+        sonnet_weekly: "Sonnet weekly",
+        code_review_weekly: "Code review weekly",
+      };
+
+      function usageStateReason(state) {
+        if (!state) return "";
+        switch (state.kind) {
+          case "disabled":
+            return "Enable in Settings";
+          case "no_data":
+            return "No data yet";
+          case "unavailable":
+            return state.reason ? `Unavailable — ${state.reason}` : "Unavailable";
+          case "stale":
+            return `stale ${Math.round((state.age_secs || 0) / 60)}m`;
+          default:
+            return "";
+        }
+      }
+
+      function usageFmtResetAt(iso) {
+        if (!iso) return "";
+        const d = new Date(iso);
+        if (Number.isNaN(d.getTime())) return "";
+        return d.toLocaleString();
+      }
+
+      function usageFmtTokens(n) {
+        if (n == null) return "—";
+        if (n >= 1000000) return `${(n / 1000000).toFixed(1)}M`;
+        if (n >= 1000) return `${Math.round(n / 1000)}k`;
+        return String(n);
+      }
+
+      function applyProviderUsageUi(snapshot) {
+        latestProviderUsage = snapshot || { accounts: [], sessions: [], consumption: [] };
+        try {
+          window.__operatorShell?.applyProviderUsage?.(latestProviderUsage);
+        } catch (e) {
+          console.warn("usage pill update failed", e);
+        }
+        try {
+          refreshUsageHoverIfOpen();
+        } catch {
+          /* no-op */
+        }
+        if ((latestProviderUsage.sessions || []).length) {
+          try {
+            renderActiveWorkOverview();
+          } catch {
+            /* no-op */
+          }
+        }
+      }
+
+      function usageForSession(sessionId) {
+        return (
+          (latestProviderUsage.sessions || []).find(
+            (s) => s.session_id === sessionId,
+          ) || null
+        );
+      }
+
+      function buildUsageBar(percent) {
+        const wrap = document.createElement("div");
+        wrap.className = "op-usage-bar";
+        const fill = document.createElement("div");
+        fill.className = "op-usage-bar__fill";
+        const pct = Math.max(0, Math.min(100, Math.round(percent)));
+        fill.style.width = `${pct}%`;
+        if (pct >= 90) fill.dataset.level = "high";
+        else if (pct >= 70) fill.dataset.level = "mid";
+        wrap.appendChild(fill);
+        return wrap;
+      }
+
+      function renderUsageAccountRow(account) {
+        const row = document.createElement("div");
+        row.className = "op-usage-account";
+        row.dataset.provider = account.provider;
+        const head = document.createElement("div");
+        head.className = "op-usage-account__head";
+        const name = document.createElement("span");
+        name.className = "op-usage-account__name";
+        name.textContent = USAGE_PROVIDER_NAME[account.provider] || account.provider;
+        head.appendChild(name);
+        if (account.plan) {
+          const plan = document.createElement("span");
+          plan.className = "op-usage-account__plan";
+          plan.textContent = account.plan;
+          head.appendChild(plan);
+        }
+        const reason = usageStateReason(account.state);
+        if (reason) {
+          const isDisabled = (account.state && account.state.kind) === "disabled";
+          const r = document.createElement(isDisabled ? "button" : "span");
+          r.className = "op-usage-account__reason";
+          r.textContent = reason;
+          if (isDisabled) {
+            r.type = "button";
+            r.classList.add("op-usage-account__reason--action");
+            r.addEventListener("click", (e) => {
+              e.stopPropagation();
+              if (typeof window.__gwtHideUsageHover === "function") {
+                window.__gwtHideUsageHover();
+              }
+              document.dispatchEvent(
+                new CustomEvent("settings:open", { detail: { target: "usage" } }),
+              );
+            });
+          }
+          head.appendChild(r);
+        }
+        row.appendChild(head);
+        for (const w of account.windows || []) {
+          const line = document.createElement("div");
+          line.className = "op-usage-window";
+          const label = document.createElement("span");
+          label.className = "op-usage-window__label";
+          label.textContent = USAGE_WINDOW_LABEL[w.kind] || w.kind;
+          const pct = document.createElement("span");
+          pct.className = "op-usage-window__pct";
+          pct.textContent = `${Math.round(w.used_percent)}%`;
+          line.appendChild(label);
+          line.appendChild(buildUsageBar(w.used_percent));
+          line.appendChild(pct);
+          if (w.resets_at) {
+            const reset = document.createElement("span");
+            reset.className = "op-usage-window__reset";
+            reset.textContent = `↻ ${usageFmtResetAt(w.resets_at)}`;
+            line.appendChild(reset);
+          }
+          row.appendChild(line);
+        }
+        return row;
+      }
+
+      function renderUsageSessionsTable(sessions) {
+        const table = document.createElement("table");
+        table.className = "op-usage-sessions";
+        const thead = document.createElement("thead");
+        const htr = document.createElement("tr");
+        for (const h of ["Session", "Prov", "Model", "Tokens", "Ctx", "Lim"]) {
+          const th = document.createElement("th");
+          th.textContent = h;
+          htr.appendChild(th);
+        }
+        thead.appendChild(htr);
+        table.appendChild(thead);
+        const tbody = document.createElement("tbody");
+        for (const s of sessions) {
+          const tr = document.createElement("tr");
+          if (s.eligible === false) tr.dataset.ineligible = "true";
+          const cells = [
+            s.session_id ? s.session_id.slice(0, 8) : "—",
+            s.provider === "claude_code" ? "Cl" : "Cx",
+            s.model || "—",
+            usageFmtTokens(s.total_tokens),
+            s.context_left_pct != null ? `${Math.round(s.context_left_pct)}%` : "—",
+            s.limit_reached ? "⚠" : "ok",
+          ];
+          for (const c of cells) {
+            const td = document.createElement("td");
+            td.textContent = c;
+            tr.appendChild(td);
+          }
+          tbody.appendChild(tr);
+        }
+        table.appendChild(tbody);
+        return table;
+      }
+
+      function consumptionTotal(b) {
+        if (!b) return 0;
+        return (b.input || 0) + (b.output || 0) + (b.cached || 0);
+      }
+
+      function fmtConsumptionBreakdown(b) {
+        if (!b) return "—";
+        return `in ${usageFmtTokens(b.input || 0)} · out ${usageFmtTokens(
+          b.output || 0,
+        )} · cached ${usageFmtTokens(b.cached || 0)}`;
+      }
+
+      function renderConsumptionChart(days) {
+        const chart = document.createElement("div");
+        chart.className = "op-usage-chart";
+        const totals = days.map((d) => consumptionTotal(d.breakdown));
+        const max = Math.max(1, ...totals);
+        days.forEach((d, i) => {
+          const col = document.createElement("div");
+          col.className = "op-usage-chart__col";
+          if (i === days.length - 1) col.dataset.today = "true";
+          const bar = document.createElement("div");
+          bar.className = "op-usage-chart__bar";
+          const total = totals[i];
+          bar.style.height = `${Math.max(2, Math.round((total / max) * 100))}%`;
+          bar.title = `${d.date}: ${usageFmtTokens(total)} tokens`;
+          col.appendChild(bar);
+          chart.appendChild(col);
+        });
+        return chart;
+      }
+
+      function usageFmtResetShort(iso) {
+        if (!iso) return "";
+        const d = new Date(iso);
+        if (Number.isNaN(d.getTime())) return "";
+        return d.toLocaleString(undefined, {
+          month: "numeric",
+          day: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+        });
+      }
+
+      function usageConsumptionFor(provider) {
+        return (
+          (latestProviderUsage.consumption || []).find((c) => c.provider === provider) || null
+        );
+      }
+
+      // One rate-limit window as an aligned row: label · bar · % · reset.
+      function buildUsageWindowRow(w) {
+        const row = document.createElement("div");
+        row.className = "op-usage-win";
+        const lbl = document.createElement("span");
+        lbl.className = "op-usage-win__lbl";
+        lbl.textContent = USAGE_WINDOW_LABEL[w.kind] || w.kind;
+        const bar = buildUsageBar(w.used_percent);
+        bar.classList.add("op-usage-win__bar");
+        const pct = document.createElement("span");
+        pct.className = "op-usage-win__pct";
+        pct.textContent = `${Math.round(w.used_percent)}%`;
+        const reset = document.createElement("span");
+        reset.className = "op-usage-win__reset";
+        reset.textContent = w.resets_at ? `↻ ${usageFmtResetShort(w.resets_at)}` : "";
+        row.appendChild(lbl);
+        row.appendChild(bar);
+        row.appendChild(pct);
+        row.appendChild(reset);
+        return row;
+      }
+
+      // Consumption as an aligned 4-column grid (period × in/out/cached).
+      function buildUsageConsumptionGrid(pc) {
+        const grid = document.createElement("div");
+        grid.className = "op-usage-cgrid";
+        const t = pc.today || {};
+        const w = pc.this_week || {};
+        const cells = [
+          ["hdr", "tokens"],
+          ["colh", "in"],
+          ["colh", "out"],
+          ["colh", "cached"],
+          ["rowh", "Today"],
+          ["num", usageFmtTokens(t.input || 0)],
+          ["num", usageFmtTokens(t.output || 0)],
+          ["num", usageFmtTokens(t.cached || 0)],
+          ["rowh", "Week"],
+          ["num", usageFmtTokens(w.input || 0)],
+          ["num", usageFmtTokens(w.output || 0)],
+          ["num", usageFmtTokens(w.cached || 0)],
+        ];
+        for (const [kind, text] of cells) {
+          const cell = document.createElement("span");
+          cell.className = `op-usage-cgrid__${kind}`;
+          cell.textContent = text;
+          grid.appendChild(cell);
+        }
+        return grid;
+      }
+
+      // A provider card: header (icon · name · plan) + rate-limit windows (or a
+      // degraded reason) + consumption grid + 7-day sparkline. Grouping all of
+      // one provider's data together is the key readability win.
+      function buildUsageProviderCard(account) {
+        const card = document.createElement("div");
+        card.className = "op-usage-card";
+        card.dataset.provider = account.provider;
+
+        const head = document.createElement("div");
+        head.className = "op-usage-card__head";
+        const icon = document.createElement("span");
+        icon.className = "op-usage-card__icon";
+        icon.textContent = account.provider === "claude_code" ? "◇" : "⬡";
+        const name = document.createElement("span");
+        name.className = "op-usage-card__name";
+        name.textContent = USAGE_PROVIDER_NAME[account.provider] || account.provider;
+        head.appendChild(icon);
+        head.appendChild(name);
+        if (account.plan) {
+          const plan = document.createElement("span");
+          plan.className = "op-usage-card__plan";
+          plan.textContent = account.plan;
+          head.appendChild(plan);
+        }
+        card.appendChild(head);
+
+        const windows = account.windows || [];
+        if (windows.length) {
+          const wins = document.createElement("div");
+          wins.className = "op-usage-wins";
+          for (const w of windows) wins.appendChild(buildUsageWindowRow(w));
+          card.appendChild(wins);
+        } else {
+          const reason = usageStateReason(account.state);
+          if (reason) {
+            const isDisabled = (account.state && account.state.kind) === "disabled";
+            const r = document.createElement(isDisabled ? "button" : "div");
+            r.className = "op-usage-card__reason";
+            r.textContent = reason;
+            if (isDisabled) {
+              r.type = "button";
+              r.classList.add("op-usage-card__reason--action");
+              r.addEventListener("click", (e) => {
+                e.stopPropagation();
+                if (typeof window.__gwtHideUsageHover === "function") {
+                  window.__gwtHideUsageHover();
+                }
+                document.dispatchEvent(
+                  new CustomEvent("settings:open", { detail: { target: "usage" } }),
+                );
+              });
+            }
+            card.appendChild(r);
+          }
+        }
+
+        const pc = usageConsumptionFor(account.provider);
+        if (pc) {
+          const cwrap = document.createElement("div");
+          cwrap.className = "op-usage-card__cons";
+          cwrap.appendChild(buildUsageConsumptionGrid(pc));
+          if (Array.isArray(pc.days) && pc.days.length) {
+            cwrap.appendChild(renderConsumptionChart(pc.days));
+          }
+          card.appendChild(cwrap);
+        }
+        return card;
+      }
+
+      // SPEC-2970 — the full usage detail as provider cards + a sessions list,
+      // appended to a container. The hover popover is the single surface for all
+      // usage info (the click-open modal was removed per UX feedback).
+      function buildUsageFullSections(container) {
+        for (const account of latestProviderUsage.accounts || []) {
+          container.appendChild(buildUsageProviderCard(account));
+        }
+        const sessions = latestProviderUsage.sessions || [];
+        const sess = document.createElement("div");
+        sess.className = "op-usage-sess";
+        const sHead = document.createElement("div");
+        sHead.className = "op-usage-sess__head";
+        sHead.textContent = sessions.length ? `Sessions (${sessions.length})` : "Sessions";
+        sess.appendChild(sHead);
+        if (sessions.length) {
+          sess.appendChild(renderUsageSessionsTable(sessions));
+        } else {
+          const empty = document.createElement("p");
+          empty.className = "op-usage-empty";
+          empty.textContent = "No active sessions.";
+          sess.appendChild(empty);
+        }
+        container.appendChild(sess);
+      }
+
+      // ---- Consolidated usage hover popover (SPEC-2970 UX) ----
+      // Hovering the status-bar USAGE cell shows EVERYTHING at once (both
+      // providers' windows with bars + full consumption with charts +
+      // sessions). The click-open modal was removed per UX feedback — the hover
+      // popover is the single surface. Move the cursor into it to scroll/read.
+      let usageHoverEl = null;
+      let usageHoverHideTimer = null;
+      let usageHoverAnchor = null;
+
+      function buildUsageHoverBody() {
+        const wrap = document.createElement("div");
+        wrap.className = "op-usage-hover__body";
+        const head = document.createElement("div");
+        head.className = "op-usage-hover__head";
+        head.textContent = "Usage & Limits";
+        wrap.appendChild(head);
+        buildUsageFullSections(wrap);
+        return wrap;
+      }
+
+      function positionUsageHover() {
+        if (!usageHoverEl || !usageHoverAnchor) return;
+        const r = usageHoverAnchor.getBoundingClientRect();
+        const w = usageHoverEl.offsetWidth;
+        const left = Math.max(8, Math.min(r.left, window.innerWidth - w - 8));
+        usageHoverEl.style.left = `${left}px`;
+        usageHoverEl.style.bottom = `${Math.max(8, window.innerHeight - r.top + 6)}px`;
+      }
+
+      function cancelUsageHoverHide() {
+        if (usageHoverHideTimer) {
+          clearTimeout(usageHoverHideTimer);
+          usageHoverHideTimer = null;
+        }
+      }
+
+      function refreshUsageHoverIfOpen() {
+        if (!usageHoverEl || usageHoverEl.hidden) return;
+        while (usageHoverEl.firstChild) usageHoverEl.removeChild(usageHoverEl.firstChild);
+        usageHoverEl.appendChild(buildUsageHoverBody());
+        positionUsageHover();
+      }
+
+      window.__gwtShowUsageHover = (anchor) => {
+        cancelUsageHoverHide();
+        usageHoverAnchor = anchor || usageHoverAnchor;
+        if (!usageHoverEl) {
+          usageHoverEl = document.createElement("div");
+          usageHoverEl.className = "op-usage-hover";
+          usageHoverEl.addEventListener("mouseenter", cancelUsageHoverHide);
+          usageHoverEl.addEventListener("mouseleave", () => window.__gwtHideUsageHover());
+          document.body.appendChild(usageHoverEl);
+        }
+        while (usageHoverEl.firstChild) usageHoverEl.removeChild(usageHoverEl.firstChild);
+        usageHoverEl.appendChild(buildUsageHoverBody());
+        usageHoverEl.hidden = false;
+        usageHoverEl.style.visibility = "hidden";
+        requestAnimationFrame(() => {
+          positionUsageHover();
+          if (usageHoverEl) usageHoverEl.style.visibility = "visible";
+        });
+      };
+
+      window.__gwtHideUsageHover = () => {
+        cancelUsageHoverHide();
+        usageHoverHideTimer = setTimeout(() => {
+          if (usageHoverEl) usageHoverEl.hidden = true;
+          usageHoverHideTimer = null;
+        }, 180);
+      };
+
+      // SPEC-2970 FR-009/FR-013 — Settings "Usage & Limits" panel: Claude
+      // account usage is opt-in (Keychain + network); Codex is local + auto.
+      function renderUsagePanel(panel) {
+        while (panel.firstChild) panel.removeChild(panel.firstChild);
+        const section = document.createElement("div");
+        section.className = "settings-section";
+
+        const heading = document.createElement("h3");
+        heading.textContent = "Provider Usage & Limits";
+        section.appendChild(heading);
+
+        const codexNote = document.createElement("p");
+        codexNote.className = "settings-hint";
+        codexNote.textContent =
+          "Codex usage is read from local session files automatically.";
+        section.appendChild(codexNote);
+
+        const label = document.createElement("label");
+        label.className = "settings-toggle";
+        const checkbox = document.createElement("input");
+        checkbox.type = "checkbox";
+        const claudeAccount = (latestProviderUsage.accounts || []).find(
+          (a) => a.provider === "claude_code",
+        );
+        checkbox.checked = !!(
+          claudeAccount &&
+          claudeAccount.state &&
+          claudeAccount.state.kind !== "disabled"
+        );
+        checkbox.addEventListener("change", () => {
+          try {
+            send({
+              kind: "set_claude_account_usage_enabled",
+              enabled: checkbox.checked,
+            });
+          } catch {
+            /* no-op */
+          }
+        });
+        const span = document.createElement("span");
+        span.textContent = "Show Claude Code account usage (5-hour / weekly)";
+        label.appendChild(checkbox);
+        label.appendChild(span);
+        section.appendChild(label);
+
+        const consent = document.createElement("p");
+        consent.className = "settings-hint";
+        consent.textContent =
+          "On by default. Claude account usage reads your OAuth token from the Keychain / credentials file and requests usage from the Anthropic API (polled at most once every 3 minutes). Uncheck to disable. Per-session token usage is read locally and is not affected by this setting.";
+        section.appendChild(consent);
+
+        panel.appendChild(section);
+      }
+
       function activeWorkFocusableAgents(work) {
         const agents = Array.isArray(work?.agents) ? work.agents : [];
         return agents.filter((agent) => {
@@ -3251,6 +3752,42 @@
             agentFocus.title = agent.current_focus;
           }
           card.appendChild(agentFocus);
+        }
+
+        // SPEC-2970 FR-019/FR-020 — per-session usage footer (enhanced CLI
+        // footer): model · tokens · context-left + this provider's account badge.
+        const sessionUsage = usageForSession(agent.session_id);
+        if (sessionUsage) {
+          const footer = createNode("div", "op-agent-usage");
+          if (sessionUsage.model) {
+            footer.appendChild(createNode("span", "op-agent-usage__model", sessionUsage.model));
+          }
+          footer.appendChild(
+            createNode("span", "op-agent-usage__tok", `${usageFmtTokens(sessionUsage.total_tokens)} tok`),
+          );
+          const eligible = sessionUsage.eligible !== false;
+          if (eligible && sessionUsage.context_left_pct != null) {
+            footer.appendChild(
+              createNode("span", "op-agent-usage__ctx", `ctx ${Math.round(sessionUsage.context_left_pct)}%`),
+            );
+          }
+          if (eligible) {
+            const acct = (latestProviderUsage.accounts || []).find(
+              (a) => a.provider === sessionUsage.provider,
+            );
+            const five = acct && (acct.windows || []).find((w) => w.kind === "five_hour");
+            const wk = acct && (acct.windows || []).find((w) => w.kind === "weekly");
+            const parts = [];
+            if (five) parts.push(`5h ${Math.round(five.used_percent)}%`);
+            if (wk) parts.push(`wk ${Math.round(wk.used_percent)}%`);
+            if (parts.length) {
+              footer.appendChild(createNode("span", "op-agent-usage__acct", parts.join(" · ")));
+            }
+          }
+          if (sessionUsage.limit_reached) {
+            footer.appendChild(createNode("span", "op-agent-usage__limit", "limit reached"));
+          }
+          card.appendChild(footer);
         }
 
         const agentActions = createNode("div", "op-agent-actions");
@@ -11133,6 +11670,8 @@
         // Kept distinct from `custom-agents` so External CLI rows and
         // built-in LLM redirection have separate physical UI.
         tabs.appendChild(buildSettingsTab("agent-backends", "Agent Backends", false));
+        // SPEC-2970: provider usage display preferences (Claude opt-in).
+        tabs.appendChild(buildSettingsTab("usage", "Usage & Limits", false));
 
         toolbar.appendChild(heading);
         toolbar.appendChild(tabs);
@@ -11158,9 +11697,16 @@
         panelBackends.dataset.settingsPanel = "agent-backends";
         panelBackends.dataset.role = "settings-scroll";
 
+        const panelUsage = document.createElement("section");
+        panelUsage.className = "settings-panel hidden";
+        panelUsage.setAttribute("role", "tabpanel");
+        panelUsage.dataset.settingsPanel = "usage";
+        panelUsage.dataset.role = "settings-scroll";
+
         bodyEl.appendChild(panelSystem);
         bodyEl.appendChild(panelAgents);
         bodyEl.appendChild(panelBackends);
+        bodyEl.appendChild(panelUsage);
 
         root.appendChild(toolbar);
         root.appendChild(bodyEl);
@@ -11186,6 +11732,7 @@
         settingsWindowBodies.add(body);
 
         renderSystemPanel(panelSystem);
+        renderUsagePanel(panelUsage);
         // Always request fresh system settings on open so the dropdown
         // reflects the on-disk config, even if the user changed it from a
         // different gwt instance.
@@ -12253,6 +12800,13 @@
           case "window_list":
             windowListEntries = event.windows || [];
             frontendUnits.projectWorkspaceShell.renderWindowList();
+            break;
+          case "provider_usage":
+            applyProviderUsageUi({
+              accounts: event.accounts || [],
+              sessions: event.sessions || [],
+              consumption: event.consumption || [],
+            });
             break;
           case "terminal_output":
             frontendUnits.terminalHost.writeOutput(event.id, event.data_base64);

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -306,6 +306,14 @@
             <span class="op-status-strip__label">WK</span>
             <span class="op-status-strip__value" id="op-strip-branches" aria-label="Work">—</span>
           </div>
+          <button
+            type="button"
+            class="op-status-strip__cell op-status-strip__cell--usage"
+            id="op-strip-usage"
+            aria-label="Provider usage and limits"
+            title="Provider usage & limits"
+            hidden
+          ></button>
           <div class="op-status-strip__cell" aria-hidden="true">
             <span class="op-status-strip__label">T</span>
             <span class="op-status-strip__value" id="op-strip-clock">--:--:--</span>

--- a/crates/gwt/web/operator-shell.js
+++ b/crates/gwt/web/operator-shell.js
@@ -377,6 +377,86 @@ export function applyTelemetryCounts(doc, counts = {}) {
 }
 
 // ------------------------------------------------------------
+// Provider usage pill (SPEC-2970)
+// ------------------------------------------------------------
+
+const USAGE_PROVIDER_ICON = { codex: "⬡", claude_code: "◇" };
+
+function usageWindowByKind(account, kind) {
+  return (account.windows || []).find((w) => w.kind === kind) || null;
+}
+
+// Stable, glanceable per-provider summary value for the status strip (weekly %
+// when available, else a short degraded token). No rotation.
+function usageSummaryValue(account) {
+  const kind = (account.state || {}).kind || "ok";
+  if (kind === "disabled") return "off";
+  if (kind === "no_data") return "—";
+  if (kind === "unavailable") return "n/a";
+  const week = usageWindowByKind(account, "weekly");
+  const five = usageWindowByKind(account, "five_hour");
+  if (week) return `${Math.round(week.used_percent)}%`;
+  if (five) return `${Math.round(five.used_percent)}%`;
+  return "—";
+}
+
+// SPEC-2970 — status-strip USAGE cell: a stable, consolidated summary
+// (`USAGE ⬡ 23% ◇ 9%`). Hover shows the full consolidated popover (all windows
+// + consumption) via the app-provided hooks; click opens the detail modal. No
+// ticker rotation — everything is visible at a glance / on hover.
+export function applyProviderUsage(doc, snapshot = {}) {
+  const cell = doc.getElementById("op-strip-usage");
+  if (!cell) return;
+  const accounts = snapshot.accounts || [];
+  if (!accounts.length) {
+    cell.hidden = true;
+    return;
+  }
+  while (cell.firstChild) cell.removeChild(cell.firstChild);
+  const label = doc.createElement("span");
+  label.className = "op-status-strip__label";
+  label.textContent = "USAGE";
+  cell.appendChild(label);
+  for (const account of accounts) {
+    const chip = doc.createElement("span");
+    chip.className = "op-usage-sum";
+    chip.dataset.provider = account.provider;
+    if (account.limit_reached) chip.dataset.limit = "true";
+    chip.textContent = `${USAGE_PROVIDER_ICON[account.provider] || ""} ${usageSummaryValue(
+      account,
+    )}`;
+    cell.appendChild(chip);
+  }
+  if (accounts.some((a) => a.limit_reached)) cell.dataset.limit = "true";
+  else delete cell.dataset.limit;
+  cell.hidden = false;
+
+  const win = doc.defaultView || window;
+  // No modal: hover (or click, for touch/non-hover) shows the full popover.
+  cell.onclick = () => {
+    try {
+      win.__gwtShowUsageHover?.(cell);
+    } catch {
+      /* no-op */
+    }
+  };
+  cell.onmouseenter = () => {
+    try {
+      win.__gwtShowUsageHover?.(cell);
+    } catch {
+      /* no-op */
+    }
+  };
+  cell.onmouseleave = () => {
+    try {
+      win.__gwtHideUsageHover?.();
+    } catch {
+      /* no-op */
+    }
+  };
+}
+
+// ------------------------------------------------------------
 // Mission Briefing intro
 // ------------------------------------------------------------
 

--- a/crates/gwt/web/socket-receive-dispatcher.js
+++ b/crates/gwt/web/socket-receive-dispatcher.js
@@ -24,6 +24,7 @@ export const DEFAULT_COALESCE_KINDS = Object.freeze(
     "workspace_state",
     "active_work_projection",
     "window_list",
+    "provider_usage",
     "project_index_status",
     "launch_wizard_state",
     "launch_wizard_open",

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -4480,3 +4480,522 @@ kbd.op-kbd {
   font-style: italic;
   padding: 4px 0;
 }
+
+/* ------------------------------------------------------------------ */
+/* Provider usage & rate limits (SPEC-2970)                            */
+/* ------------------------------------------------------------------ */
+
+.op-status-strip__cell--usage {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  padding: 0 2px;
+}
+
+/* Stable per-provider summary chips in the status strip (no rotation). */
+.op-usage-sum {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 3px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.op-usage-sum[data-provider="codex"] {
+  color: var(--agent-color-codex, #6fb1ff);
+}
+
+.op-usage-sum[data-provider="claude_code"] {
+  color: var(--agent-color-claude, #e0a06a);
+}
+
+.op-usage-sum[data-limit="true"] {
+  color: var(--color-state-blocked, #ff6b6b);
+}
+
+.op-status-strip__cell--usage:hover .op-usage-sum,
+.op-status-strip__cell--usage:focus-visible .op-usage-sum {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+/* Consolidated hover popover (everything at once, anchored above the strip). */
+.op-usage-hover {
+  position: fixed;
+  z-index: 1100;
+  width: min(440px, 92vw);
+  max-height: 70vh;
+  overflow: auto;
+  padding: var(--space-3, 12px);
+  background: var(--color-surface-elevated, #1c1f26);
+  color: var(--color-text, #e7e9ee);
+  border: 1px solid var(--color-border, rgba(127, 127, 127, 0.4));
+  border-radius: var(--radius-md, 8px);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+}
+
+.op-usage-hover__head {
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.op-usage-hover__subhead {
+  margin: 10px 0 4px;
+  font-size: var(--type-xs, 0.72rem);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted, #9aa0ad);
+}
+
+.op-usage-hover__cons {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: var(--type-sm, 0.85rem);
+  font-variant-numeric: tabular-nums;
+  padding: 1px 0;
+}
+
+.op-usage-hover__consname {
+  color: var(--color-text-muted, #9aa0ad);
+}
+
+.op-usage-hover__hint {
+  margin-top: 10px;
+  font-size: var(--type-xs, 0.72rem);
+  color: var(--color-text-muted, #9aa0ad);
+  text-align: right;
+}
+
+/* Provider cards (SPEC-2970 UX redesign) — group one provider's data together
+   for readability: header, rate-limit windows, consumption grid, sparkline. */
+.op-usage-card {
+  padding: 10px 0 12px;
+  border-top: 1px solid var(--color-border, rgba(127, 127, 127, 0.25));
+}
+
+.op-usage-card:first-of-type {
+  border-top: 0;
+}
+
+.op-usage-card__head {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.op-usage-card__icon {
+  font-size: 1.05em;
+}
+
+.op-usage-card[data-provider="codex"] .op-usage-card__icon {
+  color: var(--agent-color-codex, #6fb1ff);
+}
+
+.op-usage-card[data-provider="claude_code"] .op-usage-card__icon {
+  color: var(--agent-color-claude, #e0a06a);
+}
+
+.op-usage-card__name {
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
+.op-usage-card__plan {
+  font-size: var(--type-xs, 0.72rem);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: var(--color-surface, rgba(127, 127, 127, 0.16));
+  color: var(--color-text-muted, #9aa0ad);
+}
+
+.op-usage-card__reason {
+  font-size: var(--type-sm, 0.85rem);
+  color: var(--color-text-muted, #9aa0ad);
+  font-style: italic;
+  padding: 2px 0;
+}
+
+.op-usage-card__reason--action {
+  appearance: none;
+  -webkit-appearance: none;
+  font-style: normal;
+  font-family: var(--font-mono, inherit);
+  font-size: var(--type-xs, 0.72rem);
+  letter-spacing: var(--tracking-mono, 0.02em);
+  border: 1px solid var(--color-accent, #6fb1ff);
+  background: transparent;
+  color: var(--color-accent, #6fb1ff);
+  border-radius: 999px;
+  padding: 2px 12px;
+  cursor: pointer;
+}
+
+.op-usage-card__reason--action:hover {
+  background: var(--color-accent, #6fb1ff);
+  color: var(--color-button-fg, #0b0d10);
+}
+
+/* Rate-limit windows: label | bar | % | reset, aligned columns. */
+.op-usage-wins {
+  display: grid;
+  gap: 4px;
+}
+
+.op-usage-win {
+  display: grid;
+  grid-template-columns: 64px 1fr 38px auto;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--type-sm, 0.85rem);
+}
+
+.op-usage-win__lbl {
+  color: var(--color-text-muted, #9aa0ad);
+}
+
+.op-usage-win__bar {
+  margin: 0;
+}
+
+.op-usage-win__pct {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.op-usage-win__reset {
+  font-size: var(--type-xs, 0.72rem);
+  color: var(--color-text-muted, #9aa0ad);
+  white-space: nowrap;
+}
+
+/* Consumption grid: period × in/out/cached, right-aligned numerics. */
+.op-usage-card__cons {
+  margin-top: 10px;
+}
+
+.op-usage-cgrid {
+  display: grid;
+  grid-template-columns: auto 1fr 1fr 1fr;
+  gap: 2px 12px;
+  font-size: var(--type-sm, 0.85rem);
+  font-variant-numeric: tabular-nums;
+}
+
+.op-usage-cgrid__hdr {
+  font-size: var(--type-xs, 0.72rem);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted, #9aa0ad);
+}
+
+.op-usage-cgrid__colh {
+  text-align: right;
+  font-size: var(--type-xs, 0.72rem);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted, #9aa0ad);
+}
+
+.op-usage-cgrid__rowh {
+  color: var(--color-text-muted, #9aa0ad);
+}
+
+.op-usage-cgrid__num {
+  text-align: right;
+}
+
+/* Sessions block in the hover popover. */
+.op-usage-sess {
+  border-top: 1px solid var(--color-border, rgba(127, 127, 127, 0.25));
+  padding-top: 10px;
+  margin-top: 4px;
+}
+
+.op-usage-sess__head {
+  font-size: var(--type-xs, 0.72rem);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted, #9aa0ad);
+  margin-bottom: 6px;
+}
+
+/* Detail modal */
+.op-usage-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.45);
+}
+
+.op-usage-modal {
+  width: min(620px, 92vw);
+  max-height: 80vh;
+  overflow: auto;
+  background: var(--color-surface-elevated, #1c1f26);
+  color: var(--color-text, #e7e9ee);
+  border: 1px solid var(--color-border, rgba(255, 255, 255, 0.12));
+  border-radius: var(--radius-md, 8px);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.5);
+}
+
+.op-usage-modal__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3, 12px);
+  border-bottom: 1px solid var(--color-border, rgba(255, 255, 255, 0.12));
+}
+
+.op-usage-modal__title {
+  font-weight: 700;
+  flex: 1;
+}
+
+.op-usage-modal__refresh,
+.op-usage-modal__close {
+  appearance: none;
+  -webkit-appearance: none;
+  border: 1px solid var(--color-button-border, var(--color-border, rgba(127, 127, 127, 0.4)));
+  border-radius: var(--radius-md, 6px);
+  background: var(--color-button-bg, transparent);
+  color: var(--color-button-fg, inherit);
+  font-family: var(--font-mono, var(--font-body));
+  font-size: var(--type-xs, 0.75rem);
+  letter-spacing: var(--tracking-mono, 0.02em);
+  cursor: pointer;
+  min-height: 28px;
+  padding: 0 var(--space-3, 12px);
+  line-height: 1;
+}
+
+.op-usage-modal__close {
+  min-width: 28px;
+  padding: 0 var(--space-2, 8px);
+}
+
+.op-usage-modal__refresh:hover,
+.op-usage-modal__refresh:focus-visible,
+.op-usage-modal__close:hover,
+.op-usage-modal__close:focus-visible {
+  outline: none;
+  border-color: var(--color-focus-ring, var(--color-accent, #6fb1ff));
+  background: var(--color-button-bg-hover, rgba(127, 127, 127, 0.16));
+}
+
+.op-usage-modal__body {
+  padding: var(--space-3, 12px);
+}
+
+.op-usage-section {
+  margin-bottom: var(--space-4, 16px);
+}
+
+.op-usage-section h3 {
+  margin: 0 0 8px;
+  font-size: var(--type-sm, 0.85rem);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted, #9aa0ad);
+}
+
+.op-usage-account {
+  margin-bottom: 12px;
+}
+
+.op-usage-account__head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.op-usage-account__name {
+  font-weight: 600;
+}
+
+.op-usage-account__plan {
+  font-size: var(--type-xs, 0.72rem);
+  padding: 0 6px;
+  border-radius: 999px;
+  background: var(--color-surface, rgba(255, 255, 255, 0.08));
+  color: var(--color-text-muted, #9aa0ad);
+}
+
+.op-usage-account__reason {
+  margin-left: auto;
+  font-size: var(--type-xs, 0.72rem);
+  color: var(--color-text-muted, #9aa0ad);
+  font-style: italic;
+}
+
+.op-usage-account__reason--action {
+  appearance: none;
+  -webkit-appearance: none;
+  border: 1px solid var(--color-accent, #6fb1ff);
+  background: transparent;
+  color: var(--color-accent, #6fb1ff);
+  font-family: var(--font-mono, var(--font-body));
+  font-size: var(--type-xs, 0.72rem);
+  font-style: normal;
+  letter-spacing: var(--tracking-mono, 0.02em);
+  border-radius: 999px;
+  min-height: 24px;
+  padding: 0 12px;
+  cursor: pointer;
+}
+
+.op-usage-account__reason--action:hover,
+.op-usage-account__reason--action:focus-visible {
+  outline: none;
+  background: var(--color-accent, #6fb1ff);
+  color: var(--color-button-fg, #0b0d10);
+}
+
+.op-usage-window {
+  display: grid;
+  grid-template-columns: 92px 1fr 44px auto;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 0;
+  font-size: var(--type-sm, 0.85rem);
+}
+
+.op-usage-window__label {
+  color: var(--color-text-muted, #9aa0ad);
+}
+
+.op-usage-bar {
+  height: 8px;
+  border-radius: 999px;
+  background: var(--color-surface, rgba(255, 255, 255, 0.1));
+  overflow: hidden;
+}
+
+.op-usage-bar__fill {
+  height: 100%;
+  background: var(--color-accent, #6fb1ff);
+}
+
+.op-usage-bar__fill[data-level="mid"] {
+  background: #e0b341;
+}
+
+.op-usage-bar__fill[data-level="high"] {
+  background: var(--color-state-blocked, #ff6b6b);
+}
+
+.op-usage-window__pct {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.op-usage-window__reset {
+  font-size: var(--type-xs, 0.72rem);
+  color: var(--color-text-muted, #9aa0ad);
+  white-space: nowrap;
+}
+
+.op-usage-sessions {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--type-sm, 0.85rem);
+}
+
+.op-usage-sessions th,
+.op-usage-sessions td {
+  text-align: left;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--color-border, rgba(255, 255, 255, 0.08));
+}
+
+.op-usage-sessions th {
+  color: var(--color-text-muted, #9aa0ad);
+  font-weight: 600;
+}
+
+.op-usage-sessions tr[data-ineligible="true"] {
+  opacity: 0.5;
+}
+
+.op-usage-empty {
+  color: var(--color-text-muted, #9aa0ad);
+  font-style: italic;
+}
+
+/* Daily/weekly consumption (SPEC-2970 extension) */
+.op-usage-consumption {
+  margin-bottom: 14px;
+}
+
+.op-usage-consumption__name {
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.op-usage-consumption__line {
+  display: flex;
+  gap: 8px;
+  font-size: var(--type-sm, 0.85rem);
+  font-variant-numeric: tabular-nums;
+  padding: 1px 0;
+}
+
+.op-usage-consumption__period {
+  min-width: 76px;
+  color: var(--color-text-muted, #9aa0ad);
+}
+
+.op-usage-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  height: 40px;
+  margin-top: 6px;
+}
+
+.op-usage-chart__col {
+  flex: 1 1 0;
+  height: 100%;
+  display: flex;
+  align-items: flex-end;
+}
+
+.op-usage-chart__bar {
+  width: 100%;
+  min-height: 2px;
+  border-radius: 2px 2px 0 0;
+  background: var(--color-text-muted, #9aa0ad);
+  opacity: 0.55;
+}
+
+.op-usage-chart__col[data-today="true"] .op-usage-chart__bar {
+  background: var(--color-accent, #6fb1ff);
+  opacity: 1;
+}
+
+/* Per-session footer on agent cards (SPEC-2970 FR-019) */
+.op-agent-usage {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+  font-size: var(--type-xs, 0.72rem);
+  color: var(--color-text-muted, #9aa0ad);
+}
+
+.op-agent-usage__limit {
+  color: var(--color-state-blocked, #ff6b6b);
+  font-weight: 600;
+}

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6522,3 +6522,24 @@ Type: lesson
 Context: SPEC-2920 tray/About verification used an isolated HOME. With an empty ~/.gwt/session.json, the app opened the Open Project picker instead of the intended checkout surface.
 Learning: Isolated GUI verification that must land on an in-project surface needs a seeded session.json pointing at the checkout under test; otherwise the verification can be blocked before the changed UI is reachable.
 Future Action: Before sharing a manual GUI verification URL from a temp HOME, seed ~/.gwt/session.json with the target checkout tab and verify the served URL reaches the intended screen.
+
+## 2026-06-02 — gwt-register-spec: register phase/complete は owned --spec id を使う（start --spec 0 なら 0）
+
+Type: lesson
+Context: register start --spec 0 で owner_spec=0。その後 register phase --spec <real-n> は "state owns SPEC-Some(0), got --spec <n>" で拒否される。CLI は phase で placeholder→実 id の rebind をしない（SKILL.md の "bind the real spec id" 文言と挙動が不一致）。
+Learning: 実 SPEC Issue は issue spec create / issue spec <n> --edit spec で正しく作成・投入される。register の lifecycle 記録だけが owned id に紐づく。phase/complete は --spec 0（owned id）で実行すれば milestone 記録と stop-block 解除ができる。
+Future Action: gwt-register-spec を register start --spec 0 で開始した場合、phase/complete は新 issue 番号ではなく --spec 0 を使う。または issue 番号確定後に register start を実 id で 1 回だけ実行する。
+
+## 2026-06-02 — SPEC-2970 Usage 検証: 実 Claude /api/oauth/usage は 200 で取得可・gwt 二重起動は GWT_FORCE_NEW_INSTANCE=1
+
+Type: lesson
+Context: Provider Usage 機能の視覚検証で、(1) 既存 gwt が single-instance lock を持つため検証用 2 つ目を起動できなかった、(2) Claude account usage が取れるか不明だった、(3) 検証用 session を seed する際 session.toml の agent_id 形式でつまづいた。
+Learning: (1) 2つ目の gwt 検証インスタンスは GWT_FORCE_NEW_INSTANCE=1 と --no-tray --no-open で起動できる（HOME 隔離 + CODEX_HOME=実ディレクトリ で実 Codex を読ませる）。(2) 実トークン(Keychain `security find-generic-password -s "Claude Code-credentials" -w` の claudeAiOauth.accessToken)で `GET https://api.anthropic.com/api/oauth/usage` は HTTP 200。応答は five_hour/seven_day/seven_day_sonnet を含み、resets_at は RFC3339 `+00:00` オフセット、seven_day_opus 等は null、未知の sub-window キー多数。(3) Session の agent_id は serde adjacently-tagged (`#[serde(tag="type",content="value")]`) なので toml では `agent_id = { type = "Codex" }`。
+Future Action: GUI 視覚検証で本番 gwt と衝突する場合は GWT_FORCE_NEW_INSTANCE=1 + 隔離 HOME + CODEX_HOME 実ディレクトリで起動する。Claude usage パーサは null sub-window と +00:00 オフセットと未知キーを許容する defensive parse を維持する。
+
+## 2026-06-02 — Claude usage: macOS は Keychain の token が live、~/.claude/.credentials.json は stale/expired のことがある
+
+Type: lesson
+Context: SPEC-2970 で Claude account usage が 401 auth expired になった。原因は resolve_claude_creds が .credentials.json を先に読み、その accessToken が expiresAt 過去で失効していたため。Keychain (security find-generic-password -s "Claude Code-credentials" -w) の token は live で同 endpoint が 200 を返す。
+Learning: macOS では Keychain が live token の真実。resolve は Keychain 優先 → file fallback にする。ただし GUI でない detached プロセスから security を叩くと keychain ACL prompt が応答できず失敗し得る（実 GUI アプリは初回 Always Allow で解決）。headless 検証では CLAUDE_CONFIG_DIR を worktree 内一時ディレクトリに向け、Keychain から取り出した最新 token を .credentials.json として置けば file fallback で 200 を再現できる。claude_home は CLAUDE_CONFIG_DIR env を尊重する。
+Future Action: Claude token は Keychain 優先・file fallback。失効 access token のときは将来 refreshToken での更新も検討。検証時は CLAUDE_CONFIG_DIR + 一時 .credentials.json で実データ再現し、token file は確認後に削除する。


### PR DESCRIPTION
## Summary

- Codex / Claude Code の使用量とレートリミットを gwt GUI のステータスバーに常設表示する新ドメイン `usage` を追加。CLI 各自のフッターの「上位版」として、アカウント枠とセッション使用量を横断的に集約する。
- ステータスバーは安定サマリ（`USAGE ⬡<週次%> ◇<週次%>`）のみを常時表示し、ホバーで全情報を 1 つのポップオーバーに集約（プロバイダ別カード + セッション一覧）。クリックで開くモーダル/別ウィンドウは廃止。
- 取得は GUI 接続中のみ。Codex はローカル rollout 解析で自動 ON、Claude のアカウント枠取得（未文書エンドポイント + Keychain）のみ opt-in。

## Changes

- `crates/gwt-core/src/usage/`（新規ドメイン）:
  - `types.rs`: `UsageProvider` / `UsageWindow` / `ProviderUsage` / `SessionUsage` / `UsageState`(Ok/Disabled/NoData/Unavailable/Stale) / `UsageSnapshot`。
  - `codex.rs`: rollout JSONL の `token_count.rate_limits`（primary=5h / secondary=週次）と `total_token_usage` を解析。`resets_at` の epoch/RFC3339 両対応、exec モードの `rate_limits:null` を許容、context は `last_token_usage.input_tokens` を採用（cached の二重計上を回避）。`read_codex_account` は直近 rollout を新しい順に走査。
  - `claude.rs`: 未文書 `GET /api/oauth/usage` を opt-in 取得（必須ヘッダ + 429/非200→`UsageState`）。token は Keychain 優先・`~/.claude/.credentials.json` fallback。`claude_home` は `CLAUDE_CONFIG_DIR` を尊重。transcript からセッション使用量を集計。
  - `consumption.rs`: local 日付バケットで in/out/cached を集計。`week_start` を weekly `resets_at` に同期し、Today / This week 合計と直近 7 日シリーズを生成（走査範囲・ファイル数に上限）。
  - `state.rs` / `model_context.rs`: Claude 180s フェッチゲート、staleness 判定、モデル別 context window テーブル。
- `crates/gwt-config/src/usage_config.rs`（新規）+ `settings.rs`/`lib.rs`: `[usage]` 設定（`codex_enabled` / `claude_account_enabled`、既定 ON）。`#[serde(default)]` で旧 toml を後方互換ロード。
- `crates/gwt/src/protocol.rs`: `BackendEvent::ProviderUsage{accounts,sessions,consumption}` + `FrontendEvent::SetClaudeAccountUsageEnabled` / `RefreshUsage`。
- `crates/gwt/src/usage_poller.rs`（新規）+ `app_runtime/mod.rs` / `embedded_server.rs` / `main.rs`: GUI 接続中のみ動く poller を spawn。接続時即時取得、Claude は ≥180s ゲート、refresh/トグルは force bypass、一時失敗（429 等）は直前の good 値を stale として維持。
- `crates/gwt/web/`: 回転ティッカー/クリックモーダルを廃止し「安定サマリ + ホバー集約ポップオーバー」へ再設計（`operator-shell.js` / `app.js` / `index.html` / `styles/components.css`）。`appearance:none` + デザイントークンでボタン整形、Settings に「Usage & Limits」タブ。`socket-receive-dispatcher.js` で `provider_usage` を coalesce。
- `tasks/memory.md`: 検証で得た再発防止 memory 3 件を追加。

## Testing

- [x] `cargo fmt --check` — 差分なし
- [x] `cargo clippy -p gwt-core -p gwt-config -p gwt --all-targets --all-features -- -D warnings` — 警告ゼロ
- [x] `cargo test -p gwt-core --lib --all-features` — 403 passed
- [x] `cargo test -p gwt-config --lib` — 69 passed
- [x] `cargo test -p gwt --lib` — 814 passed
- [x] 視覚確認（ユーザー confirmed）: 実 `~/.codex`（pro）/ `~/.claude`（max）で起動し、ステータスバー USAGE サマリ → ホバーで Codex/Claude の 5h・週次バー + リセット、日/週消費（in/out/cached）+ 直近 7 日スパークライン、セッション一覧を実データ表示。Claude account usage は `/api/oauth/usage` 200（5h 27% / 週次 14%）。

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — 既存機能を変更せず純粋な追加。設定既定 ON でも劣化時は行を残し状態理由を表示するため、データが取れない環境でも破綻しない。
- Known blockers: None
- Remaining acceptance: None（v1 スコープ完了。Gemini/Copilot 等の他エージェント、API-key backend 枠、履歴グラフ/アラートは Out of Scope）

## Closing Issues

- Closes #2970

## Related Issues / Links

- None

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (if user-facing change) — N/A: 設計は SPEC #2970 に集約、README の利用者導線変更なし（ステータスバー要素の追加のみ）
- [x] Migration/backfill plan included (if schema/data change) — `[usage]` は `#[serde(default)]` で旧 config 後方互換、backfill 不要
- [x] CHANGELOG impact considered — `feat:` でマイナーバージョン対象

## Risk / Impact

- **Affected areas**: gwt GUI ステータスバー / Settings / WebSocket protocol / config schema / 新規 gwt-core `usage` ドメイン。既存コードの挙動は変更せず追加のみ。
- **Rollback plan**: 単一 `feat` コミットの revert で完全に除去可能（新規ファイル群 + 既存ファイルへの追加のみ）。

## Screenshots

| Before | After |
|--------|-------|
| ステータスバーに使用量表示なし | `USAGE ⬡<週次%> ◇<週次%>` 常設 + ホバーでプロバイダ別カード（5h/週次バー・リセット・日/週消費・7日スパークライン）+ セッション一覧 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added provider usage and rate-limit monitoring with real-time tracking across sessions
  * Integrated consumption charts showing daily and weekly token usage breakdown
  * Added per-session usage information displaying model, tokens, and context occupancy
  * Added Settings panel for managing Claude Code usage preferences with opt-in control
  * Added manual refresh capability for immediate usage updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->