### PR TITLE
fix(usage): remove per-session list from usage popover

### DIFF
--- a/crates/gwt/src/cli/tray/lock.rs
+++ b/crates/gwt/src/cli/tray/lock.rs
@@ -42,6 +42,16 @@ pub fn lock_path(gwt_home: &Path, user_id: &str) -> PathBuf {
     gwt_home.join("run").join(format!("tray-{user_id}.lock"))
 }
 
+/// Lock path for a force-spawned secondary instance
+/// (`GWT_FORCE_NEW_INSTANCE`). PID-scoped so it never contends with — or
+/// clobbers — the canonical `tray-<user>.lock` that other launches read for
+/// discovery. The forced instance owns this file and removes it on drop.
+pub fn forced_lock_path(gwt_home: &Path, user_id: &str, pid: u32) -> PathBuf {
+    gwt_home
+        .join("run")
+        .join(format!("tray-{user_id}-forced-{pid}.lock"))
+}
+
 /// Resolve the OS-level user id used as the lock scope. Falls back to
 /// the OS env vars if the `whoami` crate cannot infer the username, and
 /// to a fixed sentinel as a last resort so the lock path is always
@@ -146,8 +156,34 @@ pub enum TrayLockError {
 /// `TrayLockError::AlreadyRunning` so the caller can print the running
 /// instance's URL on stderr and exit gracefully.
 pub fn acquire(gwt_home: &Path) -> Result<TrayLockHandle, TrayLockError> {
+    acquire_inner(
+        gwt_home,
+        crate::gui_single_instance::force_new_instance_requested(),
+    )
+}
+
+/// Inner acquisition with the `GWT_FORCE_NEW_INSTANCE` decision injected so
+/// the override behaviour is unit-testable without mutating process env.
+///
+/// When `force_new_instance` is set the override targets a PID-scoped path
+/// ([`forced_lock_path`]) instead of the canonical one, so a second instance
+/// always acquires a fresh lock, binds its own server port, and never touches
+/// the primary instance's lock file or its advertised URL — matching the GUI
+/// lock's escape-hatch semantics (SPEC #2920 parity).
+fn acquire_inner(
+    gwt_home: &Path,
+    force_new_instance: bool,
+) -> Result<TrayLockHandle, TrayLockError> {
     let user_id = current_user_id();
-    let path = lock_path(gwt_home, &user_id);
+    let path = if force_new_instance {
+        tracing::warn!(
+            target: "gwt_tray_lock",
+            "GWT_FORCE_NEW_INSTANCE override: using a PID-scoped tray lock so this instance coexists with the primary one"
+        );
+        forced_lock_path(gwt_home, &user_id, std::process::id())
+    } else {
+        lock_path(gwt_home, &user_id)
+    };
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|source| TrayLockError::Io {
             path: path.clone(),
@@ -337,6 +373,58 @@ mod tests {
         }
         let read_back = read_lock_contents(&path).expect("read existing lock contents");
         assert_eq!(read_back.url, "http://127.0.0.1:55555/");
+    }
+
+    #[test]
+    fn forced_new_instance_uses_distinct_pid_scoped_path() {
+        // SPEC #2920 escape-hatch parity: GWT_FORCE_NEW_INSTANCE must let a
+        // second instance start without clobbering the primary's lock. The
+        // forced path is PID-scoped so it never collides with the canonical
+        // `tray-<user>.lock` discovered by other launches.
+        let user_id = "alice";
+        let canonical = lock_path(Path::new("/tmp/gwt-home"), user_id);
+        let forced = forced_lock_path(Path::new("/tmp/gwt-home"), user_id, 4242);
+        assert_ne!(canonical, forced);
+        assert_eq!(
+            forced,
+            PathBuf::from("/tmp/gwt-home/run/tray-alice-forced-4242.lock")
+        );
+    }
+
+    #[test]
+    fn forced_acquire_coexists_and_preserves_primary_lock() {
+        // The forced acquisition must succeed even while the canonical lock
+        // is held, must use a different file, and dropping it must NOT remove
+        // the primary lock file (only its own PID-scoped file).
+        let tmp = TempDir::new().expect("tempdir");
+        let gwt_home = tmp.path();
+        let primary = acquire_inner(gwt_home, false).expect("primary acquire");
+        let canonical = lock_path(gwt_home, &current_user_id());
+        assert_eq!(primary.path(), canonical);
+
+        let forced = acquire_inner(gwt_home, true)
+            .expect("forced acquire must succeed even with the primary lock held");
+        assert_ne!(
+            forced.path(),
+            canonical,
+            "forced instance must use a distinct lock path"
+        );
+        assert!(forced.path().exists(), "forced lock file must exist");
+        assert!(
+            canonical.exists(),
+            "primary lock must remain after forced acquire"
+        );
+
+        let forced_path = forced.path().to_path_buf();
+        drop(forced);
+        assert!(
+            canonical.exists(),
+            "dropping the forced instance must not remove the primary lock file"
+        );
+        assert!(
+            !forced_path.exists(),
+            "forced instance must clean up its own PID-scoped lock file on drop"
+        );
     }
 
     #[test]

--- a/crates/gwt/src/gui_single_instance.rs
+++ b/crates/gwt/src/gui_single_instance.rs
@@ -300,7 +300,11 @@ fn detect_other_kind_active(
     }
 }
 
-fn force_new_instance_requested() -> bool {
+/// Whether `GWT_FORCE_NEW_INSTANCE` is set to a truthy value
+/// (`1`/`true`/`yes`/`on`, case-insensitive). Public so the SPEC #2920
+/// tray-resident lock can honour the same escape hatch as the GUI lock,
+/// keeping the override's semantics uniform across both front-door locks.
+pub fn force_new_instance_requested() -> bool {
     match std::env::var(FORCE_NEW_INSTANCE_ENV) {
         Ok(value) => {
             let normalized = value.trim().to_ascii_lowercase();

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -6290,7 +6290,7 @@ fn main() -> std::io::Result<()> {
             } else {
                 eprintln!("gwt browser URL: {url}");
                 eprintln!(
-                    "gwt: another tray-resident gwt instance is already running for this user"
+                    "gwt: another tray-resident gwt instance is already running for this user (set GWT_FORCE_NEW_INSTANCE=1 to start a second, coexisting instance)"
                 );
             }
             return Ok(());

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -3334,41 +3334,6 @@
         return row;
       }
 
-      function renderUsageSessionsTable(sessions) {
-        const table = document.createElement("table");
-        table.className = "op-usage-sessions";
-        const thead = document.createElement("thead");
-        const htr = document.createElement("tr");
-        for (const h of ["Session", "Prov", "Model", "Tokens", "Ctx", "Lim"]) {
-          const th = document.createElement("th");
-          th.textContent = h;
-          htr.appendChild(th);
-        }
-        thead.appendChild(htr);
-        table.appendChild(thead);
-        const tbody = document.createElement("tbody");
-        for (const s of sessions) {
-          const tr = document.createElement("tr");
-          if (s.eligible === false) tr.dataset.ineligible = "true";
-          const cells = [
-            s.session_id ? s.session_id.slice(0, 8) : "—",
-            s.provider === "claude_code" ? "Cl" : "Cx",
-            s.model || "—",
-            usageFmtTokens(s.total_tokens),
-            s.context_left_pct != null ? `${Math.round(s.context_left_pct)}%` : "—",
-            s.limit_reached ? "⚠" : "ok",
-          ];
-          for (const c of cells) {
-            const td = document.createElement("td");
-            td.textContent = c;
-            tr.appendChild(td);
-          }
-          tbody.appendChild(tr);
-        }
-        table.appendChild(tbody);
-        return table;
-      }
-
       function consumptionTotal(b) {
         if (!b) return 0;
         return (b.input || 0) + (b.output || 0) + (b.cached || 0);
@@ -3539,29 +3504,16 @@
         return card;
       }
 
-      // SPEC-2970 — the full usage detail as provider cards + a sessions list,
-      // appended to a container. The hover popover is the single surface for all
-      // usage info (the click-open modal was removed per UX feedback).
+      // SPEC-2970 — the full usage detail as provider cards, appended to a
+      // container. The hover popover is the single surface for all usage info
+      // (the click-open modal was removed per UX feedback). The per-session
+      // list was removed per UX feedback — it grew to hundreds of rows and
+      // overwhelmed the popover; per-session token usage still drives each
+      // agent's inline footer (see usageForSession).
       function buildUsageFullSections(container) {
         for (const account of latestProviderUsage.accounts || []) {
           container.appendChild(buildUsageProviderCard(account));
         }
-        const sessions = latestProviderUsage.sessions || [];
-        const sess = document.createElement("div");
-        sess.className = "op-usage-sess";
-        const sHead = document.createElement("div");
-        sHead.className = "op-usage-sess__head";
-        sHead.textContent = sessions.length ? `Sessions (${sessions.length})` : "Sessions";
-        sess.appendChild(sHead);
-        if (sessions.length) {
-          sess.appendChild(renderUsageSessionsTable(sessions));
-        } else {
-          const empty = document.createElement("p");
-          empty.className = "op-usage-empty";
-          empty.textContent = "No active sessions.";
-          sess.appendChild(empty);
-        }
-        container.appendChild(sess);
       }
 
       // ---- Consolidated usage hover popover (SPEC-2970 UX) ----

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -4713,21 +4713,6 @@ kbd.op-kbd {
   text-align: right;
 }
 
-/* Sessions block in the hover popover. */
-.op-usage-sess {
-  border-top: 1px solid var(--color-border, rgba(127, 127, 127, 0.25));
-  padding-top: 10px;
-  margin-top: 4px;
-}
-
-.op-usage-sess__head {
-  font-size: var(--type-xs, 0.72rem);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--color-text-muted, #9aa0ad);
-  margin-bottom: 6px;
-}
-
 /* Detail modal */
 .op-usage-modal-overlay {
   position: fixed;
@@ -4905,33 +4890,6 @@ kbd.op-kbd {
   font-size: var(--type-xs, 0.72rem);
   color: var(--color-text-muted, #9aa0ad);
   white-space: nowrap;
-}
-
-.op-usage-sessions {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: var(--type-sm, 0.85rem);
-}
-
-.op-usage-sessions th,
-.op-usage-sessions td {
-  text-align: left;
-  padding: 4px 8px;
-  border-bottom: 1px solid var(--color-border, rgba(255, 255, 255, 0.08));
-}
-
-.op-usage-sessions th {
-  color: var(--color-text-muted, #9aa0ad);
-  font-weight: 600;
-}
-
-.op-usage-sessions tr[data-ineligible="true"] {
-  opacity: 0.5;
-}
-
-.op-usage-empty {
-  color: var(--color-text-muted, #9aa0ad);
-  font-style: italic;
 }
 
 /* Daily/weekly consumption (SPEC-2970 extension) */

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6578,3 +6578,17 @@ Type: lesson
 Context: SPEC-2008 の最大化で、ユーザー検証中に激しいチラつきが発生。調査の結果、syncMaximizedWindowsToViewport が各クライアントの可視領域に合わせて共有の最大化ジオメトリへ maximize_window 補正を broadcast しており、異なる viewport サイズの 2 クライアント（検証用 MCP ブラウザ1200px + ユーザーのブラウザ810px）が同時接続するとジオメトリを往復させ続けた。inset 値に依存しない既存設計問題。
 Learning: 最大化の塗りつぶしのような per-client な表示状態を shared workspace geometry に書き戻して全クライアントに broadcast すると、サイズの異なるクライアント間で ping-pong してチラつく。各クライアントが visibleBounds から fill をローカル計算してローカル適用し、共有するのは maximized フラグだけにすると解消する。さらに、エージェント検証時に検証用ブラウザ(Playwright/MCP)を開いたままユーザーに視覚確認を依頼すると、それが第2クライアントになり multi-client バグを誘発し『回帰』に見える。
 Future Action: (1) 最大化/ズーム追従など viewport 依存の表示はローカル描画にし、shared geometry へ補正を broadcast しない。(2) ユーザーに視覚確認を依頼する前に、検証用ブラウザ(MCP/Playwright)を必ず閉じて単一クライアントにする。複数クライアント挙動を確認したい場合は意図的に別サイズで開く。
+
+## 2026-06-03 — 新しい singleton/lock 機構を足す時は既存のエスケープハッチ(env override)を引き継ぐ
+
+Type: lesson
+Context: SPEC #2920 の per-user tray single-instance lock (cli/tray/lock.rs::acquire, main.rs:6283) が、レガシー gui_single_instance ロックの GWT_FORCE_NEW_INSTANCE エスケープハッチを引き継がず、debug でも 2 つ目のインスタンスを起動できなかった。ユーザーは env で回避できるはずと認識していた。
+Learning: front-door に新しいロック層を追加すると、旧ロックが honor していた env override が暗黙に失効する。tray lock は force 時に PID スコープの forced_lock_path を使い正規ロックを汚さず共存させる形で修正した。
+Future Action: singleton/lock/exclusive 系の機構を新設・置換する時は、既存ロックの bypass/override(特に GWT_FORCE_NEW_INSTANCE 等の env)を新経路にも必ず移植し、TDD で回避経路を固定する。
+
+## 2026-06-03 — 視覚検証で GWT_FORCE_NEW_INSTANCE 共存インスタンスを使わない(共有 ~/.gwt が不安定)
+
+Type: lesson
+Context: SESSIONS 一覧削除の視覚確認のため GWT_FORCE_NEW_INSTANCE=1 で dev ビルドを GWT.app と並行起動したが、同じ ~/.gwt を共有するため issues 再インデックスがループし、dev 側 usage poller が provider_usage を配信せず USAGE セルが hidden のまま(accounts 空判定)になった。WebSocket/telemetry は正常だった。
+Learning: 2 つの gwt インスタンスが同一 ~/.gwt を共有すると stateful subsystem(index/usage poller)が競合し live 検証が不安定になる。単一インスタンス(GWT.app)では browser からでも usage は正常表示される。
+Future Action: GUI の視覚検証は単一インスタンスで行う。dev を確認したい時は既存インスタンスを終了して dev を唯一の tray-resident として起動する。共存は lock 検証用に留め、live データ表示の検証には使わない。


### PR DESCRIPTION
## Summary

- Remove the per-session list from the usage popover — it grew to hundreds of rows (564 in the reported case) and overwhelmed the popover; token totals, rate-limit windows, and the 7-day chart stay.
- Restore the `GWT_FORCE_NEW_INSTANCE` escape hatch for the SPEC #2920 tray single-instance lock so a second (e.g. debug) instance can coexist with the primary one for verification.

## Changes

- `crates/gwt/web/app.js`: drop the sessions-list block from `buildUsageFullSections`; delete the now-unused `renderUsageSessionsTable`. The per-agent inline footer keeps reading per-session usage via `usageForSession` (data path untouched).
- `crates/gwt/web/styles/components.css`: remove the orphaned `.op-usage-sess` / `.op-usage-sessions` / `.op-usage-empty` rules.
- `crates/gwt/src/cli/tray/lock.rs`: split `acquire` into `acquire_inner(gwt_home, force)` so the env decision is unit-testable; add PID-scoped `forced_lock_path`; under `GWT_FORCE_NEW_INSTANCE` use the forced path so the second instance binds its own port and never clobbers the primary `tray-<user>.lock` / its advertised URL.
- `crates/gwt/src/gui_single_instance.rs`: make `force_new_instance_requested` public so the tray lock reuses the same env semantics as the legacy GUI lock.
- `crates/gwt/src/main.rs`: mention the `GWT_FORCE_NEW_INSTANCE` escape hatch in the `AlreadyRunning` stderr message.
- `tasks/memory.md`: record two reusable lessons (carry env escape hatches into new lock layers; don't use coexisting instances for visual verification).

## Testing

- [x] `cargo build -p gwt --bin gwt --bin gwtd` — success
- [x] `cargo test -p gwt --lib cli::tray::lock` — 8 passed (incl. new TDD `forced_new_instance_uses_distinct_pid_scoped_path`, `forced_acquire_coexists_and_preserves_primary_lock`)
- [x] `cargo test -p gwt --lib gui_single_instance` — 9 passed
- [x] `cargo clippy -p gwt --all-targets --all-features -- -D warnings` — clean
- [x] `bash scripts/run-frontend-unit-tests.sh` — 622 passed
- [x] `node --check crates/gwt/web/app.js` — OK
- [x] `bunx commitlint --from HEAD~3 --to HEAD` — pass
- [x] Live (built instance): served `/app.js` has 0 occurrences of `renderUsageSessionsTable`/`op-usage-sessions`; `usageForSession` retained. `GWT_FORCE_NEW_INSTANCE=1` instance bound a separate port (52579) alongside the primary (62212); its PID-scoped forced lock was created and cleanly removed on exit, leaving the canonical lock intact.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — the two fixes are independently shippable. Removing the popover list does not affect the per-agent footer (separate data path), and the tray escape-hatch restoration is additive and guarded by an env var (default behavior unchanged).
- Known blockers: None
- Remaining acceptance: None — `User Verification Result: confirmed` (user confirmed the usage popover change is OK).

## Closing Issues

- None

## Related Issues / Links

- None

## Context

- The usage popover (SPEC #2970) appended a per-session table that accumulated to 564 rows in practice, dominating the popover; the user asked to remove it.
- While trying to run the updated debug build alongside the running app for visual verification, the SPEC #2920 tray single-instance lock blocked the second instance and — unlike the legacy GUI lock — did not honor `GWT_FORCE_NEW_INSTANCE`. That regression is fixed here so the documented escape hatch works for the tray-resident front door.

## Risk / Impact

- **Affected areas**: usage popover (WebView UI); tray single-instance startup path.
- **Rollback plan**: revert the two `fix` commits; no schema/data/migration involved.

## Screenshots

- Before: usage popover showed `SESSIONS (564)` as a long per-session table below the token totals and 7-day chart (user-provided recording).
- After: the `SESSIONS` section is gone; token totals (Today/Week), rate-limit windows, and the 7-day chart remain. Per-agent inline token/ctx footer is unchanged.

## Checklist

- [x] Tests added/updated — tray lock TDD added; frontend popover has no closure-level unit-test seam (verified via served-asset assertions + 622 JS unit tests still green)
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`) — svelte-check N/A (no Svelte in this repo)
- [x] Documentation updated (if user-facing change) — N/A: README does not document the per-session popover list
- [x] Migration/backfill plan included (if schema/data change) — N/A: no schema/data change
- [x] CHANGELOG impact considered — both commits are `fix` (patch); no breaking change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for forcing a new coexisting instance via the `GWT_FORCE_NEW_INSTANCE=1` environment variable, enabling multiple instances to run simultaneously.
  * Updated error messaging to guide users on using the force-new-instance option when needed.

* **Style**
  * Redesigned usage hover popover to display daily/weekly consumption metrics instead of per-session details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->