### PR TITLE
fix: surface EMPTY_CORPUS diagnostic for unpopulated semantic search cache

### DIFF
--- a/.claude/skills/gwt-search/SKILL.md
+++ b/.claude/skills/gwt-search/SKILL.md
@@ -180,6 +180,27 @@ Pass `--no-auto-build` to disable this behavior; in that case the runner returns
 {"ok": false, "error_code": "INDEX_MISSING", "error": "index not found at ..."}
 ```
 
+## Empty corpus is a tooling failure, not "no results"
+
+`search-specs` and `search-issues` build their corpus from the GitHub Issue
+cache (`~/.gwt/cache/issues/<repo-hash>/`). When that cache is empty or
+unpopulated for the repo-hash, an auto-build search would index zero documents.
+Instead of silently returning `ok: true` with an empty list — which reads as
+"no existing SPEC/Issue owner" and causes duplicate creation — the runner
+returns a diagnostic:
+
+```json
+{"ok": false, "error_code": "EMPTY_CORPUS", "scope": "specs",
+ "issue_cache_dir": "~/.gwt/cache/issues/<repo-hash>",
+ "issue_cache_populated": false,
+ "error": "specs search corpus is empty: ... Refresh the cache ... and retry ..."}
+```
+
+When you see `EMPTY_CORPUS`, **do not conclude that no owner exists.** Refresh
+the issue cache (open the project in the gwt GUI to sync, or run a `gwtd issue`
+sync) and retry the search. Only an `ok: true` result with an empty list from a
+*populated* cache means the repository genuinely has no matching SPEC/Issue.
+
 ## Index update commands
 
 These are run automatically by the gwt GUI watcher (or by the runner's

--- a/.codex/skills/gwt-search/SKILL.md
+++ b/.codex/skills/gwt-search/SKILL.md
@@ -180,6 +180,27 @@ Pass `--no-auto-build` to disable this behavior; in that case the runner returns
 {"ok": false, "error_code": "INDEX_MISSING", "error": "index not found at ..."}
 ```
 
