### PR TITLE
fix(attachments): improve progress and unicode filenames

### DIFF
--- a/crates/gwt/playwright/tests/file-drop-attachments.spec.ts
+++ b/crates/gwt/playwright/tests/file-drop-attachments.spec.ts
@@ -139,6 +139,80 @@ test.describe("Browser file drop attachments", () => {
     await expect.poll(() => page.evaluate(() => window.__fileDropAlerts)).toEqual([]);
   });
 
+  test("drop progress is scoped to the target Agent window and keeps Japanese filenames", async ({
+    page,
+  }) => {
+    await installEmbeddedRoutes(page);
+    await installFileDropBackend(page);
+
+    await page.goto(APP_URL);
+    await expect(page.locator(".workspace-window[data-id='agent-1']")).toBeVisible();
+    await expect(page.locator(".workspace-window[data-id='shell-1']")).toBeVisible();
+
+    await dropTextFileOn(page, ".workspace-window[data-id='agent-1'] .window-body", {
+      name: "資料 日本語.txt",
+      type: "text/plain",
+      content: "nihongo filename\n",
+    });
+
+    const attach = await waitForAttachFiles(page);
+    expect(attach).toMatchObject({
+      kind: "attach_files",
+      id: "agent-1",
+    });
+    expect(attach.operation_id).toEqual(expect.stringMatching(/^attachment-/));
+    expect(attach.files[0]).toMatchObject({
+      filename: "資料 日本語.txt",
+    });
+
+    const agentProgress = page.locator(
+      ".workspace-window[data-id='agent-1'] .attachment-progress",
+    );
+    await expect(agentProgress).toBeVisible();
+    await expect(agentProgress).toContainText("資料 日本語.txt");
+    await expect(agentProgress.locator(".attachment-progress__cancel")).toHaveCount(0);
+    await expect(
+      page.locator(".workspace-window[data-id='shell-1'] .attachment-progress"),
+    ).toHaveCount(0);
+
+    await page.evaluate((operationId) => {
+      window.__emitFileDropBackendEvent?.({
+        kind: "attachment_progress",
+        id: "agent-1",
+        operation_id: operationId,
+        phase: "staging",
+        file_index: 0,
+        file_count: 1,
+        filename: "資料 日本語.txt",
+        bytes_done: 8,
+        bytes_total: 16,
+        message: null,
+      });
+    }, attach.operation_id);
+    await expect(agentProgress).toContainText("Staging");
+    await expect(agentProgress.locator('[role="progressbar"]')).toHaveAttribute(
+      "aria-valuenow",
+      "50",
+    );
+
+    await page.evaluate((operationId) => {
+      window.__emitFileDropBackendEvent?.({
+        kind: "attachment_progress",
+        id: "agent-1",
+        operation_id: operationId,
+        phase: "attached",
+        file_index: 0,
+        file_count: 1,
+        filename: "資料 日本語.txt",
+        bytes_done: 16,
+        bytes_total: 16,
+        message: null,
+      });
+    }, attach.operation_id);
+    await expect(agentProgress).toContainText("Attached");
+    await expect.poll(() => page.evaluate(() => window.__fileDropAlerts)).toEqual([]);
+  });
+
   test("pasting an image on an Agent terminal uploads and shows progress", async ({ page }) => {
     await installEmbeddedRoutes(page);
     await installFileDropBackend(page);
@@ -275,6 +349,7 @@ async function installFileDropBackend(page, options: { failUploads?: boolean } =
     window.__fileDropAlerts = [];
     window.__attachmentUploads = [];
     window.__attachmentUploadSequence = 0;
+    window.__emitFileDropBackendEvent = null;
     window.alert = (message) => {
       window.__fileDropAlerts.push(String(message));
     };
@@ -378,6 +453,7 @@ async function installFileDropBackend(page, options: { failUploads?: boolean } =
         super();
         this.url = url;
         this.readyState = FixtureWebSocket.CONNECTING;
+        window.__emitFileDropBackendEvent = (payload) => this.emit(payload);
         setTimeout(() => {
           this.readyState = FixtureWebSocket.OPEN;
           this.dispatchEvent(new Event("open"));

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 use gwt::LaunchWizardAction;
+use std::io::Write as _;
 
 #[derive(Clone)]
 pub enum AppEventProxy {
@@ -1107,29 +1108,76 @@ fn sanitize_image_paste_stem(filename: Option<&str>) -> String {
 }
 
 fn sanitize_file_attachment_name(filename: &str) -> String {
-    let raw_name = Path::new(filename)
-        .file_name()
-        .and_then(|name| name.to_str())
+    let trimmed = filename.trim();
+    let raw_name = trimmed
+        .rsplit(['/', '\\'])
+        .find(|part| !part.trim().is_empty())
         .map(str::trim)
         .filter(|name| !name.is_empty())
         .unwrap_or("file");
     let mut sanitized = String::new();
     let mut previous_dash = false;
-    for character in raw_name.chars().flat_map(char::to_lowercase) {
-        if character.is_ascii_alphanumeric() || character == '.' || character == '_' {
+    for character in raw_name.chars() {
+        let unsafe_character = character.is_control()
+            || matches!(
+                character,
+                '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|'
+            );
+        if unsafe_character || character.is_whitespace() || character == '-' {
+            if !previous_dash {
+                sanitized.push('-');
+                previous_dash = true;
+            }
+        } else if character.is_ascii() {
+            sanitized.push(character.to_ascii_lowercase());
+            previous_dash = false;
+        } else {
             sanitized.push(character);
             previous_dash = false;
-        } else if !previous_dash {
-            sanitized.push('-');
-            previous_dash = true;
         }
     }
     let sanitized = sanitized.trim_matches(['-', '.', '_']);
     if sanitized.is_empty() || sanitized == "." || sanitized == ".." {
         "file".to_string()
+    } else if is_reserved_attachment_basename(sanitized) {
+        format!("file-{sanitized}")
     } else {
         sanitized.to_string()
     }
+}
+
+fn is_reserved_attachment_basename(filename: &str) -> bool {
+    let stem = filename
+        .split('.')
+        .next()
+        .unwrap_or(filename)
+        .trim_matches([' ', '.', '_', '-'])
+        .to_ascii_uppercase();
+    matches!(
+        stem.as_str(),
+        "CON"
+            | "PRN"
+            | "AUX"
+            | "NUL"
+            | "COM1"
+            | "COM2"
+            | "COM3"
+            | "COM4"
+            | "COM5"
+            | "COM6"
+            | "COM7"
+            | "COM8"
+            | "COM9"
+            | "LPT1"
+            | "LPT2"
+            | "LPT3"
+            | "LPT4"
+            | "LPT5"
+            | "LPT6"
+            | "LPT7"
+            | "LPT8"
+            | "LPT9"
+    )
 }
 
 fn attachment_storage_paths(
@@ -1256,16 +1304,28 @@ pub(crate) fn prepare_file_attachment(
 }
 
 fn save_file_attachment(file: &PreparedFileAttachment) -> Result<(), FileAttachmentError> {
+    save_file_attachment_with_progress(file, |_bytes_done, _bytes_total| {})
+}
+
+fn save_file_attachment_with_progress(
+    file: &PreparedFileAttachment,
+    mut on_progress: impl FnMut(u64, Option<u64>),
+) -> Result<(), FileAttachmentError> {
     let Some(storage_path) = file.storage_path.as_ref() else {
         return Ok(());
     };
     if let Some(bytes) = file.bytes.as_ref() {
-        return write_attachment_bytes(storage_path, bytes)
+        return write_attachment_bytes_with_progress(storage_path, bytes, &mut on_progress)
             .map_err(FileAttachmentError::WriteFailed);
     }
     if let Some(source_path) = file.source_path.as_ref() {
-        copy_attachment_file(source_path, storage_path, file.remove_source_after_save)
-            .map_err(FileAttachmentError::WriteFailed)?;
+        copy_attachment_file_with_progress(
+            source_path,
+            storage_path,
+            file.remove_source_after_save,
+            &mut on_progress,
+        )
+        .map_err(FileAttachmentError::WriteFailed)?;
     }
     Ok(())
 }
@@ -1292,6 +1352,116 @@ pub(crate) fn format_file_attachment_prompt(paths: &[String]) -> String {
                 .join(", ")
         ),
     }
+}
+
+fn normalize_attachment_operation_id(operation_id: Option<String>) -> String {
+    operation_id
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| format!("attachment-{}", image_paste_unique_token()))
+}
+
+fn display_attachment_basename(filename: &str) -> String {
+    filename
+        .trim()
+        .rsplit(['/', '\\'])
+        .find(|part| !part.trim().is_empty())
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .unwrap_or("file")
+        .to_string()
+}
+
+fn display_name_for_file_attachment(file: &gwt::FileAttachment) -> String {
+    match file {
+        gwt::FileAttachment::NativePath { path } => display_attachment_basename(path),
+        gwt::FileAttachment::Inline { filename, .. }
+        | gwt::FileAttachment::Uploaded { filename, .. } => display_attachment_basename(filename),
+    }
+}
+
+#[derive(Debug, Clone)]
+struct AttachmentProgressUpdate {
+    id: String,
+    operation_id: String,
+    phase: AttachmentProgressPhase,
+    file_index: Option<usize>,
+    file_count: usize,
+    filename: Option<String>,
+    bytes_done: Option<u64>,
+    bytes_total: Option<u64>,
+    message: Option<String>,
+}
+
+impl AttachmentProgressUpdate {
+    fn new(
+        id: impl Into<String>,
+        operation_id: impl Into<String>,
+        phase: AttachmentProgressPhase,
+        file_count: usize,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            operation_id: operation_id.into(),
+            phase,
+            file_index: None,
+            file_count,
+            filename: None,
+            bytes_done: None,
+            bytes_total: None,
+            message: None,
+        }
+    }
+
+    fn filename(mut self, filename: Option<String>) -> Self {
+        self.filename = filename;
+        self
+    }
+
+    fn file(mut self, index: usize, filename: String) -> Self {
+        self.file_index = Some(index);
+        self.filename = Some(filename);
+        self
+    }
+
+    fn bytes(mut self, bytes_done: u64, bytes_total: Option<u64>) -> Self {
+        self.bytes_done = Some(bytes_done);
+        self.bytes_total = bytes_total;
+        self
+    }
+
+    fn message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+
+    fn outbound(self, client_id: ClientId) -> OutboundEvent {
+        OutboundEvent::reply(
+            client_id,
+            BackendEvent::AttachmentProgress {
+                id: self.id,
+                operation_id: self.operation_id,
+                phase: self.phase,
+                file_index: self.file_index,
+                file_count: self.file_count,
+                filename: self.filename,
+                bytes_done: self.bytes_done,
+                bytes_total: self.bytes_total,
+                message: self.message,
+            },
+        )
+    }
+
+    fn dispatch(self, proxy: &AppEventProxy, client_id: &ClientId) {
+        proxy.send(UserEvent::Dispatch(vec![self.outbound(client_id.clone())]));
+    }
+}
+
+struct UploadedImagePasteOperation {
+    upload_id: String,
+    mime_type: String,
+    filename: Option<String>,
+    size: u64,
 }
 
 pub(crate) fn prepare_image_paste_file(
@@ -1386,24 +1556,54 @@ fn image_paste_unique_token() -> String {
     format!("{millis}-{sequence}")
 }
 
-fn write_attachment_bytes(storage_path: &Path, bytes: &[u8]) -> Result<(), String> {
-    let Some(parent) = storage_path.parent() else {
-        return Err("attachment path has no parent directory".to_string());
-    };
-    std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
-    std::fs::write(storage_path, bytes).map_err(|error| error.to_string())
-}
-
-fn copy_attachment_file(
-    source_path: &Path,
+fn write_attachment_bytes_with_progress(
     storage_path: &Path,
-    remove_source_after_save: bool,
+    bytes: &[u8],
+    mut on_progress: impl FnMut(u64, Option<u64>),
 ) -> Result<(), String> {
     let Some(parent) = storage_path.parent() else {
         return Err("attachment path has no parent directory".to_string());
     };
     std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
-    std::fs::copy(source_path, storage_path).map_err(|error| error.to_string())?;
+    let total = bytes.len() as u64;
+    on_progress(0, Some(total));
+    std::fs::write(storage_path, bytes).map_err(|error| error.to_string())?;
+    on_progress(total, Some(total));
+    Ok(())
+}
+
+fn copy_attachment_file_with_progress(
+    source_path: &Path,
+    storage_path: &Path,
+    remove_source_after_save: bool,
+    mut on_progress: impl FnMut(u64, Option<u64>),
+) -> Result<(), String> {
+    let Some(parent) = storage_path.parent() else {
+        return Err("attachment path has no parent directory".to_string());
+    };
+    std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+    let total = std::fs::metadata(source_path)
+        .ok()
+        .map(|metadata| metadata.len());
+    on_progress(0, total);
+    let mut source = std::fs::File::open(source_path).map_err(|error| error.to_string())?;
+    let mut destination = std::fs::File::create(storage_path).map_err(|error| error.to_string())?;
+    let mut buffer = [0_u8; 64 * 1024];
+    let mut copied = 0_u64;
+    loop {
+        let read =
+            std::io::Read::read(&mut source, &mut buffer).map_err(|error| error.to_string())?;
+        if read == 0 {
+            break;
+        }
+        if let Err(error) = destination.write_all(&buffer[..read]) {
+            let _ = std::fs::remove_file(storage_path);
+            return Err(error.to_string());
+        }
+        copied += read as u64;
+        on_progress(copied, total);
+    }
+    destination.flush().map_err(|error| error.to_string())?;
     if remove_source_after_save {
         let _ = std::fs::remove_file(source_path);
     }
@@ -1411,15 +1611,23 @@ fn copy_attachment_file(
 }
 
 fn save_image_paste_file(image: &ImagePasteFile) -> Result<(), ImagePasteError> {
+    save_image_paste_file_with_progress(image, |_bytes_done, _bytes_total| {})
+}
+
+fn save_image_paste_file_with_progress(
+    image: &ImagePasteFile,
+    mut on_progress: impl FnMut(u64, Option<u64>),
+) -> Result<(), ImagePasteError> {
     if let Some(bytes) = image.bytes.as_ref() {
-        return write_attachment_bytes(&image.storage_path, bytes)
+        return write_attachment_bytes_with_progress(&image.storage_path, bytes, &mut on_progress)
             .map_err(ImagePasteError::WriteFailed);
     }
     if let Some(source_path) = image.source_path.as_ref() {
-        return copy_attachment_file(
+        return copy_attachment_file_with_progress(
             source_path,
             &image.storage_path,
             image.remove_source_after_save,
+            &mut on_progress,
         )
         .map_err(ImagePasteError::WriteFailed);
     }
@@ -3914,18 +4122,45 @@ impl AppRuntime {
             } => self.paste_image_events(&id, &data_base64, &mime_type, filename.as_deref()),
             FrontendEvent::PasteImageUploaded {
                 id,
+                operation_id,
                 upload_id,
                 mime_type,
                 filename,
                 size,
-            } => self.paste_image_uploaded_events(
-                &id,
-                &upload_id,
-                &mime_type,
-                filename.as_deref(),
-                size,
-            ),
-            FrontendEvent::AttachFiles { id, files } => self.attach_files_events(&id, files),
+            } => {
+                if operation_id.is_some() {
+                    self.paste_image_uploaded_operation_events(
+                        client_id,
+                        id,
+                        operation_id,
+                        UploadedImagePasteOperation {
+                            upload_id,
+                            mime_type,
+                            filename,
+                            size,
+                        },
+                    )
+                } else {
+                    self.paste_image_uploaded_events(
+                        &id,
+                        &upload_id,
+                        &mime_type,
+                        filename.as_deref(),
+                        size,
+                    )
+                }
+            }
+            FrontendEvent::AttachFiles {
+                id,
+                operation_id,
+                files,
+            } => {
+                if operation_id.is_some() {
+                    self.attach_files_operation_events(client_id, id, operation_id, files)
+                } else {
+                    self.attach_files_events(&id, files)
+                }
+            }
             FrontendEvent::LoadFileTree { id, path } => {
                 let path = path.unwrap_or_default();
                 vec![OutboundEvent::reply(
@@ -5566,6 +5801,52 @@ impl AppRuntime {
         }
     }
 
+    pub(crate) fn inject_attachment_prompt_events(
+        &mut self,
+        client_id: ClientId,
+        window_id: String,
+        operation_id: String,
+        prompt: String,
+        file_count: usize,
+        filename: Option<String>,
+    ) -> Vec<OutboundEvent> {
+        let mut events = vec![AttachmentProgressUpdate::new(
+            window_id.clone(),
+            operation_id.clone(),
+            AttachmentProgressPhase::Injecting,
+            file_count,
+        )
+        .filename(filename.clone())
+        .outbound(client_id.clone())];
+        let terminal_events = self.terminal_input_events(&window_id, &prompt);
+        if terminal_events.is_empty() {
+            events.push(
+                AttachmentProgressUpdate::new(
+                    window_id,
+                    operation_id,
+                    AttachmentProgressPhase::Attached,
+                    file_count,
+                )
+                .filename(filename)
+                .outbound(client_id),
+            );
+        } else {
+            events.extend(terminal_events);
+            events.push(
+                AttachmentProgressUpdate::new(
+                    window_id,
+                    operation_id,
+                    AttachmentProgressPhase::Failed,
+                    file_count,
+                )
+                .filename(filename)
+                .message("failed to inject attachment prompt")
+                .outbound(client_id),
+            );
+        }
+        events
+    }
+
     pub(crate) fn paste_image_events(
         &mut self,
         id: &str,
@@ -5625,6 +5906,119 @@ impl AppRuntime {
             "saved pasted image"
         );
         self.terminal_input_events(id, &image.prompt_text)
+    }
+
+    fn paste_image_uploaded_operation_events(
+        &mut self,
+        client_id: ClientId,
+        id: String,
+        operation_id: Option<String>,
+        upload: UploadedImagePasteOperation,
+    ) -> Vec<OutboundEvent> {
+        let Some(address) = self.window_lookup.get(&id).cloned() else {
+            tracing::debug!(window_id = %id, "uploaded image paste dropped: window not found");
+            return Vec::new();
+        };
+        if self.tab(&address.tab_id).is_none() {
+            tracing::debug!(window_id = %id, "uploaded image paste dropped: project tab not found");
+            return Vec::new();
+        }
+        let Some(session) = self.active_agent_sessions.get(&id) else {
+            tracing::debug!(
+                window_id = %id,
+                "uploaded image paste dropped: active agent session not found"
+            );
+            return Vec::new();
+        };
+        let operation_id = normalize_attachment_operation_id(operation_id);
+        let display_filename = upload
+            .filename
+            .as_deref()
+            .map(display_attachment_basename)
+            .or_else(|| Some(display_attachment_basename("image")));
+        let worktree_path = session.worktree_path.clone();
+        let upload_store = self.attachment_uploads.clone();
+        let proxy = self.proxy.clone();
+        let spawner = self.blocking_tasks.clone();
+        let worker_client_id = client_id.clone();
+        let worker_window_id = id.clone();
+        let worker_operation_id = operation_id.clone();
+        let worker_filename = display_filename.clone();
+
+        spawner.spawn(move || {
+            let image = match prepare_uploaded_image_paste_file(
+                &worktree_path,
+                &upload_store,
+                &upload.upload_id,
+                &upload.mime_type,
+                upload.filename.as_deref(),
+                upload.size,
+                &image_paste_unique_token(),
+            ) {
+                Ok(image) => image,
+                Err(error) => {
+                    AttachmentProgressUpdate::new(
+                        worker_window_id.clone(),
+                        worker_operation_id.clone(),
+                        AttachmentProgressPhase::Failed,
+                        1,
+                    )
+                    .file(
+                        0,
+                        worker_filename
+                            .clone()
+                            .unwrap_or_else(|| "image".to_string()),
+                    )
+                    .message(error.to_string())
+                    .dispatch(&proxy, &worker_client_id);
+                    return;
+                }
+            };
+            let progress_filename = worker_filename
+                .clone()
+                .or_else(|| Some(display_attachment_basename(&image.agent_path)));
+            if let Err(error) = save_image_paste_file_with_progress(&image, |bytes_done, total| {
+                AttachmentProgressUpdate::new(
+                    worker_window_id.clone(),
+                    worker_operation_id.clone(),
+                    AttachmentProgressPhase::Staging,
+                    1,
+                )
+                .file(
+                    0,
+                    progress_filename
+                        .clone()
+                        .unwrap_or_else(|| "image".to_string()),
+                )
+                .bytes(bytes_done, total)
+                .dispatch(&proxy, &worker_client_id);
+            }) {
+                AttachmentProgressUpdate::new(
+                    worker_window_id.clone(),
+                    worker_operation_id.clone(),
+                    AttachmentProgressPhase::Failed,
+                    1,
+                )
+                .filename(progress_filename)
+                .message(error.to_string())
+                .dispatch(&proxy, &worker_client_id);
+                return;
+            }
+            proxy.send(UserEvent::AttachmentPromptReady {
+                client_id: worker_client_id,
+                window_id: worker_window_id,
+                operation_id: worker_operation_id,
+                prompt: image.prompt_text,
+                file_count: 1,
+                filename: progress_filename,
+            });
+        });
+
+        vec![
+            AttachmentProgressUpdate::new(id, operation_id, AttachmentProgressPhase::Queued, 1)
+                .filename(display_filename)
+                .outbound(client_id),
+        ]
     }
 
     pub(crate) fn paste_image_uploaded_events(
@@ -5690,6 +6084,137 @@ impl AppRuntime {
             "saved uploaded pasted image"
         );
         self.terminal_input_events(id, &image.prompt_text)
+    }
+
+    fn attach_files_operation_events(
+        &mut self,
+        client_id: ClientId,
+        id: String,
+        operation_id: Option<String>,
+        files: Vec<gwt::FileAttachment>,
+    ) -> Vec<OutboundEvent> {
+        let Some(address) = self.window_lookup.get(&id).cloned() else {
+            tracing::debug!(window_id = %id, "file attachment dropped: window not found");
+            return Vec::new();
+        };
+        if self.tab(&address.tab_id).is_none() {
+            tracing::debug!(window_id = %id, "file attachment dropped: project tab not found");
+            return Vec::new();
+        }
+        let Some(session) = self.active_agent_sessions.get(&id) else {
+            tracing::debug!(
+                window_id = %id,
+                "file attachment dropped: active agent session not found"
+            );
+            return Vec::new();
+        };
+        if files.is_empty() {
+            tracing::debug!(window_id = %id, "file attachment dropped: empty selection");
+            return Vec::new();
+        }
+
+        let operation_id = normalize_attachment_operation_id(operation_id);
+        let file_count = files.len();
+        let display_filename =
+            (file_count == 1).then(|| display_name_for_file_attachment(&files[0]));
+        let worktree_path = session.worktree_path.clone();
+        let agent_project_root = session.agent_project_root.clone();
+        let runtime_target = session.runtime_target;
+        let upload_store = self.attachment_uploads.clone();
+        let limits = ContentLimits::default();
+        let proxy = self.proxy.clone();
+        let spawner = self.blocking_tasks.clone();
+        let worker_client_id = client_id.clone();
+        let worker_window_id = id.clone();
+        let worker_operation_id = operation_id.clone();
+        let worker_display_filename = display_filename.clone();
+
+        spawner.spawn(move || {
+            let mut agent_paths = Vec::with_capacity(files.len());
+            for (index, file) in files.iter().enumerate() {
+                let filename = display_name_for_file_attachment(file);
+                let token = format!("{}-{index}", image_paste_unique_token());
+                let prepared = match prepare_file_attachment(
+                    &worktree_path,
+                    &agent_project_root,
+                    runtime_target,
+                    file,
+                    &token,
+                    limits,
+                    &upload_store,
+                ) {
+                    Ok(prepared) => prepared,
+                    Err(error) => {
+                        AttachmentProgressUpdate::new(
+                            worker_window_id.clone(),
+                            worker_operation_id.clone(),
+                            AttachmentProgressPhase::Failed,
+                            file_count,
+                        )
+                        .file(index, filename)
+                        .message(error.to_string())
+                        .dispatch(&proxy, &worker_client_id);
+                        return;
+                    }
+                };
+                if let Err(error) =
+                    save_file_attachment_with_progress(&prepared, |bytes_done, total| {
+                        AttachmentProgressUpdate::new(
+                            worker_window_id.clone(),
+                            worker_operation_id.clone(),
+                            AttachmentProgressPhase::Staging,
+                            file_count,
+                        )
+                        .file(index, filename.clone())
+                        .bytes(bytes_done, total)
+                        .dispatch(&proxy, &worker_client_id);
+                    })
+                {
+                    AttachmentProgressUpdate::new(
+                        worker_window_id.clone(),
+                        worker_operation_id.clone(),
+                        AttachmentProgressPhase::Failed,
+                        file_count,
+                    )
+                    .file(index, filename)
+                    .message(error.to_string())
+                    .dispatch(&proxy, &worker_client_id);
+                    return;
+                }
+                agent_paths.push(prepared.agent_path);
+            }
+
+            let prompt = format_file_attachment_prompt(&agent_paths);
+            if prompt.is_empty() {
+                AttachmentProgressUpdate::new(
+                    worker_window_id.clone(),
+                    worker_operation_id.clone(),
+                    AttachmentProgressPhase::Failed,
+                    file_count,
+                )
+                .filename(worker_display_filename.clone())
+                .message("no attachment prompt generated")
+                .dispatch(&proxy, &worker_client_id);
+                return;
+            }
+            proxy.send(UserEvent::AttachmentPromptReady {
+                client_id: worker_client_id,
+                window_id: worker_window_id,
+                operation_id: worker_operation_id,
+                prompt,
+                file_count,
+                filename: worker_display_filename,
+            });
+        });
+
+        vec![AttachmentProgressUpdate::new(
+            id,
+            operation_id,
+            AttachmentProgressPhase::Queued,
+            file_count,
+        )
+        .filename(display_filename)
+        .outbound(client_id)]
     }
 
     pub(crate) fn attach_files_events(
@@ -9698,10 +10223,10 @@ mod tests {
     use super::{
         active_work_projection_from_saved, dispatch_agent_launch_success,
         save_start_work_workspace_projection, save_workspace_launch_projection, ActiveAgentSession,
-        AgentLaunchCompletion, AppEventProxy, AppRuntime, BlockingTaskSpawner, DispatchTarget,
-        KnowledgeLoadRequest, KnowledgeRefreshTask, KnowledgeSearchRequest,
-        LaunchWizardMemoryCache, LaunchWizardSession, OutboundEvent, ProcessLaunch,
-        ProjectTabRuntime, UserEvent, WindowRuntime, WorkspaceResumeContext,
+        AgentLaunchCompletion, AppEventProxy, AppRuntime, AttachmentProgressPhase,
+        BlockingTaskSpawner, DispatchTarget, KnowledgeLoadRequest, KnowledgeRefreshTask,
+        KnowledgeSearchRequest, LaunchWizardMemoryCache, LaunchWizardSession, OutboundEvent,
+        ProcessLaunch, ProjectTabRuntime, UserEvent, WindowRuntime, WorkspaceResumeContext,
     };
     use crate::{
         combined_window_id, geometry_to_pty_size, same_worktree_path, AttachmentUploadStore,
@@ -10594,6 +11119,49 @@ exit 1
     }
 
     #[test]
+    fn file_attachment_prepare_preserves_japanese_unicode_basename() {
+        let temp = tempdir().expect("tempdir");
+        let worktree = temp.path().join("repo");
+        fs::create_dir_all(&worktree).expect("create worktree");
+        let payload = base64::engine::general_purpose::STANDARD.encode(b"unicode-notes");
+
+        let prepared = super::prepare_file_attachment(
+            &worktree,
+            &worktree.display().to_string(),
+            gwt_agent::LaunchRuntimeTarget::Host,
+            &gwt::FileAttachment::Inline {
+                filename: "../資料 日本語.txt".to_string(),
+                mime_type: Some("text/plain".to_string()),
+                size: 13,
+                data_base64: payload,
+            },
+            "20260604-inline",
+            ContentLimits::default(),
+            &AttachmentUploadStore::in_system_temp(),
+        )
+        .expect("prepare unicode filename attachment");
+
+        assert_eq!(
+            prepared.storage_path.as_deref(),
+            Some(
+                worktree
+                    .join(".gwt")
+                    .join("drop-files")
+                    .join("20260604-inline-資料-日本語.txt")
+                    .as_path()
+            )
+        );
+        assert_eq!(
+            prepared.agent_path,
+            ".gwt/drop-files/20260604-inline-資料-日本語.txt"
+        );
+        assert_eq!(
+            super::format_file_attachment_prompt(&[prepared.agent_path]),
+            "File: \".gwt/drop-files/20260604-inline-資料-日本語.txt\""
+        );
+    }
+
+    #[test]
     fn file_attachment_prepare_copies_native_file_for_docker_agent_path() {
         let temp = tempdir().expect("tempdir");
         let worktree = temp.path().join("repo");
@@ -10907,6 +11475,139 @@ exit 1
         assert!(
             !uploaded_path.exists(),
             "uploaded temp file should be removed after staging"
+        );
+    }
+
+    #[test]
+    fn file_attachment_operation_dispatches_failed_progress_without_prompt_on_stage_failure() {
+        let temp = tempdir().expect("tempdir");
+        let worktree = temp.path().join("repo");
+        fs::create_dir_all(&worktree).expect("create worktree");
+        let tab_id = "tab-1";
+        let raw_window_id = "agent-1";
+        let window_id = combined_window_id(tab_id, raw_window_id);
+        let tab = sample_project_tab_with_window_at(
+            tab_id,
+            raw_window_id,
+            worktree.clone(),
+            WindowPreset::Agent,
+            WindowProcessStatus::Running,
+        );
+        let (mut runtime, recorded_events) =
+            sample_runtime_with_events(temp.path(), vec![tab], Some(tab_id));
+        runtime.active_agent_sessions.insert(
+            window_id.clone(),
+            ActiveAgentSession {
+                window_id: window_id.clone(),
+                session_id: "session-1".to_string(),
+                agent_id: "codex".to_string(),
+                branch_name: "feature/file-drop".to_string(),
+                display_name: "Codex".to_string(),
+                worktree_path: worktree.clone(),
+                agent_project_root: worktree.display().to_string(),
+                runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+                tab_id: tab_id.to_string(),
+            },
+        );
+        let event: FrontendEvent = serde_json::from_value(serde_json::json!({
+            "kind": "attach_files",
+            "id": window_id,
+            "operation_id": "attachment-op-fail",
+            "files": [
+                {
+                    "source": "native_path",
+                    "path": temp.path().display().to_string()
+                }
+            ]
+        }))
+        .expect("deserialize operation attach files event");
+
+        let events = runtime.handle_frontend_event("client-1".to_string(), event);
+
+        assert!(
+            events.iter().any(|event| matches!(
+                &event.event,
+                BackendEvent::AttachmentProgress {
+                    id,
+                    operation_id,
+                    phase: AttachmentProgressPhase::Queued,
+                    ..
+                } if id == &window_id && operation_id == "attachment-op-fail"
+            )),
+            "operation-aware attachment handling should acknowledge queued progress immediately: {events:?}"
+        );
+        wait_for_recorded_event("failed attachment progress", &recorded_events, |events| {
+            events.iter().any(|event| {
+                matches!(
+                    event,
+                    UserEvent::Dispatch(dispatched)
+                        if dispatched.iter().any(|outbound| matches!(
+                            &outbound.event,
+                            BackendEvent::AttachmentProgress {
+                                id,
+                                operation_id,
+                                phase: AttachmentProgressPhase::Failed,
+                                message: Some(message),
+                                ..
+                            } if id == &window_id
+                                && operation_id == "attachment-op-fail"
+                                && message.contains("not a file")
+                        ))
+                )
+            })
+        });
+        {
+            let events = recorded_events.lock().expect("event log");
+            assert!(
+                !events
+                    .iter()
+                    .any(|event| matches!(event, UserEvent::AttachmentPromptReady { .. })),
+                "failed staging must not enqueue terminal prompt injection"
+            );
+        }
+    }
+
+    #[test]
+    fn file_attachment_copy_reports_byte_progress() {
+        let temp = tempdir().expect("tempdir");
+        let source = temp.path().join("日本語-source.bin");
+        let storage = temp
+            .path()
+            .join("repo")
+            .join(".gwt")
+            .join("drop-files")
+            .join("20260604-日本語-source.bin");
+        let payload = vec![b'x'; 192 * 1024 + 7];
+        fs::write(&source, &payload).expect("write source file");
+        let prepared = super::PreparedFileAttachment {
+            bytes: None,
+            source_path: Some(source.clone()),
+            remove_source_after_save: false,
+            storage_path: Some(storage.clone()),
+            agent_path: ".gwt/drop-files/20260604-日本語-source.bin".to_string(),
+        };
+        let mut progress = Vec::new();
+
+        super::save_file_attachment_with_progress(&prepared, |bytes_done, bytes_total| {
+            progress.push((bytes_done, bytes_total));
+        })
+        .expect("copy attachment with progress");
+
+        assert_eq!(fs::read(&storage).expect("read copied file"), payload);
+        assert!(
+            progress.len() >= 3,
+            "copy should report an initial sample, at least one chunk, and final completion: {progress:?}"
+        );
+        assert_eq!(progress.first(), Some(&(0, Some(192 * 1024 + 7))));
+        assert_eq!(
+            progress.last(),
+            Some(&(192 * 1024 + 7, Some(192 * 1024 + 7)))
+        );
+        assert!(
+            progress
+                .windows(2)
+                .all(|pair| pair[0].0 <= pair[1].0 && pair[0].1 == pair[1].1),
+            "copy progress must be monotonic with stable total: {progress:?}"
         );
     }
 

--- a/crates/gwt/src/embedded_server.rs
+++ b/crates/gwt/src/embedded_server.rs
@@ -1419,6 +1419,65 @@ mod tests {
         server.shutdown();
     }
 
+    #[test]
+    fn embedded_server_preserves_unicode_attachment_upload_filename() {
+        let runtime = Runtime::new().expect("tokio runtime");
+        let (proxy, _events) = AppEventProxy::stub();
+        let clients = ClientHub::default();
+        let pty_writers = Arc::new(RwLock::new(HashMap::new()));
+        let upload_store = AttachmentUploadStore::in_system_temp();
+        let mut server =
+            EmbeddedServer::start(&runtime, proxy, clients, pty_writers, upload_store.clone())
+                .expect("embedded server");
+        let client = reqwest::blocking::Client::new();
+        let token_response: serde_json::Value = client
+            .get(format!("{}internal/attachment-upload-token", server.url()))
+            .send()
+            .expect("token request")
+            .json()
+            .expect("token json");
+        let token = token_response
+            .get("token")
+            .and_then(|value| value.as_str())
+            .expect("token field")
+            .to_string();
+
+        let upload_response: serde_json::Value = client
+            .post(format!(
+                "{}internal/attachments/upload?filename=%E8%B3%87%E6%96%99%20%E6%97%A5%E6%9C%AC%E8%AA%9E.txt&mime_type=text%2Fplain&size=7",
+                server.url()
+            ))
+            .header("x-gwt-upload-token", token)
+            .body("nihongo")
+            .send()
+            .expect("unicode filename upload request")
+            .json()
+            .expect("unicode filename upload json");
+        assert_eq!(
+            upload_response
+                .get("filename")
+                .and_then(|value| value.as_str()),
+            Some("資料 日本語.txt")
+        );
+        let upload_id = upload_response
+            .get("upload_id")
+            .and_then(|value| value.as_str())
+            .expect("upload id");
+
+        let uploaded = upload_store
+            .take(upload_id)
+            .expect("take upload")
+            .expect("uploaded file registered");
+        assert_eq!(uploaded.filename, "資料 日本語.txt");
+        assert_eq!(uploaded.size, 7);
+        assert_eq!(
+            std::fs::read(uploaded.path).expect("read uploaded temp"),
+            b"nihongo"
+        );
+
+        server.shutdown();
+    }
+
     // ---------------------------------------------------------------
     // SPEC-1942 US-14: bind / port surface + access log middleware
     // ---------------------------------------------------------------

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -787,8 +787,16 @@ mod tests {
         assert!(
             html.contains("kind: \"attach_files\"")
                 && html.contains("source: \"uploaded\"")
-                && html.contains("upload_id"),
-            "expected browser file drops to send uploaded attach_files payloads",
+                && html.contains("upload_id")
+                && html.contains("operation_id"),
+            "expected browser file drops to send uploaded attach_files payloads with operation ids",
+        );
+        assert!(
+            html.contains("attachmentProgressControllers")
+                && html.contains("handleAttachmentProgress")
+                && html.contains("workspaceWindowElement")
+                && !html.contains("attachment-progress__cancel"),
+            "expected attachment progress to be scoped to the Agent window without a Cancel action",
         );
         let drop_start = html
             .find("function installTerminalFileDropHandlers")
@@ -832,8 +840,10 @@ mod tests {
             "expected native drops to map the WebView pointer to the terminal under it",
         );
         assert!(
-            html.contains("source: \"native_path\"") && html.contains("kind: \"attach_files\""),
-            "expected native drops to send native_path attach_files payloads",
+            html.contains("source: \"native_path\"")
+                && html.contains("kind: \"attach_files\"")
+                && html.contains("operation_id"),
+            "expected native drops to send native_path attach_files payloads with operation ids",
         );
     }
 

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -122,14 +122,14 @@ pub use preset::{
 };
 pub use protocol::{
     ActiveWorkAgentView, ActiveWorkCleanupCandidateView, ActiveWorkItemView,
-    ActiveWorkProjectionView, AppStateView, ArrangeMode, BackendEvent, BranchEntriesPhase,
-    CustomAgentErrorCode, FileAttachment, FileContentErrorKind, FileContentMode,
-    FileContentSaveErrorKind, FocusCycleDirection, FrontendEvent, GitHubRepositorySearchResultView,
-    IndexSearchMatchMode, IndexSearchResult, IndexSearchScope, IndexSearchTarget, ProfileEntryView,
-    ProfileEnvEntryView, ProfileSnapshotView, ProjectTabView, RecentProjectView,
-    RunningAgentSummary, UiTraceEntry, UiTracePayload, WorkspaceExecutionContainerView,
-    WorkspaceHistoryAgentView, WorkspaceHistoryEventView, WorkspaceHistoryView,
-    WorkspaceJournalEntryView, WorkspaceResumeSource, WorkspaceView, WorkspaceWorkAgentView,
-    WorkspaceWorkEventView, WorkspaceWorkItemView,
+    ActiveWorkProjectionView, AppStateView, ArrangeMode, AttachmentProgressPhase, BackendEvent,
+    BranchEntriesPhase, CustomAgentErrorCode, FileAttachment, FileContentErrorKind,
+    FileContentMode, FileContentSaveErrorKind, FocusCycleDirection, FrontendEvent,
+    GitHubRepositorySearchResultView, IndexSearchMatchMode, IndexSearchResult, IndexSearchScope,
+    IndexSearchTarget, ProfileEntryView, ProfileEnvEntryView, ProfileSnapshotView, ProjectTabView,
+    RecentProjectView, RunningAgentSummary, UiTraceEntry, UiTracePayload,
+    WorkspaceExecutionContainerView, WorkspaceHistoryAgentView, WorkspaceHistoryEventView,
+    WorkspaceHistoryView, WorkspaceJournalEntryView, WorkspaceResumeSource, WorkspaceView,
+    WorkspaceWorkAgentView, WorkspaceWorkEventView, WorkspaceWorkItemView,
 };
 pub use workspace::WorkspaceState;

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -19,10 +19,11 @@ use gwt::{
     load_restored_workspace_state, load_session_state, migrate_legacy_workspace_state,
     read_binary_chunk, read_text_file,
     refresh_managed_gwt_assets_for_agent_with_codex_hook_discovery_mode, resolve_launch_spec,
-    workspace_state_path, BackendEvent, BranchCleanupOptions, BranchEntriesPhase, BranchListEntry,
-    ContentLimits, DockerWizardContext, FileContentError, FrontendEvent, HookForwardTarget,
-    KnowledgeKind, LaunchWizardState, LiveSessionEntry, ShellLaunchConfig, UiTracePayload,
-    WindowGeometry, WindowPreset, WindowProcessStatus, WorkspaceState, APP_NAME,
+    workspace_state_path, AttachmentProgressPhase, BackendEvent, BranchCleanupOptions,
+    BranchEntriesPhase, BranchListEntry, ContentLimits, DockerWizardContext, FileContentError,
+    FrontendEvent, HookForwardTarget, KnowledgeKind, LaunchWizardState, LiveSessionEntry,
+    ShellLaunchConfig, UiTracePayload, WindowGeometry, WindowPreset, WindowProcessStatus,
+    WorkspaceState, APP_NAME,
 };
 use gwt_terminal::{Pane, PaneStatus, PtyHandle};
 use tao::{
@@ -925,6 +926,14 @@ enum UserEvent {
     LaunchProgress {
         window_id: String,
         message: String,
+    },
+    AttachmentPromptReady {
+        client_id: ClientId,
+        window_id: String,
+        operation_id: String,
+        prompt: String,
+        file_count: usize,
+        filename: Option<String>,
     },
     LaunchWizardRuntimeResolved {
         wizard_id: String,
@@ -6645,6 +6654,24 @@ fn main() -> std::io::Result<()> {
                         message,
                     },
                 )]);
+            }
+            Event::UserEvent(UserEvent::AttachmentPromptReady {
+                client_id,
+                window_id,
+                operation_id,
+                prompt,
+                file_count,
+                filename,
+            }) => {
+                let events = app.inject_attachment_prompt_events(
+                    client_id,
+                    window_id,
+                    operation_id,
+                    prompt,
+                    file_count,
+                    filename,
+                );
+                clients.dispatch(events);
             }
             Event::UserEvent(UserEvent::LaunchWizardRuntimeResolved { wizard_id, result }) => {
                 let events = app.handle_launch_wizard_runtime_resolved(wizard_id, *result);

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -178,6 +178,16 @@ pub enum FileAttachment {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AttachmentProgressPhase {
+    Queued,
+    Staging,
+    Injecting,
+    Attached,
+    Failed,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum FrontendEvent {
@@ -273,6 +283,8 @@ pub enum FrontendEvent {
     },
     PasteImageUploaded {
         id: String,
+        #[serde(default)]
+        operation_id: Option<String>,
         upload_id: String,
         mime_type: String,
         filename: Option<String>,
@@ -280,6 +292,8 @@ pub enum FrontendEvent {
     },
     AttachFiles {
         id: String,
+        #[serde(default)]
+        operation_id: Option<String>,
         files: Vec<FileAttachment>,
     },
     LoadFileTree {
@@ -1084,6 +1098,17 @@ pub enum BackendEvent {
         status: WindowProcessStatus,
         detail: Option<String>,
     },
+    AttachmentProgress {
+        id: String,
+        operation_id: String,
+        phase: AttachmentProgressPhase,
+        file_index: Option<usize>,
+        file_count: usize,
+        filename: Option<String>,
+        bytes_done: Option<u64>,
+        bytes_total: Option<u64>,
+        message: Option<String>,
+    },
     WindowState {
         window_id: String,
         state: WindowProcessStatus,
@@ -1689,6 +1714,11 @@ pub const BACKEND_EVENT_POLICIES: &[BackendEventPolicy] = &[
         BackendEventBackpressurePolicy::BestEffort,
     ),
     BackendEventPolicy::new(
+        "attachment_progress",
+        BackendEventDeliveryClass::EphemeralStatus,
+        BackendEventBackpressurePolicy::BestEffort,
+    ),
+    BackendEventPolicy::new(
         "window_state",
         BackendEventDeliveryClass::EphemeralStatus,
         BackendEventBackpressurePolicy::BestEffort,
@@ -2077,6 +2107,7 @@ impl BackendEvent {
             BackendEvent::TerminalOutput { .. } => "terminal_output",
             BackendEvent::TerminalSnapshot { .. } => "terminal_snapshot",
             BackendEvent::TerminalStatus { .. } => "terminal_status",
+            BackendEvent::AttachmentProgress { .. } => "attachment_progress",
             BackendEvent::WindowState { .. } => "window_state",
             BackendEvent::FileTreeEntries { .. } => "file_tree_entries",
             BackendEvent::FileTreeError { .. } => "file_tree_error",
@@ -2219,10 +2250,11 @@ mod tests {
     };
 
     use super::{
-        backend_event_policy, BackendEvent, BackendEventBackpressurePolicy,
-        BackendEventDeliveryClass, BranchEntriesPhase, FrontendEvent, IndexSearchMatchMode,
-        IndexSearchResult, IndexSearchScope, IndexSearchTarget, ProfileEntryView,
-        ProfileEnvEntryView, ProfileSnapshotView, UiTracePayload, BACKEND_EVENT_POLICIES,
+        backend_event_policy, AttachmentProgressPhase, BackendEvent,
+        BackendEventBackpressurePolicy, BackendEventDeliveryClass, BranchEntriesPhase,
+        FrontendEvent, IndexSearchMatchMode, IndexSearchResult, IndexSearchScope,
+        IndexSearchTarget, ProfileEntryView, ProfileEnvEntryView, ProfileSnapshotView,
+        UiTracePayload, BACKEND_EVENT_POLICIES,
     };
 
     #[test]
@@ -2993,6 +3025,7 @@ mod tests {
         let event: FrontendEvent = serde_json::from_value(serde_json::json!({
             "kind": "paste_image_uploaded",
             "id": "tab-1::agent-1",
+            "operation_id": "attachment-op-1",
             "upload_id": "upload-1",
             "mime_type": "image/png",
             "filename": "screenshot.png",
@@ -3005,17 +3038,43 @@ mod tests {
                 event,
                 FrontendEvent::PasteImageUploaded {
                     id,
+                    operation_id: Some(operation_id),
                     upload_id,
                     mime_type,
                     filename: Some(filename),
                     size,
                 } if id == "tab-1::agent-1"
+                    && operation_id == "attachment-op-1"
                     && upload_id == "upload-1"
                     && mime_type == "image/png"
                     && filename == "screenshot.png"
                     && size == 12
             ),
-            "uploaded image paste must expose upload id and image metadata"
+            "uploaded image paste must expose operation id, upload id, and image metadata"
+        );
+    }
+
+    #[test]
+    fn frontend_event_accepts_uploaded_terminal_image_paste_without_operation_id() {
+        let event: FrontendEvent = serde_json::from_value(serde_json::json!({
+            "kind": "paste_image_uploaded",
+            "id": "tab-1::agent-1",
+            "upload_id": "upload-1",
+            "mime_type": "image/png",
+            "filename": "screenshot.png",
+            "size": 12
+        }))
+        .expect("deserialize legacy uploaded image paste event");
+
+        assert!(
+            matches!(
+                event,
+                FrontendEvent::PasteImageUploaded {
+                    operation_id: None,
+                    ..
+                }
+            ),
+            "legacy uploaded image paste events must remain accepted"
         );
     }
 
@@ -3036,7 +3095,7 @@ mod tests {
         assert!(
             matches!(
                 event,
-                FrontendEvent::AttachFiles { id, files }
+                FrontendEvent::AttachFiles { id, files, .. }
                     if id == "tab-1::agent-1"
                         && matches!(
                             files.as_slice(),
@@ -3068,7 +3127,7 @@ mod tests {
         assert!(
             matches!(
                 event,
-                FrontendEvent::AttachFiles { id, files }
+                FrontendEvent::AttachFiles { id, files, .. }
                     if id == "tab-1::agent-1"
                         && matches!(
                             files.as_slice(),
@@ -3092,6 +3151,7 @@ mod tests {
         let event: FrontendEvent = serde_json::from_value(serde_json::json!({
             "kind": "attach_files",
             "id": "tab-1::agent-1",
+            "operation_id": "attachment-op-2",
             "files": [
                 {
                     "source": "uploaded",
@@ -3107,8 +3167,13 @@ mod tests {
         assert!(
             matches!(
                 event,
-                FrontendEvent::AttachFiles { id, files }
+                FrontendEvent::AttachFiles {
+                    id,
+                    operation_id: Some(operation_id),
+                    files,
+                }
                     if id == "tab-1::agent-1"
+                        && operation_id == "attachment-op-2"
                         && matches!(
                             files.as_slice(),
                             [super::FileAttachment::Uploaded {
@@ -3123,6 +3188,69 @@ mod tests {
                         )
             ),
             "browser streaming uploads must expose upload id and metadata"
+        );
+    }
+
+    #[test]
+    fn frontend_event_accepts_terminal_file_attachments_without_operation_id() {
+        let event: FrontendEvent = serde_json::from_value(serde_json::json!({
+            "kind": "attach_files",
+            "id": "tab-1::agent-1",
+            "files": [
+                {
+                    "source": "native_path",
+                    "path": "/Users/me/report.pdf"
+                }
+            ]
+        }))
+        .expect("deserialize legacy file attachment event");
+
+        assert!(
+            matches!(
+                event,
+                FrontendEvent::AttachFiles {
+                    operation_id: None,
+                    ..
+                }
+            ),
+            "legacy file attachment events must remain accepted"
+        );
+    }
+
+    #[test]
+    fn backend_event_serializes_attachment_progress_contract() {
+        let event = BackendEvent::AttachmentProgress {
+            id: "tab-1::agent-1".to_string(),
+            operation_id: "attachment-op-3".to_string(),
+            phase: AttachmentProgressPhase::Staging,
+            file_index: Some(0),
+            file_count: 2,
+            filename: Some("資料 日本語.txt".to_string()),
+            bytes_done: Some(64),
+            bytes_total: Some(128),
+            message: None,
+        };
+
+        let value = serde_json::to_value(&event).expect("serialize attachment progress");
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "kind": "attachment_progress",
+                "id": "tab-1::agent-1",
+                "operation_id": "attachment-op-3",
+                "phase": "staging",
+                "file_index": 0,
+                "file_count": 2,
+                "filename": "資料 日本語.txt",
+                "bytes_done": 64,
+                "bytes_total": 128,
+                "message": null
+            })
+        );
+        assert_eq!(
+            event.delivery_policy().kind,
+            "attachment_progress",
+            "attachment progress must be registered in the backend event policy catalog"
         );
     }
 

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1802,13 +1802,13 @@ test("Launch wizard separates launch settings from runtime controls", () => {
 test("Launch wizard runtime confirmation shows summary without setup forms", () => {
   assert.match(
     appSource,
-    /const showManualSetup = launchWizard\.show_manual_setup !== false;[\s\S]*?const isRuntimeConfirmation = Boolean\([\s\S]*?const showStartMethods = Boolean\([\s\S]*?launchWizard\.show_start_methods[\s\S]*?const showSetupForms = showManualSetup && !isRuntimeConfirmation;/,
-    "expected showManualSetup to be initialized before Runtime confirmation setup gating",
+    /const showConfirm = Boolean\(launchWizard\.show_confirm\);[\s\S]*?const isRuntimeConfirmation = Boolean\(\s*launchWizard\.runtime_context_resolved\s*&&\s*launchWizard\.show_runtime_confirmation\s*&&\s*!showConfirm\s*\);[\s\S]*?const showManualSetup =\s*launchWizard\.show_manual_setup !== false\s*&&\s*!isRuntimeConfirmation\s*&&\s*!showConfirm;[\s\S]*?const showStartMethods = Boolean\(\s*launchWizard\.show_start_methods\s*&&\s*!isRuntimeConfirmation\s*&&\s*!showConfirm[\s\S]*?const showSetupForms = showManualSetup && !isRuntimeConfirmation;/,
+    "expected renderer to derive mutually exclusive Runtime/Confirm/setup gating",
   );
   assert.match(
     appSource,
-    /const isRuntimeConfirmation = Boolean\(\s*launchWizard\.runtime_context_resolved\s*&&\s*launchWizard\.show_runtime_confirmation\s*\);/,
-    "expected renderer to derive a dedicated Runtime confirmation state",
+    /const isRuntimeConfirmation = Boolean\(\s*launchWizard\.runtime_context_resolved\s*&&\s*launchWizard\.show_runtime_confirmation\s*&&\s*!showConfirm\s*\);/,
+    "expected renderer to derive a dedicated Runtime confirmation state outside Confirm",
   );
   assert.match(
     appSource,

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1432,6 +1432,10 @@
         return activeWorkspace().windows.find((windowData) => windowData.id === windowId) || null;
       }
 
+      function workspaceWindowElement(windowId) {
+        return windowMap.get(windowId) || null;
+      }
+
       function windowGroupId(windowData) {
         return windowData?.tab_group_id || windowData?.id || "";
       }
@@ -4424,12 +4428,29 @@
         return files.reduce((total, file) => total + (file.size || 0), 0);
       }
 
+      function displayAttachmentBasename(filename) {
+        const value = String(filename || "").trim();
+        const parts = value.split(/[\\/]+/).filter(Boolean);
+        return parts.at(-1) || "file";
+      }
+
       function attachmentFileCountLabel(count) {
         return `${count} ${count === 1 ? "file" : "files"}`;
       }
 
-      function ensureAttachmentProgressSurface() {
-        let surface = document.querySelector(".attachment-progress");
+      function createAttachmentOperationId() {
+        const random =
+          typeof globalThis.crypto?.randomUUID === "function"
+            ? globalThis.crypto.randomUUID()
+            : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+        return `attachment-${random}`;
+      }
+
+      const attachmentProgressControllers = new Map();
+
+      function ensureAttachmentProgressSurface(windowId) {
+        const host = workspaceWindowElement(windowId) || document.body;
+        let surface = host.querySelector(".attachment-progress");
         if (surface) {
           return surface;
         }
@@ -4441,27 +4462,43 @@
         surface.innerHTML = `
           <div class="attachment-progress__row">
             <span class="attachment-progress__label"></span>
-            <button class="attachment-progress__cancel" type="button" title="Cancel upload">Cancel</button>
           </div>
           <div class="attachment-progress__track" role="progressbar" aria-valuemin="0" aria-valuemax="100">
             <div class="attachment-progress__bar"></div>
           </div>
         `;
-        document.body.appendChild(surface);
+        host.appendChild(surface);
         return surface;
       }
 
-      function createAttachmentProgressController(files) {
-        const surface = ensureAttachmentProgressSurface();
+      function attachmentPhaseLabel(phase, fallback = "") {
+        switch (phase) {
+          case "queued":
+            return "Queued";
+          case "staging":
+            return "Staging";
+          case "injecting":
+            return "Injecting";
+          case "attached":
+            return "Attached";
+          case "failed":
+            return fallback || "Could not attach";
+          default:
+            return fallback || "Uploading";
+        }
+      }
+
+      function createAttachmentProgressController(windowId, files, operationId = createAttachmentOperationId()) {
+        const surface = ensureAttachmentProgressSurface(windowId);
         const label = surface.querySelector(".attachment-progress__label");
         const track = surface.querySelector(".attachment-progress__track");
         const bar = surface.querySelector(".attachment-progress__bar");
-        const cancel = surface.querySelector(".attachment-progress__cancel");
         const abortController = new AbortController();
-        const totalBytes = totalFileBytes(files);
         const fileCount = files.length;
         const state = {
           phase: "Uploading",
+          filename: fileCount === 1 ? displayAttachmentBasename(files[0]?.name) : "",
+          totalBytes: totalFileBytes(files),
           loadedBytes: 0,
           failed: false,
           done: false,
@@ -4469,12 +4506,12 @@
         };
 
         function percent() {
-          if (totalBytes <= 0) {
+          if (state.totalBytes <= 0) {
             return state.done ? 100 : 0;
           }
           return Math.max(
             0,
-            Math.min(100, Math.round((state.loadedBytes / totalBytes) * 100)),
+            Math.min(100, Math.round((state.loadedBytes / state.totalBytes) * 100)),
           );
         }
 
@@ -4483,13 +4520,13 @@
             return;
           }
           const value = percent();
-          const suffix = totalBytes > 0 ? ` · ${value}%` : "";
+          const filename = state.filename ? ` · ${state.filename}` : "";
+          const suffix = state.totalBytes > 0 ? ` · ${value}%` : "";
           surface.hidden = false;
           surface.dataset.state = state.failed ? "error" : state.done ? "done" : "active";
-          label.textContent = `${state.phase} ${attachmentFileCountLabel(fileCount)}${suffix}`;
+          label.textContent = `${state.phase} ${attachmentFileCountLabel(fileCount)}${filename}${suffix}`;
           track.setAttribute("aria-valuenow", String(value));
           bar.style.width = `${value}%`;
-          cancel.hidden = state.done || state.failed;
         }
 
         function showNow() {
@@ -4498,17 +4535,16 @@
         }
 
         render();
-        cancel.onclick = () => {
-          abortController.abort();
-          fail("Upload cancelled.");
-        };
 
         function setPhase(phase) {
           state.phase = phase;
           render();
         }
 
-        function setUploadProgress(loadedBytes) {
+        function setUploadProgress(loadedBytes, totalBytes = null) {
+          if (Number.isFinite(totalBytes) && totalBytes >= 0) {
+            state.totalBytes = totalBytes;
+          }
           state.loadedBytes = Math.max(0, loadedBytes || 0);
           render();
         }
@@ -4516,11 +4552,13 @@
         function succeed() {
           state.done = true;
           state.phase = "Attached";
+          state.loadedBytes = state.totalBytes;
           if (state.visible) {
             render();
             setTimeout(() => {
               if (surface.dataset.state === "done") {
                 surface.hidden = true;
+                attachmentProgressControllers.delete(operationId);
               }
             }, 700);
           }
@@ -4532,13 +4570,66 @@
           showNow();
         }
 
-        return {
+        function applyBackendProgress(event) {
+          if (event.filename) {
+            state.filename = displayAttachmentBasename(event.filename);
+          }
+          if (Number.isFinite(event.bytes_total)) {
+            state.totalBytes = event.bytes_total;
+          }
+          if (Number.isFinite(event.bytes_done)) {
+            state.loadedBytes = event.bytes_done;
+          }
+          if (event.phase === "failed") {
+            fail(event.message || "Could not attach");
+            return;
+          }
+          if (event.phase === "attached") {
+            succeed();
+            return;
+          }
+          setPhase(attachmentPhaseLabel(event.phase));
+        }
+
+        const controller = {
+          operationId,
           signal: abortController.signal,
           setPhase,
           setUploadProgress,
           succeed,
           fail,
+          applyBackendProgress,
         };
+        attachmentProgressControllers.set(operationId, controller);
+        return controller;
+      }
+
+      function handleAttachmentProgress(event) {
+        const operationId = event?.operation_id || "";
+        if (!operationId) {
+          return;
+        }
+        let controller = attachmentProgressControllers.get(operationId);
+        if (!controller) {
+          controller = createAttachmentProgressController(
+            event.id,
+            [
+              {
+                name: event.filename || "file",
+                size: event.bytes_total || 0,
+              },
+            ],
+            operationId,
+          );
+        }
+        controller.applyBackendProgress(event);
+      }
+
+      function attachmentFilesFromNativePaths(paths) {
+        return paths.map((path) => ({
+          name: displayAttachmentBasename(path),
+          size: 0,
+        }));
       }
 
       let attachmentUploadTokenPromise = null;
@@ -4613,11 +4704,14 @@
           const uploaded = await uploadAttachmentFile(file, {
             signal: progress.signal,
             onProgress: ({ loaded }) => {
-              progress.setUploadProgress(completedBytes + (loaded || 0));
+              progress.setUploadProgress(completedBytes + (loaded || 0), totalBytes);
             },
           });
           completedBytes += file.size || uploaded?.size || 0;
-          progress.setUploadProgress(totalBytes > 0 ? Math.min(completedBytes, totalBytes) : 0);
+          progress.setUploadProgress(
+            totalBytes > 0 ? Math.min(completedBytes, totalBytes) : 0,
+            totalBytes,
+          );
           attachments.push({
             source: "uploaded",
             upload_id: uploaded.upload_id,
@@ -4631,22 +4725,22 @@
 
       async function uploadPastedImage(windowId, blob, { mimeType, filename } = {}) {
         const file = uploadFileFromImageBlob(blob, mimeType, filename);
-        const progress = createAttachmentProgressController([file]);
+        const progress = createAttachmentProgressController(windowId, [file]);
         try {
           const uploaded = await uploadAttachmentFile(file, {
             signal: progress.signal,
-            onProgress: ({ loaded }) => progress.setUploadProgress(loaded || 0),
+            onProgress: ({ loaded, total }) => progress.setUploadProgress(loaded || 0, total),
           });
-          progress.setPhase("Attaching");
+          progress.setPhase("Queued");
           send({
             kind: "paste_image_uploaded",
             id: windowId,
+            operation_id: progress.operationId,
             upload_id: uploaded.upload_id,
             mime_type: uploaded.mime_type ?? file.type ?? mimeType ?? "",
             filename: uploaded.filename || file.name || filename || null,
             size: uploaded.size ?? file.size ?? 0,
           });
-          progress.succeed();
         } catch (_error) {
           progress.fail(IMAGE_PASTE_UPLOAD_FAILURE_MESSAGE);
           showFileDropAlert(IMAGE_PASTE_UPLOAD_FAILURE_MESSAGE);
@@ -4987,16 +5081,16 @@
           return;
         }
 
-        const progress = createAttachmentProgressController(files);
+        const progress = createAttachmentProgressController(windowId, files);
         try {
           const attachments = await uploadFilesAsAttachments(files, progress);
-          progress.setPhase("Attaching");
+          progress.setPhase("Queued");
           send({
             kind: "attach_files",
             id: windowId,
+            operation_id: progress.operationId,
             files: attachments,
           });
-          progress.succeed();
         } catch (_error) {
           progress.fail(FILE_DROP_UPLOAD_FAILURE_MESSAGE);
           showFileDropAlert(FILE_DROP_UPLOAD_FAILURE_MESSAGE);
@@ -5054,9 +5148,15 @@
           if (!windowId) {
             return;
           }
+          const progress = createAttachmentProgressController(
+            windowId,
+            attachmentFilesFromNativePaths(paths),
+          );
+          progress.setPhase("Queued");
           send({
             kind: "attach_files",
             id: windowId,
+            operation_id: progress.operationId,
             files: paths.map((path) => ({
               source: "native_path",
               path,
@@ -13267,6 +13367,9 @@
               event.status,
               event.detail,
             );
+            break;
+          case "attachment_progress":
+            handleAttachmentProgress(event);
             break;
           case "window_state":
             frontendUnits.terminalHost.applyStatus(event.window_id, event.state);

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -2832,13 +2832,13 @@ body {
 }
 
 .attachment-progress {
-  position: fixed;
-  right: 18px;
-  bottom: 18px;
-  z-index: 1001;
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  z-index: 12;
   display: grid;
   gap: 8px;
-  width: min(360px, calc(100vw - 36px));
+  width: min(360px, calc(100% - 24px));
   padding: 10px 12px;
   border: 1px solid var(--color-border-strong);
   border-radius: var(--radius-md);
@@ -2870,22 +2870,6 @@ body {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.attachment-progress__cancel {
-  flex: 0 0 auto;
-  min-height: 24px;
-  padding: 3px 8px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  color: var(--color-text-muted);
-  background: var(--color-surface);
-  font: inherit;
-  cursor: pointer;
-}
-
-.attachment-progress__cancel[hidden] {
-  display: none;
 }
 
 .attachment-progress__track {

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6697,3 +6697,10 @@ Type: lesson
 Context: SPEC-2012 visual verification was blocked twice because the isolated browser-check HOME had no Git HTTPS credentials and the user attempted Start Work/Launch flows that created remote work branches.
 Learning: For UI verification that needs an Agent window, prepare the fresh checkout with a current-branch Agent window before handing off the URL. For Claude Code startup auto-resume, the seeded session must include exact agent_session_id plus lifecycle evidence such as last_hook_event_at or last_completed_stop_at; otherwise it is filtered out.
 Future Action: When using browser-check for Agent-window behavior, never ask the user to Start Work in the isolated HOME. Seed or launch the required current-branch Agent window first, verify with headless/browser checks that no branch-auth error is present, then share the URL.
+
+## 2026-06-04 — Fresh Claude verification can be blocked by existing live Work agent focus
+
+Type: lesson
+Context: SPEC-2012 visual verification needed a Claude Code window in an isolated browser-check HOME. Launch Wizard normal mode appeared to close successfully but did not create Claude while a live Codex pane was already assigned to the same Work.
+Learning: spawn_agent_window_with_placement first focuses any existing live agent for the same worktree/branch without checking the requested agent type. In fresh verification environments, this can make Add Agent/Launch Agent look like a no-op when switching from Codex to Claude.
+Future Action: When browser-check needs a specific second agent for the same Work, either close the existing fresh-check agent pane first or explicitly verify the product supports multiple agents before using Launch Wizard as the setup path.

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6690,3 +6690,10 @@ Type: workflow
 Context: 「Claude Code の使用量が怪しい」調査で Explore サブエージェントが『月$8,462の従量課金』『cacheを5分TTLで毎ターン破壊』『cache_read 11億/per-turn 966k』『無限リトライループ・264回暴走起動』と報告したが全て実データで反証された。実際は ~/.claude/.credentials.json が subscriptionType=max / rateLimitTier=default_claude_max_20x で ANTHROPIC_API_KEY 未設定（ドル従量課金ゼロ・Maxサブスク枠）、cacheは ephemeral_1h TTL、11億はメインとサブエージェント(subagents/配下)の二重計上、retryは有限(100ms bootstrap完了待ち)、264回は1791行の2日間テスト集中だった。真因は Opus 4.8 + 1M context(per-turn最大995k)常用 × 長大セッション × subagent多用で gwt が Opus の81%。
 Learning: 使用量/コスト調査でサブエージェントの定量報告は誇張・二重計上・誤前提を含みやすく鵜呑み厳禁。(1)課金体系は ~/.claude/.credentials.json の subscriptionType/rateLimitTier と ANTHROPIC_API_KEY 有無で先に確定する(サブスク枠かAPI従量かで結論が真逆)。(2)transcript集計はメインセッションとサブエージェント(subagents/*.jsonl)を分離し各assistant messageを1回だけ model別 group_by する。(3)per-turnの input+cache_read が context window(200k/1M)を超えたら集計バグのサイン。
 Future Action: 使用量調査では結論前に自分で credentials 種別確認と jq による model別/二重計上排除の集計を実行し、エージェントの数値と断定を一次データで裏取りする。
+
+## 2026-06-04 — Fresh browser checks must seed agent windows, not rely on Start Work
+
+Type: lesson
+Context: SPEC-2012 visual verification was blocked twice because the isolated browser-check HOME had no Git HTTPS credentials and the user attempted Start Work/Launch flows that created remote work branches.
+Learning: For UI verification that needs an Agent window, prepare the fresh checkout with a current-branch Agent window before handing off the URL. For Claude Code startup auto-resume, the seeded session must include exact agent_session_id plus lifecycle evidence such as last_hook_event_at or last_completed_stop_at; otherwise it is filtered out.
+Future Action: When using browser-check for Agent-window behavior, never ask the user to Start Work in the isolated HOME. Seed or launch the required current-branch Agent window first, verify with headless/browser checks that no branch-auth error is present, then share the URL.


### PR DESCRIPTION
## Summary
- Adds operation-scoped attachment progress for file drop, paste, and native attach flows.
- Preserves Unicode/Japanese filenames from upload/staging through prompt injection.
- Keeps attachment progress scoped to the target Agent window and removes misleading cancel affordances.

## Changes
- `crates/gwt/src/protocol.rs`: adds operation IDs and attachment progress events.
- `crates/gwt/src/app_runtime/mod.rs`: adds staging/copy/injection progress and Unicode filename sanitization.
- `crates/gwt/web/app.js` and `crates/gwt/web/styles/app.css`: render scoped attachment progress per Agent window.
- `crates/gwt/playwright/tests/file-drop-attachments.spec.ts`, `crates/gwt/src/embedded_server.rs`, and `crates/gwt/src/embedded_web.rs`: cover progress behavior and Japanese filenames.
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: updates the Launch Wizard source contract to the current mutually exclusive Runtime/Confirm/setup gating so the full frontend unit suite is green.
- `tasks/memory.md`: records verification lessons from fresh browser and Claude Code checks.

## User Verification
- Result: confirmed on 2026-06-06.
- Scope: Claude Code file drop flow showed attachment progress and Japanese filename handling correctly.

## Testing
- `cargo fmt -- --check` - PASS
- `git diff --check` - PASS
- `bash scripts/run-frontend-unit-tests.sh` - PASS, 638 tests
- `bash scripts/run-visual-tests.sh --project=chromium-dark crates/gwt/playwright/tests/file-drop-attachments.spec.ts --reporter=list` - PASS, 7 tests
- `cargo build -p gwt --bin gwt --bin gwtd` - PASS
- `cargo test -p gwt-core -p gwt --all-features` - PASS
- `cargo clippy --all-targets --all-features -- -D warnings` - PASS
- `bunx commitlint --from origin/develop --to HEAD` - PASS
- GitHub checks for PR #2991 head `edb175d13` - PASS for Build, Check (macOS), Check (Windows), Clippy & Rustfmt, Cargo Deny, Commit Message Lint, Test (Rust), Test (Rust, Windows), and Test (Python runner). Optional e5 e2e and auto-merge jobs are skipped by workflow policy.

## PR Readiness
- State: Ready for review.
- Releaseable slice: yes. The attachment behavior is self-contained and does not expose incomplete UI.
- Known blockers: none.
- Remaining acceptance: none.

## Risk / Impact
- Affects browser/WebView attachment flows for Agent windows.
- Main regression risk is progress lifecycle drift between backend operation IDs and frontend controllers; covered by protocol, embedded web/server, frontend unit, and Playwright tests.
- Rollback path is reverting this branch's attachment progress commits.

## Closing Issues
None

## Related Issues
- SPEC #2012

## Checklist
- [x] Tests added/updated for attachment progress, Unicode filenames, and current Launch Wizard source contract.
- [x] Lint/format/test matrix passed.
- [x] Documentation update considered; no README change required for this UI behavior fix.
- [x] Migration/backfill plan considered; not applicable because no schema or data migration is involved.
- [x] CHANGELOG impact considered; this is a non-breaking fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Real-time attachment upload progress tracking with phase indicators (Queued, Staging, Injecting, Attached)
  * Improved filename preservation for Unicode and non-ASCII characters during file uploads
  * Per-window scoped progress UI ensures attachment progress indicators appear only in the targeted window

<!-- end of auto-generated comment: release notes by coderabbit.ai -->