### PR TITLE
fix(usage): Claude account usage を opt-in 既定 OFF に戻し空 snapshot で stale footer を消す

### DIFF
--- a/crates/gwt-config/src/settings.rs
+++ b/crates/gwt-config/src/settings.rs
@@ -159,12 +159,13 @@ mod tests {
 
     #[test]
     fn legacy_config_without_usage_section_defaults() {
-        // A config written before SPEC-2970 has no [usage] table; both
-        // providers default on (FR-013 migration).
+        // A config written before SPEC-2970 has no [usage] table; Codex
+        // (local-only) defaults on while Claude account usage stays opt-in
+        // and defaults off (FR-009/FR-013 consent model).
         let s: Settings =
             toml::from_str("default_base_branch = \"main\"\ndebug = false\n").unwrap();
         assert!(s.usage.codex_enabled);
-        assert!(s.usage.claude_account_enabled);
+        assert!(!s.usage.claude_account_enabled);
     }
 
     #[test]

--- a/crates/gwt-config/src/usage_config.rs
+++ b/crates/gwt-config/src/usage_config.rs
@@ -1,9 +1,13 @@
 //! Provider usage display configuration (SPEC-2970 FR-008/FR-009/FR-013).
 //!
-//! Controls which provider usage axes gwt collects. Both providers default on.
-//! Claude **account** usage reads OAuth credentials (Keychain) and contacts
-//! Anthropic; it can be turned off in Settings. Claude per-session usage
-//! (local transcript) is not gated here.
+//! Controls which provider usage axes gwt collects.
+//!
+//! - **Codex** usage reads local rollout files only, so it defaults **on**.
+//! - **Claude account** usage reads OAuth credentials (Keychain) and contacts
+//!   Anthropic, so it is **opt-in** and defaults **off**. Enable it in
+//!   Settings → Usage & Limits. Until then the Claude account row shows
+//!   `Enable in Settings` and no Keychain read / external request happens.
+//! - Claude per-session usage (local transcript) is not gated here.
 
 use serde::{Deserialize, Serialize};
 
@@ -18,9 +22,9 @@ pub struct UsageConfig {
     /// Collect Codex usage (local rollout files). Defaults on.
     #[serde(default = "default_enabled")]
     pub codex_enabled: bool,
-    /// Collect Claude account usage (Keychain + Anthropic request). Defaults
-    /// on; can be disabled in Settings.
-    #[serde(default = "default_enabled")]
+    /// Collect Claude account usage (Keychain + Anthropic request). Opt-in;
+    /// defaults off and is enabled from Settings.
+    #[serde(default)]
     pub claude_account_enabled: bool,
 }
 
@@ -28,7 +32,7 @@ impl Default for UsageConfig {
     fn default() -> Self {
         Self {
             codex_enabled: true,
-            claude_account_enabled: true,
+            claude_account_enabled: false,
         }
     }
 }
@@ -38,25 +42,34 @@ mod tests {
     use super::*;
 
     #[test]
-    fn defaults_both_on() {
+    fn codex_defaults_on_claude_defaults_off() {
+        // Codex is local-only (auto on); Claude account is opt-in (off).
         let c = UsageConfig::default();
         assert!(c.codex_enabled);
-        assert!(c.claude_account_enabled);
+        assert!(!c.claude_account_enabled);
     }
 
     #[test]
     fn missing_table_uses_defaults() {
-        // No [usage] table at all → both default on.
+        // No [usage] table at all → Codex on, Claude account opt-in (off).
         let c: UsageConfig = toml::from_str("").unwrap();
+        assert!(c.codex_enabled);
+        assert!(!c.claude_account_enabled);
+    }
+
+    #[test]
+    fn claude_opt_in_is_honored_when_set() {
+        // Explicit opt-in flips Claude on while Codex stays defaulted on.
+        let c: UsageConfig = toml::from_str("claude_account_enabled = true\n").unwrap();
         assert!(c.codex_enabled);
         assert!(c.claude_account_enabled);
     }
 
     #[test]
-    fn partial_table_keeps_other_default_on() {
-        // Only one flag is set; the missing one must stay defaulted on.
-        let c: UsageConfig = toml::from_str("claude_account_enabled = false\n").unwrap();
-        assert!(c.codex_enabled);
+    fn codex_can_be_disabled_without_enabling_claude() {
+        // Disabling Codex must not silently enable the opt-in Claude path.
+        let c: UsageConfig = toml::from_str("codex_enabled = false\n").unwrap();
+        assert!(!c.codex_enabled);
         assert!(!c.claude_account_enabled);
     }
 

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -3223,12 +3223,14 @@
         } catch {
           /* no-op */
         }
-        if ((latestProviderUsage.sessions || []).length) {
-          try {
-            renderActiveWorkOverview();
-          } catch {
-            /* no-op */
-          }
+        // Re-render regardless of session count: when a snapshot drops back to
+        // sessions:[] (agent stopped, rollout/transcript unreadable, settings
+        // change) the Active Work footer must clear its stale token/context
+        // instead of keeping the previous poll's values.
+        try {
+          renderActiveWorkOverview();
+        } catch {
+          /* no-op */
         }
       }
 
@@ -3663,7 +3665,7 @@
         const consent = document.createElement("p");
         consent.className = "settings-hint";
         consent.textContent =
-          "On by default. Claude account usage reads your OAuth token from the Keychain / credentials file and requests usage from the Anthropic API (polled at most once every 3 minutes). Uncheck to disable. Per-session token usage is read locally and is not affected by this setting.";
+          "Off by default (opt-in). When enabled, Claude account usage reads your OAuth token from the Keychain / credentials file and requests usage from the Anthropic API (polled at most once every 3 minutes). While disabled, no Keychain read or network request happens. Per-session token usage is read locally and is not affected by this setting.";
         section.appendChild(consent);
 
         panel.appendChild(section);

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6564,3 +6564,10 @@ Type: workflow
 Context: gwt-fix-issue SKILL.md 強化で新規 references/closure-comment.md を追加した際、git status に出ず原因調査した。
 Learning: `.claude/skills/gwt-*` と `.codex/skills/gwt-*` は .git/info/exclude で除外されており、新規ファイルは untracked 扱い。既存 tracked ファイル(SKILL.md 等)の編集は通常反映される。.codex は distribute.rs が embedded .claude を逐語コピーするが tracked-path 保護で上書きされない手動ミラーで、参照パスのみ .codex/ に書き換える。
 Future Action: skill 編集時は .claude と .codex の両ミラーを同一コミットで更新し、新規 managed skill ファイルは git add -f で tracked 化する。SKILL.md 内の自己参照パスは mirror 側で .codex/ prefix にする。
+
+## 2026-06-02 — SPEC-2970 Claude usage は opt-in 既定 OFF が consent 正。default-on は外部送信を同意なしに発火させる
+
+Type: lesson
+Context: Provider Usage 実装で Claude account 既定を ON にしたところ Codex 自動レビューが P1 指摘: [usage] 未設定の既存ユーザーが GUI 接続直後に opt-in 同意なしで Keychain 読取 + Anthropic /api/oauth/usage 送信を受ける。承認済み SPEC の同意モデルは『Claude アカウント枠のみ opt-in』だった。
+Learning: 外部送信/資格情報読取を伴う機能の既定値は『承認済み SPEC の consent 契約』に従う。デバッグ中の『既定で見たい』要望で default-on にすると spec と矛盾し privacy regression になる。フラグgate は呼び出し経路の最前段(early-return)に置き、未同意時は資格情報にも通信にも一切触れないことを敵対的監査で確認する。per-session のローカル読取は opt-in 不要(FR-017)。
+Future Action: consent を伴う設定の既定は false(opt-in)。SPEC FR の同意モデルとコード default を必ず一致させ、UI 説明文(Settings hint)・FR 全箇所の『既定で有効』表現も同時に掃き出す。視覚検証は隔離 HOME(未 opt-in 状態)で『Enable in Settings』が既定表示されることを確認する。


### PR DESCRIPTION
## Summary

- PR #2974（SPEC-2970 Provider Usage）の自動レビュー指摘 2 件を修正するフォロー PR。
- P1: Claude アカウント枠取得を **opt-in / 既定 OFF** に戻し、未同意ユーザーへの無断な Keychain 読取・Anthropic 通信を防ぐ。
- P2: usage snapshot が空セッションに戻った時に Active Work footer の stale な token/context を確実にクリアする。

## Changes

- `crates/gwt-config/src/usage_config.rs`: `claude_account_enabled` の既定を `true` → `false`（opt-in）。doc コメントとテストを「Codex=auto / Claude account=opt-in（既定 OFF）」に更新。未 opt-in では Keychain 読取・外部通信が発生しないことを明文化。
- `crates/gwt-config/src/settings.rs`: 旧 config（`[usage]` 欄なし）マイグレーションテストを Codex=ON / Claude account=OFF の期待値に修正。
- `crates/gwt/web/app.js`:
  - `applyProviderUsageUi` で session 数に関係なく `renderActiveWorkOverview()` を常時呼ぶよう変更（P2）。`sessions:[]` へ戻った時に古い footer を消す。
  - Settings → Usage & Limits の Claude opt-in 説明文を「Off by default (opt-in)」に修正。チェックボックスの初期状態はライブ snapshot の Claude account state（disabled → unchecked）から導出（ハードコード無し）。
- SPEC #2970 `spec` セクション: FR-009 / FR-013 を opt-in / 既定 OFF に整合（受け入れシナリオ 2・FR-012 の `Enable in Settings` と一致）。

## Testing

- [x] `cargo fmt --check` — 差分なし
- [x] `cargo clippy -p gwt-core -p gwt-config -p gwt --all-targets --all-features -- -D warnings` — 警告ゼロ
- [x] `cargo test -p gwt-config` — 70 passed（opt-in 既定 OFF の新テスト含む）
- [x] `cargo test -p gwt-core --lib --all-features` — 403 passed
- [x] `cargo test -p gwt --lib` — 814 passed
- [x] `cargo test -p gwt --bins` — 507 passed（`claude_disabled_yields_disabled_state` 含む）
- [x] 敵対的監査ワークフロー（3 agent）: consent 完全性 `correct`（未 opt-in 時 Keychain/通信ゼロ、early-return gate at `usage_poller.rs:169`）/ render 安全性 `correct`（無条件 re-render は安全・再帰/perf 問題なし）
- [x] 視覚確認（ユーザー confirmed）: 隔離インスタンス（未 opt-in、実 Codex データ）で Codex は 5h/週次/消費/スパークラインを実表示、Claude は既定で「Enable in Settings」、ステータスバー `USAGE ⬡ 23% ◇ off`

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — privacy 退行の解消 + 表示バグ修正で単独配信可能。既存挙動を壊さず、未 opt-in ユーザーの外部通信を止める方向の安全な変更。
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- #2970（SPEC: Provider Usage & Rate Limits — フォロー対象 SPEC）
- #2974（元 PR — マージ済み。本 PR がそのレビュー指摘 P1/P2 を解消）

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (if user-facing change) — Settings hint + SPEC FR を更新
- [x] Migration/backfill plan included (if schema/data change) — `#[serde(default)]` で旧 config は Codex=ON / Claude account=OFF に解決、backfill 不要
- [x] CHANGELOG impact considered — `fix:` でパッチ対象

## Risk / Impact

- **Affected areas**: usage 設定既定値 / Settings UI 文言 / Active Work footer 再描画。挙動は「外部通信を止める」「stale 表示を消す」方向のみで退行リスクは低い。
- **Rollback plan**: 単一 `fix` コミットの revert で従来挙動（既定 ON / 条件付き再描画）に戻せる。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Claude account usage is now opt-in and disabled by default; Codex usage remains enabled by default.
  * Updated settings UI messaging to clarify Claude account usage requires explicit enablement and may access credentials and external services.
  * Fixed Active Work footer to properly refresh and clear when provider usage snapshots are updated.

* **Documentation**
  * Added internal guidelines on default settings security considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->