+## Empty corpus is a tooling failure, not "no results"
+
+`search-specs` and `search-issues` build their corpus from the GitHub Issue
+cache (`~/.gwt/cache/issues/<repo-hash>/`). When that cache is empty or
+unpopulated for the repo-hash, an auto-build search would index zero documents.
+Instead of silently returning `ok: true` with an empty list — which reads as
+"no existing SPEC/Issue owner" and causes duplicate creation — the runner
+returns a diagnostic:
+
+```json
+{"ok": false, "error_code": "EMPTY_CORPUS", "scope": "specs",
+ "issue_cache_dir": "~/.gwt/cache/issues/<repo-hash>",
+ "issue_cache_populated": false,
+ "error": "specs search corpus is empty: ... Refresh the cache ... and retry ..."}
+```
+
+When you see `EMPTY_CORPUS`, **do not conclude that no owner exists.** Refresh
+the issue cache (open the project in the gwt GUI to sync, or run a `gwtd issue`
+sync) and retry the search. Only an `ok: true` result with an empty list from a
+*populated* cache means the repository genuinely has no matching SPEC/Issue.
+
 ## Index update commands
 
 These are run automatically by the gwt GUI watcher (or by the runner's

--- a/crates/gwt-core/runtime/chroma_index_runner.py
+++ b/crates/gwt-core/runtime/chroma_index_runner.py
@@ -1956,6 +1956,28 @@ def _issue_cache_root(repo_hash: str) -> Path:
     return home / ".gwt" / "cache" / "issues" / repo_hash
 
 
+def _issue_cache_is_populated(repo_hash: str) -> bool:
+    """Return True when the GitHub Issue cache holds at least one cached issue.
+
+    Both the issues and specs scopes build their search corpus from
+    ``~/.gwt/cache/issues/<repo_hash>/`` (one-directional GitHub -> cache -> UI
+    flow, SPEC-12). An absent or entry-less cache root means the cache was never
+    synced for this repo-hash (or the repo-hash does not match the populated
+    cache), which is distinct from a repository that genuinely has no Issues.
+    """
+    root = _issue_cache_root(repo_hash)
+    if not root.is_dir():
+        return False
+    try:
+        entries = root.iterdir()
+    except OSError:
+        return False
+    for entry in entries:
+        if entry.is_dir() and entry.name.isdigit() and (entry / "meta.json").is_file():
+            return True
+    return False
+
+
 def _normalize_labels(labels: Any) -> List[str]:
     if isinstance(labels, str):
         return [labels]
@@ -3537,6 +3559,36 @@ def _format_scope_results(
     return _format_issue_results(items)[:n_results]
 
 
+def _empty_corpus_diagnostic(scope: str, repo_hash: str) -> dict:
+    """Build the non-OK payload for an unpopulated issues/specs search corpus.
+
+    Returned by :func:`action_search_v2` when an auto-build search finds an
+    empty index that the issue cache cannot explain (Issue #2979). The message
+    is agent-facing: it states the empty result is a tooling failure, points at
+    the cache directory, and tells the caller to refresh rather than treat the
+    empty list as "no existing SPEC/Issue".
+    """
+    cache_dir = _issue_cache_root(repo_hash)
+    noun = "SPECs" if scope == "specs" else "Issues"
+    return {
+        "ok": False,
+        "error_code": "EMPTY_CORPUS",
+        "scope": scope,
+        "indexed": 0,
+        "issue_cache_dir": str(cache_dir),
+        "issue_cache_populated": False,
+        "error": (
+            f"{scope} search corpus is empty: the GitHub Issue cache at "
+            f"{cache_dir} holds no cached issues for repo-hash {repo_hash}. "
+            "This is a tooling failure (the cache was never synced for this "
+            "repository, or the repo-hash does not match the populated cache), "
+            f"not proof that the repository has no {noun}. Refresh the cache "
+            "(open the project in the gwt GUI to sync, or run a gwtd issue "
+            "sync) and retry the search before concluding no owner exists."
+        ),
+    }
+
+
 def action_search_v2(
     action: str,
     repo_hash: str,
@@ -3645,10 +3697,29 @@ def action_search_v2(
     with acquire_lock(db_path, exclusive=False):
         client, collection = _open_chroma_collection(db_path, _scope_collection_name(scope))
         try:
+            collection_count = _safe_collection_count(collection)
             fetch_n = _search_fetch_count(scope, n_results, match_mode)
             items = _search_collection_v2(collection, query, fetch_n)
         finally:
             _close_chroma_client(client)
+
+    # Issue #2979: an issues/specs search whose corpus is empty *because the
+    # source issue cache was never populated for this repo-hash* must not
+    # silently report `ok: true` with no results — agents read that empty list
+    # as proof that no SPEC/Issue owner exists and create duplicates. Surface a
+    # diagnostic so the failure is visible. This is gated to the agent
+    # auto-build preflight (no_auto_build is False); the interactive GUI search
+    # (search-multi, no_auto_build=True) keeps returning empty results so one
+    # empty scope never fails the whole multi-scope search. A populated cache
+    # that simply has no matching SPECs is a legitimate empty result and is left
+    # untouched.
+    if (
+        scope in ("issues", "specs")
+        and not no_auto_build
+        and collection_count == 0
+        and not _issue_cache_is_populated(repo_hash)
+    ):
+        return _empty_corpus_diagnostic(scope, repo_hash)
 
     strict_items, suggestion_items = _apply_match_mode(items, query, match_mode)
     payload = {

--- a/crates/gwt-core/runtime/tests/test_auto_build_fallback.py
+++ b/crates/gwt-core/runtime/tests/test_auto_build_fallback.py
@@ -268,6 +268,118 @@ class AutoBuildFallbackTests(unittest.TestCase):
             self.assertFalse(result["ok"], result)
             self.assertEqual(result["error_code"], "INDEX_MISSING")
 
+    def test_search_specs_empty_corpus_returns_diagnostic_when_cache_unpopulated(self):
+        # Issue #2979: when the issue cache is empty/unpopulated, an auto-built
+        # spec index has zero documents. The runner must NOT silently succeed
+        # with `ok: true, specResults: []` (which agents misread as "no SPEC
+        # owner exists"); it must return a non-OK diagnostic.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            db_root = Path(tmp) / "index_root"
+            with mock.patch.dict(os.environ, {"HOME": tmp}, clear=False):
+                result = runner.action_search_v2(
+                    action="search-specs",
+                    repo_hash="abc1234567890def",
+                    worktree_hash=None,
+                    project_root=str(root),
+                    query="watcher debounce",
+                    n_results=5,
+                    no_auto_build=False,
+                    db_root=db_root,
+                )
+
+            self.assertFalse(result["ok"], result)
+            self.assertEqual(result.get("error_code"), "EMPTY_CORPUS", result)
+            self.assertEqual(result.get("scope"), "specs", result)
+            self.assertIn("cache", result.get("error", "").lower(), result)
+
+    def test_search_issues_empty_corpus_returns_diagnostic_when_cache_unpopulated(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            db_root = Path(tmp) / "index_root"
+            with mock.patch.dict(os.environ, {"HOME": tmp}, clear=False):
+                result = runner.action_search_v2(
+                    action="search-issues",
+                    repo_hash="abc1234567890def",
+                    worktree_hash=None,
+                    project_root=str(root),
+                    query="anything",
+                    n_results=5,
+                    no_auto_build=False,
+                    db_root=db_root,
+                )
+
+            self.assertFalse(result["ok"], result)
+            self.assertEqual(result.get("error_code"), "EMPTY_CORPUS", result)
+            self.assertEqual(result.get("scope"), "issues", result)
+
+    def test_search_specs_returns_empty_results_when_cache_has_no_specs(self):
+        # A populated issue cache that simply contains no `gwt-spec` issues is a
+        # legitimate empty result, not a tooling failure. The runner must keep
+        # returning `ok: true, specResults: []` here (no false positive).
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            cache_root = Path(tmp) / ".gwt" / "cache" / "issues" / "abc1234567890def"
+            self._write_cached_issue(
+                cache_root,
+                2000,
+                "Plain issue",
+                "# Plain issue\nNo spec label here.\n",
+                ["bug"],
+            )
+            db_root = Path(tmp) / "index_root"
+            with mock.patch.dict(os.environ, {"HOME": tmp}, clear=False):
+                result = runner.action_search_v2(
+                    action="search-specs",
+                    repo_hash="abc1234567890def",
+                    worktree_hash=None,
+                    project_root=str(root),
+                    query="watcher debounce",
+                    n_results=5,
+                    no_auto_build=False,
+                    db_root=db_root,
+                )
+
+            self.assertTrue(result["ok"], result)
+            self.assertEqual(result.get("specResults"), [], result)
+
+    def test_no_auto_build_empty_index_does_not_emit_empty_corpus_diagnostic(self):
+        # The interactive GUI search path (search-multi) always passes
+        # no_auto_build=True and must not fail the whole multi-scope search just
+        # because one scope's existing index is empty. The diagnostic is scoped
+        # to the agent auto-build preflight only.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "repo"
+            root.mkdir()
+            db_root = Path(tmp) / "index_root"
+            with mock.patch.dict(os.environ, {"HOME": tmp}, clear=False):
+                build = runner.action_index_specs_v2(
+                    project_root=str(root),
+                    repo_hash="abc1234567890def",
+                    worktree_hash=None,
+                    mode="full",
+                    db_root=db_root,
+                )
+                self.assertTrue(build["ok"], build)
+                self.assertEqual(build["indexed"], 0, build)
+
+                result = runner.action_search_v2(
+                    action="search-specs",
+                    repo_hash="abc1234567890def",
+                    worktree_hash=None,
+                    project_root=str(root),
+                    query="watcher debounce",
+                    n_results=5,
+                    no_auto_build=True,
+                    db_root=db_root,
+                )
+
+            self.assertTrue(result["ok"], result)
+            self.assertEqual(result.get("specResults"), [], result)
+
     def test_search_specs_refreshes_existing_index_from_issue_cache(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp) / "repo"

--- a/crates/gwt/src/knowledge_bridge.rs
+++ b/crates/gwt/src/knowledge_bridge.rs
@@ -199,43 +199,62 @@ impl SemanticSearchClient for RunnerSemanticSearchClient {
         }
         let payload: Value = serde_json::from_slice(&output.stdout)
             .map_err(|error| format!("parse semantic search result: {error}"))?;
-        if !payload.get("ok").and_then(Value::as_bool).unwrap_or(false) {
-            return Err(payload_error(&payload));
-        }
-        Ok(match kind {
-            KnowledgeKind::Issue => payload
-                .get("issueResults")
-                .and_then(Value::as_array)
-                .map(|items| {
-                    items
-                        .iter()
-                        .filter_map(|item| {
-                            Some(SemanticSearchHit {
-                                number: value_u64(item.get("number")?)?,
-                                distance: item.get("distance").and_then(Value::as_f64),
-                            })
-                        })
-                        .collect()
-                })
-                .unwrap_or_default(),
-            KnowledgeKind::Spec => payload
-                .get("specResults")
-                .and_then(Value::as_array)
-                .map(|items| {
-                    items
-                        .iter()
-                        .filter_map(|item| {
-                            Some(SemanticSearchHit {
-                                number: value_u64(item.get("spec_id")?)?,
-                                distance: item.get("distance").and_then(Value::as_f64),
-                            })
-                        })
-                        .collect()
-                })
-                .unwrap_or_default(),
-            KnowledgeKind::Pr => Vec::new(),
-        })
+        semantic_hits_from_payload(kind, &payload)
     }
+}
+
+/// Interpret a runner search payload into [`SemanticSearchHit`]s.
+///
+/// Issue #2979: when the runner reports `error_code: "EMPTY_CORPUS"` the issue
+/// cache is unpopulated for this repo-hash. The Knowledge Bridge already
+/// renders cache-backed entries directly and exposes a Refresh affordance, so
+/// an empty semantic corpus is treated as "no semantic hits" rather than a hard
+/// error. Any other non-OK payload remains an error. The agent-facing preflight
+/// (which invokes the runner directly via the gwt-search skill) still sees the
+/// raw diagnostic so its duplicate check does not silently pass with `[]`.
+fn semantic_hits_from_payload(
+    kind: KnowledgeKind,
+    payload: &Value,
+) -> Result<Vec<SemanticSearchHit>, String> {
+    if !payload.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+        if payload.get("error_code").and_then(Value::as_str) == Some("EMPTY_CORPUS") {
+            return Ok(Vec::new());
+        }
+        return Err(payload_error(payload));
+    }
+    Ok(match kind {
+        KnowledgeKind::Issue => payload
+            .get("issueResults")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(|item| {
+                        Some(SemanticSearchHit {
+                            number: value_u64(item.get("number")?)?,
+                            distance: item.get("distance").and_then(Value::as_f64),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+        KnowledgeKind::Spec => payload
+            .get("specResults")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(|item| {
+                        Some(SemanticSearchHit {
+                            number: value_u64(item.get("spec_id")?)?,
+                            distance: item.get("distance").and_then(Value::as_f64),
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+        KnowledgeKind::Pr => Vec::new(),
+    })
 }
 
 pub fn load_knowledge_bridge(
@@ -2003,5 +2022,60 @@ Extra context.
             });
         let err = result.expect_err("missing cache entry must error");
         assert!(err.contains("not in local cache"), "got: {err}");
+    }
+
+    #[test]
+    fn semantic_hits_from_payload_extracts_issue_and_spec_hits() {
+        let issue_hits = semantic_hits_from_payload(
+            KnowledgeKind::Issue,
+            &serde_json::json!({
+                "ok": true,
+                "issueResults": [{"number": 42, "distance": 0.25}]
+            }),
+        )
+        .expect("issue hits");
+        assert_eq!(issue_hits.len(), 1);
+        assert_eq!(issue_hits[0].number, 42);
+
+        let spec_hits = semantic_hits_from_payload(
+            KnowledgeKind::Spec,
+            &serde_json::json!({
+                "ok": true,
+                "specResults": [{"spec_id": 1939, "distance": 0.1}]
+            }),
+        )
+        .expect("spec hits");
+        assert_eq!(spec_hits.len(), 1);
+        assert_eq!(spec_hits[0].number, 1939);
+    }
+
+    #[test]
+    fn semantic_hits_from_payload_treats_empty_corpus_as_no_hits() {
+        // Issue #2979: an unpopulated-cache diagnostic must not crash the GUI
+        // Knowledge Bridge search; it renders cache-backed entries separately.
+        let hits = semantic_hits_from_payload(
+            KnowledgeKind::Spec,
+            &serde_json::json!({
+                "ok": false,
+                "error_code": "EMPTY_CORPUS",
+                "error": "specs search corpus is empty: ..."
+            }),
+        )
+        .expect("empty corpus must degrade to no hits, not an error");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn semantic_hits_from_payload_propagates_other_errors() {
+        let err = semantic_hits_from_payload(
+            KnowledgeKind::Issue,
+            &serde_json::json!({
+                "ok": false,
+                "error_code": "INDEX_UNHEALTHY",
+                "error": "index unhealthy at ..."
+            }),
+        )
+        .expect_err("non-EMPTY_CORPUS failures must surface as errors");
+        assert!(err.contains("index unhealthy"), "got: {err}");
     }
 }


### PR DESCRIPTION
## Summary

- `search-specs` / `search-issues` の auto-build が、未populate な issue cache（`~/.gwt/cache/issues/<repo_hash>/`）から空 corpus を構築したとき `ok:true, specResults:[]` を silent に返し、agent の必須 preflight が「既存 SPEC/Issue なし」と誤判定して重複作成を招いていた (#2979)。
- 空 corpus かつ cache 未populate のケースを tooling failure として可視化する非OK診断（`error_code: EMPTY_CORPUS`）を返すよう修正し、agent が誤って重複を作らないようにした。

## Changes

- `crates/gwt-core/runtime/chroma_index_runner.py`: `action_search_v2` で issues/specs scope の検索 collection が空 かつ issue cache が未populate のとき `_empty_corpus_diagnostic` を返す。`_issue_cache_is_populated` ヘルパを追加。GUI の `search-multi`（`no_auto_build=True`）と cache populate 済みケースには影響しないよう gate（`no_auto_build=False` かつ collection 空 かつ cache 未populate）。
- `crates/gwt/src/knowledge_bridge.rs`: GUI Knowledge Bridge の `RunnerSemanticSearchClient` が `EMPTY_CORPUS` を空結果として扱い、cache-backed entries 表示と Refresh 動線を維持。payload 解釈を `semantic_hits_from_payload` に抽出してテスト可能化。
- `.claude/skills/gwt-search/SKILL.md` / `.codex/skills/gwt-search/SKILL.md`: `EMPTY_CORPUS` 診断の意味と対処（cache refresh して retry、空結果を「owner なし」と誤読しない）を agent 向けに明文化。
- `crates/gwt-core/runtime/tests/test_auto_build_fallback.py`: TDD テストを追加（空 cache→診断 / populated-no-spec→空結果 / no-auto-build→診断抑止）。

## Testing

- [x] `python3 -m pytest crates/gwt-core/runtime/tests crates/gwt-core/runtime/test_chroma_index_runner.py` — 104 passed（新規 4 件含む）
- [x] `cargo test -p gwt --lib knowledge_bridge` — 22 passed（新規 3 件含む）
- [x] `cargo test -p gwt-skills` — 193 passed / `cargo test -p gwt-core --lib` — 418 passed
- [x] `cargo clippy -p gwt --all-targets --all-features -- -D warnings` — クリーン / `cargo fmt -p gwt --check` — クリーン
- [x] `markdownlint --config .markdownlint.json`（変更した SKILL.md 2 本）— 0 violations
- [x] E2E 再現: 未populate cache に対する `search-specs` / `search-issues` が `{"ok":false,"error_code":"EMPTY_CORPUS",...}` を返すことを確認（旧挙動 `{"ok":true,"specResults":[]}` を解消）

> 注: `cargo test -p gwt --lib`（全 921 件）では `board_audience::tests::*_reads_projection_from_disk` 2 件が並列実行時に共有 `~/.gwt` projection 状態を取り合って flaky に落ちるが、単独実行では PASS。本変更（`knowledge_bridge.rs` と Python runner のみ）とは無関係の既存 flakiness。

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — agent-facing の semantic search 挙動を後方互換のまま改善する単独配信可能な bug fix。GUI（search-multi / Knowledge Bridge）と genuinely-empty repo の挙動は不変。
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- Closes #2979

## Related Issues / Links

- SPEC-1939（セマンティック検索基盤 — 本変更の owner SPEC）
- #2933（GWT_REPO_HASH/GWT_WORKTREE_HASH export 不足 — 関連 failure mode、本 PR では対象外）

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, markdownlint)
- [x] Documentation updated (if user-facing change) — gwt-search SKILL.md に agent 向けガイダンス追記
- [x] Migration/backfill plan included (if schema/data change) — N/A（スキーマ/データ変更なし）
- [x] CHANGELOG impact considered (breaking change flagged in commit) — `fix:` patch、破壊的変更なし

## Risk / Impact

- **Affected areas**: agent-facing semantic search preflight（gwt-search / gwt-issue-search 経由の `search-specs` / `search-issues`）と GUI Knowledge Bridge の検索 payload 解釈。
- **Rollback plan**: 単一コミットの revert で完全に旧挙動へ戻せる。データ/スキーマ migration なし。

## Notes

- User verification: UI 影響のない agent-facing fix のため、ユーザーが `AskUserQuestion` で "Skip — proceed to commit/PR"（理由: no UI surface; behavior proven by tests + E2E）を明示選択。`User Verification Result: skipped(no UI surface; behavior proven by tests + E2E)`。
- アーキテクチャ判断: 一方向フロー GitHub → cache → UI（SPEC-12）を維持するため、runner は GitHub を直接叩かず cache の状態のみで診断する。cache 再同期は gwtd / GUI の責務。
