### PR TITLE
fix(board): align storage for workspace home

### DIFF
--- a/crates/gwt-core/src/coordination.rs
+++ b/crates/gwt-core/src/coordination.rs
@@ -12,7 +12,7 @@ use fs2::FileExt;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{paths::gwt_project_dir_for_repo_path, GwtError, Result};
+use crate::{config::BareProjectConfig, paths::gwt_project_dir_for_repo_path, GwtError, Result};
 
 pub const COORDINATION_RELATIVE_DIR: &str = ".gwt/coordination";
 pub const EVENTS_FILE_NAME: &str = "events.jsonl";
@@ -762,20 +762,47 @@ fn coordination_project_dir(worktree_root: &Path) -> Option<PathBuf> {
 
 fn coordination_repo_root(worktree_root: &Path) -> Option<PathBuf> {
     let mut cmd = crate::process::hidden_command("git");
-    cmd.args(["rev-parse", "--show-toplevel"])
+    cmd.args(["rev-parse", "--path-format=absolute", "--git-common-dir"])
         .current_dir(worktree_root);
     crate::process::scrub_git_env(&mut cmd);
-    let output = cmd.output().ok()?;
-    if !output.status.success() {
-        return None;
+    let output = cmd.output().ok();
+    if let Some(output) = output.filter(|output| output.status.success()) {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let common_dir = stdout
+            .lines()
+            .next()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())?;
+        let common_dir = PathBuf::from(common_dir);
+        let repo_root = if common_dir.file_name().and_then(|name| name.to_str()) == Some(".git") {
+            common_dir.parent()?.to_path_buf()
+        } else {
+            common_dir
+        };
+        return Some(dunce::canonicalize(&repo_root).unwrap_or(repo_root));
     }
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let repo_root = stdout
-        .lines()
-        .next()
-        .map(str::trim)
-        .filter(|value| !value.is_empty())?;
-    Some(dunce::canonicalize(repo_root).unwrap_or_else(|_| PathBuf::from(repo_root)))
+    coordination_child_bare_repo(worktree_root)
+}
+
+fn coordination_child_bare_repo(worktree_root: &Path) -> Option<PathBuf> {
+    if let Ok(Some(config)) = BareProjectConfig::load(worktree_root) {
+        let candidate = worktree_root.join(config.bare_repo_name);
+        if is_bare_git_dir(&candidate) {
+            return Some(dunce::canonicalize(&candidate).unwrap_or(candidate));
+        }
+    }
+
+    let entries = std::fs::read_dir(worktree_root).ok()?;
+    entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| is_bare_git_dir(path))
+        .min()
+        .map(|path| dunce::canonicalize(&path).unwrap_or(path))
+}
+
+fn is_bare_git_dir(path: &Path) -> bool {
+    path.join("HEAD").exists() && path.join("objects").exists() && path.join("refs").exists()
 }
 
 fn coordination_migration_marker_path(project_dir: &Path) -> PathBuf {
@@ -920,9 +947,11 @@ fn rebuild_event_manifest_from_segments(coordination_root: &Path) -> Result<Even
 }
 
 fn discover_legacy_coordination_dirs(worktree_root: &Path) -> Vec<PathBuf> {
+    let repo_root = coordination_repo_root(worktree_root);
+    let list_root = repo_root.as_deref().unwrap_or(worktree_root);
     let mut cmd = crate::process::hidden_command("git");
     cmd.args(["worktree", "list", "--porcelain"])
-        .current_dir(worktree_root);
+        .current_dir(list_root);
     crate::process::scrub_git_env(&mut cmd);
     let output = cmd.output();
     let mut dirs = match output {
@@ -937,6 +966,18 @@ fn discover_legacy_coordination_dirs(worktree_root: &Path) -> Vec<PathBuf> {
         }
         _ => vec![legacy_coordination_dir(worktree_root)],
     };
+    dirs.push(legacy_coordination_dir(worktree_root));
+    if let Some(repo_root) = repo_root
+        .as_deref()
+        .filter(|root| is_bare_git_dir(root))
+        .and_then(Path::parent)
+    {
+        dirs.push(legacy_coordination_dir(repo_root));
+    }
+    dirs = dirs
+        .into_iter()
+        .map(|dir| dunce::canonicalize(&dir).unwrap_or(dir))
+        .collect();
     dirs.sort();
     dirs.dedup();
     dirs
@@ -1745,7 +1786,7 @@ impl BoardProvider for LocalProvider {
 
 #[cfg(test)]
 mod tests {
-    use std::{str::FromStr, sync::Arc, thread};
+    use std::{path::Path, str::FromStr, sync::Arc, thread};
 
     use chrono::TimeZone;
 
@@ -3190,6 +3231,153 @@ mod tests {
         assert_eq!(snapshot.board.entries[0].body, "legacy board post");
         assert!(!legacy_dir.exists());
         assert!(coordination_migration_marker_path(&project_dir).exists());
+    }
+
+    #[test]
+    fn workspace_home_with_child_bare_repo_shares_board_storage_with_worktree() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let workspace = tempfile::tempdir().unwrap();
+        let gwt_home = tempfile::tempdir().unwrap();
+        let _home_guard = ScopedEnvVar::set("HOME", gwt_home.path());
+        let _userprofile_guard = ScopedEnvVar::set("USERPROFILE", gwt_home.path());
+        let (_bare_repo, worktree) =
+            make_workspace_home_with_child_bare_and_worktree(workspace.path());
+
+        let entry = BoardEntry::new(
+            AuthorKind::Agent,
+            "Codex",
+            BoardEntryKind::Status,
+            "from linked worktree",
+            None,
+            None,
+            vec![],
+            vec![],
+        );
+        let entry_id = entry.id.clone();
+        post_entry(&worktree, entry).unwrap();
+
+        assert_eq!(
+            coordination_dir(workspace.path()),
+            coordination_dir(&worktree)
+        );
+
+        let snapshot = load_snapshot(workspace.path()).unwrap();
+        assert!(
+            snapshot
+                .board
+                .entries
+                .iter()
+                .any(|entry| entry.id == entry_id),
+            "workspace home must read entries written from linked worktrees"
+        );
+        assert!(!legacy_coordination_dir(workspace.path()).exists());
+    }
+
+    #[test]
+    fn workspace_home_legacy_coordination_is_migrated_to_project_scoped_board() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let workspace = tempfile::tempdir().unwrap();
+        let gwt_home = tempfile::tempdir().unwrap();
+        let _home_guard = ScopedEnvVar::set("HOME", gwt_home.path());
+        let _userprofile_guard = ScopedEnvVar::set("USERPROFILE", gwt_home.path());
+        let (_bare_repo, worktree) =
+            make_workspace_home_with_child_bare_and_worktree(workspace.path());
+
+        let entry = BoardEntry::new(
+            AuthorKind::User,
+            "You",
+            BoardEntryKind::Status,
+            "legacy workspace-home post",
+            None,
+            None,
+            vec![],
+            vec![],
+        );
+        let legacy_dir = legacy_coordination_dir(workspace.path());
+        write_events(
+            &legacy_dir.join(EVENTS_FILE_NAME),
+            &[CoordinationEvent::MessageAppended {
+                entry: entry.clone(),
+            }],
+        );
+
+        let snapshot = load_snapshot(workspace.path()).unwrap();
+
+        assert_eq!(
+            coordination_dir(workspace.path()),
+            coordination_dir(&worktree)
+        );
+        assert!(
+            snapshot
+                .board
+                .entries
+                .iter()
+                .any(|actual| actual.id == entry.id),
+            "workspace-home legacy Board entry must migrate into project-scoped storage"
+        );
+        assert!(!legacy_dir.exists());
+    }
+
+    fn make_workspace_home_with_child_bare_and_worktree(
+        workspace_home: &Path,
+    ) -> (std::path::PathBuf, std::path::PathBuf) {
+        std::fs::create_dir_all(workspace_home).unwrap();
+        let seed = workspace_home.join(".seed");
+        let bare_repo = workspace_home.join("gwt.git");
+        let worktree = workspace_home.join("work").join("feature");
+
+        run_git(
+            workspace_home,
+            &["init", "--initial-branch=main", seed.to_str().unwrap()],
+        );
+        run_git(&seed, &["config", "user.email", "test@example.com"]);
+        run_git(&seed, &["config", "user.name", "Test User"]);
+        std::fs::write(seed.join("README.md"), "# gwt\n").unwrap();
+        run_git(&seed, &["add", "README.md"]);
+        run_git(&seed, &["commit", "-m", "init"]);
+        run_git(
+            workspace_home,
+            &[
+                "clone",
+                "--bare",
+                seed.to_str().unwrap(),
+                bare_repo.to_str().unwrap(),
+            ],
+        );
+        run_git(
+            &bare_repo,
+            &[
+                "remote",
+                "set-url",
+                "origin",
+                "https://github.com/example/gwt.git",
+            ],
+        );
+        std::fs::create_dir_all(worktree.parent().unwrap()).unwrap();
+        run_git(
+            &bare_repo,
+            &["worktree", "add", worktree.to_str().unwrap(), "main"],
+        );
+
+        (bare_repo, worktree)
+    }
+
+    fn run_git(cwd: &Path, args: &[&str]) {
+        let mut cmd = crate::process::hidden_command("git");
+        cmd.args(args).current_dir(cwd);
+        crate::process::scrub_git_env(&mut cmd);
+        let output = cmd.output().expect("git command");
+        assert!(
+            output.status.success(),
+            "git {:?} failed in {}: {}",
+            args,
+            cwd.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
     }
 
     fn write_events(path: &std::path::Path, events: &[CoordinationEvent]) {

--- a/crates/gwt/src/board_audience.rs
+++ b/crates/gwt/src/board_audience.rs
@@ -208,7 +208,7 @@ mod tests {
     use gwt_core::workspace_projection::{
         save_workspace_projection, WorkspaceAgentAffiliationStatus, WorkspaceStatusCategory,
     };
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use tempfile::tempdir;
 
     fn agent(
@@ -248,6 +248,36 @@ mod tests {
             target: target.to_string(),
             label: None,
         }
+    }
+
+    struct ScopedEnvVar {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl ScopedEnvVar {
+        fn set(key: &'static str, value: &Path) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for ScopedEnvVar {
+        fn drop(&mut self) {
+            if let Some(previous) = &self.previous {
+                std::env::set_var(self.key, previous);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
+    fn isolate_gwt_home() -> (tempfile::TempDir, ScopedEnvVar, ScopedEnvVar) {
+        let home = tempdir().unwrap();
+        let home_guard = ScopedEnvVar::set("HOME", home.path());
+        let userprofile_guard = ScopedEnvVar::set("USERPROFILE", home.path());
+        (home, home_guard, userprofile_guard)
     }
 
     #[test]
@@ -315,6 +345,10 @@ mod tests {
 
     #[test]
     fn session_scope_reads_projection_from_disk() {
+        let _guard = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let (_home, _home_guard, _userprofile_guard) = isolate_gwt_home();
         let dir = tempdir().unwrap();
         let repo = dir.path();
 
@@ -365,6 +399,10 @@ mod tests {
 
     #[test]
     fn gui_default_scope_reads_projection_from_disk() {
+        let _guard = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let (_home, _home_guard, _userprofile_guard) = isolate_gwt_home();
         let dir = tempdir().unwrap();
         let repo = dir.path();
 
@@ -413,6 +451,10 @@ mod tests {
 
     #[test]
     fn post_audience_for_session_attaches_workspace_and_respects_broadcast() {
+        let _guard = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let (_home, _home_guard, _userprofile_guard) = isolate_gwt_home();
         let dir = tempdir().unwrap();
         let repo = dir.path();
         // Broadcast short-circuits before any projection load.

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6676,3 +6676,10 @@ Type: failure-pattern
 Context: Issue #2981: bunx probe 失敗後の host package-runner fallback が bare "npx" をハードコードしており、Windows では CreateProcess が POSIX shim(npx) を spawn できず program not found で PTY 開始前に失敗。primary runner は package_runner_candidates で npx.cmd を優先(SPEC-1921 FR-080)していたが fallback だけがこの解決をバイパスしていた。
 Learning: spawn する executable は platform で解決形が異なる(Windows は .cmd 必須)。fallback/secondary 経路で runner 名をハードコードすると primary の Windows-aware 解決(find_package_runner_in_path)を取りこぼし、Windows 限定 bug を生む。
 Future Action: launch/spawn 系で runner executable を選ぶ箇所は必ず find_package_runner_in_path 系の platform-aware 解決を経由する。新しい fallback を足すときは bare 名のハードコードを禁止し、未解決時のみ bare 名へフォールバックする。
+
+## 2026-06-04 — Board/storage tests must share env lock
+
+Type: lesson
+Context: SPEC-1974 Board storage split fix exposed flaky tests that write project-scoped coordination/workspace data while HOME/USERPROFILE point at the developer machine.
+Learning: Tests that call project-scoped storage helpers must isolate HOME/USERPROFILE and use the crate-wide env_test_lock/env_lock, not a local Mutex, because cargo test runs modules in parallel.
+Future Action: Before adding tests around Board, workspace projection, or project-scoped paths, acquire the existing crate-wide env lock and point HOME/USERPROFILE at a tempdir.


### PR DESCRIPTION
## Summary

- Workspace home と linked worktree が同じ Board coordination storage を参照するようにしました。
- Workspace home 側の legacy `.gwt/coordination` 投稿を project-scoped storage へ migration できるようにしました。
- HOME 依存の Board audience tests を隔離し、全体テストの並列実行で壊れないようにしました。

## Changes

- `crates/gwt-core/src/coordination.rs`: `git rev-parse --git-common-dir` と child bare repo detection を使い、workspace home と linked worktree の repo identity を同じ bare repo に揃えました。
- `crates/gwt-core/src/coordination.rs`: workspace home legacy coordination dir を migration source に含め、canonicalized path で dedup する回帰テストを追加しました。
- `crates/gwt/src/board_audience.rs`: project-scoped storage を使う tests で HOME/USERPROFILE を tempdir に隔離し、crate-wide env lock を使うようにしました。
- `tasks/memory.md`: Board/storage tests の env lock 再発防止メモを追記しました。

## Testing

- [x] `cargo test -p gwt-core workspace_home_ -- --nocapture` - PASS
- [x] `cargo test -p gwt-core coordination::tests::git_repo_without_origin_uses_project_scoped_coordination_dir -- --nocapture` - PASS
- [x] `cargo test -p gwt-core coordination::tests::migrate_legacy_coordination_dirs -- --nocapture` - PASS
- [x] `cargo test -p gwt board_audience::tests --all-features -- --nocapture` - PASS
- [x] `cargo test -p gwt cli::board::tests::board_family_run_post_attaches_current_session_origin_metadata --all-features -- --nocapture` - PASS
- [x] `cargo test -p gwt-core -p gwt --all-features` - PASS
- [x] `cargo fmt --check` - PASS
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - PASS
- [x] `bunx --bun markdownlint-cli tasks/memory.md --config .markdownlint.json --ignore target --ignore CHANGELOG.md --ignore tasks/todo.md` - PASS
- [x] `bunx commitlint --from HEAD~1 --to HEAD` - PASS
- User Verification Result: n/a - UI/front-end surface was not changed.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes - Board storage identity and legacy migration are fixed without changing GUI/provider wire shape.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- #1974

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`; `svelte-check` N/A because no Svelte surface)
- [x] Documentation updated (N/A: no user-facing docs change)
- [x] Migration/backfill plan included (legacy Board storage migration covered by regression test)
- [x] CHANGELOG impact considered (patch-level `fix`, no breaking change)

## Context

- The reported symptom was that Board entries posted from an agent/worktree were not visible when the local provider read Board data from the workspace home.
- Root cause was that workspace home and linked worktree could resolve different project-scoped coordination directories when the workspace home itself was not the Git worktree root.

## Risk / Impact

- **Affected areas**: Board local provider storage resolution and legacy coordination migration.
- **Rollback plan**: Revert this PR; no schema change or irreversible migration is introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of workspace coordination directories in child/bare repository layouts and linked worktree scenarios.

* **Tests**
  * Enhanced test environment isolation to prevent flakiness in workspace and storage-related tests.

* **Documentation**
  * Added guidance on best practices for test environment configuration and isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->