### PR TITLE
feat(workspace): タブホバーでタイトル表示と余白ゼロの完全最大化（複数クライアントのチラつき修正）

### DIFF
--- a/crates/gwt/playwright/tests/agent-window-maximize-multiclient.spec.ts
+++ b/crates/gwt/playwright/tests/agent-window-maximize-multiclient.spec.ts
@@ -1,0 +1,180 @@
+import { expect, test } from "@playwright/test";
+import { APP_URL, installEmbeddedRoutes } from "./_helpers/embedded-frontend";
+
+// Regression: a maximized window's fill is a LOCAL, per-client view concern.
+// Two clients with different viewport sizes used to ping-pong the shared
+// maximized geometry forever (each client forced its own visibleBounds back
+// into the shared state), which the user saw as severe flicker.
+//
+// The fix makes each client render the maximized fill locally and never send a
+// `maximize_window` correction. This test simulates a *competing client* by
+// injecting a workspace_state where the same window is maximized at a much
+// smaller width, then asserts the client neither sends a correction nor lets
+// the foreign geometry shrink its own window.
+test.describe("Maximize multi-client (no ping-pong)", () => {
+  test.use({
+    deviceScaleFactor: 1,
+    viewport: { width: 1440, height: 900 },
+  });
+
+  test("a competing client's maximized geometry never triggers a correction", async ({
+    page,
+  }) => {
+    await installEmbeddedRoutes(page);
+    await installMaximizeBackend(page);
+
+    await page.goto(APP_URL);
+
+    const win = page.locator(".workspace-window[data-id='agent-1']");
+    await expect(win).toBeVisible({ timeout: 10_000 });
+
+    // Record every outgoing message kind from this point on.
+    await page.evaluate(() => {
+      window.__sent = [];
+      const ws = window.__fixtureWs;
+      const orig = ws.send.bind(ws);
+      ws.send = (data) => {
+        try {
+          window.__sent.push(JSON.parse(data).kind);
+        } catch (e) {}
+        return orig(data);
+      };
+    });
+
+    // Maximize (user action → one maximize_window is expected here).
+    await win.locator(".titlebar button[data-action='maximize']").click();
+    await expect(win).toHaveClass(/maximized/);
+
+    const localWidth = await win.evaluate((el) =>
+      Math.round(el.getBoundingClientRect().width),
+    );
+    // No inset → the maximized window fills nearly the full viewport width.
+    expect(localWidth).toBeGreaterThan(1000);
+
+    // Now a *second client* with a narrow canvas maximizes the same window to
+    // width 400 and the backend broadcasts that geometry to us.
+    await page.evaluate(() => {
+      window.__sent = [];
+      window.__injectCompetingMaximize(400);
+    });
+    await page.waitForTimeout(400);
+
+    // The fix: we must NOT send a maximize_window correction (that is what
+    // produced the infinite ping-pong), and our own window must stay at our
+    // local fill instead of shrinking to the foreign 400px geometry.
+    const sent = await page.evaluate(() => window.__sent);
+    expect(sent.filter((k) => k === "maximize_window").length).toBe(0);
+
+    const widthAfter = await win.evaluate((el) =>
+      Math.round(el.getBoundingClientRect().width),
+    );
+    expect(Math.abs(widthAfter - localWidth)).toBeLessThan(5);
+  });
+});
+
+async function installMaximizeBackend(page) {
+  await page.addInitScript(() => {
+    const win = {
+      id: "agent-1",
+      title: "Codex",
+      preset: "agent",
+      geometry: { x: 180, y: 120, width: 720, height: 360 },
+      geometry_revision: 0,
+      z_index: 1,
+      status: "idle",
+      minimized: false,
+      maximized: false,
+      pre_maximize_geometry: null,
+      persist: true,
+      purpose_title: null,
+      dynamic_title: null,
+      dynamic_title_detail: null,
+      agent_id: "codex",
+      agent_color: "cyan",
+      tab_group_id: null,
+      tab_group_active: false,
+    };
+
+    function stateMsg() {
+      return {
+        kind: "workspace_state",
+        workspace: {
+          app_version: "playwright",
+          tabs: [
+            {
+              id: "tab-1",
+              title: "Maximize Fixture",
+              project_root: "/fixture",
+              kind: "git",
+              workspace: {
+                viewport: { x: 0, y: 0, zoom: 1 },
+                windows: [{ ...win }],
+              },
+            },
+          ],
+          active_tab_id: "tab-1",
+          recent_projects: [],
+        },
+      };
+    }
+
+    class FixtureWebSocket extends EventTarget {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+
+      constructor(url) {
+        super();
+        this.url = url;
+        this.readyState = FixtureWebSocket.CONNECTING;
+        window.__fixtureWs = this;
+        setTimeout(() => {
+          this.readyState = FixtureWebSocket.OPEN;
+          this.dispatchEvent(new Event("open"));
+          this.emit(stateMsg());
+        }, 0);
+      }
+
+      send(data) {
+        try {
+          const msg = JSON.parse(data);
+          if (msg.kind === "maximize_window") {
+            win.maximized = true;
+            if (msg.bounds) win.geometry = msg.bounds;
+            this.emit(stateMsg());
+          } else if (msg.kind === "restore_window") {
+            win.maximized = false;
+            this.emit(stateMsg());
+          }
+        } catch (e) {}
+      }
+
+      close() {
+        this.readyState = FixtureWebSocket.CLOSED;
+        this.dispatchEvent(new CloseEvent("close"));
+      }
+
+      emit(payload) {
+        setTimeout(() => {
+          this.dispatchEvent(
+            new MessageEvent("message", { data: JSON.stringify(payload) }),
+          );
+        }, 0);
+      }
+    }
+
+    // Simulate a competing client that maximized this window at a different
+    // (narrow) width; the backend broadcasts that shared geometry to us.
+    window.__injectCompetingMaximize = (width) => {
+      win.maximized = true;
+      win.geometry = { x: 0, y: 0, width, height: 600 };
+      window.__fixtureWs.emit(stateMsg());
+    };
+
+    Object.defineProperty(window, "WebSocket", {
+      configurable: true,
+      value: FixtureWebSocket,
+    });
+  });
+}

