### PR TITLE
fix(file-tree): resolve bare repo before listing worktrees in picker

### DIFF
--- a/crates/gwt/src/worktree_inventory.rs
+++ b/crates/gwt/src/worktree_inventory.rs
@@ -59,14 +59,21 @@ pub fn enumerate_worktrees_with_sessions_dir(
     active_root: Option<&Path>,
     sessions_dir: &Path,
 ) -> Result<Vec<WorktreeEntry>, InventoryError> {
-    let manager = WorktreeManager::new(repo_root);
+    // `repo_root` may be a "workspace home" directory that contains a child
+    // bare repo but is not itself a git work tree (workspace home without a
+    // default worktree). Running `git worktree list` directly in that home
+    // dir fails with "not a git repository (or any of the parent
+    // directories): .git". Resolve the main/bare repo first so the listing
+    // runs inside the actual git directory; `main_worktree_root` already
+    // handles linked worktrees, normal repos, and child-bare layouts.
+    let main_root = main_worktree_root(repo_root).ok();
+    let list_root = main_root.as_deref().unwrap_or(repo_root);
+    let manager = WorktreeManager::new(list_root);
     let infos = manager
         .list()
         .map_err(|err| InventoryError::List(err.to_string()))?;
 
-    let canonical_main = main_worktree_root(repo_root)
-        .ok()
-        .map(|path| canonicalize_or(path.as_path()));
+    let canonical_main = main_root.map(|path| canonicalize_or(path.as_path()));
     let canonical_active = active_root.map(canonicalize_or);
     let session_ids_by_worktree = load_session_ids_by_worktree(sessions_dir);
 

--- a/crates/gwt/tests/worktree_inventory_test.rs
+++ b/crates/gwt/tests/worktree_inventory_test.rs
@@ -104,6 +104,69 @@ fn enumerate_worktrees_skips_prunable_entries() {
 }
 
 #[test]
+fn enumerate_worktrees_lists_entries_from_workspace_home_with_child_bare_repo() {
+    // Regression: the File Tree "SELECT WORKTREE" picker passes the project
+    // root (which may be a "workspace home" directory that contains a child
+    // bare repo but is not itself a git work tree) to `enumerate_worktrees`.
+    // Running `git worktree list` directly in that home dir fails with
+    // "not a git repository (or any of the parent directories): .git". The
+    // inventory must instead resolve the bare repo and enumerate its worktrees.
+    let dir = tempdir().expect("tempdir");
+    let home = dir.path(); // workspace home — NOT a git work tree itself
+    let bare = home.join("project.git");
+    let bare_str = bare.to_str().expect("bare path str");
+
+    git(&["init", "--bare", "--initial-branch=main", bare_str], home);
+
+    // Bootstrap an initial commit so the bare repo has a ref to base worktrees on.
+    let bootstrap = home.join("bootstrap");
+    git(
+        &[
+            "clone",
+            bare_str,
+            bootstrap.to_str().expect("bootstrap str"),
+        ],
+        home,
+    );
+    git(&["config", "user.email", "test@example.com"], &bootstrap);
+    git(&["config", "user.name", "tester"], &bootstrap);
+    std::fs::write(bootstrap.join("README.md"), "hello\n").expect("write readme");
+    git(&["add", "README.md"], &bootstrap);
+    git(&["commit", "-m", "init"], &bootstrap);
+    git(&["push", "origin", "HEAD:refs/heads/main"], &bootstrap);
+
+    // Add a linked worktree directly from the bare repo.
+    let worktree_path = home.join("feature-a");
+    git(
+        &[
+            "worktree",
+            "add",
+            "-b",
+            "feature/a",
+            worktree_path.to_str().expect("worktree str"),
+            "main",
+        ],
+        &bare,
+    );
+
+    let entries = enumerate_worktrees(home, Some(home))
+        .expect("inventory should succeed for a workspace home with a child bare repo");
+
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry.kind == WorktreeEntryKind::BareMain),
+        "the bare repo should be listed as the main entry: {entries:?}"
+    );
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry.branch.as_deref() == Some("feature/a")),
+        "the linked worktree feature/a should be listed: {entries:?}"
+    );
+}
+
+#[test]
 fn enumerate_worktrees_includes_session_ids_for_each_worktree() {
     let dir = tempdir().expect("tempdir");
     let repo = dir.path().join("repo");

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6655,3 +6655,17 @@ Type: lesson
 Context: SESSIONS 一覧削除の視覚確認のため GWT_FORCE_NEW_INSTANCE=1 で dev ビルドを GWT.app と並行起動したが、同じ ~/.gwt を共有するため issues 再インデックスがループし、dev 側 usage poller が provider_usage を配信せず USAGE セルが hidden のまま(accounts 空判定)になった。WebSocket/telemetry は正常だった。
 Learning: 2 つの gwt インスタンスが同一 ~/.gwt を共有すると stateful subsystem(index/usage poller)が競合し live 検証が不安定になる。単一インスタンス(GWT.app)では browser からでも usage は正常表示される。
 Future Action: GUI の視覚検証は単一インスタンスで行う。dev を確認したい時は既存インスタンスを終了して dev を唯一の tray-resident として起動する。共存は lock 検証用に留め、live データ表示の検証には使わない。
+
+## 2026-06-04 — worktree 列挙は main_worktree_root を先に解決する
+
+Type: lesson
+Context: File Tree の SELECT WORKTREE ピッカーが workspace home (子に bare repo を持つが home 自体は git work tree でないレイアウト) で 'failed to list worktrees: ... not a git repository ... .git' (exit 128) で失敗した。enumerate_worktrees が git worktree list を tab.project_root で直接実行していたのが原因。
+Learning: gwt は 'workspace home without default worktree' レイアウトをサポートしており、project_root が git work tree でない場合がある。git worktree list はその home から実行すると失敗する。main_worktree_root は first_child_bare_repository で child-bare を解決できるので、worktree 列挙系は必ず main_worktree_root を先に解決してから WorktreeManager に渡す。
+Future Action: git worktree list / WorktreeManager::new を新規に呼ぶコードを書くときは、渡す repo_root が linked worktree / 通常 repo / workspace-home(child-bare) のいずれでも動くよう main_worktree_root で解決してから渡す。
+
+## 2026-06-04 — board_audience テストは並行実行で flaky (workspace projection 共有状態)
+
+Type: lesson
+Context: gwt-managed worktree 内で cargo test -p gwt --all-features を並行(default threads)実行すると board_audience::tests の gui_default_scope_reads_projection_from_disk / post_audience_for_session_attaches_workspace_and_respects_broadcast が実行ごとに異なるテスト・assertion 行で落ちる。--test-threads=1 では全 PASS。
+Learning: これらのテストは tempdir を repo_path に渡すが、workspace projection の save/load が共有可変状態 (~/.gwt 配下の project-state や env 由来) で並行競合し、projection 読み出しが None/All に化ける。worktree_inventory など無関係な変更の PR 検証でも踏むため、変更起因の regression と誤認しやすい。
+Future Action: cargo test 並行実行で board_audience が落ちたら、まず --test-threads=1 で再実行して flaky か変更起因かを切り分ける。flaky の場合は変更の diff が board_audience/workspace_projection に触れていないことを確認し pre-existing として分離報告する。テスト分離の根本修正は別 Issue で扱う。


### PR DESCRIPTION
## Summary

- File Tree の SELECT WORKTREE ピッカーが workspace-home レイアウト（home 自体は git work tree でなく子に bare repo を持つ）で `failed to list worktrees: ... not a git repository ... .git` (exit 128) を出して worktree 一覧を取得できない不具合を修正する。
- `enumerate_worktrees` が `git worktree list` を非 git の `project_root` で直接実行していたのが原因で、`main_worktree_root` で実 git ディレクトリを先に解決してから列挙するようにした。

## Changes

- `crates/gwt/src/worktree_inventory.rs`: `enumerate_worktrees_with_sessions_dir` で `main_worktree_root(repo_root)` を先に解決し、その結果（linked worktree / 通常 repo / child-bare home を解決）を `WorktreeManager` の list 経路と `canonical_main` の両方で再利用。解決できない真に非 git のディレクトリでは従来通り `List` エラーを返す。
- `crates/gwt/tests/worktree_inventory_test.rs`: 回帰テスト `enumerate_worktrees_lists_entries_from_workspace_home_with_child_bare_repo` を追加。修正前は同一エラーで RED、修正後は GREEN。
- `tasks/memory.md`: 再発防止 lesson（worktree 列挙は `main_worktree_root` を先に解決する／board_audience テストの並行 flaky 切り分け）を追記。

## Testing

- [x] `cargo test -p gwt --test worktree_inventory_test` — 5 passed（既存 4 + 回帰 1、回帰なし）
- [x] `cargo test -p gwt-git worktree` — main_worktree_root 系含め PASS
- [x] `cargo clippy -p gwt --all-targets --all-features -- -D warnings` — 警告なし
- [x] `cargo fmt -p gwt -- --check` — clean
- [x] 視覚検証: 修正版バイナリ（`127.0.0.1:52339`）で File Tree → SELECT WORKTREE をクリックし、エラーが消え worktree 一覧が表示されることをユーザーが confirmed

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — 列挙経路の外科的修正で、既存（通常 repo / linked worktree）の結果は不変。workspace-home レイアウトのみ挙動が改善する。
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- Closes #2984

## Related Issues / Links

- None

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [] Documentation updated (if user-facing change) — N/A: 内部バグ修正で README 等の利用者向け記述に変更なし
- [ ] Migration/backfill plan included (if schema/data change) — N/A: スキーマ/データ変更なし
- [x] CHANGELOG impact considered — `fix:` でパッチバージョン対象

## Notes

- 既知の pre-existing flaky: `cargo test -p gwt-core -p gwt --all-features` を並行実行すると `board_audience::tests`（workspace projection の共有可変状態）が実行ごとに異なるテスト/行で落ちる。`--test-threads=1` で全 PASS。本 PR の diff は `board_audience`/`workspace_projection` に一切触れておらず変更起因ではない。テスト分離の根本修正は別 Issue 扱い。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed worktree enumeration to properly handle workspace home directories that contain child repositories.

* **Tests**
  * Added regression test to ensure worktree enumeration works correctly in workspace home directory configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->