### PR TITLE
fix: Codex の PreToolUse/PostToolUse hook が毎回 exit code 1 になる問題を解消

### DIFF
--- a/crates/gwt/src/cli/hook/runtime_state.rs
+++ b/crates/gwt/src/cli/hook/runtime_state.rs
@@ -148,10 +148,20 @@ fn validated_hook_agent_session_id(
     match resolve_hook_agent_session_id(session, hook_event) {
         HookAgentSessionId::Provided(session_id) => Ok(Some(session_id)),
         HookAgentSessionId::MissingRequiredForCodex => {
-            log_missing_codex_hook_session_id(event, gwt_session_id, session, hook_event);
-            Err(HookError::InvalidEvent(format!(
-                "missing session_id for Codex hook event {event}"
-            )))
+            // Fail open, mirroring daemon_runtime::live_event_agent_session_id.
+            // Codex omits a usable session_id on tool-use events (PreToolUse /
+            // PostToolUse), but the id was already captured at SessionStart and
+            // persisted in the session .toml. Returning Ok(None) skips
+            // sync_agent_session_id (so the persisted id is preserved and the
+            // "agent-session" placeholder is never written) while the caller
+            // still writes runtime state and records the hook event. Failing
+            // closed here surfaces "hook exited with code 1" to the user on
+            // every tool call for no functional gain. Only warn when there is
+            // genuinely no persisted id to fall back to.
+            if session.and_then(Session::exact_resume_session_id).is_none() {
+                log_missing_codex_hook_session_id(event, gwt_session_id, session, hook_event);
+            }
+            Ok(None)
         }
         HookAgentSessionId::MissingOptional => Ok(None),
     }
@@ -535,7 +545,12 @@ mod tests {
     }
 
     #[test]
-    fn codex_runtime_state_rejects_missing_hook_session_id() {
+    fn codex_runtime_state_fails_open_when_hook_session_id_missing() {
+        // A Codex tool-use payload without a session_id (the shape Codex
+        // actually sends on PreToolUse/PostToolUse) must NOT break the tool
+        // call. The agent_session_id was already captured at SessionStart, so
+        // the hook fails open: it preserves the persisted id (never writing the
+        // "agent-session" placeholder) and still records runtime state.
         let _lock = env_lock();
         let mut env = EnvGuard::new();
         let dir = tempfile::tempdir().unwrap();
@@ -555,25 +570,25 @@ mod tests {
         );
         env.unset("CODEX_THREAD_ID");
 
-        let err = handle_with_input("PreToolUse", r#"{"tool_name":"Bash"}"#)
-            .expect_err("managed Codex hooks must include session_id");
+        handle_with_input("PreToolUse", r#"{"tool_name":"Bash"}"#)
+            .expect("missing Codex hook session_id must fail open, not break the tool call");
 
-        match err {
-            HookError::InvalidEvent(message) => {
-                assert!(message.contains("missing session_id"), "{message}");
-            }
-            other => panic!("expected InvalidEvent, got {other:?}"),
-        }
         let loaded = Session::load(&sessions_dir.join(format!("{session_id}.toml"))).unwrap();
         assert_eq!(loaded.agent_session_id.as_deref(), Some("agent-existing"));
-        assert!(
-            !runtime_path.exists(),
-            "invalid payload must not write state"
-        );
+        assert_eq!(loaded.last_hook_event.as_deref(), Some("PreToolUse"));
+
+        let raw = std::fs::read_to_string(&runtime_path).expect("runtime state written");
+        let state: RuntimeState = serde_json::from_str(&raw).unwrap();
+        assert_eq!(state.status, "Running");
+        assert_eq!(state.source_event, "PreToolUse");
     }
 
     #[test]
-    fn codex_runtime_state_rejects_blank_hook_session_id() {
+    fn codex_runtime_state_fails_open_when_hook_session_id_blank() {
+        // A blank session_id resolves to MissingRequiredForCodex with no
+        // persisted id to fall back to. The hook must still fail open: write
+        // runtime state and leave agent_session_id unset (never the placeholder
+        // or the blank value).
         let _lock = env_lock();
         let mut env = EnvGuard::new();
         let dir = tempfile::tempdir().unwrap();
@@ -585,22 +600,23 @@ mod tests {
         let session_id = session.id.clone();
         session.save(&sessions_dir).unwrap();
         let runtime_path = gwt_agent::runtime_state_path(&sessions_dir, &session_id);
-        env.set(GWT_SESSION_ID_ENV, session_id);
+        env.set(GWT_SESSION_ID_ENV, session_id.clone());
         env.set(
             gwt_agent::GWT_SESSION_RUNTIME_PATH_ENV,
             runtime_path.as_os_str().to_os_string(),
         );
         env.unset("CODEX_THREAD_ID");
 
-        let err = handle_with_input("PreToolUse", r#"{"session_id":"   "}"#)
-            .expect_err("blank Codex session_id must fail");
+        handle_with_input("PostToolUse", r#"{"session_id":"   "}"#)
+            .expect("blank Codex session_id must fail open");
 
-        match err {
-            HookError::InvalidEvent(message) => {
-                assert!(message.contains("missing session_id"), "{message}");
-            }
-            other => panic!("expected InvalidEvent, got {other:?}"),
-        }
+        let loaded = Session::load(&sessions_dir.join(format!("{session_id}.toml"))).unwrap();
+        assert_eq!(loaded.agent_session_id, None);
+
+        let raw = std::fs::read_to_string(&runtime_path).expect("runtime state written");
+        let state: RuntimeState = serde_json::from_str(&raw).unwrap();
+        assert_eq!(state.status, "Running");
+        assert_eq!(state.source_event, "PostToolUse");
     }
 
     #[test]

--- a/crates/gwt/src/daemon_runtime.rs
+++ b/crates/gwt/src/daemon_runtime.rs
@@ -190,16 +190,22 @@ fn live_event_agent_session_id(
             return Some(agent_session_id.into_string());
         }
         HookAgentSessionId::MissingRequiredForCodex => {
-            let gwt_session_id =
-                std::env::var(GWT_SESSION_ID_ENV).unwrap_or_else(|_| "-".to_string());
-            let persisted_agent_session_id = session
+            // Codex omits a usable session_id on tool-use events; fall back to
+            // the persisted resume id (captured at SessionStart). Only warn when
+            // there is genuinely nothing to fall back to, so the common case
+            // does not spam stderr on every tool call.
+            if session
                 .and_then(gwt_agent::Session::exact_resume_session_id)
-                .unwrap_or("-");
-            let source_event = source_event.unwrap_or("-");
-            let tool_name = hook_event.and_then(RawHookEvent::tool_name).unwrap_or("-");
-            eprintln!(
-                "gwtd hook live event: missing Codex hook session_id kind={kind:?} source_event={source_event} gwt_session_id={gwt_session_id} persisted_agent_session_id={persisted_agent_session_id} tool_name={tool_name}"
-            );
+                .is_none()
+            {
+                let gwt_session_id =
+                    std::env::var(GWT_SESSION_ID_ENV).unwrap_or_else(|_| "-".to_string());
+                let source_event = source_event.unwrap_or("-");
+                let tool_name = hook_event.and_then(RawHookEvent::tool_name).unwrap_or("-");
+                eprintln!(
+                    "gwtd hook live event: missing Codex hook session_id kind={kind:?} source_event={source_event} gwt_session_id={gwt_session_id} persisted_agent_session_id=- tool_name={tool_name}"
+                );
+            }
         }
         HookAgentSessionId::MissingOptional => {}
     }

--- a/crates/gwt/tests/hook_exit_codes_test.rs
+++ b/crates/gwt/tests/hook_exit_codes_test.rs
@@ -307,3 +307,47 @@ fn event_dispatcher_keeps_blocked_stop_runtime_state_running() {
         "\"Running\""
     );
 }
+
+/// Regression for the user-visible symptom: Codex's managed PreToolUse /
+/// PostToolUse hooks ran `gwtd hook event <event>` and exited with code 1 on
+/// every tool call because the runtime-state step failed closed when the
+/// payload carried no session_id (the shape Codex sends on tool-use events)
+/// and `CODEX_THREAD_ID` was unset. The dispatcher must now fail open and
+/// return `HookOutput::Silent` (exit code 0) while preserving the persisted
+/// agent_session_id.
+#[test]
+fn event_dispatcher_codex_tool_use_fails_open_without_hook_session_id() {
+    let _env_lock = env_test_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let tmp = tempfile::tempdir().unwrap();
+    let sessions_dir = tmp.path().join(".gwt").join("sessions");
+    let mut session = Session::new(tmp.path(), "feature/demo", AgentId::Codex);
+    session.agent_session_id = Some("agent-existing".to_string());
+    let session_id = session.id.clone();
+    session.save(&sessions_dir).unwrap();
+    let runtime_path = gwt_agent::runtime_state_path(&sessions_dir, &session_id);
+    let _session_id = ScopedEnvVar::set(GWT_SESSION_ID_ENV, &session_id);
+    let _runtime_path = ScopedEnvVar::set(GWT_SESSION_RUNTIME_PATH_ENV, &runtime_path);
+    let _codex_thread_id = ScopedEnvVar::unset("CODEX_THREAD_ID");
+
+    for event in ["PreToolUse", "PostToolUse"] {
+        let output = event_dispatcher::handle_with_input(
+            event,
+            r#"{"tool_name":"Bash","tool_input":{"command":"ls"}}"#,
+            tmp.path(),
+            Some(&session_id),
+        )
+        .unwrap_or_else(|err| panic!("{event} must fail open, got {err:?}"));
+        assert_eq!(output, HookOutput::Silent, "{event}");
+    }
+
+    // The id captured at SessionStart is preserved (placeholder never written).
+    let loaded = Session::load(&sessions_dir.join(format!("{session_id}.toml"))).unwrap();
+    assert_eq!(loaded.agent_session_id.as_deref(), Some("agent-existing"));
+
+    // Runtime state is still written so the Branches tab keeps tracking status.
+    let runtime_raw = std::fs::read_to_string(&runtime_path).unwrap();
+    let runtime_state: RuntimeState = serde_json::from_str(&runtime_raw).unwrap();
+    assert_eq!(runtime_state.status, "Running");
+}

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6690,3 +6690,10 @@ Type: workflow
 Context: 「Claude Code の使用量が怪しい」調査で Explore サブエージェントが『月$8,462の従量課金』『cacheを5分TTLで毎ターン破壊』『cache_read 11億/per-turn 966k』『無限リトライループ・264回暴走起動』と報告したが全て実データで反証された。実際は ~/.claude/.credentials.json が subscriptionType=max / rateLimitTier=default_claude_max_20x で ANTHROPIC_API_KEY 未設定（ドル従量課金ゼロ・Maxサブスク枠）、cacheは ephemeral_1h TTL、11億はメインとサブエージェント(subagents/配下)の二重計上、retryは有限(100ms bootstrap完了待ち)、264回は1791行の2日間テスト集中だった。真因は Opus 4.8 + 1M context(per-turn最大995k)常用 × 長大セッション × subagent多用で gwt が Opus の81%。
 Learning: 使用量/コスト調査でサブエージェントの定量報告は誇張・二重計上・誤前提を含みやすく鵜呑み厳禁。(1)課金体系は ~/.claude/.credentials.json の subscriptionType/rateLimitTier と ANTHROPIC_API_KEY 有無で先に確定する(サブスク枠かAPI従量かで結論が真逆)。(2)transcript集計はメインセッションとサブエージェント(subagents/*.jsonl)を分離し各assistant messageを1回だけ model別 group_by する。(3)per-turnの input+cache_read が context window(200k/1M)を超えたら集計バグのサイン。
 Future Action: 使用量調査では結論前に自分で credentials 種別確認と jq による model別/二重計上排除の集計を実行し、エージェントの数値と断定を一次データで裏取りする。
+
+## 2026-06-06 — Codex managed hook は tool-use event の session_id 欠落で fail-closed にしない
+
+Type: lesson
+Context: Codex の PreToolUse/PostToolUse hook が毎回 exit code 1。runtime_state::validated_hook_agent_session_id が Codex セッションで CODEX_THREAD_ID 未設定かつ payload に session_id 無しのとき HookError::InvalidEvent を返していた。Codex は SessionStart では id を渡すが tool-use event では渡さないため毎回失敗。agent_session_id は session .toml に永続化済みなのに hook 全体を落としていた。live-event 経路 (daemon_runtime) は同条件で既に fail-open だった (commit c2c83469b で混入, SPEC-2077 ドメイン)。
+Learning: Provider 由来 (Codex) の hook payload フィールドは event ごとに有無が変わる。必須化して fail-closed にすると、ツール呼び出しごとに exit 1 がユーザーに露出する。永続済みメタデータ (exact_resume_session_id) があるなら fail-open + 既存値再利用が正しい。診断ログも persisted id がある通常ケースでは出さず、shipped behavior と分離する (2026-05-07 lesson と一致)。
+Future Action: hook handler に必須フィールド検査を追加するときは、(1) gwt 自身の不変条件 (GWT_SESSION_ID) だけ fail-closed、(2) provider 供給値の欠落は fail-open し persisted session metadata を破壊しない、(3) regression test で persisted id 保持と exit 0 を固定、(4) 診断ログは fallback 不能時のみ。runtime_state と daemon_runtime の両経路を必ず揃える。


### PR DESCRIPTION
## 概要

Codex の gwt-managed hook（`gwtd hook event PreToolUse` / `PostToolUse`）が、ツール呼び出しのたびに `hook exited with code 1` で失敗していた不具合を修正します。

Closes #2992 / Domain: SPEC-2077 (Runtime Daemon — hook/live bridge)

## 根本原因（実バイナリ v9.53.0 で再現確認済み）

`runtime_state::validated_hook_agent_session_id` が Codex セッションで `HookAgentSessionId::MissingRequiredForCodex` を `Err(HookError::InvalidEvent)` に変換し、`emit_hook_error` 経由で exit code 1 になっていた。

`MissingRequiredForCodex` は「`CODEX_THREAD_ID` 未設定 かつ payload の `session_id` が欠落／placeholder `agent-session`」のとき発生する。Codex は SessionStart では id を渡す（`agent_session_id` は session `.toml` に永続化済み）が、tool-use イベントでは渡さないため、毎回 Pre/PostToolUse が失敗していた。live-event 経路（`daemon_runtime`）は同条件で既に fail-open だった、という不整合が原因。

## 修正

- `crates/gwt/src/cli/hook/runtime_state.rs`: `MissingRequiredForCodex` を fail-open（`Ok(None)`）に変更。`sync_agent_session_id` を skip して persisted id を保持（placeholder は書かない）、runtime state は書き、hook を exit 0 で終了。
- `crates/gwt/src/daemon_runtime.rs`: live-event の同診断ログを persisted id が無い場合のみ出力（毎呼び出しの stderr ノイズ抑制）。
- `GWT_SESSION_ID` 欠落（gwt 自身の不変条件）は従来どおり fail-closed を維持。

## テスト

- unit 2 件を fail-open 検証へ反転（`codex_runtime_state_fails_open_when_hook_session_id_missing` / `_blank`）
- dispatcher E2E regression test を追加（`event_dispatcher_codex_tool_use_fails_open_without_hook_session_id`）— 症状（Pre/PostToolUse が exit 1）を直接固定

## 検証

- [x] 反転 unit + dispatcher E2E: RED→GREEN
- [x] `cargo test -p gwt-core -p gwt --all-features`: 全 PASS（失敗 0）
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: clean
- [x] `cargo fmt --check`: clean
- [x] commitlint: PASS
- [x] ビルド済み `gwtd` の隔離再現: 修正前 exit 1 → 修正後 exit 0、persisted id 保持、stderr ノイズ無し
- [x] **User Verification Result: confirmed**（ユーザーによる挙動検証 OK）

## デプロイ注意

Codex が実行するのは `/Applications/GWT.app/Contents/MacOS/gwtd`。この修正は新しい gwtd ビルドがインストールされて初めて Codex 側に反映される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