--- a/crates/gwt/playwright/tests/agent-window-tab-title.spec.ts
+++ b/crates/gwt/playwright/tests/agent-window-tab-title.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test } from "@playwright/test";
+import { APP_URL, installEmbeddedRoutes } from "./_helpers/embedded-frontend";
+
+// A tabbed window tab truncates its label at max-width, so hovering must reveal
+// the full title via the native `title` tooltip. The tooltip text mirrors the
+// titlebar/window-list helper `windowTitleTooltip`: it prefers
+// `dynamic_title_detail`, otherwise falls back to the display title.
+test.describe("Agent window tab hover title", () => {
+  test.use({
+    deviceScaleFactor: 1,
+    viewport: { width: 1440, height: 900 },
+  });
+
+  test("tabbed window tabs expose the full title as a native tooltip", async ({
+    page,
+  }) => {
+    await installEmbeddedRoutes(page);
+    await installTabbedAgentsBackend(page);
+
+    await page.goto(APP_URL);
+
+    const activeWindow = page.locator(".workspace-window[data-id='agent-1']");
+    await expect(activeWindow).toBeVisible({ timeout: 10_000 });
+    await expect(activeWindow).toHaveClass(/tabbed/);
+
+    const strip = activeWindow.locator(".window-tab-strip");
+    const detailTab = strip.locator(".window-tab[data-window-tab-id='agent-1']");
+    const fallbackTab = strip.locator(
+      ".window-tab[data-window-tab-id='agent-2']",
+    );
+
+    // agent-1 carries a dynamic detail, so the tooltip shows that detail.
+    await expect(detailTab).toHaveAttribute(
+      "title",
+      "Codex · implementing complete maximize",
+    );
+    // agent-2 has no dynamic detail, so the tooltip falls back to the title.
+    await expect(fallbackTab).toHaveAttribute("title", "Claude");
+  });
+});
+
+async function installTabbedAgentsBackend(page) {
+  await page.addInitScript(() => {
+    const baseWindow = {
+      preset: "agent",
+      geometry: { x: 180, y: 120, width: 720, height: 360 },
+      geometry_revision: 0,
+      status: "idle",
+      minimized: false,
+      maximized: false,
+      pre_maximize_geometry: null,
+      persist: true,
+      purpose_title: null,
+      dynamic_title: null,
+      dynamic_title_detail: null,
+      tab_group_id: "grp-1",
+    };
+
+    const workspaceState = {
+      kind: "workspace_state",
+      workspace: {
+        app_version: "playwright",
+        tabs: [
+          {
+            id: "tab-1",
+            title: "Tab Title Fixture",
+            project_root: "/fixture",
+            kind: "git",
+            workspace: {
+              viewport: { x: 0, y: 0, zoom: 1 },
+              windows: [
+                {
+                  ...baseWindow,
+                  id: "agent-1",
+                  title: "Codex",
+                  z_index: 2,
+                  agent_id: "codex",
+                  agent_color: "cyan",
+                  dynamic_title_detail: "Codex · implementing complete maximize",
+                  tab_group_active: true,
+                },
+                {
+                  ...baseWindow,
+                  id: "agent-2",
+                  title: "Claude",
+                  z_index: 1,
+                  agent_id: "claude",
+                  agent_color: "violet",
+                  tab_group_active: false,
+                },
+              ],
+            },
+          },
+        ],
+        active_tab_id: "tab-1",
+        recent_projects: [],
+      },
+    };
+
+    class FixtureWebSocket extends EventTarget {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+
+      constructor(url) {
+        super();
+        this.url = url;
+        this.readyState = FixtureWebSocket.CONNECTING;
+        setTimeout(() => {
+          this.readyState = FixtureWebSocket.OPEN;
+          this.dispatchEvent(new Event("open"));
+          this.emit(workspaceState);
+        }, 0);
+      }
+
+      send() {}
+
+      close() {
+        this.readyState = FixtureWebSocket.CLOSED;
+        this.dispatchEvent(new CloseEvent("close"));
+      }
+
+      emit(payload) {
+        setTimeout(() => {
+          this.dispatchEvent(
+            new MessageEvent("message", { data: JSON.stringify(payload) }),
+          );
+        }, 0);
+      }
+    }
+
+    Object.defineProperty(window, "WebSocket", {
+      configurable: true,
+      value: FixtureWebSocket,
+    });
+  });
+}

