### PR TITLE
fix(windows): resolve npx.cmd for host package-runner fallback after bunx probe failure

### DIFF
--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -308,6 +308,41 @@ fn find_package_runner_in_path(
     None
 }
 
+/// Platform priority list of `npx` fallback executables consulted when the host
+/// `bunx` package-runner probe fails (Issue #2981). On Windows the `.cmd`
+/// variant comes first so `CreateProcess` can spawn it; the bare `npx` POSIX
+/// shim is not directly spawnable there (SPEC-1921 FR-080). Other platforms use
+/// the bare canonical name.
+fn npx_fallback_candidates() -> &'static [(&'static str, bool)] {
+    #[cfg(windows)]
+    {
+        &[("npx.cmd", true), ("npx", true)]
+    }
+    #[cfg(not(windows))]
+    {
+        &[("npx", true)]
+    }
+}
+
+/// Resolve the host `npx` fallback executable used when the `bunx`
+/// package-runner probe fails during launch.
+///
+/// Resolution flows through the same Windows-aware `find_package_runner_in_path`
+/// machinery as the primary runner, so on Windows the spawnable `npx.cmd` is
+/// preferred over the bare `npx` shim (Issue #2981). Falls back to the canonical
+/// bare `"npx"` name when no candidate resolves on the launch `PATH`, preserving
+/// the prior behavior for environments without a resolvable npx.
+pub fn resolve_host_npx_fallback_executable(env: &HashMap<String, String>) -> String {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    find_package_runner_in_path(
+        npx_fallback_candidates(),
+        env.get("PATH").map(String::as_str),
+        &cwd,
+    )
+    .map(|(executable, _needs_yes)| executable)
+    .unwrap_or_else(|| "npx".to_string())
+}
+
 /// Final configuration used to spawn an agent process.
 #[derive(Debug, Clone)]
 pub struct LaunchConfig {
@@ -1977,6 +2012,72 @@ mod tests {
 
         assert_eq!(PathBuf::from(runner.executable), bunx);
         assert_eq!(runner.base_args, vec!["@openai/codex@latest".to_string()]);
+    }
+
+    // Issue #2981: the host `bunx`→`npx` fallback must resolve a Windows-spawnable
+    // executable. `find_package_runner_in_path` is the shared resolver, so given
+    // an npx-only candidate list it must prefer the `.cmd` variant ahead of the
+    // bare POSIX shim when both are present on PATH (SPEC-1921 FR-080).
+    #[cfg(all(not(windows), unix))]
+    #[test]
+    fn npx_fallback_resolution_prefers_cmd_variant_when_both_present() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        write_test_runner(&temp.path().join("npx.cmd"));
+        write_test_runner(&temp.path().join("npx"));
+        let path = temp.path().display().to_string();
+        let cwd = std::env::current_dir().expect("cwd");
+        let candidates: &'static [(&'static str, bool)] = &[("npx.cmd", true), ("npx", true)];
+
+        let (executable, needs_yes) =
+            find_package_runner_in_path(candidates, Some(path.as_str()), &cwd).expect("npx runner");
+
+        assert_eq!(PathBuf::from(&executable), temp.path().join("npx.cmd"));
+        assert!(needs_yes);
+    }
+
+    #[cfg(all(not(windows), unix))]
+    #[test]
+    fn resolve_host_npx_fallback_executable_resolves_npx_on_path() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        write_test_runner(&temp.path().join("npx"));
+        let env = HashMap::from([("PATH".to_string(), temp.path().display().to_string())]);
+
+        let resolved = resolve_host_npx_fallback_executable(&env);
+
+        assert_eq!(PathBuf::from(resolved), temp.path().join("npx"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn resolve_host_npx_fallback_executable_defaults_to_bare_npx_when_absent() {
+        // Empty PATH dir: no npx anywhere → canonical bare name is preserved so
+        // the launch PTY can still resolve it at spawn time (prior behavior).
+        let temp = tempfile::tempdir().expect("tempdir");
+        let env = HashMap::from([("PATH".to_string(), temp.path().display().to_string())]);
+
+        let resolved = resolve_host_npx_fallback_executable(&env);
+
+        assert_eq!(resolved, "npx");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn resolve_host_npx_fallback_executable_prefers_cmd_on_windows() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(temp.path().join("npx.cmd"), "@echo off\r\n").expect("write npx.cmd");
+        std::fs::write(temp.path().join("npx"), "#!/bin/sh\n").expect("write npx shim");
+        let env = HashMap::from([("PATH".to_string(), temp.path().display().to_string())]);
+
+        let resolved = resolve_host_npx_fallback_executable(&env);
+
+        assert!(
+            Path::new(&resolved)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(|name| name.eq_ignore_ascii_case("npx.cmd"))
+                .unwrap_or(false),
+            "expected npx.cmd, got {resolved}"
+        );
     }
 
     #[test]

--- a/crates/gwt-agent/src/lib.rs
+++ b/crates/gwt-agent/src/lib.rs
@@ -38,8 +38,8 @@ pub use custom::CustomCodingAgent;
 pub use detect::{AgentDetector, DetectedAgent};
 pub use environment::LaunchEnvironment;
 pub use launch::{
-    canonical_launch_args, normalize_launch_args, resolve_runner, AgentLaunchBuilder, LaunchConfig,
-    ResolvedRunner,
+    canonical_launch_args, normalize_launch_args, resolve_host_npx_fallback_executable,
+    resolve_runner, AgentLaunchBuilder, LaunchConfig, ResolvedRunner,
 };
 pub use migration::{migrate_legacy_backend_rows, resolve_legacy_backend_remap, MigrationReport};
 pub use prepare::{

--- a/crates/gwt-agent/src/prepare.rs
+++ b/crates/gwt-agent/src/prepare.rs
@@ -182,10 +182,12 @@ where
         .apply_to_parts(&mut config.env_vars, &mut config.remove_env);
     refresh_worktree_assets(&worktree_path)?;
 
+    let npx_fallback_executable =
+        crate::launch::resolve_host_npx_fallback_executable(&config.env_vars);
     let used_host_package_runner_fallback = config.runtime_target == LaunchRuntimeTarget::Host
         && apply_host_package_runner_fallback_with_probe(
             &mut config,
-            "npx".to_string(),
+            npx_fallback_executable,
             probe_host_runner,
         );
 
@@ -1769,7 +1771,15 @@ mod tests {
 
         assert_eq!(refresh_calls.load(Ordering::SeqCst), 1);
         assert!(prepared.used_host_package_runner_fallback);
-        assert_eq!(prepared.process_launch.command, "npx");
+        // Issue #2981: the bunx→npx fallback now resolves the npx executable on
+        // PATH (a full path when npx is installed), so assert the runner identity
+        // by file stem rather than an exact bare-name string.
+        assert_eq!(
+            Path::new(&prepared.process_launch.command)
+                .file_stem()
+                .and_then(|stem| stem.to_str()),
+            Some("npx"),
+        );
         assert_eq!(
             prepared.process_launch.cwd.as_deref(),
             Some(worktree.as_path())
@@ -1810,7 +1820,12 @@ mod tests {
         assert!(sessions_dir
             .join(format!("{}.toml", prepared.session.id))
             .exists());
-        assert_eq!(prepared.session.launch_command, "npx");
+        assert_eq!(
+            Path::new(&prepared.session.launch_command)
+                .file_stem()
+                .and_then(|stem| stem.to_str()),
+            Some("npx"),
+        );
         assert_eq!(prepared.session.branch, "feature/demo");
     }
 
@@ -1849,7 +1864,15 @@ mod tests {
         .expect("prepare launch");
 
         assert!(prepared.used_host_package_runner_fallback);
-        assert_eq!(prepared.process_launch.command, "npx");
+        // Issue #2981: the bunx→npx fallback now resolves the npx executable on
+        // PATH (a full path when npx is installed), so assert the runner identity
+        // by file stem rather than an exact bare-name string.
+        assert_eq!(
+            Path::new(&prepared.process_launch.command)
+                .file_stem()
+                .and_then(|stem| stem.to_str()),
+            Some("npx"),
+        );
         assert_eq!(
             prepared.process_launch.args,
             vec![
@@ -1858,7 +1881,12 @@ mod tests {
                 "--print".to_string(),
             ]
         );
-        assert_eq!(prepared.session.launch_command, "npx");
+        assert_eq!(
+            Path::new(&prepared.session.launch_command)
+                .file_stem()
+                .and_then(|stem| stem.to_str()),
+            Some("npx"),
+        );
         assert_eq!(
             prepared.session.launch_args,
             vec![

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -539,9 +539,12 @@ pub struct HostPackageRunnerFallbackReport {
 pub fn apply_host_package_runner_fallback_checked(
     config: &mut gwt_agent::LaunchConfig,
 ) -> Result<HostPackageRunnerFallbackReport, String> {
+    // Issue #2981: resolve a Windows-spawnable npx (prefers `npx.cmd`) instead of
+    // a bare `npx` that `CreateProcess` cannot launch after a failed bunx probe.
+    let fallback_executable = gwt_agent::resolve_host_npx_fallback_executable(&config.env_vars);
     apply_host_package_runner_fallback_checked_with_probe_and_repair(
         config,
-        "npx".to_string(),
+        fallback_executable,
         default_windows_npx_cache_base(),
         probe_host_package_runner_outcome,
         repair_windows_npx_cache,
@@ -1860,7 +1863,12 @@ mod tests {
             .expect("resolution must never abort the launch");
 
         assert!(report.switched_to_fallback);
-        assert_eq!(config.command, "npx");
+        // Issue #2981: the fallback now resolves the npx executable on PATH
+        // (mirroring the primary runner) instead of emitting a bare `"npx"`.
+        assert_eq!(
+            config.command,
+            temp.path().join("npx").display().to_string()
+        );
         assert_eq!(config.args.first().map(String::as_str), Some("--yes"));
     }
 

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6655,3 +6655,10 @@ Type: lesson
 Context: SESSIONS 一覧削除の視覚確認のため GWT_FORCE_NEW_INSTANCE=1 で dev ビルドを GWT.app と並行起動したが、同じ ~/.gwt を共有するため issues 再インデックスがループし、dev 側 usage poller が provider_usage を配信せず USAGE セルが hidden のまま(accounts 空判定)になった。WebSocket/telemetry は正常だった。
 Learning: 2 つの gwt インスタンスが同一 ~/.gwt を共有すると stateful subsystem(index/usage poller)が競合し live 検証が不安定になる。単一インスタンス(GWT.app)では browser からでも usage は正常表示される。
 Future Action: GUI の視覚検証は単一インスタンスで行う。dev を確認したい時は既存インスタンスを終了して dev を唯一の tray-resident として起動する。共存は lock 検証用に留め、live データ表示の検証には使わない。
+
+## 2026-06-04 — Host launch fallback executable must reuse platform-aware runner resolution, not hardcode bare names
+
+Type: failure-pattern
+Context: Issue #2981: bunx probe 失敗後の host package-runner fallback が bare "npx" をハードコードしており、Windows では CreateProcess が POSIX shim(npx) を spawn できず program not found で PTY 開始前に失敗。primary runner は package_runner_candidates で npx.cmd を優先(SPEC-1921 FR-080)していたが fallback だけがこの解決をバイパスしていた。
+Learning: spawn する executable は platform で解決形が異なる(Windows は .cmd 必須)。fallback/secondary 経路で runner 名をハードコードすると primary の Windows-aware 解決(find_package_runner_in_path)を取りこぼし、Windows 限定 bug を生む。
+Future Action: launch/spawn 系で runner executable を選ぶ箇所は必ず find_package_runner_in_path 系の platform-aware 解決を経由する。新しい fallback を足すときは bare 名のハードコードを禁止し、未解決時のみ bare 名へフォールバックする。


### PR DESCRIPTION
## Summary

Windows 版 GWT Operator で Claude Code を `latest` / semver から Launch すると、`bunx` probe 失敗後の host package-runner fallback が bare `npx` を spawn し、`CreateProcess` が POSIX shim を実行できず `program not found` で PTY 開始前に失敗していた問題を修正します。

Closes #2981

## Root Cause

fallback executable が 2 つの production 経路でハードコード `"npx"` になっていた:

- `crates/gwt/src/launch_runtime.rs::apply_host_package_runner_fallback_checked`（GUI Launch 経路）
- `crates/gwt-agent/src/prepare.rs::prepare_agent_launch`

`crates/gwt-agent/src/launch.rs::package_runner_candidates` は SPEC-1921 FR-080 に従い primary runner では `npx.cmd` を優先解決するが、fallback はこの解決を完全にバイパスしていた。Windows では `where.exe npx` が bare `npx`（POSIX shim）を `npx.cmd` より先に返すため、bare `"npx"` は `CreateProcess` で spawn 不可。

## Changes

- **`gwt-agent/src/launch.rs`**: `resolve_host_npx_fallback_executable(env)` を新設。primary runner と同じ `find_package_runner_in_path` 経路で npx を解決し、Windows では `npx.cmd` → `npx` の順に PATH 解決する（`npx_fallback_candidates`）。未解決時は従来どおり bare `"npx"` にフォールバック。
- **`gwt-agent/src/lib.rs`**: 上記関数を re-export。
- **`gwt-agent/src/prepare.rs`** / **`gwt/src/launch_runtime.rs`**: ハードコード `"npx"` を新リゾルバ呼び出しに置換。
- 既存テストを full-path 解決の挙動に追従（runner identity を file stem で判定）。

## Test / Verification (`gwt-verify --mode full` → Overall: PASS)

- `cargo fmt --check`: PASS
- `cargo clippy -p gwt-agent -p gwt --all-targets --all-features -- -D warnings`: PASS (0 warnings)
- `cargo test -p gwt-agent --lib`: PASS (331)
- `cargo test -p gwt --lib`: PASS (918, single-threaded)
- `cargo test -p gwt --bins`: PASS (511 + 2; `launch_runtime` / `host_package_runner_*` fallback tests を含む)

新規/更新テスト:

- `npx_fallback_resolution_prefers_cmd_variant_when_both_present`（cross-platform: `.cmd` 優先の core 保証）
- `resolve_host_npx_fallback_executable_resolves_npx_on_path` / `..._defaults_to_bare_npx_when_absent`
- `resolve_host_npx_fallback_executable_prefers_cmd_on_windows`（Windows-gated regression test: npx.cmd 優先）
- `host_launch_switches_to_npx_when_bunx_absent_but_npx_present`、`prepare_agent_launch_uses_npx_fallback_for_claude_code_bunx_launch`（full-path 解決へ追従）

### User Verification

UI 影響なし（host-launch executable 解決のみ）。bug/fix は Windows 限定で macOS 上では `program not found` を再現観察できないため、**User Verification Result: n/a**（AGENTS.md の n/a 許容条件: UI 影響無し）。Windows-gated unit test で fix path をカバー。

### Regression guard

既存の installed-agent shim normalization (#2062) と package-runner timeout / 破損 `_npx` cache 修復 (#2948 / SPEC-2809) のテストは全て通過（未解決時の bare `"npx"` フォールバックを維持）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced package runner fallback resolution to properly support Windows by preferring platform-appropriate executables. Ensures correct runner selection when the primary package manager is unavailable, improving cross-platform reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->