--- a/crates/gwt/web/__tests__/window-geometry-sync.test.mjs
+++ b/crates/gwt/web/__tests__/window-geometry-sync.test.mjs
@@ -132,45 +132,47 @@ test("resize release geometry uses the pointer-end event coordinates", () => {
   });
 });
 
-// maximizedGeometry must keep a CONSTANT 24px SCREEN inset at every zoom.
-// bounds are world-space (viewport divided by zoom); the window lives inside
-// #canvas-stage which applies scale(zoom). A raw +24 world-unit inset rendered
-// as 24*zoom screen px and drifted the maximized window off the viewport at
-// zoom != 1. Screen inset = geometry.x * zoom + viewport.x; with
-// geometry.x = bounds.x + 24/zoom and bounds.x = -viewport.x/zoom this is a
-// constant 24px regardless of zoom.
-test("maximizedGeometry keeps a constant 24px screen inset at zoom = 1", () => {
+// "Complete maximize": a maximized window fills the ENTIRE visible work area
+// with NO inset, so it returns the visible bounds verbatim. bounds are
+// world-space (viewport divided by zoom); the window lives inside #canvas-stage
+// which applies scale(zoom). With a zero inset the geometry equals bounds at
+// every zoom, so the maximized window spans edge-to-edge of the canvas area
+// (between the project bar and status strip) and never drifts when zoomed.
+test("maximizedGeometry fills the full visible bounds with no inset at zoom = 1", () => {
   // viewport.x = 0, zoom = 1 → visibleBounds.x = 0
   const g = geometrySync.maximizedGeometry({ x: 0, y: 0, width: 1000, height: 800 }, 1);
-  assert.deepEqual(g, { x: 24, y: 24, width: 952, height: 752 });
+  assert.deepEqual(g, { x: 0, y: 0, width: 1000, height: 800 });
 });
 
-test("maximizedGeometry divides the screen inset by zoom so it does not drift when zoomed in", () => {
+test("maximizedGeometry stays edge-to-edge with no drift when zoomed in", () => {
   // zoom = 2, viewport.x = 0 → visibleBounds = { x: 0, width: clientWidth/zoom }
   // For a 1000px-wide canvas at zoom 2: visibleBounds.width = 500.
   const z = 2;
   const bounds = { x: 0, y: 0, width: 1000 / z, height: 800 / z };
   const g = geometrySync.maximizedGeometry(bounds, z);
-  // world inset must be 24/zoom = 12 so that *zoom screen = 24px constant.
-  assert.equal(g.x, 12);
-  assert.equal(g.y, 12);
-  // screen-space left = g.x * zoom + viewport.x(0) = 24 (constant)
-  assert.equal(g.x * z, 24);
-  // screen-space width = g.width * zoom = clientWidth - 48 (24 each side)
-  assert.equal(g.width * z, 1000 - 48);
+  // No world inset: geometry equals bounds.
+  assert.equal(g.x, 0);
+  assert.equal(g.y, 0);
+  // screen-space left = g.x * zoom + viewport.x(0) = 0 (flush to the edge)
+  assert.equal(g.x * z, 0);
+  // screen-space width = g.width * zoom = full client width (no inset).
+  assert.equal(g.width * z, 1000);
 });
 
-test("maximizedGeometry divides the screen inset by zoom when zoomed out", () => {
+test("maximizedGeometry stays edge-to-edge with no drift when zoomed out", () => {
   const z = 0.5;
   const bounds = { x: 0, y: 0, width: 1000 / z, height: 800 / z };
   const g = geometrySync.maximizedGeometry(bounds, z);
-  assert.equal(g.x * z, 24);
-  assert.equal(g.width * z, 1000 - 48);
+  assert.equal(g.x * z, 0);
+  assert.equal(g.width * z, 1000);
 });
 
 test("maximizedGeometry defaults zoom to 1 and never returns negative size", () => {
   const g = geometrySync.maximizedGeometry({ x: 5, y: 5, width: 10, height: 10 });
-  assert.equal(g.x, 29);
-  assert.equal(g.width, 0); // 10 - 48 clamped to 0
-  assert.equal(g.height, 0);
+  // No inset: bounds pass through verbatim.
+  assert.deepEqual(g, { x: 5, y: 5, width: 10, height: 10 });
+  // The non-negative clamp still guards degenerate bounds.
+  const clamped = geometrySync.maximizedGeometry({ x: 0, y: 0, width: -4, height: -8 });
+  assert.equal(clamped.width, 0);
+  assert.equal(clamped.height, 0);
 });

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1924,21 +1924,39 @@
       }
 
       function syncMaximizedWindowsToViewport() {
-        const nextGeometry = maximizedGeometry(visibleBounds(), viewport.zoom);
+        // A maximized window fills THIS client's viewport locally. Re-apply the
+        // fill directly to the element and NEVER send a maximize_window
+        // correction: broadcasting one let two clients with different viewport
+        // sizes ping-pong the shared maximized geometry forever (the flicker
+        // bug). The shared `maximized` flag is enough; the pixel fill is a
+        // per-client view concern computed from each client's visibleBounds.
+        const fill = maximizedGeometry(visibleBounds(), viewport.zoom);
         for (const windowData of activeWorkspace().windows || []) {
-          if (!windowData.maximized) {
+          if (!windowData.maximized || windowData.minimized) {
             continue;
           }
-          if (geometryMatches(windowData.geometry, nextGeometry)) {
+          const element = windowMap.get(windowData.id);
+          if (!element) {
             continue;
           }
-          send({
-            kind: "maximize_window",
-            id: windowData.id,
-            // The frontend now sends the FINAL maximized geometry (zoom-corrected
-            // screen inset); the backend stores it as-is. See maximizedGeometry.
-            bounds: nextGeometry,
-          });
+          const current = {
+            x: parseFloat(element.style.left || "0"),
+            y: parseFloat(element.style.top || "0"),
+            width: parseFloat(element.style.width || "0"),
+            height: parseFloat(element.style.height || "0"),
+          };
+          if (geometryMatches(current, fill)) {
+            continue;
+          }
+          element.style.left = `${fill.x}px`;
+          element.style.top = `${fill.y}px`;
+          element.style.width = `${fill.width}px`;
+          element.style.height = `${fill.height}px`;
+          if (presetSurface(windowData.preset) === "terminal") {
+            // Visual re-fit only (persist=false): never round-trip geometry from
+            // the sync path, so this client cannot churn the shared state.
+            requestAnimationFrame(() => fitTerminal(windowData.id, false));
+          }
         }
       }
 
@@ -3754,6 +3772,10 @@
             tabButton.setAttribute("aria-current", "page");
           }
           tabButton.textContent = tab.title;
+          // Native tooltip with the full window title (or dynamic detail) so a
+          // tab truncated by max-width still reveals its title on hover. Mirrors
+          // the titlebar (titleText.title) and window-list row tooltips.
+          tabButton.title = windowTitleTooltip(tab);
           tabButton.addEventListener("click", (event) => {
             event.stopPropagation();
             send({ kind: "activate_window_tab", id: tab.id });
@@ -11922,17 +11944,33 @@
           id: windowData.id,
           geometryRevision: workspaceGeometryRevision(windowData),
         });
+        // SPEC-2008: a maximized window fills THIS client's viewport locally.
+        // Each client computes its own fill and never renders/persists the
+        // shared geometry while maximized, so two clients with different
+        // viewport sizes cannot ping-pong the shared maximized geometry (the
+        // flicker bug). See syncMaximizedWindowsToViewport — it re-fills locally
+        // and never broadcasts a maximize_window correction.
+        const maximizedFill =
+          windowData.maximized && !windowData.minimized
+            ? maximizedGeometry(visibleBounds(), viewport.zoom)
+            : null;
+        const targetGeometry = maximizedFill || windowData.geometry;
         const dimensionsChanged =
-          applyWorkspaceGeometry &&
-          (previousWidth !== windowData.geometry.width ||
-            previousHeight !== windowData.geometry.height);
+          (applyWorkspaceGeometry || Boolean(maximizedFill)) &&
+          (previousWidth !== targetGeometry.width ||
+            previousHeight !== targetGeometry.height);
         const shouldPersistTerminalGeometry =
-          applyWorkspaceGeometry &&
+          (applyWorkspaceGeometry || Boolean(maximizedFill)) &&
           ((wasMinimized && !windowData.minimized) || dimensionsChanged);
         element.classList.toggle("minimized", Boolean(windowData.minimized));
         element.classList.toggle("maximized", Boolean(windowData.maximized));
         element.classList.toggle("tabbed", windowTabsFor(windowData).length > 1);
-        if (applyWorkspaceGeometry) {
+        if (maximizedFill) {
+          element.style.left = `${maximizedFill.x}px`;
+          element.style.top = `${maximizedFill.y}px`;
+          element.style.width = `${maximizedFill.width}px`;
+          element.style.height = `${maximizedFill.height}px`;
+        } else if (applyWorkspaceGeometry) {
           element.style.left = `${windowData.geometry.x}px`;
           element.style.top = `${windowData.geometry.y}px`;
           element.style.width = `${windowData.geometry.width}px`;
@@ -11943,7 +11981,7 @@
           Boolean(windowData.minimized) || Boolean(windowData.maximized);
         applyStatus(windowData.id, windowData.status, detailMap.get(windowData.id));
         if (
-          applyWorkspaceGeometry &&
+          (applyWorkspaceGeometry || Boolean(maximizedFill)) &&
           presetSurface(windowData.preset) === "terminal" &&
           !windowData.minimized
         ) {

--- a/crates/gwt/web/window-geometry-sync.js
+++ b/crates/gwt/web/window-geometry-sync.js
@@ -14,8 +14,11 @@ function positiveFiniteNumber(value, fallback) {
 }
 
 // Screen-space inset (px) between a maximized window and the visible viewport
-// edges. Mirrors `ARRANGE_PADDING` in crates/gwt/src/workspace.rs.
-const MAXIMIZE_SCREEN_INSET = 24;
+// edges. A "complete maximize" fills the entire canvas work area edge-to-edge
+// (between the project bar and the status strip), so this inset is 0. The
+// division-by-zoom logic below is kept intact so any future non-zero inset
+// would still render as a constant SCREEN-space gap regardless of zoom.
+const MAXIMIZE_SCREEN_INSET = 0;
 
 /**
  * Compute a maximized window's geometry from the visible viewport bounds.
@@ -24,10 +27,9 @@ const MAXIMIZE_SCREEN_INSET = 24;
  * the window is positioned inside `#canvas-stage`, which applies
  * `scale(zoom)`. The inset is a constant SCREEN-space gap, so it must be
  * divided by zoom: `screenInset = worldInset * zoom`, hence
- * `worldInset = MAXIMIZE_SCREEN_INSET / zoom`. The previous code added a raw
- * `MAXIMIZE_SCREEN_INSET` in world units, which rendered as
- * `MAXIMIZE_SCREEN_INSET * zoom` screen px and drifted the maximized window off
- * the viewport at any zoom != 1.
+ * `worldInset = MAXIMIZE_SCREEN_INSET / zoom`. With a zero inset the geometry
+ * equals `bounds` verbatim at every zoom, so the maximized window spans the
+ * full canvas work area and never drifts off the viewport.
  */
 export function maximizedGeometry(bounds, zoom = 1) {
   const normalizedZoom = positiveFiniteNumber(zoom, 1);

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6564,3 +6564,10 @@ Type: workflow
 Context: gwt-fix-issue SKILL.md 強化で新規 references/closure-comment.md を追加した際、git status に出ず原因調査した。
 Learning: `.claude/skills/gwt-*` と `.codex/skills/gwt-*` は .git/info/exclude で除外されており、新規ファイルは untracked 扱い。既存 tracked ファイル(SKILL.md 等)の編集は通常反映される。.codex は distribute.rs が embedded .claude を逐語コピーするが tracked-path 保護で上書きされない手動ミラーで、参照パスのみ .codex/ に書き換える。
 Future Action: skill 編集時は .claude と .codex の両ミラーを同一コミットで更新し、新規 managed skill ファイルは git add -f で tracked 化する。SKILL.md 内の自己参照パスは mirror 側で .codex/ prefix にする。
+
+## 2026-06-02 — 最大化など per-client 表示状態を共有ジオメトリに broadcast すると複数クライアントでチラつく
+
+Type: lesson
+Context: SPEC-2008 の最大化で、ユーザー検証中に激しいチラつきが発生。調査の結果、syncMaximizedWindowsToViewport が各クライアントの可視領域に合わせて共有の最大化ジオメトリへ maximize_window 補正を broadcast しており、異なる viewport サイズの 2 クライアント（検証用 MCP ブラウザ1200px + ユーザーのブラウザ810px）が同時接続するとジオメトリを往復させ続けた。inset 値に依存しない既存設計問題。
+Learning: 最大化の塗りつぶしのような per-client な表示状態を shared workspace geometry に書き戻して全クライアントに broadcast すると、サイズの異なるクライアント間で ping-pong してチラつく。各クライアントが visibleBounds から fill をローカル計算してローカル適用し、共有するのは maximized フラグだけにすると解消する。さらに、エージェント検証時に検証用ブラウザ(Playwright/MCP)を開いたままユーザーに視覚確認を依頼すると、それが第2クライアントになり multi-client バグを誘発し『回帰』に見える。
+Future Action: (1) 最大化/ズーム追従など viewport 依存の表示はローカル描画にし、shared geometry へ補正を broadcast しない。(2) ユーザーに視覚確認を依頼する前に、検証用ブラウザ(MCP/Playwright)を必ず閉じて単一クライアントにする。複数クライアント挙動を確認したい場合は意図的に別サイズで開く。


### PR DESCRIPTION
## 概要

エージェントウィンドウ（canvas floating window chrome / SPEC-2008）への 2 つの UX 改善と、検証中に判明した最大化チラつきの根本修正です。

### 1. タブホバーでタイトル表示（feat）
タブ化したウィンドウのタブに既存ヘルパー `windowTitleTooltip` を `title` 属性として付与。ホバーで、max-width で省略されたタイトルの全文（`dynamic_title_detail` または表示タイトル）を表示します。タイトルバー / window list と同一パターン。

### 2. 余白ゼロの完全最大化（feat）
`MAXIMIZE_SCREEN_INSET` を 24→0 にし、最大化を canvas 作業領域（上部 project bar と下部 status strip の間）いっぱいに広げます。四辺の余白を撤廃。

### 3. 複数クライアント最大化チラつきの根本修正（fix）
**根本原因**: `syncMaximizedWindowsToViewport()` が、接続中の各クライアントの可視領域に合わせて共有の最大化ジオメトリへ `maximize_window` 補正を broadcast していたため、異なる viewport サイズの 2 クライアントが同時接続すると最大化ジオメトリを往復させ続け（ping-pong）、激しいチラつきになっていました（inset 値に依存しない既存バグ）。

**修正**: 最大化ウィンドウの塗りつぶしを各クライアントのローカル描画扱いに変更。
- 描画時、maximized ウィンドウは共有 `windowData.geometry` ではなく自分の `maximizedGeometry(visibleBounds, zoom)` をローカル適用（共有ジオメトリが揺れても視覚的に動かない）。
- `syncMaximizedWindowsToViewport` は補正を送信せず、ローカルに塗りを再適用（ターミナルは視覚 fit のみ persist=false）。共有 `maximized` フラグのみ共有。

## 検証

- 回帰テスト（TDD）: `agent-window-maximize-multiclient.spec.ts` — 競合クライアントの geometry(幅620) を注入し、補正送信ゼロ・ローカル幅維持を検証（修正前 RED → 修正後 GREEN）。
- `window-geometry-sync.test.mjs` を inset 0 前提へ更新。`agent-window-tab-title.spec.ts` を追加。
- frontend unit **622 件 PASS**、`agent-resize` / `agent-window-scroll` PASS、`cargo build -p gwt --bin gwt` 成功、commitlint PASS。
- **実機検証（隔離ビルド）**: 最大化ジオメトリが canvas 作業領域 (x0,y44〜1200x738) と完全一致・余白ゼロ。修正版バイナリへ幅620注入で「補正し返さない」ことを確認。
- diff の敵対的コードレビュー（render-path / multi-client churn / terminal-PTY / restore の 4 観点）で確定回帰ゼロ。

## User Verification Result

`confirmed` — 修正版（隔離サーバ）でユーザーが「最大化のチラつき解消・余白ゼロ・タブ tooltip 表示」を視覚確認済み。

## SPEC

SPEC-2008 の US-5 / US-14 / FR-012 を「完全最大化（padding 0）」「per-client local fill（複数クライアントでチラつかない）」「タブ hover tooltip」に更新済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
