### PR TITLE
fix: reduce browser hot path latency

### DIFF
--- a/crates/gwt/playwright/tests/_helpers/embedded-frontend.ts
+++ b/crates/gwt/playwright/tests/_helpers/embedded-frontend.ts
@@ -44,6 +44,7 @@ const ROOT_MODULES = new Set([
   "socket-receive-dispatcher.js",
   "terminal-copy-shortcut.js",
   "terminal-context-menu.js",
+  "terminal-output-buffer.js",
   "terminal-wheel-scroll.js",
   "terminal-viewport-reflow.js",
   "theme-manager.js",

--- a/crates/gwt/playwright/tests/index-status.spec.ts
+++ b/crates/gwt/playwright/tests/index-status.spec.ts
@@ -1,6 +1,7 @@
 /* SPEC-1939 Phase 13+15 — project-bar Index badge withdrawn. The remaining
- * coverage exercises the per-tab dot aggregator and the dedicated Index
- * window health panel (per-cell rebuild IPC) using the SPEC-2017 Kanban fixture pattern:
+ * coverage exercises the dedicated Index window health panel (per-cell
+ * rebuild IPC) and the separation from the project-tab Agent activity dot
+ * using the SPEC-2017 Kanban fixture pattern:
  * the embedded frontend is served via `installEmbeddedRoutes`
  * (`_helpers/embedded-frontend.ts`) and the WebSocket is stubbed with a
  * deterministic backend that emits canned `workspace_state` +
@@ -23,15 +24,22 @@ test.describe("Project Index status surface", () => {
     await expect(page.locator("#index-status")).toHaveCount(0);
   });
 
-  test("project tab dot reflects aggregated worktree health (T-IDX-107)", async ({ page }) => {
+  test("project_index_status does not drive the project tab Agent activity dot", async ({ page }) => {
     await installEmbeddedRoutes(page);
 
-    // Initial state: one healthy file scope in wtA — dot should be green.
+    // SPEC-2013 Phase 6 supersedes the old Index-health project-tab dot:
+    // the dot now reflects only running Agent windows. Index health remains
+    // visible in the dedicated Index window Health surface.
     await installIndexStatusBackend(page, {
-      state: "ready",
+      state: "repair_required",
       scopes: {
         files: {
-          wtAhash: { healthy: true, repair_required: false, document_count: 310 },
+          wtAhash: {
+            healthy: false,
+            repair_required: true,
+            document_count: 0,
+            reason: "manifest_missing",
+          },
         },
         "files-docs": {
           wtAhash: { healthy: true, repair_required: false, document_count: 16 },
@@ -44,40 +52,10 @@ test.describe("Project Index status surface", () => {
 
     await page.goto(APP_URL);
     const dot = page.locator(".project-tab .project-tab-dot");
-    await expect(dot).toHaveAttribute("data-state", "ready", { timeout: 10_000 });
+    await expect(dot).toHaveAttribute("data-state", "", { timeout: 10_000 });
 
-    // Drive an unhealthy `files` cell on the same worktree → dot should
-    // flip to `error` (red).
-    await page.evaluate(() => {
-      window.__gwtFixtureWebSocket.emit({
-        kind: "project_index_status",
-        project_root: "/fixture",
-        status: {
-          state: "repair_required",
-          detail: "",
-          progress: null,
-          scopes: {
-            files: {
-              wtAhash: {
-                healthy: false,
-                repair_required: true,
-                document_count: 0,
-                reason: "manifest_missing",
-              },
-            },
-            "files-docs": {
-              wtAhash: { healthy: true, repair_required: false, document_count: 16 },
-            },
-          },
-          worktrees: {
-            wtAhash: { branch: "develop", path: "/abs/wtA" },
-          },
-        },
-      });
-    });
-    await expect(dot).toHaveAttribute("data-state", "error", { timeout: 5_000 });
-
-    // Transition to repairing (state==="repairing") → dot should be yellow.
+    // Project Index transitions still update the Index Health surface, but
+    // must not light the project tab activity dot.
     await page.evaluate(() => {
       window.__gwtFixtureWebSocket.emit({
         kind: "project_index_status",
@@ -104,72 +82,8 @@ test.describe("Project Index status surface", () => {
         },
       });
     });
-    await expect(dot).toHaveAttribute("data-state", "repairing", { timeout: 5_000 });
-  });
+    await expect(dot).toHaveAttribute("data-state", "", { timeout: 5_000 });
 
-  test("multi-worktree dot aggregates: unhealthy in one worktree turns the dot red", async ({
-    page,
-  }) => {
-    await installEmbeddedRoutes(page);
-
-    // wtA healthy, wtB healthy → dot ready.
-    await installIndexStatusBackend(page, {
-      state: "ready",
-      scopes: {
-        files: {
-          wtAhash: { healthy: true, repair_required: false, document_count: 310 },
-          wtBhash: { healthy: true, repair_required: false, document_count: 200 },
-        },
-        "files-docs": {
-          wtAhash: { healthy: true, repair_required: false, document_count: 16 },
-          wtBhash: { healthy: true, repair_required: false, document_count: 10 },
-        },
-      },
-      worktrees: {
-        wtAhash: { branch: "develop", path: "/abs/wtA" },
-        wtBhash: { branch: "feature/x", path: "/abs/wtB" },
-      },
-    });
-
-    await page.goto(APP_URL);
-    const dot = page.locator(".project-tab .project-tab-dot");
-    await expect(dot).toHaveAttribute("data-state", "ready", { timeout: 10_000 });
-
-    // Force wtB's files unhealthy → dot must flip to error even though
-    // wtA stays healthy (aggregation is "any unhealthy → red").
-    await page.evaluate(() => {
-      window.__gwtFixtureWebSocket.emit({
-        kind: "project_index_status",
-        project_root: "/fixture",
-        status: {
-          state: "repair_required",
-          detail: "",
-          progress: null,
-          scopes: {
-            files: {
-              wtAhash: { healthy: true, repair_required: false, document_count: 310 },
-              wtBhash: {
-                healthy: false,
-                repair_required: true,
-                document_count: 0,
-                reason: "manifest_missing",
-              },
-            },
-            "files-docs": {
-              wtAhash: { healthy: true, repair_required: false, document_count: 16 },
-              wtBhash: { healthy: true, repair_required: false, document_count: 10 },
-            },
-          },
-          worktrees: {
-            wtAhash: { branch: "develop", path: "/abs/wtA" },
-            wtBhash: { branch: "feature/x", path: "/abs/wtB" },
-          },
-        },
-      });
-    });
-    await expect(dot).toHaveAttribute("data-state", "error", { timeout: 5_000 });
-
-    // Restore wtB to healthy → dot returns to ready.
     await page.evaluate(() => {
       window.__gwtFixtureWebSocket.emit({
         kind: "project_index_status",
@@ -185,17 +99,15 @@ test.describe("Project Index status surface", () => {
             },
             "files-docs": {
               wtAhash: { healthy: true, repair_required: false, document_count: 16 },
-              wtBhash: { healthy: true, repair_required: false, document_count: 10 },
             },
           },
           worktrees: {
             wtAhash: { branch: "develop", path: "/abs/wtA" },
-            wtBhash: { branch: "feature/x", path: "/abs/wtB" },
           },
         },
       });
     });
-    await expect(dot).toHaveAttribute("data-state", "ready", { timeout: 5_000 });
+    await expect(dot).toHaveAttribute("data-state", "", { timeout: 5_000 });
   });
 
   test("Index window Health renders the scope health table from project_index_status (T-IDX-106)", async ({

--- a/crates/gwt/playwright/tests/project-tabs.spec.ts
+++ b/crates/gwt/playwright/tests/project-tabs.spec.ts
@@ -59,6 +59,112 @@ test.describe("Project tabs", () => {
     );
   });
 
+  test("tab switching under streamed output stays within CPU and heap budgets", async ({
+    page,
+  }) => {
+    const burstSize = 500;
+    const streamedStateBoundary = 32;
+    const latencyBudgetMs = 1_000;
+    const longTaskBudgetMs = 100;
+    const rafGapBudgetMs = 250;
+    const heapDriftBudgetBytes = 32 * 1024 * 1024;
+    await installEmbeddedRoutes(page);
+    await installProjectTabsBackend(page, projectTabsFixture(12, {
+      hotAgentWindowId: "agent-burst",
+    }));
+
+    await page.goto(APP_URL);
+    await expect(page.locator(".project-tab")).toHaveCount(12, {
+      timeout: 10_000,
+    });
+    const first = page.locator(".project-tab").nth(0);
+    const second = page.locator(".project-tab").nth(1);
+    await expect(first).toHaveAttribute("aria-current", "page");
+
+    const heapBefore = await sampleBrowserHeap(page);
+    await runPaletteCommand(page, "Start UI Trace");
+    expect(burstSize / streamedStateBoundary).toBeGreaterThanOrEqual(10);
+    await page.evaluate(
+      ({ count, windowId }) => {
+        const socket = window.__gwtProjectTabsFixtureSocket;
+        if (
+          !socket ||
+          typeof socket.emitTerminalOutputBurstSync !== "function"
+        ) {
+          throw new Error("project tabs fixture socket burst helper is missing");
+        }
+        socket.emitTerminalOutputBurstSync({ count, windowId });
+      },
+      { count: burstSize, windowId: "agent-burst" },
+    );
+
+    const start = await page.evaluate(() => performance.now());
+    await second.click();
+    await expect(second).toHaveAttribute("aria-current", "page", {
+      timeout: latencyBudgetMs,
+    });
+    const latencyMs = await page.evaluate((startedAt) => {
+      return performance.now() - startedAt;
+    }, start);
+    await page.waitForTimeout(100);
+    const tracePayload = await stopUiTraceViaPalette(page);
+    const heapAfter = await sampleBrowserHeap(page);
+    const trace = tracePayload?.trace;
+    expect(
+      trace,
+      "fixture socket should capture the UI trace save payload",
+    ).toBeTruthy();
+
+    const entries = trace.entries ?? [];
+    const terminalMessages = entries.filter(
+      (entry) =>
+        entry.kind === "ws_message" &&
+        entry.event_kind === "terminal_output",
+    );
+    const overBudgetLongTasks = entries.filter(
+      (entry) =>
+        entry.kind === "long_task" &&
+        Number(entry.duration_ms ?? 0) > longTaskBudgetMs,
+    );
+    const overBudgetRafGaps = entries.filter(
+      (entry) =>
+        entry.kind === "raf_gap" &&
+        Number(entry.gap_ms ?? 0) > rafGapBudgetMs,
+    );
+    const heapDriftBytes =
+      heapBefore.supported && heapAfter.supported
+        ? heapAfter.usedJSHeapSize - heapBefore.usedJSHeapSize
+        : null;
+
+    expect(latencyMs).toBeLessThan(latencyBudgetMs);
+    expect(terminalMessages.length).toBeGreaterThanOrEqual(burstSize);
+    expect(overBudgetLongTasks).toEqual([]);
+    expect(overBudgetRafGaps).toEqual([]);
+    if (heapDriftBytes !== null) {
+      expect(heapDriftBytes).toBeLessThan(heapDriftBudgetBytes);
+    }
+
+    const memorySummary =
+      heapDriftBytes === null
+        ? "memory=unsupported"
+        : `heap_drift=${heapDriftBytes}`;
+    test.info().annotations.push({
+      type: "measurement",
+      description:
+        `tab switch latency=${latencyMs.toFixed(1)}ms ` +
+        `long_tasks=${overBudgetLongTasks.length} ` +
+        `raf_gaps=${overBudgetRafGaps.length} ${memorySummary}`,
+    });
+    console.log(
+      `[project-tabs] budget latency=${latencyMs.toFixed(1)}ms ` +
+        `ws_terminal_messages=${terminalMessages.length} ` +
+        `long_tasks_over_${longTaskBudgetMs}ms=${overBudgetLongTasks.length} ` +
+        `raf_gaps_over_${rafGapBudgetMs}ms=${overBudgetRafGaps.length} ` +
+        `${memorySummary} burst=${burstSize} ` +
+        `streamed_state_boundary=${streamedStateBoundary}`,
+    );
+  });
+
   test("many project tabs keep project actions visible and remain switchable", async ({
     page,
   }) => {
@@ -157,6 +263,39 @@ test.describe("Project tabs", () => {
   });
 });
 
+async function runPaletteCommand(page, query: string) {
+  await page.locator("#op-palette-button").click();
+  const input = page.locator("#op-palette-input");
+  await expect(input).toBeVisible();
+  await input.fill(query);
+  await page.keyboard.press("Enter");
+  await expect(page.locator("#op-palette-backdrop")).not.toHaveAttribute(
+    "data-open",
+    "true",
+  );
+}
+
+async function stopUiTraceViaPalette(page) {
+  await runPaletteCommand(page, "Stop UI Trace");
+  return await page.evaluate(() => {
+    const socket = window.__gwtProjectTabsFixtureSocket;
+    return socket?.savedUiTracePayload ?? null;
+  });
+}
+
+async function sampleBrowserHeap(page) {
+  return await page.evaluate(() => {
+    const memory = performance.memory;
+    if (!memory || typeof memory.usedJSHeapSize !== "number") {
+      return { supported: false };
+    }
+    return {
+      supported: true,
+      usedJSHeapSize: memory.usedJSHeapSize,
+    };
+  });
+}
+
 function projectTabsFixture(
   count: number,
   { hotAgentWindowId }: { hotAgentWindowId?: string } = {},
@@ -241,6 +380,10 @@ async function installProjectTabsBackend(page, tabFixture: number | unknown[]) {
         }
         if (message.kind === "frontend_ready") {
           this.emit(workspaceState);
+          return;
+        }
+        if (message.kind === "save_ui_trace") {
+          this.savedUiTracePayload = message;
           return;
         }
         if (

--- a/crates/gwt/playwright/tests/project-tabs.spec.ts
+++ b/crates/gwt/playwright/tests/project-tabs.spec.ts
@@ -4,6 +4,61 @@ import { APP_URL, installEmbeddedRoutes } from "./_helpers/embedded-frontend";
 test.describe("Project tabs", () => {
   test.use({ viewport: { width: 1440, height: 900 } });
 
+  test("tab switching stays responsive while streamed WebSocket output is backlogged", async ({
+    page,
+  }) => {
+    const burstSize = 500;
+    const streamedStateBoundary = 32;
+    await installEmbeddedRoutes(page);
+    await installProjectTabsBackend(page, projectTabsFixture(12, {
+      hotAgentWindowId: "agent-burst",
+    }));
+
+    await page.goto(APP_URL);
+    await expect(page.locator(".project-tab")).toHaveCount(12, {
+      timeout: 10_000,
+    });
+    const first = page.locator(".project-tab").nth(0);
+    const second = page.locator(".project-tab").nth(1);
+    await expect(first).toHaveAttribute("aria-current", "page");
+
+    expect(burstSize / streamedStateBoundary).toBeGreaterThanOrEqual(10);
+    await page.evaluate(
+      ({ count, windowId }) => {
+        const socket = window.__gwtProjectTabsFixtureSocket;
+        if (
+          !socket ||
+          typeof socket.emitTerminalOutputBurstSync !== "function"
+        ) {
+          throw new Error("project tabs fixture socket burst helper is missing");
+        }
+        socket.emitTerminalOutputBurstSync({ count, windowId });
+      },
+      { count: burstSize, windowId: "agent-burst" },
+    );
+
+    const start = await page.evaluate(() => performance.now());
+    await second.click();
+    await expect(second).toHaveAttribute("aria-current", "page", {
+      timeout: 1_000,
+    });
+    const latencyMs = await page.evaluate((startedAt) => {
+      return performance.now() - startedAt;
+    }, start);
+
+    expect(latencyMs).toBeLessThan(1_000);
+    test.info().annotations.push({
+      type: "measurement",
+      description:
+        `tab switch latency under ${burstSize} streamed events: ` +
+        `${latencyMs.toFixed(1)}ms`,
+    });
+    console.log(
+      `[project-tabs] high-load tab switch latency=${latencyMs.toFixed(1)}ms ` +
+        `burst=${burstSize} streamed_state_boundary=${streamedStateBoundary}`,
+    );
+  });
+
   test("many project tabs keep project actions visible and remain switchable", async ({
     page,
   }) => {
@@ -102,6 +157,37 @@ test.describe("Project tabs", () => {
   });
 });
 
+function projectTabsFixture(
+  count: number,
+  { hotAgentWindowId }: { hotAgentWindowId?: string } = {},
+) {
+  return Array.from({ length: count }, (_, index) => {
+    const number = String(index + 1).padStart(2, "0");
+    return {
+      id: `tab-${number}`,
+      title: `known-project-${number}`,
+      project_root: `/fixture/known-project-${number}`,
+      kind: "git",
+      workspace: {
+        viewport: { x: 0, y: 0, zoom: 1 },
+        windows:
+          index === 0 && hotAgentWindowId
+            ? [
+                {
+                  id: hotAgentWindowId,
+                  title: "Burst Agent",
+                  preset: "codex",
+                  status: "running",
+                  geometry: { x: 96, y: 96, width: 720, height: 420 },
+                  z_index: 1,
+                },
+              ]
+            : [],
+      },
+    };
+  });
+}
+
 async function installProjectTabsBackend(page, tabFixture: number | unknown[]) {
   await page.addInitScript((fixture) => {
     const tabs = Array.isArray(fixture)
@@ -139,6 +225,7 @@ async function installProjectTabsBackend(page, tabFixture: number | unknown[]) {
         super();
         this.url = url;
         this.readyState = FixtureWebSocket.CONNECTING;
+        window.__gwtProjectTabsFixtureSocket = this;
         setTimeout(() => {
           this.readyState = FixtureWebSocket.OPEN;
           this.dispatchEvent(new Event("open"));
@@ -161,7 +248,7 @@ async function installProjectTabsBackend(page, tabFixture: number | unknown[]) {
           tabs.some((tab) => tab.id === message.tab_id)
         ) {
           workspaceState.workspace.active_tab_id = message.tab_id;
-          this.emit(workspaceState);
+          this.emitSync(workspaceState);
         }
       }
 
@@ -172,10 +259,25 @@ async function installProjectTabsBackend(page, tabFixture: number | unknown[]) {
 
       emit(payload) {
         setTimeout(() => {
-          this.dispatchEvent(
-            new MessageEvent("message", { data: JSON.stringify(payload) }),
-          );
+          this.emitSync(payload);
         }, 0);
+      }
+
+      emitSync(payload) {
+        this.dispatchEvent(
+          new MessageEvent("message", { data: JSON.stringify(payload) }),
+        );
+      }
+
+      emitTerminalOutputBurstSync({ count, windowId }) {
+        const data_base64 = btoa("gwt responsiveness burst\\r\\n");
+        for (let i = 0; i < count; i += 1) {
+          this.emitSync({
+            kind: "terminal_output",
+            id: windowId,
+            data_base64,
+          });
+        }
       }
     }
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -13146,7 +13146,7 @@ exit 1
     }
 
     #[test]
-    fn app_runtime_open_start_work_ensures_remote_develop_without_creating_work_branch() {
+    fn app_runtime_open_start_work_defers_remote_develop_preparation_until_launch() {
         let _env_guard = env_test_lock().lock().expect("env lock");
         let temp = tempdir().expect("tempdir");
         let _home = ScopedEnvVar::set("HOME", temp.path());
@@ -13159,6 +13159,21 @@ exit 1
         run_git(&repo, &["checkout", "develop"]);
         run_git(&repo, &["remote", "set-head", "origin", "-a"]);
         run_git(&origin, &["branch", "-D", "develop"]);
+        run_git(&repo, &["update-ref", "-d", "refs/remotes/origin/develop"]);
+        let develop_before_open = gwt_core::process::hidden_command("git")
+            .args([
+                "show-ref",
+                "--verify",
+                "--quiet",
+                "refs/remotes/origin/develop",
+            ])
+            .current_dir(&repo)
+            .status()
+            .expect("check origin/develop before open");
+        assert!(
+            !develop_before_open.success(),
+            "fixture must start without origin/develop"
+        );
 
         let tab = sample_project_tab(
             "tab-1",
@@ -13199,8 +13214,8 @@ exit 1
             .status()
             .expect("check origin/develop");
         assert!(
-            develop.success(),
-            "opening Start Work should restore origin/develop from the remote default branch"
+            !develop.success(),
+            "opening Start Work must not fetch or restore origin/develop before the user launches"
         );
 
         let refs = gwt_core::process::hidden_command("git")

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -17409,6 +17409,61 @@ exit 1
     }
 
     #[test]
+    fn app_runtime_duplicate_viewport_update_skips_workspace_broadcast_and_persist() {
+        let _env_lock = env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let temp = tempdir().expect("tempdir");
+        let _home = ScopedEnvVar::set("HOME", temp.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("create repo");
+        let tab = sample_project_tab_with_window_at(
+            "tab-1",
+            "shell-1",
+            repo,
+            WindowPreset::Shell,
+            WindowProcessStatus::Ready,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let viewport = gwt::CanvasViewport {
+            x: 12.0,
+            y: 34.0,
+            zoom: 1.25,
+        };
+
+        assert_eq!(runtime.update_viewport_events(viewport.clone()).len(), 1);
+        assert_eq!(runtime.persist_dispatcher.enqueued_count(), 1);
+
+        assert!(
+            runtime.update_viewport_events(viewport).is_empty(),
+            "duplicate viewport payload should not broadcast a workspace_state",
+        );
+        assert_eq!(
+            runtime.persist_dispatcher.enqueued_count(),
+            1,
+            "duplicate viewport payload should not enqueue another persist snapshot",
+        );
+
+        assert_eq!(
+            runtime
+                .update_viewport_events(gwt::CanvasViewport {
+                    x: 12.0,
+                    y: 34.0,
+                    zoom: 1.5,
+                })
+                .len(),
+            1,
+            "changed zoom must still broadcast workspace_state",
+        );
+        assert_eq!(
+            runtime.persist_dispatcher.enqueued_count(),
+            2,
+            "changed viewport must still enqueue persistence",
+        );
+    }
+
+    #[test]
     fn app_runtime_geometry_update_rejects_stale_base_revision() {
         let _env_lock = env_test_lock()
             .lock()

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -17101,6 +17101,125 @@ exit 1
     }
 
     #[test]
+    fn app_runtime_duplicate_runtime_state_hooks_emit_status_events_only_once() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab_with_window(
+            "tab-1",
+            "codex-1",
+            WindowPreset::Codex,
+            WindowProcessStatus::Running,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "codex-1");
+        runtime.active_agent_sessions.insert(
+            window_id.clone(),
+            sample_active_agent_session("tab-1", &window_id),
+        );
+
+        let events = (0..1_000)
+            .flat_map(|_| {
+                runtime.handle_runtime_hook_event(runtime_hook_state("Waiting", "session-1"))
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event.event, BackendEvent::RuntimeHookEvent { .. }))
+                .count(),
+            0
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event.event, BackendEvent::WindowState { .. }))
+                .count(),
+            1
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event.event, BackendEvent::TerminalStatus { .. }))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn app_runtime_runtime_state_change_after_duplicate_burst_emits_status_events() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab_with_window(
+            "tab-1",
+            "codex-1",
+            WindowPreset::Codex,
+            WindowProcessStatus::Running,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "codex-1");
+        runtime.active_agent_sessions.insert(
+            window_id.clone(),
+            sample_active_agent_session("tab-1", &window_id),
+        );
+
+        let first_events =
+            runtime.handle_runtime_hook_event(runtime_hook_state("Waiting", "session-1"));
+        let duplicate_events =
+            runtime.handle_runtime_hook_event(runtime_hook_state("Waiting", "session-1"));
+        let changed_events =
+            runtime.handle_runtime_hook_event(runtime_hook_state("Running", "session-1"));
+
+        assert!(first_events
+            .iter()
+            .any(|event| matches!(event.event, BackendEvent::TerminalStatus { .. })));
+        assert!(
+            duplicate_events.is_empty(),
+            "unchanged RuntimeState hooks should not fan out status events"
+        );
+        assert!(changed_events.iter().any(|event| matches!(
+            event.event,
+            BackendEvent::WindowState {
+                state: WindowProcessStatus::Running,
+                ..
+            }
+        )));
+        assert!(changed_events.iter().any(|event| matches!(
+            event.event,
+            BackendEvent::TerminalStatus {
+                status: WindowProcessStatus::Running,
+                ..
+            }
+        )));
+    }
+
+    #[test]
+    fn app_runtime_stopped_runtime_state_after_prior_state_still_auto_closes() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab_with_window(
+            "tab-1",
+            "codex-1",
+            WindowPreset::Codex,
+            WindowProcessStatus::Running,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "codex-1");
+        runtime.active_agent_sessions.insert(
+            window_id.clone(),
+            sample_active_agent_session("tab-1", &window_id),
+        );
+        let _ = runtime.handle_runtime_hook_event(runtime_hook_state("Waiting", "session-1"));
+
+        let events = runtime.handle_runtime_hook_event(runtime_hook_state("Stopped", "session-1"));
+
+        assert!(matches!(
+            events.first().map(|event| &event.event),
+            Some(BackendEvent::WorkspaceState { .. })
+        ));
+        assert!(!runtime.active_agent_sessions.contains_key(&window_id));
+        assert!(!runtime.window_lookup.contains_key(&window_id));
+        assert!(runtime.tabs[0].workspace.window("codex-1").is_none());
+    }
+
+    #[test]
     fn app_runtime_start_window_registers_running_process_runtime_and_pty_writer() {
         let temp = tempdir().expect("tempdir");
         let repo = temp.path().join("repo");

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -11051,6 +11051,21 @@ exit 1
         }
     }
 
+    fn runtime_hook_coordination_event(session_id: &str) -> gwt::RuntimeHookEvent {
+        gwt::RuntimeHookEvent {
+            kind: gwt::RuntimeHookEventKind::CoordinationEvent,
+            source_event: Some("PostToolUse".to_string()),
+            gwt_session_id: Some(session_id.to_string()),
+            agent_session_id: Some("agent-session-1".to_string()),
+            project_root: Some("E:/gwt/test-repo".to_string()),
+            branch: Some("feature/test".to_string()),
+            status: None,
+            tool_name: Some("TodoWrite".to_string()),
+            message: Some("coordination:PostToolUse".to_string()),
+            occurred_at: "2026-04-25T00:00:00Z".to_string(),
+        }
+    }
+
     fn sample_runtime(
         temp_root: &Path,
         tabs: Vec<ProjectTabRuntime>,
@@ -16947,13 +16962,9 @@ exit 1
 
         let events = runtime.handle_runtime_hook_event(runtime_hook_state("Stopped", "session-1"));
 
-        assert_eq!(events.len(), 2);
+        assert_eq!(events.len(), 1);
         assert!(matches!(
             events[0].event,
-            BackendEvent::RuntimeHookEvent { .. }
-        ));
-        assert!(matches!(
-            events[1].event,
             BackendEvent::WorkspaceState { .. }
         ));
         assert!(!runtime.active_agent_sessions.contains_key(&window_id));
@@ -17005,13 +17016,88 @@ exit 1
 
         let events = runtime.handle_runtime_hook_event(runtime_hook_state("Stopped", "session-1"));
 
+        assert!(events.is_empty());
+        assert!(runtime.window_lookup.contains_key(&window_id));
+        assert!(runtime.tabs[0].workspace.window("codex-1").is_some());
+    }
+
+    #[test]
+    fn app_runtime_runtime_state_hooks_use_status_events_without_browser_hook_event() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab_with_window(
+            "tab-1",
+            "codex-1",
+            WindowPreset::Codex,
+            WindowProcessStatus::Running,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "codex-1");
+        runtime.active_agent_sessions.insert(
+            window_id.clone(),
+            sample_active_agent_session("tab-1", &window_id),
+        );
+
+        let events = runtime.handle_runtime_hook_event(runtime_hook_state("Waiting", "session-1"));
+
+        assert!(
+            !events
+                .iter()
+                .any(|event| matches!(event.event, BackendEvent::RuntimeHookEvent { .. })),
+            "runtime_state hooks are browser-internal noise; status events carry the visible chrome state"
+        );
+        assert!(events
+            .iter()
+            .any(|event| matches!(event.event, BackendEvent::WindowState { .. })));
+        assert!(events
+            .iter()
+            .any(|event| matches!(event.event, BackendEvent::TerminalStatus { .. })));
+    }
+
+    #[test]
+    fn app_runtime_coordination_hooks_still_emit_browser_hook_event() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab_with_window(
+            "tab-1",
+            "board-1",
+            WindowPreset::Board,
+            WindowProcessStatus::Running,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+
+        let events =
+            runtime.handle_runtime_hook_event(runtime_hook_coordination_event("session-1"));
+
         assert_eq!(events.len(), 1);
         assert!(matches!(
             events[0].event,
             BackendEvent::RuntimeHookEvent { .. }
         ));
-        assert!(runtime.window_lookup.contains_key(&window_id));
-        assert!(runtime.tabs[0].workspace.window("codex-1").is_some());
+    }
+
+    #[test]
+    fn app_runtime_runtime_state_bursts_emit_no_browser_hook_events() {
+        let temp = tempdir().expect("tempdir");
+        let tab = sample_project_tab_with_window(
+            "tab-1",
+            "codex-1",
+            WindowPreset::Codex,
+            WindowProcessStatus::Running,
+        );
+        let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+        let window_id = combined_window_id("tab-1", "codex-1");
+        runtime.active_agent_sessions.insert(
+            window_id.clone(),
+            sample_active_agent_session("tab-1", &window_id),
+        );
+
+        let browser_hook_events = (0..1_000)
+            .flat_map(|_| {
+                runtime.handle_runtime_hook_event(runtime_hook_state("Waiting", "session-1"))
+            })
+            .filter(|event| matches!(event.event, BackendEvent::RuntimeHookEvent { .. }))
+            .count();
+
+        assert_eq!(browser_hook_events, 0);
     }
 
     #[test]
@@ -20892,13 +20978,16 @@ exit 1
 
         assert!(events
             .iter()
-            .any(|event| matches!(event.event, BackendEvent::RuntimeHookEvent { .. })));
+            .all(|event| !matches!(event.event, BackendEvent::RuntimeHookEvent { .. })));
         assert!(
             !events
                 .iter()
                 .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
             "non-structural runtime hook state changes must not force a full workspace_state"
         );
+        assert!(events
+            .iter()
+            .any(|event| matches!(event.event, BackendEvent::WindowState { .. })));
         assert!(events
             .iter()
             .any(|event| matches!(event.event, BackendEvent::TerminalStatus { .. })));

--- a/crates/gwt/src/app_runtime/persist_dispatcher.rs
+++ b/crates/gwt/src/app_runtime/persist_dispatcher.rs
@@ -24,7 +24,7 @@ use gwt::{save_session_state, save_workspace_state};
 use super::BlockingTaskSpawner;
 
 /// Snapshot of state that the persist worker should flush to disk.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct PersistSnapshot {
     pub(crate) session_path: PathBuf,
     pub(crate) session: gwt::PersistedSessionState,
@@ -42,6 +42,7 @@ struct DispatcherState {
     shutdown: bool,
     enqueued: u64,
     completed: u64,
+    last_successful_snapshot: Option<PersistSnapshot>,
     last_error: Option<String>,
 }
 
@@ -144,6 +145,12 @@ impl PersistDispatcher {
             .state
             .lock()
             .unwrap_or_else(PoisonError::into_inner);
+        if state.latest.as_ref() == Some(&snapshot)
+            || (state.latest.is_none()
+                && state.last_successful_snapshot.as_ref() == Some(&snapshot))
+        {
+            return;
+        }
         state.enqueued = state.enqueued.saturating_add(1);
         state.latest = Some(snapshot);
         state.latest_updated_at = Some(Instant::now());
@@ -189,6 +196,24 @@ impl PersistDispatcher {
             .last_error
             .clone()
     }
+
+    #[cfg(test)]
+    pub(crate) fn enqueued_count(&self) -> u64 {
+        self.inner
+            .state
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .enqueued
+    }
+
+    #[cfg(test)]
+    pub(crate) fn completed_count(&self) -> u64 {
+        self.inner
+            .state
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .completed
+    }
 }
 
 fn worker_loop(inner: Arc<DispatcherInner>) {
@@ -233,17 +258,23 @@ fn worker_loop(inner: Arc<DispatcherInner>) {
             (state.latest.take(), state.enqueued)
         };
 
-        let outcome = if let Some(snap) = snapshot {
-            write_snapshot(&snap)
-        } else {
-            Ok(())
+        let (outcome, successful_snapshot) = match snapshot {
+            Some(snap) => {
+                let outcome = write_snapshot(&snap);
+                let successful_snapshot = if outcome.is_ok() { Some(snap) } else { None };
+                (outcome, successful_snapshot)
+            }
+            None => (Ok(()), None),
         };
 
         let mut state = inner.state.lock().unwrap_or_else(PoisonError::into_inner);
         if covered > state.completed {
             state.completed = covered;
         }
-        if let Err(error) = outcome {
+        if let Some(snap) = successful_snapshot {
+            state.last_successful_snapshot = Some(snap);
+            state.last_error = None;
+        } else if let Err(error) = outcome {
             tracing::warn!(error = %error, "persist dispatcher failed to write snapshot");
             state.last_error = Some(error.to_string());
         }
@@ -279,6 +310,22 @@ mod tests {
             tabs: Vec::new(),
             active_tab_id: None,
             recent_projects: Vec::new(),
+        }
+    }
+
+    fn sample_session(active_tab_id: &str) -> gwt::PersistedSessionState {
+        gwt::PersistedSessionState {
+            tabs: Vec::new(),
+            active_tab_id: Some(active_tab_id.to_string()),
+            recent_projects: Vec::new(),
+        }
+    }
+
+    fn sample_snapshot(session_path: PathBuf, active_tab_id: &str) -> PersistSnapshot {
+        PersistSnapshot {
+            session_path,
+            session: sample_session(active_tab_id),
+            workspaces: Vec::new(),
         }
     }
 
@@ -391,6 +438,103 @@ mod tests {
             elapsed >= Duration::from_millis(50),
             "writer should respect the 50ms coalesce window from the most recent enqueue (elapsed = {elapsed:?})",
         );
+    }
+
+    #[test]
+    fn suppresses_identical_snapshot_after_successful_write() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("session-state.json");
+        let dispatcher = PersistDispatcher::new(&BlockingTaskSpawner::thread());
+        let snapshot = sample_snapshot(path.clone(), "stable");
+
+        dispatcher.enqueue(snapshot.clone());
+        assert!(dispatcher.wait_idle(Duration::from_secs(5)));
+        assert_eq!(dispatcher.completed_count(), 1);
+
+        for _ in 0..25 {
+            dispatcher.enqueue(snapshot.clone());
+        }
+        assert!(dispatcher.wait_idle(Duration::from_millis(100)));
+
+        assert_eq!(
+            dispatcher.enqueued_count(),
+            1,
+            "identical snapshots that already persisted should not enqueue new disk work",
+        );
+        assert_eq!(
+            dispatcher.completed_count(),
+            1,
+            "identical snapshots that already persisted should not complete extra writes",
+        );
+
+        dispatcher.enqueue(sample_snapshot(path.clone(), "changed"));
+        assert!(dispatcher.wait_idle(Duration::from_secs(5)));
+        let on_disk = load_session_state(&path).expect("load persisted session");
+        assert_eq!(
+            on_disk.active_tab_id.as_deref(),
+            Some("changed"),
+            "changed snapshots must still persist after duplicate suppression",
+        );
+        assert_eq!(dispatcher.completed_count(), 2);
+    }
+
+    #[test]
+    fn suppresses_identical_snapshot_while_pending() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("session-state.json");
+        let dispatcher = PersistDispatcher::new(&BlockingTaskSpawner::thread());
+        let snapshot = sample_snapshot(path.clone(), "pending");
+
+        let started = std::time::Instant::now();
+        dispatcher.enqueue(snapshot.clone());
+        std::thread::sleep(Duration::from_millis(20));
+        dispatcher.enqueue(snapshot);
+
+        assert_eq!(
+            dispatcher.enqueued_count(),
+            1,
+            "identical pending snapshots should not increment enqueue count",
+        );
+        assert!(dispatcher.wait_idle(Duration::from_secs(5)));
+        let elapsed = started.elapsed();
+
+        let on_disk = load_session_state(&path).expect("load persisted session");
+        assert_eq!(on_disk.active_tab_id.as_deref(), Some("pending"));
+        assert_eq!(dispatcher.completed_count(), 1);
+        assert!(
+            elapsed < Duration::from_millis(95),
+            "identical pending enqueue should not restart the coalesce window (elapsed = {elapsed:?})",
+        );
+    }
+
+    #[test]
+    fn failed_write_does_not_suppress_later_retry() {
+        let temp = tempdir().expect("tempdir");
+        let path = temp.path().join("session-state.json");
+        std::fs::create_dir(&path).expect("create blocking directory");
+        let dispatcher = PersistDispatcher::new(&BlockingTaskSpawner::thread());
+        let snapshot = sample_snapshot(path.clone(), "retryable");
+
+        dispatcher.enqueue(snapshot.clone());
+        assert!(dispatcher.wait_idle(Duration::from_secs(5)));
+        assert_eq!(dispatcher.completed_count(), 1);
+        assert!(
+            dispatcher.last_error().is_some(),
+            "first write should fail so the snapshot must not enter the successful duplicate cache",
+        );
+
+        std::fs::remove_dir(&path).expect("remove blocking directory");
+        dispatcher.enqueue(snapshot);
+        assert!(dispatcher.wait_idle(Duration::from_secs(5)));
+
+        let on_disk = load_session_state(&path).expect("load persisted session");
+        assert_eq!(on_disk.active_tab_id.as_deref(), Some("retryable"));
+        assert_eq!(
+            dispatcher.completed_count(),
+            2,
+            "identical snapshot after a failed write must retry instead of being suppressed",
+        );
+        assert!(dispatcher.last_error().is_none());
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/runtime_events.rs
+++ b/crates/gwt/src/app_runtime/runtime_events.rs
@@ -184,6 +184,9 @@ impl AppRuntime {
         let Some(hook_state) = gwt::window_state::runtime_hook_window_state(&event) else {
             return events;
         };
+        if self.window_hook_states.get(&window_id).copied() == Some(hook_state) {
+            return events;
+        }
         self.window_hook_states
             .insert(window_id.clone(), hook_state);
         let Some(composed_state) = self.recompute_window_state(&window_id) else {

--- a/crates/gwt/src/app_runtime/runtime_events.rs
+++ b/crates/gwt/src/app_runtime/runtime_events.rs
@@ -172,9 +172,12 @@ impl AppRuntime {
                 publish_runtime_hook_change(&project_root, &event);
             }
         }
-        let mut events = vec![OutboundEvent::broadcast(BackendEvent::RuntimeHookEvent {
-            event: event.clone(),
-        })];
+        let mut events = Vec::new();
+        if Self::should_broadcast_runtime_hook_event_to_frontend(&event) {
+            events.push(OutboundEvent::broadcast(BackendEvent::RuntimeHookEvent {
+                event: event.clone(),
+            }));
+        }
         let Some(window_id) = self.active_window_for_runtime_event(&event) else {
             return events;
         };
@@ -218,6 +221,10 @@ impl AppRuntime {
         }
         events.extend(Self::status_events(window_id, composed_state, detail));
         events
+    }
+
+    fn should_broadcast_runtime_hook_event_to_frontend(event: &gwt::RuntimeHookEvent) -> bool {
+        event.kind != gwt::RuntimeHookEventKind::RuntimeState
     }
 }
 

--- a/crates/gwt/src/app_runtime/window.rs
+++ b/crates/gwt/src/app_runtime/window.rs
@@ -139,7 +139,9 @@ impl AppRuntime {
         let Some(tab) = self.active_tab_mut() else {
             return Vec::new();
         };
-        tab.workspace.update_viewport(viewport);
+        if !tab.workspace.update_viewport(viewport) {
+            return Vec::new();
+        }
         let _ = self.persist();
         vec![self.workspace_state_broadcast()]
     }

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -845,15 +845,7 @@ impl AppRuntime {
         project_root: &Path,
         workspace_resume_context: Option<WorkspaceResumeContext>,
     ) -> Result<(), String> {
-        // SPEC-2014 FR-PERF-003: reuse the tab's cached `main_worktree_root`
-        // so Start Work does not spawn another `git rev-parse
-        // --git-common-dir` per open.
-        let git_root = self.tab(tab_id).map(|tab| tab.main_worktree_root());
-        let base_branch = match git_root.as_deref() {
-            Some(root) => gwt::start_work::resolve_start_work_base_branch_in(root),
-            None => gwt::start_work::resolve_start_work_base_branch(project_root),
-        }
-        .map_err(|error| error.to_string())?;
+        let base_branch = gwt::start_work::START_WORK_BASE_BRANCH_CANDIDATES[0].to_string();
         let work_branch =
             gwt::start_work::reserve_start_work_branch_name_for_project(project_root, Utc::now())
                 .map_err(|error| error.to_string())?;

--- a/crates/gwt/src/embedded_server.rs
+++ b/crates/gwt/src/embedded_server.rs
@@ -675,6 +675,8 @@ fn display_host(ip: IpAddr) -> String {
 ///
 /// `/healthz` is demoted to `tracing::debug!` so periodic health probes do not
 /// dominate the stderr stream when the operator wants to spot real LAN access.
+/// Successful `/internal/hook-live` posts are internal hook-forwarding traffic
+/// and are omitted entirely; failures remain visible for diagnosis.
 async fn access_log_middleware(
     State(sink): State<AccessLogSink>,
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
@@ -703,6 +705,10 @@ async fn access_log_middleware(
         elapsed_ms,
     };
 
+    if should_drop_access_log_record(&record) {
+        return response;
+    }
+
     if record.path == "/healthz" {
         tracing::debug!(
             target: "gwt_access",
@@ -729,6 +735,10 @@ async fn access_log_middleware(
     sink.record(record);
 
     response
+}
+
+fn should_drop_access_log_record(record: &AccessLogRecord) -> bool {
+    record.method == "POST" && record.path == "/internal/hook-live" && record.status == 204
 }
 
 async fn websocket_handler(
@@ -981,6 +991,21 @@ mod tests {
             },
             events,
         )
+    }
+
+    fn sample_runtime_hook_event() -> RuntimeHookEvent {
+        RuntimeHookEvent {
+            kind: RuntimeHookEventKind::RuntimeState,
+            source_event: Some("PreToolUse".to_string()),
+            gwt_session_id: Some("session-1".to_string()),
+            agent_session_id: Some("agent-1".to_string()),
+            project_root: Some("E:/gwt/test-repo".to_string()),
+            branch: Some("feature/runtime".to_string()),
+            status: Some("Running".to_string()),
+            tool_name: Some("Bash".to_string()),
+            message: None,
+            occurred_at: "2026-04-21T00:00:00Z".to_string(),
+        }
     }
 
     #[test]
@@ -1310,18 +1335,7 @@ mod tests {
             "expected embedded server to serve the segmented theme toggle module",
         );
 
-        let event = RuntimeHookEvent {
-            kind: RuntimeHookEventKind::RuntimeState,
-            source_event: Some("PreToolUse".to_string()),
-            gwt_session_id: Some("session-1".to_string()),
-            agent_session_id: Some("agent-1".to_string()),
-            project_root: Some("E:/gwt/test-repo".to_string()),
-            branch: Some("feature/runtime".to_string()),
-            status: Some("Running".to_string()),
-            tool_name: Some("Bash".to_string()),
-            message: None,
-            occurred_at: "2026-04-21T00:00:00Z".to_string(),
-        };
+        let event = sample_runtime_hook_event();
 
         let unauthorized = client
             .post(&hook.url)
@@ -1358,6 +1372,77 @@ mod tests {
                         && recorded_event.agent_session_id.as_deref() == Some("agent-1")
             )
         }));
+
+        server.shutdown();
+    }
+
+    #[test]
+    fn successful_hook_live_requests_do_not_fill_access_log_ring() {
+        let runtime = Runtime::new().expect("tokio runtime");
+        let (proxy, _events) = AppEventProxy::stub();
+        let clients = ClientHub::default();
+        let pty_writers = Arc::new(RwLock::new(HashMap::new()));
+        let mut server = EmbeddedServer::start(
+            &runtime,
+            proxy,
+            clients,
+            pty_writers,
+            AttachmentUploadStore::in_system_temp(),
+        )
+        .expect("server");
+
+        let hook = server.hook_forward_target();
+        let client = reqwest::blocking::Client::new();
+        let accepted = client
+            .post(&hook.url)
+            .bearer_auth(&hook.token)
+            .json(&sample_runtime_hook_event())
+            .send()
+            .expect("authorized hook request");
+        assert_eq!(accepted.status(), HttpStatusCode::NO_CONTENT);
+
+        let records = server.access_log().snapshot();
+        assert!(
+            records
+                .iter()
+                .all(|record| record.path != "/internal/hook-live"),
+            "successful internal hook-live traffic must not evict operator-relevant access records"
+        );
+
+        server.shutdown();
+    }
+
+    #[test]
+    fn unsuccessful_hook_live_requests_remain_in_access_log_ring() {
+        let runtime = Runtime::new().expect("tokio runtime");
+        let (proxy, _events) = AppEventProxy::stub();
+        let clients = ClientHub::default();
+        let pty_writers = Arc::new(RwLock::new(HashMap::new()));
+        let mut server = EmbeddedServer::start(
+            &runtime,
+            proxy,
+            clients,
+            pty_writers,
+            AttachmentUploadStore::in_system_temp(),
+        )
+        .expect("server");
+
+        let hook = server.hook_forward_target();
+        let client = reqwest::blocking::Client::new();
+        let unauthorized = client
+            .post(&hook.url)
+            .json(&sample_runtime_hook_event())
+            .send()
+            .expect("unauthorized hook request");
+        assert_eq!(unauthorized.status(), HttpStatusCode::UNAUTHORIZED);
+
+        let records = server.access_log().snapshot();
+        let hook_record = records
+            .iter()
+            .find(|record| record.path == "/internal/hook-live")
+            .expect("failed hook-live access should remain visible");
+        assert_eq!(hook_record.method, "POST");
+        assert_eq!(hook_record.status, 401);
 
         server.shutdown();
     }

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -3878,7 +3878,7 @@ mod tests {
     fn embedded_web_tab_visibility_transition_triggers_terminal_focus_activation() {
         let js = app_js();
         let visibility_block = regex::Regex::new(
-            r"(?s)for \(const windowData of workspace\.windows\) \{(?P<body>.*?)\}\s*\n\s*requestAnimationFrame\(syncMaximizedWindowsToViewport\);",
+            r"(?s)for \(const windowData of workspace\.windows\) \{(?P<body>.*?)\}\s*\n\s*scheduleMaximizedWindowsToViewportSync\(\);",
         )
         .expect("valid regex");
         let captures = visibility_block
@@ -3903,6 +3903,16 @@ mod tests {
             "expected hidden->visible transition to schedule terminal focus activation \
              (fit + viewport refresh + focus) so scrollback responds without a manual \
              resize (SPEC-2008 FR-051); body: {body}",
+        );
+        assert!(
+            js.contains("function scheduleMaximizedWindowsToViewportSync()")
+                && js.contains("let maximizedViewportSyncFrame = null;"),
+            "expected maximized viewport sync to be routed through the coalesced \
+             frame scheduler (SPEC-1939 Phase 52)",
+        );
+        assert!(
+            !js.contains("requestAnimationFrame(syncMaximizedWindowsToViewport)"),
+            "expected renderWorkspace to avoid raw maximized viewport sync rAF fan-out",
         );
     }
 }

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -993,7 +993,8 @@ mod tests {
                 && html.contains("const previousHeight = parseFloat(element.style.height")
                 && html.contains("const dimensionsChanged =")
                 && html.contains("(wasMinimized && !windowData.minimized) || dimensionsChanged",)
-                && html.contains("fitTerminal(windowData.id, shouldPersistTerminalGeometry)"),
+                && html
+                    .contains("scheduleTerminalFit(windowData.id, shouldPersistTerminalGeometry)"),
             "expected terminals to persist fitted geometry to backend on \
              restore-from-minimized OR window resize (Tile/Stack/Align)",
         );
@@ -3825,9 +3826,10 @@ mod tests {
              can fan out to every visible terminal window (SPEC-2008 FR-050), body: {body}",
         );
         assert!(
-            body.contains("fitTerminal,"),
-            "expected attachHostResizeReflow to receive fitTerminal so cols/rows refit and \
-             UpdateWindowGeometry persists to the backend; body: {body}",
+            js.contains("createTerminalFitScheduler({ fitTerminal })")
+                && body.contains("fitTerminal: scheduleTerminalFit"),
+            "expected attachHostResizeReflow to route fit requests through the shared \
+             terminal fit scheduler while preserving fitTerminal semantics; body: {body}",
         );
         assert!(
             body.contains("syncMaximizedWindowsToViewport()"),

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -145,6 +145,11 @@ pub fn socket_receive_dispatcher_js() -> &'static str {
     include_str!("../web/socket-receive-dispatcher.js")
 }
 
+// SPEC-1939 Phase 24 — per-window terminal output batching before xterm write.
+pub fn terminal_output_buffer_js() -> &'static str {
+    include_str!("../web/terminal-output-buffer.js")
+}
+
 // Issue #2698 PR 1 (B7) — interaction-guard primitive that defers
 // destructive wizard re-renders while the user has a native <select>
 // dropdown open.
@@ -329,6 +334,11 @@ pub const ROOT_JS_MODULE_ASSETS: &[RootJsModuleAsset] = &[
         path: "/socket-receive-dispatcher.js",
         source: socket_receive_dispatcher_js,
         marker: "createSocketReceiveDispatcher",
+    },
+    RootJsModuleAsset {
+        path: "/terminal-output-buffer.js",
+        source: terminal_output_buffer_js,
+        marker: "createTerminalOutputBatcher",
     },
     RootJsModuleAsset {
         path: "/interaction-guard.js",
@@ -875,8 +885,12 @@ mod tests {
     #[test]
     fn embedded_web_terminal_writes_refresh_viewport_after_xterm_parse() {
         let html = frontend_bundle_source();
+        let streaming_enqueue = regex::Regex::new(
+            r"(?s)function writeOutput\(windowId, base64\) \{[\s\S]*?terminalOutputBatcher\.enqueue\(\s*windowId,\s*decoder\.decode\(decodeBase64\(base64\),\s*\{\s*stream:\s*true\s*\}\),\s*\);",
+        )
+        .expect("valid regex");
         let streaming_write = regex::Regex::new(
-            r"runtime\.terminal\.write\(\s*decoder\.decode\(decodeBase64\(base64\),\s*\{\s*stream:\s*true\s*\}\),\s*\(\)\s*=>\s*\{\s*scheduleTerminalViewportRefresh\(windowId\);\s*\}\s*\);",
+            r"(?s)const terminalOutputBatcher = createTerminalOutputBatcher\(\{[\s\S]*?write:\s*\(windowId,\s*text,\s*onWritten\)\s*=>\s*\{[\s\S]*?runtime\.terminal\.write\(text,\s*onWritten\);[\s\S]*?onFlush:\s*\(windowId\)\s*=>\s*\{[\s\S]*?scheduleTerminalViewportRefresh\(windowId\);[\s\S]*?\},[\s\S]*?\}\);",
         )
         .expect("valid regex");
         // SPEC-2008 Phase 26.B / FR-056: snapshot replays must force the
@@ -906,8 +920,18 @@ mod tests {
             "expected terminal runtime to debounce viewport refreshes",
         );
         assert!(
+            html.contains(
+                r#"import { createTerminalOutputBatcher } from "/terminal-output-buffer.js";"#
+            ),
+            "expected app.js to import the terminal output batcher root module",
+        );
+        assert!(
+            streaming_enqueue.is_match(html),
+            "expected streaming terminal output to enter the per-window batcher after TextDecoder streaming decode",
+        );
+        assert!(
             streaming_write.is_match(html),
-            "expected streaming terminal output to refresh viewport after xterm parses it",
+            "expected terminal output batch flushes to refresh viewport after xterm parses them",
         );
         assert!(
             snapshot_write.is_match(html),
@@ -932,6 +956,10 @@ mod tests {
         assert!(
             html.contains("cancelAnimationFrame(runtime.viewportRefreshFrame)"),
             "expected pending terminal viewport refresh frames to be cancelled during cleanup",
+        );
+        assert!(
+            html.contains("terminalOutputBatcher.clear(windowId);"),
+            "expected pending terminal output batches to be cleared on snapshot and removed-window cleanup",
         );
         assert!(
             html.contains("if (runtime && runtime.viewportRefreshFrame !== null)"),

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -3051,7 +3051,7 @@ mod tests {
         // guard preamble between the case label and the assignment. A
         // null tombstone must not clear an open-error modal during reconnect.
         let wizard_state = regex::Regex::new(
-            r#"case\s*"launch_wizard_state":[\s\S]*?clearLaunchWizardPendingAction\(\);\s*if\s*\(event\.wizard\)\s*\{[\s\S]*?launchWizardOpenError\s*=\s*null;[\s\S]*?\}\s*launchWizard\s*=\s*event\.wizard;\s*(?:renderLaunchWizard|frontendUnits\.launchWizardSurface\.render)\(\);\s*break;"#,
+            r#"case\s*"launch_wizard_state":[\s\S]*?clearLaunchWizardPendingAction\(\);\s*clearLaunchWizardOpening\(\);\s*if\s*\(event\.wizard\)\s*\{[\s\S]*?launchWizardOpenError\s*=\s*null;[\s\S]*?\}\s*launchWizard\s*=\s*event\.wizard;\s*(?:renderLaunchWizard|frontendUnits\.launchWizardSurface\.render)\(\);\s*break;"#,
         )
         .expect("valid regex");
         assert!(
@@ -3249,7 +3249,7 @@ mod tests {
         // guard preamble between the case label and the mutation. A
         // null tombstone must not clear an open-error modal during reconnect.
         let wizard_event = regex::Regex::new(
-            r#"case\s*"launch_wizard_state":[\s\S]*?clearLaunchWizardPendingAction\(\);\s*if\s*\(event\.wizard\)\s*\{[\s\S]*?launchWizardOpenError\s*=\s*null;[\s\S]*?\}\s*launchWizard\s*=\s*event\.wizard;\s*frontendUnits\.launchWizardSurface\.render\(\);\s*break;"#,
+            r#"case\s*"launch_wizard_state":[\s\S]*?clearLaunchWizardPendingAction\(\);\s*clearLaunchWizardOpening\(\);\s*if\s*\(event\.wizard\)\s*\{[\s\S]*?launchWizardOpenError\s*=\s*null;[\s\S]*?\}\s*launchWizard\s*=\s*event\.wizard;\s*frontendUnits\.launchWizardSurface\.render\(\);\s*break;"#,
         )
         .expect("valid regex");
         let wizard_open_error_event = regex::Regex::new(

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -920,8 +920,9 @@ mod tests {
             "expected terminal viewport refresh scheduling helper",
         );
         assert!(
-            html.contains("viewportRefreshFrame"),
-            "expected terminal runtime to debounce viewport refreshes",
+            html.contains("createTerminalViewportRefreshScheduler({")
+                && html.contains("terminalViewportRefreshScheduler.enqueue(windowId)"),
+            "expected terminal runtime to route viewport refreshes through the shared scheduler",
         );
         assert!(
             html.contains(
@@ -962,16 +963,12 @@ mod tests {
             "expected document visibility restore to re-arm visible terminal refreshes",
         );
         assert!(
-            html.contains("cancelAnimationFrame(runtime.viewportRefreshFrame)"),
-            "expected pending terminal viewport refresh frames to be cancelled during cleanup",
-        );
-        assert!(
             html.contains("terminalOutputBatcher.clear(windowId);"),
             "expected pending terminal output batches to be cleared on snapshot and removed-window cleanup",
         );
         assert!(
-            html.contains("if (runtime && runtime.viewportRefreshFrame !== null)"),
-            "expected terminal cleanup to guard non-terminal windows before cancelling refresh frames",
+            html.contains("terminalViewportRefreshScheduler?.clear(windowId);"),
+            "expected terminal cleanup to clear pending shared viewport refreshes",
         );
         assert!(
             html.contains("function canRefreshTerminalViewport(windowId)")

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -885,8 +885,12 @@ mod tests {
     #[test]
     fn embedded_web_terminal_writes_refresh_viewport_after_xterm_parse() {
         let html = frontend_bundle_source();
+        let streaming_merge = regex::Regex::new(
+            r"(?s)const terminalOutputBatcher = createTerminalOutputBatcher\(\{[\s\S]*?mergeChunks:\s*\(chunks,\s*windowId\)\s*=>\s*\{[\s\S]*?decoderMap\.get\(windowId\)[\s\S]*?chunks\s*\.\s*map\(\(chunk\) => decoder\.decode\(decodeBase64\(chunk\),\s*\{\s*stream:\s*true\s*\}\)\)",
+        )
+        .expect("valid regex");
         let streaming_enqueue = regex::Regex::new(
-            r"(?s)function writeOutput\(windowId, base64\) \{[\s\S]*?terminalOutputBatcher\.enqueue\(\s*windowId,\s*decoder\.decode\(decodeBase64\(base64\),\s*\{\s*stream:\s*true\s*\}\),\s*\);",
+            r"(?s)function writeOutput\(windowId, base64\) \{[\s\S]*?terminalOutputBatcher\.enqueue\(\s*windowId,\s*base64\s*\);",
         )
         .expect("valid regex");
         let streaming_write = regex::Regex::new(
@@ -926,8 +930,12 @@ mod tests {
             "expected app.js to import the terminal output batcher root module",
         );
         assert!(
+            streaming_merge.is_match(html),
+            "expected terminal output batcher to decode encoded chunks during scheduled flush",
+        );
+        assert!(
             streaming_enqueue.is_match(html),
-            "expected streaming terminal output to enter the per-window batcher after TextDecoder streaming decode",
+            "expected streaming terminal output to enqueue encoded chunks without receive-path decode",
         );
         assert!(
             streaming_write.is_match(html),

--- a/crates/gwt/src/index_worker.rs
+++ b/crates/gwt/src/index_worker.rs
@@ -234,6 +234,22 @@ pub struct WorktreeMeta {
     pub path: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectIndexStatusCoverageScope {
+    CurrentWorktree,
+    AllWorktrees,
+    PartialAllWorktrees,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
+pub struct ProjectIndexStatusCoverage {
+    pub scope: ProjectIndexStatusCoverageScope,
+    pub probed_worktrees: usize,
+    pub total_worktrees: usize,
+    pub truncated: bool,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
 pub struct ProjectIndexStatusView {
     pub state: ProjectIndexStatusState,
@@ -246,6 +262,8 @@ pub struct ProjectIndexStatusView {
     pub scopes: ProjectIndexScopes,
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     pub worktrees: BTreeMap<String, WorktreeMeta>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub coverage: Option<ProjectIndexStatusCoverage>,
 }
 
 impl ProjectIndexStatusView {
@@ -257,7 +275,13 @@ impl ProjectIndexStatusView {
             progress: None,
             scopes: ProjectIndexScopes::default(),
             worktrees: BTreeMap::new(),
+            coverage: None,
         }
+    }
+
+    fn with_coverage(mut self, coverage: ProjectIndexStatusCoverage) -> Self {
+        self.coverage = Some(coverage);
+        self
     }
 }
 
@@ -435,6 +459,7 @@ pub fn build_aggregated_status_view(
         progress: None,
         scopes,
         worktrees,
+        coverage: None,
     }
 }
 
@@ -550,6 +575,65 @@ enum StatusProbeScope {
     CurrentWorktree,
 }
 
+#[derive(Debug, Clone)]
+struct ProbeInputSelection {
+    inputs: Vec<WorktreeProbeInput>,
+    coverage: ProjectIndexStatusCoverage,
+}
+
+const DEFAULT_ALL_WORKTREE_STATUS_BATCH_LIMIT: usize = 32;
+
+fn all_worktree_status_batch_limit() -> usize {
+    std::env::var("GWT_INDEX_STATUS_WORKTREE_BATCH_LIMIT")
+        .ok()
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .filter(|limit| *limit > 0)
+        .unwrap_or(DEFAULT_ALL_WORKTREE_STATUS_BATCH_LIMIT)
+}
+
+fn select_probe_inputs_for_scope(
+    inputs: Vec<WorktreeProbeInput>,
+    probe_scope: StatusProbeScope,
+    current_worktree_root: Option<&Path>,
+    all_worktree_limit: usize,
+) -> ProbeInputSelection {
+    let total_worktrees = inputs.len();
+    match probe_scope {
+        StatusProbeScope::CurrentWorktree => {
+            let selected = current_worktree_root
+                .map(|root| collect_current_worktree_probe_inputs(inputs, root))
+                .unwrap_or_default();
+            ProbeInputSelection {
+                coverage: ProjectIndexStatusCoverage {
+                    scope: ProjectIndexStatusCoverageScope::CurrentWorktree,
+                    probed_worktrees: selected.len(),
+                    total_worktrees,
+                    truncated: false,
+                },
+                inputs: selected,
+            }
+        }
+        StatusProbeScope::AllWorktrees => {
+            let limit = all_worktree_limit.max(1);
+            let truncated = total_worktrees > limit;
+            let selected: Vec<WorktreeProbeInput> = inputs.into_iter().take(limit).collect();
+            ProbeInputSelection {
+                coverage: ProjectIndexStatusCoverage {
+                    scope: if truncated {
+                        ProjectIndexStatusCoverageScope::PartialAllWorktrees
+                    } else {
+                        ProjectIndexStatusCoverageScope::AllWorktrees
+                    },
+                    probed_worktrees: selected.len(),
+                    total_worktrees,
+                    truncated,
+                },
+                inputs: selected,
+            }
+        }
+    }
+}
+
 fn aggregate_project_index_status_for_path_inner(
     project_root: &Path,
     probe_scope: StatusProbeScope,
@@ -567,6 +651,25 @@ fn aggregate_project_index_status_for_path_inner(
             "No origin remote configured",
         ));
     };
+    let selection = select_probe_inputs_for_scope(
+        list_worktree_probe_inputs(&repo_root)?,
+        probe_scope,
+        context.current_worktree_root.as_deref(),
+        all_worktree_status_batch_limit(),
+    );
+    if selection.inputs.is_empty() {
+        let detail = match probe_scope {
+            StatusProbeScope::CurrentWorktree => {
+                "No matching current worktree for project index status"
+            }
+            StatusProbeScope::AllWorktrees => "No active worktrees for project index status",
+        };
+        return Ok(
+            ProjectIndexStatusView::new(ProjectIndexStatusState::Skipped, detail)
+                .with_coverage(selection.coverage),
+        );
+    }
+
     let runtime_started = Instant::now();
     let report =
         gwt_core::runtime::ensure_project_index_runtime().map_err(|err| err.to_string())?;
@@ -577,19 +680,9 @@ fn aggregate_project_index_status_for_path_inner(
         "project index runtime ensured for aggregated status"
     );
 
-    let inputs = match probe_scope {
-        StatusProbeScope::AllWorktrees => list_worktree_probe_inputs(&repo_root)?,
-        StatusProbeScope::CurrentWorktree => {
-            let inputs = list_worktree_probe_inputs(&repo_root)?;
-            if let Some(current_worktree_root) = context.current_worktree_root.as_deref() {
-                collect_current_worktree_probe_inputs(inputs, current_worktree_root)
-            } else {
-                inputs
-            }
-        }
-    };
-    let mut probes: Vec<WorktreeProbeOutcome> = Vec::with_capacity(inputs.len());
-    for input in inputs {
+    let coverage = selection.coverage;
+    let mut probes: Vec<WorktreeProbeOutcome> = Vec::with_capacity(selection.inputs.len());
+    for input in selection.inputs {
         let payload = probe_worktree_status(&repo_root, &repo_hash, &input.worktree_hash);
         probes.push(WorktreeProbeOutcome {
             input,
@@ -597,10 +690,15 @@ fn aggregate_project_index_status_for_path_inner(
         });
     }
 
-    Ok(build_aggregated_status_view(
-        report.runner_hash.as_str(),
-        &probes,
-    ))
+    let mut view = build_aggregated_status_view(report.runner_hash.as_str(), &probes);
+    if coverage.truncated {
+        view.detail = format!(
+            "Partial status: probed {}/{} worktrees; {}",
+            coverage.probed_worktrees, coverage.total_worktrees, view.detail
+        );
+    }
+    view.coverage = Some(coverage);
+    Ok(view)
 }
 
 fn collect_current_worktree_probe_inputs(
@@ -740,7 +838,21 @@ fn probe_worktree_status(
         .current_dir(repo_root)
         .output()
         .map_err(|err| format!("run project index status: {err}"))?;
-    tracing::info!(
+    if !output.status.success() {
+        tracing::warn!(
+            target: "gwt::index",
+            project_root = %repo_root.display(),
+            worktree_hash,
+            elapsed_ms = runner_started.elapsed().as_millis() as u64,
+            exit_status = %output.status,
+            "project index status runner failed for worktree"
+        );
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if stderr.is_empty() { stdout } else { stderr };
+        return Err(format!("runner exit {}: {detail}", output.status));
+    }
+    tracing::debug!(
         target: "gwt::index",
         project_root = %repo_root.display(),
         worktree_hash,
@@ -748,12 +860,6 @@ fn probe_worktree_status(
         exit_status = %output.status,
         "project index status runner completed for worktree"
     );
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        let detail = if stderr.is_empty() { stdout } else { stderr };
-        return Err(format!("runner exit {}: {detail}", output.status));
-    }
     serde_json::from_slice(&output.stdout)
         .map_err(|err| format!("parse project index status: {err}"))
 }
@@ -1065,6 +1171,7 @@ where
         }),
         scopes: initial_scopes.clone(),
         worktrees: initial_worktrees.clone(),
+        coverage: None,
     });
 
     let project_root_for_thread = project_root.clone();
@@ -1087,6 +1194,7 @@ where
                             }),
                             scopes: initial_scopes.clone(),
                             worktrees: initial_worktrees.clone(),
+                            coverage: None,
                         });
                     }
                     Err(error) => {
@@ -1512,6 +1620,7 @@ detached
                 ..Default::default()
             },
             worktrees: BTreeMap::new(),
+            coverage: None,
         };
         std::fs::write(
             &fixture_path,
@@ -1677,6 +1786,7 @@ detached
             progress: None,
             scopes: ProjectIndexScopes::default(),
             worktrees: BTreeMap::new(),
+            coverage: None,
         };
 
         let payload = serde_json::to_value(&view).expect("serialize ready view");
@@ -1709,6 +1819,7 @@ detached
             }),
             scopes: ProjectIndexScopes::default(),
             worktrees: BTreeMap::new(),
+            coverage: None,
         };
 
         let payload = serde_json::to_value(&view).expect("serialize repairing view");
@@ -1919,6 +2030,64 @@ detached
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].worktree_hash, "current-hash");
         assert_eq!(filtered[0].branch, "develop");
+    }
+
+    #[test]
+    fn current_worktree_probe_selection_without_match_does_not_fall_back_to_all_worktrees() {
+        let current = tempfile::tempdir().expect("current worktree");
+        let inactive_a = tempfile::tempdir().expect("inactive worktree a");
+        let inactive_b = tempfile::tempdir().expect("inactive worktree b");
+        let inputs = vec![
+            WorktreeProbeInput {
+                worktree_hash: "inactive-a".to_string(),
+                branch: "feature/a".to_string(),
+                path: inactive_a.path().to_path_buf(),
+            },
+            WorktreeProbeInput {
+                worktree_hash: "inactive-b".to_string(),
+                branch: "feature/b".to_string(),
+                path: inactive_b.path().to_path_buf(),
+            },
+        ];
+
+        let selection = select_probe_inputs_for_scope(
+            inputs,
+            StatusProbeScope::CurrentWorktree,
+            Some(current.path()),
+            32,
+        );
+
+        assert!(selection.inputs.is_empty());
+        assert_eq!(
+            selection.coverage.scope,
+            ProjectIndexStatusCoverageScope::CurrentWorktree
+        );
+        assert_eq!(selection.coverage.probed_worktrees, 0);
+        assert_eq!(selection.coverage.total_worktrees, 2);
+        assert!(!selection.coverage.truncated);
+    }
+
+    #[test]
+    fn all_worktree_probe_selection_is_batch_limited_and_reports_partial_coverage() {
+        let inputs: Vec<WorktreeProbeInput> = (0..5)
+            .map(|index| WorktreeProbeInput {
+                worktree_hash: format!("wt-{index}"),
+                branch: format!("branch-{index}"),
+                path: PathBuf::from(format!("/tmp/worktree-{index}")),
+            })
+            .collect();
+
+        let selection =
+            select_probe_inputs_for_scope(inputs, StatusProbeScope::AllWorktrees, None, 3);
+
+        assert_eq!(selection.inputs.len(), 3);
+        assert_eq!(
+            selection.coverage.scope,
+            ProjectIndexStatusCoverageScope::PartialAllWorktrees
+        );
+        assert_eq!(selection.coverage.probed_worktrees, 3);
+        assert_eq!(selection.coverage.total_worktrees, 5);
+        assert!(selection.coverage.truncated);
     }
 
     #[test]
@@ -2157,6 +2326,7 @@ detached
             progress: None,
             scopes,
             worktrees: BTreeMap::new(),
+            coverage: None,
         }
     }
 
@@ -2384,6 +2554,7 @@ detached
             }),
             scopes,
             worktrees,
+            coverage: None,
         };
 
         let payload = serde_json::to_value(&view).expect("serialize aggregated view");

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -1426,6 +1426,107 @@ mod tests {
         config
     }
 
+    fn run_git(repo: &Path, args: &[&str]) {
+        let output = gwt_core::process::hidden_command("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    fn git_status(repo: &Path, args: &[&str]) -> bool {
+        gwt_core::process::hidden_command("git")
+            .args(args)
+            .current_dir(repo)
+            .status()
+            .expect("git status")
+            .success()
+    }
+
+    #[test]
+    fn start_work_launch_materialization_prepares_origin_develop_at_launch_time() {
+        let temp = tempdir().expect("tempdir");
+        let origin = temp.path().join("origin.git");
+        let repo = temp.path().join("repo");
+        run_git(temp.path(), &["init", "--bare", origin.to_str().unwrap()]);
+        run_git(
+            temp.path(),
+            &["clone", origin.to_str().unwrap(), repo.to_str().unwrap()],
+        );
+        run_git(&repo, &["config", "user.email", "gwt@example.invalid"]);
+        run_git(&repo, &["config", "user.name", "gwt"]);
+        run_git(&repo, &["checkout", "-qb", "develop"]);
+        fs::write(repo.join("README.md"), "develop\n").expect("write readme");
+        run_git(&repo, &["add", "README.md"]);
+        run_git(&repo, &["commit", "-m", "seed develop"]);
+        run_git(&repo, &["push", "-u", "origin", "develop"]);
+        run_git(&origin, &["symbolic-ref", "HEAD", "refs/heads/develop"]);
+        run_git(&repo, &["remote", "set-head", "origin", "-a"]);
+        run_git(&repo, &["checkout", "-qb", "main"]);
+        fs::write(repo.join("README.md"), "main\n").expect("write readme");
+        run_git(&repo, &["commit", "-am", "seed main"]);
+        run_git(&repo, &["push", "-u", "origin", "main"]);
+        run_git(&origin, &["symbolic-ref", "HEAD", "refs/heads/main"]);
+        run_git(&repo, &["remote", "set-head", "origin", "-a"]);
+        run_git(&repo, &["checkout", "develop"]);
+        run_git(&origin, &["branch", "-D", "develop"]);
+        run_git(&repo, &["update-ref", "-d", "refs/remotes/origin/develop"]);
+        assert!(
+            !git_status(
+                &repo,
+                &[
+                    "show-ref",
+                    "--verify",
+                    "--quiet",
+                    "refs/remotes/origin/develop"
+                ],
+            ),
+            "fixture should start without local origin/develop"
+        );
+
+        let mut base_branch = Some("origin/develop".to_string());
+        let mut working_dir = None;
+        let mut env_vars = HashMap::new();
+
+        resolve_launch_worktree_request(
+            &repo,
+            Some("work/20260607-1200"),
+            &mut base_branch,
+            &mut working_dir,
+            &mut env_vars,
+        )
+        .expect("resolve Start Work launch worktree");
+
+        assert_eq!(base_branch.as_deref(), Some("origin/develop"));
+        assert!(
+            git_status(
+                &repo,
+                &[
+                    "show-ref",
+                    "--verify",
+                    "--quiet",
+                    "refs/remotes/origin/develop"
+                ],
+            ),
+            "final Start Work launch must prepare origin/develop"
+        );
+        let worktree = working_dir.expect("launch worktree path");
+        assert!(
+            worktree.exists(),
+            "final Start Work launch must materialize a worktree"
+        );
+        assert_eq!(
+            env_vars.get("GWT_PROJECT_ROOT").map(String::as_str),
+            Some(worktree.to_str().expect("utf8 worktree")),
+        );
+    }
+
     #[test]
     fn windows_shell_process_command_maps_all_variants() {
         assert_eq!(

--- a/crates/gwt/src/project_index_bootstrap.rs
+++ b/crates/gwt/src/project_index_bootstrap.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     sync::{Arc, Mutex, OnceLock},
     thread,
@@ -55,6 +55,7 @@ pub enum IndexInFlightKey {
 #[derive(Clone, Default)]
 pub struct ProjectIndexBootstrapService {
     in_flight: Arc<Mutex<HashSet<IndexInFlightKey>>>,
+    last_full_status: Arc<Mutex<HashMap<PathBuf, gwt::ProjectIndexStatusView>>>,
 }
 
 impl ProjectIndexBootstrapService {
@@ -198,10 +199,12 @@ impl ProjectIndexBootstrapService {
                         );
                         let kick_orchestrator =
                             status.state == gwt::ProjectIndexStatusState::RepairRequired;
-                        proxy.send(UserEvent::ProjectIndexStatus {
-                            project_root: project_root_label.clone(),
-                            status: status.clone(),
-                        });
+                        service_for_thread.emit_full_status_if_changed(
+                            &proxy,
+                            &project_key,
+                            &project_root_label,
+                            status.clone(),
+                        );
                         if kick_orchestrator {
                             trigger_auto_repair_for_project(
                                 service_for_thread,
@@ -220,15 +223,18 @@ impl ProjectIndexBootstrapService {
                             error = %error,
                             "project index full status refresh bootstrap failed"
                         );
-                        proxy.send(UserEvent::ProjectIndexStatus {
-                            project_root: project_root_label,
-                            status: gwt::ProjectIndexStatusView::new(
-                                gwt::ProjectIndexStatusState::Error,
-                                format!(
-                                    "Project index full status refresh failed after {elapsed_ms} ms: {error}"
-                                ),
+                        let status = gwt::ProjectIndexStatusView::new(
+                            gwt::ProjectIndexStatusState::Error,
+                            format!(
+                                "Project index full status refresh failed after {elapsed_ms} ms: {error}"
                             ),
-                        });
+                        );
+                        service_for_thread.emit_full_status_if_changed(
+                            &proxy,
+                            &project_key,
+                            &project_root_label,
+                            status,
+                        );
                     }
                 }
             });
@@ -315,6 +321,45 @@ impl ProjectIndexBootstrapService {
                 ProjectIndexBootstrapRequest::SpawnFailed
             }
         }
+    }
+
+    fn emit_full_status_if_changed(
+        &self,
+        proxy: &AppEventProxy,
+        project_key: &Path,
+        project_root_label: &str,
+        status: gwt::ProjectIndexStatusView,
+    ) -> bool {
+        let key = normalize_project_root(project_key);
+        if let Ok(mut last) = self.last_full_status.lock() {
+            if last.get(&key) == Some(&status) {
+                tracing::debug!(
+                    target: "gwt::index",
+                    worktree = %project_root_label,
+                    state = %status.state,
+                    "skipping unchanged project index full status broadcast"
+                );
+                return false;
+            }
+            last.insert(key, status.clone());
+        }
+        proxy.send(UserEvent::ProjectIndexStatus {
+            project_root: project_root_label.to_string(),
+            status,
+        });
+        true
+    }
+
+    #[cfg(test)]
+    fn full_status_is_idle_for_test(&self, project_root: &Path) -> bool {
+        let project_key = normalize_project_root(project_root);
+        let full_status_key = IndexInFlightKey::FullStatus {
+            project_root: project_key.clone(),
+        };
+        let retry_key = IndexInFlightKey::FullStatusRetry {
+            project_root: project_key,
+        };
+        !self.is_reserved(&full_status_key) && !self.is_reserved(&retry_key)
     }
 
     pub(crate) fn spawn_with<B, S>(
@@ -646,6 +691,7 @@ pub(crate) fn spawn_per_cell_rebuild_with(
                 }),
                 scopes: gwt::ProjectIndexScopes::default(),
                 worktrees: std::collections::BTreeMap::new(),
+                coverage: None,
             },
         });
 
@@ -1007,6 +1053,61 @@ mod tests {
             full_probe_calls.load(Ordering::SeqCst),
             1,
             "duplicate Settings.Index refresh requests must collapse into the in-flight full refresh"
+        );
+    }
+
+    #[test]
+    fn repeated_full_status_refresh_suppresses_unchanged_status_broadcast() {
+        let service = super::ProjectIndexBootstrapService::new_for_test();
+        let temp = tempdir().expect("tempdir");
+        let expected_project_root = dunce::canonicalize(temp.path())
+            .unwrap_or_else(|_| temp.path().to_path_buf())
+            .display()
+            .to_string();
+        let (proxy, events) = AppEventProxy::stub();
+        let status_probe_calls = Arc::new(AtomicUsize::new(0));
+
+        for _ in 0..2 {
+            let status_probe_calls_for_closure = status_probe_calls.clone();
+            let request = service.spawn_full_status_refresh_with_retry(
+                proxy.clone(),
+                temp.path().to_path_buf(),
+                Arc::new(|_project_root: &Path| Ok(())),
+                Arc::new(move |_project_root: &Path| {
+                    status_probe_calls_for_closure.fetch_add(1, Ordering::SeqCst);
+                    gwt::ProjectIndexStatusView::new(
+                        gwt::ProjectIndexStatusState::Ready,
+                        "unchanged full table",
+                    )
+                }),
+                Duration::from_millis(5),
+            );
+            assert_eq!(request, super::ProjectIndexBootstrapRequest::Spawned);
+            wait_for_project_status_detail(&events, &expected_project_root, "unchanged full table");
+            for _ in 0..100 {
+                if service.full_status_is_idle_for_test(temp.path()) {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            }
+        }
+
+        assert_eq!(status_probe_calls.load(Ordering::SeqCst), 2);
+        let recorded = events.lock().expect("events");
+        let full_status_events = recorded
+            .iter()
+            .filter(|event| {
+                matches!(
+                    event,
+                    UserEvent::ProjectIndexStatus { project_root, status }
+                        if project_root == &expected_project_root
+                            && status.detail == "unchanged full table"
+                )
+            })
+            .count();
+        assert_eq!(
+            full_status_events, 1,
+            "unchanged full status payload should not be re-broadcast"
         );
     }
 

--- a/crates/gwt/src/workspace.rs
+++ b/crates/gwt/src/workspace.rs
@@ -143,8 +143,12 @@ impl WorkspaceState {
         true
     }
 
-    pub fn update_viewport(&mut self, viewport: CanvasViewport) {
+    pub fn update_viewport(&mut self, viewport: CanvasViewport) -> bool {
+        if self.persisted.viewport == viewport {
+            return false;
+        }
         self.persisted.viewport = viewport;
+        true
     }
 
     pub fn arrange_windows(&mut self, mode: ArrangeMode, bounds: WindowGeometry) -> bool {
@@ -1089,11 +1093,12 @@ mod tests {
     #[test]
     fn updating_viewport_replaces_canvas_transform_state() {
         let mut workspace = WorkspaceState::from_persisted(default_workspace_state());
-        workspace.update_viewport(CanvasViewport {
+        let viewport = CanvasViewport {
             x: 180.0,
             y: -90.0,
             zoom: 1.35,
-        });
+        };
+        assert!(workspace.update_viewport(viewport.clone()));
         assert_eq!(
             workspace.persisted().viewport,
             CanvasViewport {
@@ -1101,6 +1106,10 @@ mod tests {
                 y: -90.0,
                 zoom: 1.35
             }
+        );
+        assert!(
+            !workspace.update_viewport(viewport),
+            "same viewport should report no mutation"
         );
     }
 

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1287,7 +1287,24 @@ test("Runtime status updates skip unchanged DOM and dependent surface writes", (
 
 test("Runtime status key covers state detail preset visibility and cleanup", () => {
   const keyBody = extractFunctionBody(appSource, "windowRuntimeStatusRenderKey");
+  assert.match(
+    appSource,
+    /function\s+appendRenderKeyPart\s*\(/,
+    "app.js must expose the primitive render-key append helper",
+  );
+  assert.match(
+    keyBody,
+    /appendRenderKeyPart\s*\(/,
+    "Runtime status key must append primitive fields directly",
+  );
+  assert.doesNotMatch(
+    keyBody,
+    /JSON\.stringify\s*\(/,
+    "Runtime status key must not serialize an object on every window_status event",
+  );
   for (const pattern of [
+    /windowId/,
+    /windowMap\.has\s*\(\s*windowId\s*\)/,
     /runtimeState/,
     /effectiveDetail/,
     /windowData\?\.preset/,

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1079,6 +1079,40 @@ test("Focus class updates touch previous/current elements and keep no-topmost re
   );
 });
 
+test("Workspace visibility classification reuses direct id sets", () => {
+  const renderWorkspaceBody = extractFunctionBody(appSource, "renderWorkspace");
+  assert.match(
+    appSource,
+    /function\s+workspaceWindowIdSet\s*\(/,
+    "app.js must provide a direct-loop active window id set helper",
+  );
+  assert.match(
+    appSource,
+    /function\s+allProjectWindowIdSet\s*\(/,
+    "app.js must provide a direct-loop all-project window id set helper",
+  );
+  assert.doesNotMatch(
+    renderWorkspaceBody,
+    /workspace\.windows\.map\s*\(\s*\(?\s*windowData\s*\)?\s*=>\s*windowData\.id\s*\)/,
+    "renderWorkspace must not allocate an active window id array before classification",
+  );
+  assert.match(
+    renderWorkspaceBody,
+    /const\s+activeWindowIdSet\s*=\s*workspaceWindowIdSet\s*\(\s*workspace\s*\)/,
+    "renderWorkspace must derive active window ids as a Set once",
+  );
+  assert.match(
+    renderWorkspaceBody,
+    /activeWindowIdSet\s*,[\s\S]*allProjectWindowIdSet:\s*allProjectWindowIdSet\s*\(\s*\)/,
+    "renderWorkspace must pass id sets to classifyProjectWindowVisibility",
+  );
+  assert.match(
+    renderWorkspaceBody,
+    /topmostId\s*&&\s*activeWindowIdSet\.has\s*\(\s*topmostId\s*\)/,
+    "renderWorkspace must reuse the active id set for topmost focus membership",
+  );
+});
+
 test("Runtime status updates skip unchanged DOM and dependent surface writes", () => {
   assert.match(
     appSource,

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -343,6 +343,35 @@ test("Project Tabs shell key ignores workspace geometry but includes tab identit
   }
 });
 
+test("Project Tabs shell key avoids JSON stringify allocation", () => {
+  const keyBody = extractFunctionBody(appSource, "projectTabsRenderKey");
+  assert.match(
+    appSource,
+    /function\s+appendRenderKeyPart\s*\(/,
+    "app.js must expose the primitive render-key append helper",
+  );
+  assert.match(
+    keyBody,
+    /appendRenderKeyPart\s*\(/,
+    "Project Tabs shell key must append primitive fields directly",
+  );
+  assert.doesNotMatch(
+    keyBody,
+    /JSON\.stringify\s*\(/,
+    "Project Tabs shell key must not serialize an object graph on every workspace_state",
+  );
+  assert.doesNotMatch(
+    keyBody,
+    /\.map\s*\(/,
+    "Project Tabs shell key must not allocate a mapped tab array",
+  );
+  assert.match(
+    keyBody,
+    /for\s*\(\s*const\s+tab\s+of\s+tabs\s*\)/,
+    "Project Tabs shell key must iterate tabs directly",
+  );
+});
+
 test("hidden project picker does not rebuild Recent Projects on workspace_state", () => {
   const renderProjectPickerBody = extractFunctionBody(appSource, "renderProjectPicker");
   assert.match(

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -738,6 +738,26 @@ test("Window List skips unchanged row rebuilds after updating open state", () =>
 test("Window List render key ignores viewport and includes row shell fields", () => {
   const keyBody = extractFunctionBody(appSource, "windowListRenderKey");
   assert.match(
+    appSource,
+    /function\s+appendRenderKeyPart\s*\(/,
+    "app.js must expose the primitive render-key append helper",
+  );
+  assert.match(
+    keyBody,
+    /appendRenderKeyPart\s*\(/,
+    "Window List key must append primitive fields directly",
+  );
+  assert.doesNotMatch(
+    keyBody,
+    /JSON\.stringify\s*\(/,
+    "Window List key must not serialize an object graph while open",
+  );
+  assert.doesNotMatch(
+    keyBody,
+    /\.map\s*\(/,
+    "Window List key must not allocate mapped arrays while open",
+  );
+  assert.match(
     keyBody,
     /active_tab_id/,
     "Window List key must include active tab identity",

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -808,6 +808,87 @@ test("Focus class updates touch previous/current elements and keep no-topmost re
   );
 });
 
+test("Runtime status updates skip unchanged DOM and dependent surface writes", () => {
+  assert.match(
+    appSource,
+    /const\s+renderedRuntimeStatusKeys\s*=\s*new\s+Map\s*\(/,
+    "app.js must track per-window runtime status render keys",
+  );
+  assert.match(
+    appSource,
+    /function\s+windowRuntimeStatusRenderKey\s*\(/,
+    "app.js must define a runtime status render key helper",
+  );
+
+  const statusBody = extractFunctionBody(appSource, "applyStatus");
+  const keyIndex = statusBody.indexOf(
+    "const nextRuntimeStatusKey = windowRuntimeStatusRenderKey(",
+  );
+  const guardIndex = statusBody.indexOf(
+    "renderedRuntimeStatusKeys.get(windowId) === nextRuntimeStatusKey",
+  );
+  const chipIndex = statusBody.indexOf("chip.classList.remove(");
+  const overlayIndex = statusBody.indexOf("const overlay = element.querySelector");
+  const telemetryIndex = statusBody.indexOf("recomputeOperatorTelemetry");
+  const windowListIndex = statusBody.lastIndexOf("renderWindowList()");
+  const dotsIndex = statusBody.indexOf("refreshProjectTabDots()");
+
+  assert.notEqual(keyIndex, -1, "applyStatus must compute a runtime status key");
+  assert.notEqual(guardIndex, -1, "applyStatus must guard unchanged runtime status");
+  for (const [label, index] of [
+    ["status chip class writes", chipIndex],
+    ["overlay lookup/writes", overlayIndex],
+    ["telemetry recompute", telemetryIndex],
+    ["Window List refresh", windowListIndex],
+    ["project tab dot refresh", dotsIndex],
+  ]) {
+    assert.notEqual(index, -1, `applyStatus must still contain ${label}`);
+    assert.ok(guardIndex < index, `unchanged runtime status must return before ${label}`);
+  }
+  assert.match(
+    statusBody.slice(guardIndex, chipIndex),
+    /return\s*;/,
+    "unchanged runtime status guard must return before DOM/dependent-surface writes",
+  );
+});
+
+test("Runtime status key covers state detail preset visibility and cleanup", () => {
+  const keyBody = extractFunctionBody(appSource, "windowRuntimeStatusRenderKey");
+  for (const pattern of [
+    /runtimeState/,
+    /effectiveDetail/,
+    /windowData\?\.preset/,
+    /shouldShowRuntimeStatus\s*\(/,
+    /mapAgentTelemetryState\s*\(/,
+  ]) {
+    assert.match(keyBody, pattern, `runtime status key must include ${pattern}`);
+  }
+
+  const statusBody = extractFunctionBody(appSource, "applyStatus");
+  const stateMapIndex = statusBody.indexOf("windowRuntimeStateMap.set(windowId, runtimeState);");
+  const effectiveDetailIndex = statusBody.indexOf("const effectiveDetail = detailMap.get(windowId)");
+  const keyIndex = statusBody.indexOf(
+    "const nextRuntimeStatusKey = windowRuntimeStatusRenderKey(",
+  );
+  assert.ok(
+    stateMapIndex !== -1 && stateMapIndex < keyIndex,
+    "applyStatus must update runtime state before computing the status key",
+  );
+  assert.ok(
+    effectiveDetailIndex !== -1 && effectiveDetailIndex < keyIndex,
+    "applyStatus must compute effective detail before the status key",
+  );
+
+  const renderWorkspaceBody = extractFunctionBody(appSource, "renderWorkspace");
+  const cleanupIndex = renderWorkspaceBody.indexOf("renderedRuntimeStatusKeys.delete(windowId);");
+  const removeIndex = renderWorkspaceBody.indexOf("element.remove();");
+  assert.notEqual(cleanupIndex, -1, "window removal must clear runtime status render key");
+  assert.ok(
+    cleanupIndex < removeIndex,
+    "runtime status render key cleanup must happen before element removal",
+  );
+});
+
 test("Sidebar Layers Agents counter filters non-agent preset windows", () => {
   // SPEC-2356 follow-up: recomputeOperatorTelemetry walked windowMap.values()
   // without checking preset, so every workspace window with data-agent-state

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -311,6 +311,92 @@ test("Recent Projects render key ignores workspace state and split menu refreshe
   );
 });
 
+test("viewport-only workspace_state skips unchanged window reconciliation", () => {
+  const renderWorkspaceBody = extractFunctionBody(appSource, "renderWorkspace");
+  assert.match(
+    appSource,
+    /let\s+renderedWorkspaceWindowsKey\s*=/,
+    "app.js must track the last reconciled Workspace Windows shell key",
+  );
+  assert.match(
+    appSource,
+    /function\s+workspaceWindowsRenderKey\s*\(/,
+    "app.js must define a Workspace Windows render key helper",
+  );
+
+  const applyViewportIndex = renderWorkspaceBody.indexOf("applyViewport();");
+  const keyIndex = renderWorkspaceBody.indexOf(
+    "const nextWorkspaceWindowsKey = workspaceWindowsRenderKey(workspace);",
+  );
+  const guardIndex = renderWorkspaceBody.indexOf(
+    "if (renderedWorkspaceWindowsKey === nextWorkspaceWindowsKey)",
+  );
+  const classifyIndex = renderWorkspaceBody.indexOf(
+    "classifyProjectWindowVisibility",
+  );
+  const ensureIndex = renderWorkspaceBody.indexOf("ensureWindow(windowData)");
+  const focusIndex = renderWorkspaceBody.indexOf("focusWindowLocally(topmostId)");
+
+  assert.notEqual(applyViewportIndex, -1, "renderWorkspace must apply viewport");
+  assert.ok(keyIndex > applyViewportIndex, "window key guard must run after viewport");
+  assert.ok(guardIndex > keyIndex, "renderWorkspace must guard on the window key");
+  assert.ok(
+    guardIndex < classifyIndex && guardIndex < ensureIndex && guardIndex < focusIndex,
+    "unchanged window key must return before reconciliation and focus activation",
+  );
+  assert.match(
+    renderWorkspaceBody.slice(guardIndex, classifyIndex),
+    /return\s*;/,
+    "unchanged window key guard must return before reconciliation",
+  );
+});
+
+test("Workspace Windows render key ignores viewport and includes window shell fields", () => {
+  const keyBody = extractFunctionBody(appSource, "workspaceWindowsRenderKey");
+  assert.match(
+    keyBody,
+    /active_tab_id/,
+    "Workspace Windows key must include active tab identity",
+  );
+  assert.match(
+    keyBody,
+    /allProjectWindowIds\s*\(\s*\)/,
+    "Workspace Windows key must include all project window ids for stale mounted window cleanup",
+  );
+  for (const field of [
+    "id",
+    "preset",
+    "title",
+    "dynamic_title",
+    "dynamic_title_detail",
+    "purpose_title",
+    "agent_id",
+    "agent_color",
+    "status",
+    "geometry",
+    "x",
+    "y",
+    "width",
+    "height",
+    "minimized",
+    "maximized",
+    "z_index",
+    "tab_group_id",
+    "tab_group_active",
+  ]) {
+    assert.match(
+      keyBody,
+      new RegExp(`\\b${field}\\b`),
+      `Workspace Windows key must include ${field}`,
+    );
+  }
+  assert.doesNotMatch(
+    keyBody,
+    /\bviewport\b/,
+    "Workspace Windows key must ignore viewport-only state",
+  );
+});
+
 test("Sidebar Layers Agents counter filters non-agent preset windows", () => {
   // SPEC-2356 follow-up: recomputeOperatorTelemetry walked windowMap.values()
   // without checking preset, so every workspace window with data-agent-state

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -179,6 +179,51 @@ test("project bar and command palette expose Start Work outside the Branches sur
   );
 });
 
+test("Start Work command opens a pending wizard before backend state arrives", () => {
+  const commandCase = appSource.match(
+    /case\s+"start-work":[\s\S]*?case\s+"theme-cycle"/,
+  );
+  assert.ok(commandCase, "expected Start Work command case");
+  assert.match(
+    commandCase[0],
+    /openStartWorkPendingWizard\(\)[\s\S]*?kind:\s*"open_start_work"/,
+    "expected Start Work to render a local pending wizard before sending open_start_work",
+  );
+  assert.match(
+    appSource,
+    /let\s+launchWizardOpening\s*=\s*null/,
+    "expected local pending wizard state",
+  );
+  assert.match(
+    appSource,
+    /if\s*\(!launchWizard\s*&&\s*!launchWizardOpenError\s*&&\s*!launchWizardOpening\)/,
+    "renderLaunchWizard must keep the modal open for local pending Start Work state",
+  );
+});
+
+test("Start Work pending wizard clears when backend state, error, or local close wins", () => {
+  assert.match(
+    appSource,
+    /function\s+clearLaunchWizardOpening\(\)\s*\{[\s\S]{0,120}?launchWizardOpening\s*=\s*null/,
+    "expected a helper that clears pending open state",
+  );
+  assert.match(
+    appSource,
+    /function\s+closeLaunchWizardLocal\(\)[\s\S]{0,260}?clearLaunchWizardOpening\(\)/,
+    "local wizard close must clear pending open state",
+  );
+  assert.match(
+    appSource,
+    /case\s+"launch_wizard_open_error":[\s\S]{0,900}?clearLaunchWizardOpening\(\)[\s\S]{0,240}?launchWizardOpenError\s*=/,
+    "backend open errors must replace pending open state",
+  );
+  assert.match(
+    appSource,
+    /case\s+"launch_wizard_state":[\s\S]{0,900}?clearLaunchWizardOpening\(\)[\s\S]{0,260}?launchWizard\s*=\s*event\.wizard/,
+    "backend wizard state must replace pending open state",
+  );
+});
+
 test("frontend handles active work projection as status-strip telemetry", () => {
   assert.match(
     appSource,

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -351,6 +351,45 @@ test("viewport-only workspace_state skips unchanged window reconciliation", () =
   );
 });
 
+test("maximized viewport sync is coalesced across unchanged workspace_state events", () => {
+  const renderWorkspaceBody = extractFunctionBody(appSource, "renderWorkspace");
+  const schedulerBody = extractFunctionBody(
+    appSource,
+    "scheduleMaximizedWindowsToViewportSync",
+  );
+
+  assert.match(
+    appSource,
+    /let\s+maximizedViewportSyncFrame\s*=\s*null\s*;/,
+    "app.js must track a pending maximized viewport sync frame",
+  );
+  assert.match(
+    schedulerBody,
+    /if\s*\(\s*maximizedViewportSyncFrame\s*!==\s*null\s*\)[\s\S]*?return\s*;/,
+    "maximized viewport sync scheduler must coalesce duplicate pending requests",
+  );
+  assert.match(
+    schedulerBody,
+    /maximizedViewportSyncFrame\s*=\s*requestAnimationFrame\s*\(\s*\(\s*\)\s*=>\s*\{/,
+    "maximized viewport sync scheduler must own the animation-frame reservation",
+  );
+  assert.match(
+    schedulerBody,
+    /maximizedViewportSyncFrame\s*=\s*null\s*;[\s\S]*?syncMaximizedWindowsToViewport\s*\(\s*\)/,
+    "maximized viewport sync scheduler must clear the pending handle before running the existing sync body",
+  );
+  assert.match(
+    renderWorkspaceBody,
+    /scheduleMaximizedWindowsToViewportSync\s*\(\s*\)/,
+    "renderWorkspace must route maximized sync through the coalesced scheduler",
+  );
+  assert.doesNotMatch(
+    renderWorkspaceBody,
+    /requestAnimationFrame\s*\(\s*syncMaximizedWindowsToViewport\s*\)/,
+    "renderWorkspace must not schedule raw maximized sync frames per workspace_state",
+  );
+});
+
 test("clamped no-op zoom returns before local viewport apply and persist work", () => {
   const zoomBody = extractFunctionBody(appSource, "zoomCanvasAt");
   assert.match(

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -45,7 +45,23 @@ function terminalOptionNumber(name) {
 function extractFunctionBody(source, name) {
   const start = source.indexOf(`function ${name}(`);
   assert.notEqual(start, -1, `expected function ${name} in source`);
-  const open = source.indexOf("{", start);
+  const paramsOpen = source.indexOf("(", start);
+  assert.notEqual(paramsOpen, -1, `expected function ${name} parameters`);
+  let parenDepth = 0;
+  let paramsClose = -1;
+  for (let i = paramsOpen; i < source.length; i += 1) {
+    const char = source[i];
+    if (char === "(") parenDepth += 1;
+    if (char === ")") {
+      parenDepth -= 1;
+      if (parenDepth === 0) {
+        paramsClose = i;
+        break;
+      }
+    }
+  }
+  assert.notEqual(paramsClose, -1, `expected function ${name} parameter close`);
+  const open = source.indexOf("{", paramsClose);
   assert.notEqual(open, -1, `expected function ${name} body`);
   let depth = 0;
   for (let i = open; i < source.length; i += 1) {
@@ -369,6 +385,40 @@ test("Project Tabs shell key avoids JSON stringify allocation", () => {
     keyBody,
     /for\s*\(\s*const\s+tab\s+of\s+tabs\s*\)/,
     "Project Tabs shell key must iterate tabs directly",
+  );
+});
+
+test("Project Tabs renderer avoids mapped selector snapshots on tab switches", () => {
+  const renderBody = extractFunctionBody(projectTabsRendererSource, "renderProjectTabs");
+  assert.doesNotMatch(
+    renderBody,
+    /nextTabs\.map\s*\(/,
+    "Project Tabs renderer must not allocate a mapped tab id source",
+  );
+  assert.doesNotMatch(
+    renderBody,
+    /querySelectorAll\s*\(/,
+    "Project Tabs renderer hot path must walk existing child buttons directly",
+  );
+  assert.doesNotMatch(
+    renderBody,
+    /Array\.from\s*\(/,
+    "Project Tabs renderer must not snapshot child buttons into an array",
+  );
+  assert.doesNotMatch(
+    renderBody,
+    /nextTabs\.forEach\s*\(/,
+    "Project Tabs renderer must not allocate a per-render callback for tab ordering",
+  );
+  assert.match(
+    renderBody,
+    /for\s*\(\s*let\s+index\s*=\s*0;\s*index\s*<\s*nextTabs\.length;\s*index\s*\+=\s*1\s*\)/,
+    "Project Tabs renderer must update tabs with an indexed direct loop",
+  );
+  assert.match(
+    renderBody,
+    /projectTabs\.children/,
+    "Project Tabs renderer must reuse the live child collection for stale cleanup and ordering",
   );
 });
 

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -211,6 +211,91 @@ test("workspace_state hot path leaves Active Work overview redraw to active_work
   );
 });
 
+test("Board workspace id sync avoids stringify and reuses active Work id cache", () => {
+  const renderAppStateBody = extractFunctionBody(appSource, "renderAppState");
+  assert.match(
+    appSource,
+    /let\s+currentProjectWorkspaceKey\s*=/,
+    "app.js must track a stable key for the current Board workspace id set",
+  );
+  assert.match(
+    appSource,
+    /let\s+activeWorkProjectionWorkspaceIds\s*=/,
+    "app.js must cache active Work projection workspace ids",
+  );
+  assert.match(
+    appSource,
+    /function\s+syncCurrentProjectWorkspaceIds\s*\(/,
+    "app.js must centralize Board workspace id synchronization",
+  );
+  assert.doesNotMatch(
+    renderAppStateBody,
+    /JSON\.stringify\s*\(/,
+    "workspace_state renderAppState must not serialize workspace id arrays for Board sync",
+  );
+  assert.match(
+    renderAppStateBody,
+    /syncCurrentProjectWorkspaceIds\s*\(\s*deriveCurrentProjectWorkspaceIds\s*\(\s*tab\?\.workspace\s*\|\|\s*\{\}\s*\)\s*,?\s*\)/,
+    "renderAppState must route Board workspace id updates through the shared sync helper",
+  );
+
+  const deriveBody = extractFunctionBody(appSource, "deriveCurrentProjectWorkspaceIds");
+  const cachedProjectionIndex = deriveBody.indexOf("activeWorkProjectionWorkspaceIds");
+  const workspaceAgentsIndex = deriveBody.indexOf("workspaceState?.workspace?.agents");
+  assert.ok(
+    cachedProjectionIndex >= 0,
+    "deriveCurrentProjectWorkspaceIds must read cached active Work projection ids",
+  );
+  assert.ok(
+    workspaceAgentsIndex >= 0,
+    "deriveCurrentProjectWorkspaceIds must keep the workspace-agent fallback",
+  );
+  assert.ok(
+    cachedProjectionIndex < workspaceAgentsIndex,
+    "cached active Work projection ids must be used before walking workspace agents",
+  );
+  assert.doesNotMatch(
+    deriveBody,
+    /activeWorkProjection\.active_works\.map/,
+    "workspace_state id derivation must not remap active_work_projection on every render",
+  );
+
+  const receiveBody = extractFunctionBody(appSource, "receive");
+  const activeProjectionCase = receiveBody.match(
+    /case\s+"active_work_projection":[\s\S]*?break;/,
+  );
+  assert.ok(activeProjectionCase, "expected active_work_projection receive case");
+  const cacheIndex = activeProjectionCase[0].indexOf(
+    "cacheActiveWorkProjectionWorkspaceIds(activeWorkProjection)",
+  );
+  const syncIndex = activeProjectionCase[0].indexOf("syncCurrentProjectWorkspaceIds(");
+  assert.ok(
+    cacheIndex >= 0,
+    "active_work_projection must update the cached active Work id set",
+  );
+  assert.ok(
+    syncIndex > cacheIndex,
+    "active_work_projection must sync Board ids after refreshing the cache",
+  );
+  assert.doesNotMatch(
+    activeProjectionCase[0],
+    /currentProjectWorkspaceId\s*=\s*deriveCurrentProjectWorkspaceIds/,
+    "active_work_projection must not bypass the shared sync helper",
+  );
+
+  const syncBody = extractFunctionBody(appSource, "syncCurrentProjectWorkspaceIds");
+  assert.match(
+    syncBody,
+    /workIdsKey\s*\(/,
+    "sync helper must compare stable Board workspace id keys",
+  );
+  assert.match(
+    syncBody,
+    /refreshBoardCurrentWorkspaceId\s*\(\s*\)/,
+    "sync helper must still refresh Board states when the id set changes",
+  );
+});
+
 test("workspace_state hot path gates Project Tabs redraw by tab shell key", () => {
   const renderAppStateBody = extractFunctionBody(appSource, "renderAppState");
   assert.match(

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -211,6 +211,53 @@ test("workspace_state hot path leaves Active Work overview redraw to active_work
   );
 });
 
+test("workspace_state hot path gates Project Tabs redraw by tab shell key", () => {
+  const renderAppStateBody = extractFunctionBody(appSource, "renderAppState");
+  assert.match(
+    appSource,
+    /let\s+renderedProjectTabsKey\s*=/,
+    "app.js must track the last rendered Project Tabs shell key",
+  );
+  assert.match(
+    appSource,
+    /function\s+projectTabsRenderKey\s*\(/,
+    "app.js must define a Project Tabs shell key helper",
+  );
+  assert.match(
+    renderAppStateBody,
+    /projectTabsRenderKey\s*\(\s*appState\s*\)/,
+    "renderAppState must derive the next Project Tabs shell key from appState",
+  );
+  assert.match(
+    renderAppStateBody,
+    /renderedProjectTabsKey[\s\S]*!==[\s\S]*nextProjectTabsKey[\s\S]*renderProjectTabs\(\)/,
+    "renderAppState must redraw Project Tabs only when the shell key changes",
+  );
+});
+
+test("Project Tabs shell key ignores workspace geometry but includes tab identity", () => {
+  const keyBody = extractFunctionBody(appSource, "projectTabsRenderKey");
+  assert.match(
+    keyBody,
+    /active_tab_id/,
+    "Project Tabs shell key must include active_tab_id",
+  );
+  for (const field of ["id", "title", "project_root"]) {
+    assert.match(
+      keyBody,
+      new RegExp(`\\b${field}\\b`),
+      `Project Tabs shell key must include tab ${field}`,
+    );
+  }
+  for (const workspaceField of ["workspace", "windows", "geometry", "viewport"]) {
+    assert.doesNotMatch(
+      keyBody,
+      new RegExp(`\\b${workspaceField}\\b`),
+      `Project Tabs shell key must ignore ${workspaceField}`,
+    );
+  }
+});
+
 test("Sidebar Layers Agents counter filters non-agent preset windows", () => {
   // SPEC-2356 follow-up: recomputeOperatorTelemetry walked windowMap.values()
   // without checking preset, so every workspace window with data-agent-state

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1052,8 +1052,13 @@ test("Per-window render key covers DOM shell fields and removal cleanup", () => 
   );
   assert.match(
     keyBody,
-    /windowTabsFor\s*\(/,
-    "per-window key must include tab strip inputs",
+    /windowGroupId\s*\(\s*windowData\s*\)/,
+    "per-window key must derive the tab group for tab strip inputs",
+  );
+  assert.match(
+    keyBody,
+    /appendRenderKeyPart\s*\(/,
+    "per-window key must append primitive key fields directly",
   );
   assert.match(
     keyBody,
@@ -1085,6 +1090,8 @@ test("Per-window render key covers DOM shell fields and removal cleanup", () => 
     "z_index",
     "tab_group_id",
     "tab_group_active",
+    "maximized_fill",
+    "tabs",
   ]) {
     assert.match(
       keyBody,
@@ -1101,6 +1108,53 @@ test("Per-window render key covers DOM shell fields and removal cleanup", () => 
     cleanupIndex < removeIndex,
     "per-window render key cleanup must happen before element removal",
   );
+});
+
+test("Per-window render key avoids JSON stringify and mapped tab allocation", () => {
+  const keyBody = extractFunctionBody(appSource, "windowElementRenderKey");
+  assert.doesNotMatch(
+    keyBody,
+    /JSON\.stringify\s*\(/,
+    "per-window key must not serialize an object graph for each changed window",
+  );
+  assert.doesNotMatch(
+    keyBody,
+    /windowTabsFor\s*\(\s*windowData\s*\)\.map\s*\(/,
+    "per-window key must not allocate a mapped tab shell array",
+  );
+  assert.doesNotMatch(
+    keyBody,
+    /windowTabsFor\s*\(\s*windowData\s*\)/,
+    "per-window key must avoid allocating a filtered tab array",
+  );
+  assert.match(
+    keyBody,
+    /for\s*\(\s*const\s+tab\s+of\s+activeWorkspace\s*\(\s*\)\.windows\s*\|\|\s*\[\]\s*\)/,
+    "per-window key must iterate workspace tab candidates directly",
+  );
+  assert.match(
+    keyBody,
+    /windowGroupId\s*\(\s*tab\s*\)\s*!==\s*tabGroupId[\s\S]+continue\s*;/,
+    "per-window key must keep only tabs in the same group",
+  );
+  for (const field of [
+    "runtime_state",
+    "detail",
+    "display_title",
+    "title_tooltip",
+    "role_badge",
+    "geometry_revision",
+    "maximized_fill",
+    "tabs",
+    "tab_group_id",
+    "tab_group_active",
+  ]) {
+    assert.match(
+      keyBody,
+      new RegExp(`\\b${field}\\b`),
+      `per-window primitive key must keep ${field}`,
+    );
+  }
 });
 
 test("Focus class updates skip unchanged focus and avoid all-window scans", () => {

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -889,6 +889,86 @@ test("Runtime status key covers state detail preset visibility and cleanup", () 
   );
 });
 
+test("Operator telemetry skips unchanged counts before DOM writes", () => {
+  assert.match(
+    appSource,
+    /let\s+renderedOperatorTelemetryKey\s*=\s*""/,
+    "app.js must track the last rendered telemetry counts key",
+  );
+  assert.match(
+    appSource,
+    /function\s+operatorTelemetryRenderKey\s*\(/,
+    "app.js must define a telemetry counts key helper",
+  );
+  assert.match(
+    appSource,
+    /function\s+applyOperatorTelemetryCounts\s*\(/,
+    "app.js must route telemetry DOM writes through a guarded helper",
+  );
+
+  const helperBody = extractFunctionBody(appSource, "applyOperatorTelemetryCounts");
+  const keyIndex = helperBody.indexOf("const nextOperatorTelemetryKey = operatorTelemetryRenderKey(counts);");
+  const guardIndex = helperBody.indexOf(
+    "renderedOperatorTelemetryKey === nextOperatorTelemetryKey",
+  );
+  const applyIndex = helperBody.indexOf("window.__operatorShell.applyTelemetryCounts(counts)");
+  const storeIndex = helperBody.indexOf("renderedOperatorTelemetryKey = nextOperatorTelemetryKey");
+
+  assert.notEqual(keyIndex, -1, "telemetry helper must compute a stable key");
+  assert.ok(guardIndex > keyIndex, "telemetry helper must guard after key computation");
+  assert.ok(
+    guardIndex < applyIndex,
+    "unchanged telemetry counts must return before applyTelemetryCounts DOM writes",
+  );
+  assert.ok(
+    applyIndex < storeIndex,
+    "telemetry key should be stored after applyTelemetryCounts succeeds",
+  );
+  assert.match(
+    helperBody.slice(guardIndex, applyIndex),
+    /return\s*;/,
+    "unchanged telemetry guard must return before DOM writes",
+  );
+});
+
+test("Operator telemetry key covers status strip fields and branch telemetry uses guard", () => {
+  const keyBody = extractFunctionBody(appSource, "operatorTelemetryRenderKey");
+  for (const field of [
+    "active",
+    "idle",
+    "blocked",
+    "done",
+    "agents",
+    "branches",
+    "git",
+    "hooks",
+    "layers",
+  ]) {
+    assert.match(
+      keyBody,
+      new RegExp(`\\b${field}\\b`),
+      `telemetry key must include ${field}`,
+    );
+  }
+
+  const telemetryBody = extractFunctionBody(appSource, "recomputeOperatorTelemetry");
+  assert.match(
+    telemetryBody,
+    /applyOperatorTelemetryCounts\s*\(\s*counts\s*\)/,
+    "runtime telemetry must use the guarded telemetry helper",
+  );
+  assert.doesNotMatch(
+    telemetryBody,
+    /applyTelemetryCounts\s*\(\s*counts\s*\)/,
+    "runtime telemetry must not call applyTelemetryCounts directly",
+  );
+  assert.match(
+    appSource,
+    /case\s+"branch_entries"[\s\S]+applyOperatorTelemetryCounts\s*\(\s*\{\s*branches:\s*branchesCount,\s*git:\s*branchesCount,\s*\}\s*\)/,
+    "branch telemetry must use the guarded telemetry helper",
+  );
+});
+
 test("Sidebar Layers Agents counter filters non-agent preset windows", () => {
   // SPEC-2356 follow-up: recomputeOperatorTelemetry walked windowMap.values()
   // without checking preset, so every workspace window with data-agent-state

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -258,6 +258,59 @@ test("Project Tabs shell key ignores workspace geometry but includes tab identit
   }
 });
 
+test("hidden project picker does not rebuild Recent Projects on workspace_state", () => {
+  const renderProjectPickerBody = extractFunctionBody(appSource, "renderProjectPicker");
+  assert.match(
+    appSource,
+    /let\s+renderedRecentProjectsKey\s*=/,
+    "app.js must track the visible picker Recent Projects render key",
+  );
+  assert.match(
+    appSource,
+    /let\s+renderedRecentProjectsMenuKey\s*=/,
+    "app.js must track the split-menu Recent Projects render key separately",
+  );
+  assert.match(
+    appSource,
+    /function\s+recentProjectsRenderKey\s*\(/,
+    "app.js must define a Recent Projects render key helper",
+  );
+  assert.match(
+    renderProjectPickerBody,
+    /if\s*\(\s*shouldShow\s*\)[\s\S]*renderRecentProjects\(\)/,
+    "renderProjectPicker must render Recent Projects only when the picker is visible",
+  );
+  assert.doesNotMatch(
+    renderProjectPickerBody.replace(/if\s*\(\s*shouldShow\s*\)[\s\S]*?renderRecentProjects\(\)\s*;?/, ""),
+    /renderRecentProjects\(\)/,
+    "renderProjectPicker must not also call renderRecentProjects unconditionally",
+  );
+});
+
+test("Recent Projects render key ignores workspace state and split menu refreshes on open", () => {
+  const keyBody = extractFunctionBody(appSource, "recentProjectsRenderKey");
+  for (const field of ["title", "kind", "path"]) {
+    assert.match(
+      keyBody,
+      new RegExp(`\\b${field}\\b`),
+      `Recent Projects key must include ${field}`,
+    );
+  }
+  for (const workspaceField of ["workspace", "windows", "geometry", "viewport"]) {
+    assert.doesNotMatch(
+      keyBody,
+      new RegExp(`\\b${workspaceField}\\b`),
+      `Recent Projects key must ignore ${workspaceField}`,
+    );
+  }
+  const openMenuBody = extractFunctionBody(appSource, "openOpenProjectMenu");
+  assert.match(
+    openMenuBody,
+    /renderRecentProjectsIntoMenu\s*\(\s*\{\s*force:\s*true\s*\}\s*\)/,
+    "Open Project split menu must force-refresh Recent Projects from current appState when opened",
+  );
+});
+
 test("Sidebar Layers Agents counter filters non-agent preset windows", () => {
   // SPEC-2356 follow-up: recomputeOperatorTelemetry walked windowMap.values()
   // without checking preset, so every workspace window with data-agent-state

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -764,8 +764,11 @@ test("Per-window renderer guards unchanged DOM writes after mount and preset syn
     "if (renderedWindowElementKeys.get(windowData.id) === nextWindowElementKey)",
   );
   const storeIndex = ensureWindowBody.indexOf(
-    "renderedWindowElementKeys.set(windowData.id, windowElementRenderKey(windowData));",
+    "renderedWindowElementKeys.set(windowData.id, nextWindowElementKey);",
   );
+  const renderKeyCalls = [
+    ...ensureWindowBody.matchAll(/windowElementRenderKey\(windowData\)/g),
+  ];
   const titleIndex = ensureWindowBody.indexOf(".title-text");
   const roleBadgeIndex = ensureWindowBody.indexOf("setWindowRoleBadge");
   const tabsIndex = ensureWindowBody.indexOf("renderWindowTabs");
@@ -778,6 +781,11 @@ test("Per-window renderer guards unchanged DOM writes after mount and preset syn
   assert.notEqual(mountIndex, -1, "ensureWindow must keep preset/body mount logic");
   assert.ok(keyIndex > mountIndex, "per-window key must run after preset/body mounting");
   assert.ok(guardIndex > keyIndex, "ensureWindow must guard on the per-window key");
+  assert.equal(
+    renderKeyCalls.length,
+    1,
+    "ensureWindow must reuse the computed per-window key instead of recomputing it",
+  );
   for (const [label, index] of [
     ["title", titleIndex],
     ["role badge", roleBadgeIndex],
@@ -794,6 +802,11 @@ test("Per-window renderer guards unchanged DOM writes after mount and preset syn
       `unchanged per-window key must return before ${label} writes`,
     );
   }
+  assert.notEqual(
+    storeIndex,
+    -1,
+    "ensureWindow must store the previously computed per-window key",
+  );
   assert.ok(
     statusIndex < storeIndex,
     "ensureWindow must store changed keys after status/detail normalization",

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -758,6 +758,56 @@ test("Per-window render key covers DOM shell fields and removal cleanup", () => 
   );
 });
 
+test("Focus class updates skip unchanged focus and avoid all-window scans", () => {
+  const focusBody = extractFunctionBody(appSource, "focusWindowLocally");
+  assert.match(
+    focusBody,
+    /const\s+targetElement\s*=\s*windowMap\.get\s*\(\s*windowId\s*\)/,
+    "focusWindowLocally must resolve the requested window directly",
+  );
+  assert.match(
+    focusBody,
+    /focusedId\s*===\s*windowId[\s\S]+targetElement\?\.classList\.contains\s*\(\s*"focused"\s*\)[\s\S]+return\s*;/,
+    "focusWindowLocally must return when focus is unchanged and the class is already applied",
+  );
+  assert.doesNotMatch(
+    focusBody,
+    /windowMap\.entries\s*\(/,
+    "focusWindowLocally must not scan every mounted window",
+  );
+});
+
+test("Focus class updates touch previous/current elements and keep no-topmost reset", () => {
+  const focusBody = extractFunctionBody(appSource, "focusWindowLocally");
+  assert.match(
+    focusBody,
+    /const\s+previousFocusedId\s*=\s*focusedId/,
+    "focusWindowLocally must remember the previous focused window",
+  );
+  assert.match(
+    focusBody,
+    /focusedId\s*=\s*windowId/,
+    "focusWindowLocally must update focusedId to the requested window",
+  );
+  assert.match(
+    focusBody,
+    /previousFocusedId\s*!==\s*windowId[\s\S]+previousElement\?\.classList\.remove\s*\(\s*"focused"\s*\)/,
+    "focusWindowLocally must remove focus from the previous element only",
+  );
+  assert.match(
+    focusBody,
+    /targetElement\.classList\.add\s*\(\s*"focused"\s*\)/,
+    "focusWindowLocally must add focus to the requested element",
+  );
+
+  const renderWorkspaceBody = extractFunctionBody(appSource, "renderWorkspace");
+  assert.match(
+    renderWorkspaceBody,
+    /focusedId\s*=\s*null\s*;/,
+    "renderWorkspace must still clear focusedId when no topmost active window exists",
+  );
+});
+
 test("Sidebar Layers Agents counter filters non-agent preset windows", () => {
   // SPEC-2356 follow-up: recomputeOperatorTelemetry walked windowMap.values()
   // without checking preset, so every workspace window with data-agent-state

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -889,6 +889,44 @@ test("Runtime status key covers state detail preset visibility and cleanup", () 
   );
 });
 
+test("Terminal output decode is deferred out of the receive path", () => {
+  const batcherConfig = appSource.match(
+    /const\s+terminalOutputBatcher\s*=\s*createTerminalOutputBatcher\(\{([\s\S]*?)\n\s{6}\}\);/,
+  );
+  assert.ok(batcherConfig, "app.js must configure the terminal output batcher");
+  assert.match(
+    batcherConfig[1],
+    /mergeChunks:\s*\(\s*chunks\s*,\s*windowId\s*\)/,
+    "terminal output batcher must merge encoded chunks during scheduled flush",
+  );
+  assert.match(
+    batcherConfig[1],
+    /decoderMap\.get\s*\(\s*windowId\s*\)/,
+    "flush merge must use the per-window TextDecoder",
+  );
+  assert.match(
+    batcherConfig[1],
+    /chunks\s*\.\s*map[\s\S]*decodeBase64\s*\(\s*chunk\s*\)/,
+    "flush merge must decode each encoded chunk in order",
+  );
+
+  const writeOutputBody = extractFunctionBody(appSource, "writeOutput");
+  assert.match(
+    writeOutputBody,
+    /terminalOutputBatcher\.enqueue\(\s*windowId,\s*base64\s*\)/,
+    "ready terminal output must enqueue encoded chunks without eager decode",
+  );
+  const readyEnqueueIndex = writeOutputBody.indexOf(
+    "terminalOutputBatcher.enqueue(",
+  );
+  const readyPath = writeOutputBody.slice(readyEnqueueIndex);
+  assert.doesNotMatch(
+    readyPath,
+    /decoder\.decode\s*\(|decodeBase64\s*\(/,
+    "writeOutput ready path must not decode before the scheduled flush",
+  );
+});
+
 test("Operator telemetry skips unchanged counts before DOM writes", () => {
   assert.match(
     appSource,

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -42,6 +42,25 @@ function terminalOptionNumber(name) {
   return Number(match[1]);
 }
 
+function extractFunctionBody(source, name) {
+  const start = source.indexOf(`function ${name}(`);
+  assert.notEqual(start, -1, `expected function ${name} in source`);
+  const open = source.indexOf("{", start);
+  assert.notEqual(open, -1, `expected function ${name} body`);
+  let depth = 0;
+  for (let i = open; i < source.length; i += 1) {
+    const char = source[i];
+    if (char === "{") depth += 1;
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(open + 1, i);
+      }
+    }
+  }
+  assert.fail(`unterminated function ${name}`);
+}
+
 // SPEC-2356 — extract every @media block matching the supplied condition,
 // using brace-depth tracking so nested rules don't truncate the body.
 function extractMediaBlocks(css, condition) {
@@ -159,6 +178,36 @@ test("frontend handles active work projection as status-strip telemetry", () => 
     appSource,
     /counts\.branches[\s\S]+activeWorks\.length/,
     "expected Status Strip Work telemetry to count active Works, not only branch-list rows",
+  );
+});
+
+test("workspace_state hot path leaves Active Work overview redraw to active_work_projection", () => {
+  const renderAppStateBody = extractFunctionBody(appSource, "renderAppState");
+  assert.doesNotMatch(
+    renderAppStateBody,
+    /renderActiveWorkOverview\s*\(/,
+    "workspace_state renderAppState must not rebuild Active Work overview DOM",
+  );
+
+  const receiveBody = extractFunctionBody(appSource, "receive");
+  const activeProjectionCase = receiveBody.match(
+    /case\s+"active_work_projection":[\s\S]*?break;/,
+  );
+  assert.ok(activeProjectionCase, "expected active_work_projection receive case");
+  assert.match(
+    activeProjectionCase[0],
+    /activeWorkProjection\s*=\s*event\.projection/,
+    "active_work_projection must still own the projection state",
+  );
+  assert.match(
+    activeProjectionCase[0],
+    /renderActiveWorkOverview\(\);/,
+    "active_work_projection must redraw Active Work overview immediately",
+  );
+  assert.match(
+    activeProjectionCase[0],
+    /workspaceOverviewSurface\.renderWindows\(\);/,
+    "active_work_projection must still refresh Workspace Overview windows",
   );
 });
 

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -631,6 +631,133 @@ test("Static project chrome keys ignore workspace geometry and include visible t
   }
 });
 
+test("Per-window renderer guards unchanged DOM writes after mount and preset sync", () => {
+  assert.match(
+    appSource,
+    /const\s+renderedWindowElementKeys\s*=\s*new\s+Map\s*\(/,
+    "app.js must track per-window element render keys",
+  );
+  assert.match(
+    appSource,
+    /function\s+windowElementRenderKey\s*\(/,
+    "app.js must define a per-window element render key helper",
+  );
+
+  const ensureWindowBody = extractFunctionBody(appSource, "ensureWindow");
+  const mountIndex = ensureWindowBody.indexOf("mountWindowBody(windowData, element);");
+  const keyIndex = ensureWindowBody.indexOf(
+    "const nextWindowElementKey = windowElementRenderKey(windowData);",
+  );
+  const guardIndex = ensureWindowBody.indexOf(
+    "if (renderedWindowElementKeys.get(windowData.id) === nextWindowElementKey)",
+  );
+  const storeIndex = ensureWindowBody.indexOf(
+    "renderedWindowElementKeys.set(windowData.id, windowElementRenderKey(windowData));",
+  );
+  const titleIndex = ensureWindowBody.indexOf(".title-text");
+  const roleBadgeIndex = ensureWindowBody.indexOf("setWindowRoleBadge");
+  const tabsIndex = ensureWindowBody.indexOf("renderWindowTabs");
+  const agentColorIndex = ensureWindowBody.indexOf("agentColor");
+  const classIndex = ensureWindowBody.indexOf('classList.toggle("minimized"');
+  const styleIndex = ensureWindowBody.indexOf("element.style.zIndex");
+  const statusIndex = ensureWindowBody.indexOf("applyStatus");
+  const fitIndex = ensureWindowBody.indexOf("fitTerminal");
+
+  assert.notEqual(mountIndex, -1, "ensureWindow must keep preset/body mount logic");
+  assert.ok(keyIndex > mountIndex, "per-window key must run after preset/body mounting");
+  assert.ok(guardIndex > keyIndex, "ensureWindow must guard on the per-window key");
+  for (const [label, index] of [
+    ["title", titleIndex],
+    ["role badge", roleBadgeIndex],
+    ["tab strip", tabsIndex],
+    ["agent color", agentColorIndex],
+    ["class", classIndex],
+    ["style", styleIndex],
+    ["status", statusIndex],
+    ["terminal fit", fitIndex],
+  ]) {
+    assert.notEqual(index, -1, `ensureWindow must still contain ${label} writes`);
+    assert.ok(
+      guardIndex < index,
+      `unchanged per-window key must return before ${label} writes`,
+    );
+  }
+  assert.ok(
+    statusIndex < storeIndex,
+    "ensureWindow must store changed keys after status/detail normalization",
+  );
+  assert.match(
+    ensureWindowBody.slice(guardIndex, titleIndex),
+    /return\s*;/,
+    "unchanged per-window key guard must return before window DOM writes",
+  );
+});
+
+test("Per-window render key covers DOM shell fields and removal cleanup", () => {
+  const keyBody = extractFunctionBody(appSource, "windowElementRenderKey");
+  assert.match(
+    keyBody,
+    /windowDisplayTitle\s*\(/,
+    "per-window key must include displayed title",
+  );
+  assert.match(
+    keyBody,
+    /windowTitleTooltip\s*\(/,
+    "per-window key must include title tooltip",
+  );
+  assert.match(
+    keyBody,
+    /windowTabsFor\s*\(/,
+    "per-window key must include tab strip inputs",
+  );
+  assert.match(
+    keyBody,
+    /detailMap\.get\s*\(\s*windowData\.id\s*\)/,
+    "per-window key must include status detail text",
+  );
+  assert.match(
+    keyBody,
+    /maximizedGeometry\s*\(\s*visibleBounds\s*\(\s*\)\s*,\s*viewport\.zoom\s*\)/,
+    "per-window key must include viewport-relative maximized fill",
+  );
+  for (const field of [
+    "id",
+    "preset",
+    "title",
+    "dynamic_title",
+    "dynamic_title_detail",
+    "purpose_title",
+    "agent_id",
+    "agent_color",
+    "status",
+    "geometry",
+    "x",
+    "y",
+    "width",
+    "height",
+    "minimized",
+    "maximized",
+    "z_index",
+    "tab_group_id",
+    "tab_group_active",
+  ]) {
+    assert.match(
+      keyBody,
+      new RegExp(`\\b${field}\\b`),
+      `per-window key must include ${field}`,
+    );
+  }
+
+  const renderWorkspaceBody = extractFunctionBody(appSource, "renderWorkspace");
+  const cleanupIndex = renderWorkspaceBody.indexOf("renderedWindowElementKeys.delete(windowId);");
+  const removeIndex = renderWorkspaceBody.indexOf("element.remove();");
+  assert.notEqual(cleanupIndex, -1, "window removal must clear per-window render key");
+  assert.ok(
+    cleanupIndex < removeIndex,
+    "per-window render key cleanup must happen before element removal",
+  );
+});
+
 test("Sidebar Layers Agents counter filters non-agent preset windows", () => {
   // SPEC-2356 follow-up: recomputeOperatorTelemetry walked windowMap.values()
   // without checking preset, so every workspace window with data-agent-state

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -1463,6 +1463,25 @@ test("Operator telemetry skips unchanged counts before DOM writes", () => {
   );
 });
 
+test("Operator telemetry key avoids JSON stringify allocation", () => {
+  const keyBody = extractFunctionBody(appSource, "operatorTelemetryRenderKey");
+  assert.match(
+    appSource,
+    /function\s+appendRenderKeyPart\s*\(/,
+    "app.js must expose the primitive render-key append helper",
+  );
+  assert.match(
+    keyBody,
+    /appendRenderKeyPart\s*\(/,
+    "telemetry key must append primitive count fields directly",
+  );
+  assert.doesNotMatch(
+    keyBody,
+    /JSON\.stringify\s*\(/,
+    "telemetry key must not serialize a counts object graph",
+  );
+});
+
 test("Operator telemetry key covers status strip fields and branch telemetry uses guard", () => {
   const keyBody = extractFunctionBody(appSource, "operatorTelemetryRenderKey");
   for (const field of [

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -961,6 +961,30 @@ test("Terminal output decode is deferred out of the receive path", () => {
   );
 });
 
+test("Terminal output writes are gated while windows are hidden", () => {
+  const batcherConfig = appSource.match(
+    /const\s+terminalOutputBatcher\s*=\s*createTerminalOutputBatcher\(\{([\s\S]*?)\n\s{6}\}\);/,
+  );
+  assert.ok(batcherConfig, "app.js must configure the terminal output batcher");
+  assert.match(
+    batcherConfig[1],
+    /canWrite:\s*canRefreshTerminalViewport/,
+    "terminal output batcher must reuse the terminal visibility predicate before decode/write",
+  );
+
+  const renderWorkspaceBody = extractFunctionBody(appSource, "renderWorkspace");
+  assert.match(
+    renderWorkspaceBody,
+    /onReveal:\s*\(\)\s*=>\s*\{[\s\S]*?terminalOutputBatcher\.schedulePending\(windowId\)[\s\S]*?rearmPendingTerminalViewportRefresh\(windowId\)[\s\S]*?scheduleTerminalFocusActivation\(windowId\)/,
+    "hidden project-tab reveal must re-arm pending output before viewport/focus activation",
+  );
+  assert.match(
+    renderWorkspaceBody,
+    /onReveal:\s*\(\)\s*=>\s*\{[\s\S]*?terminalOutputBatcher\.schedulePending\(windowData\.id\)[\s\S]*?rearmPendingTerminalViewportRefresh\(windowData\.id\)[\s\S]*?scheduleTerminalFocusActivation\(windowData\.id\)/,
+    "hidden window-tab reveal must re-arm pending output before viewport/focus activation",
+  );
+});
+
 test("Operator telemetry skips unchanged counts before DOM writes", () => {
   assert.match(
     appSource,

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -504,6 +504,133 @@ test("Window List render key ignores viewport and includes row shell fields", ()
   );
 });
 
+test("Static project chrome renderers guard unchanged DOM writes", () => {
+  assert.match(
+    appSource,
+    /let\s+renderedAppVersionLabel\s*=/,
+    "app.js must track the last rendered app version label",
+  );
+  assert.match(
+    appSource,
+    /let\s+renderedProjectPickerKey\s*=/,
+    "app.js must track the last rendered Project Picker key",
+  );
+  assert.match(
+    appSource,
+    /let\s+renderedProjectOnboardingKey\s*=/,
+    "app.js must track the last rendered Project Onboarding key",
+  );
+  assert.match(
+    appSource,
+    /let\s+renderedActionAvailabilityKey\s*=/,
+    "app.js must track the last rendered action availability key",
+  );
+
+  const renderAppVersionBody = extractFunctionBody(appSource, "renderAppVersion");
+  const versionGuardIndex = renderAppVersionBody.indexOf(
+    "if (renderedAppVersionLabel === label)",
+  );
+  const versionHiddenIndex = renderAppVersionBody.indexOf("appVersionLabel.hidden");
+  assert.ok(
+    versionGuardIndex !== -1 && versionGuardIndex < versionHiddenIndex,
+    "renderAppVersion must return before unchanged label DOM writes",
+  );
+
+  const renderProjectPickerBody = extractFunctionBody(appSource, "renderProjectPicker");
+  const pickerKeyIndex = renderProjectPickerBody.indexOf(
+    "const nextProjectPickerKey = projectPickerRenderKey();",
+  );
+  const pickerGuardIndex = renderProjectPickerBody.indexOf(
+    "if (renderedProjectPickerKey === nextProjectPickerKey)",
+  );
+  const pickerClassIndex = renderProjectPickerBody.indexOf(
+    "projectPicker.classList.toggle",
+  );
+  assert.ok(
+    pickerKeyIndex !== -1 &&
+      pickerGuardIndex > pickerKeyIndex &&
+      pickerGuardIndex < pickerClassIndex,
+    "renderProjectPicker must return before unchanged picker DOM writes",
+  );
+
+  const renderProjectOnboardingBody = extractFunctionBody(appSource, "renderProjectOnboarding");
+  const onboardingKeyIndex = renderProjectOnboardingBody.indexOf(
+    "const nextProjectOnboardingKey = projectOnboardingRenderKey(tab);",
+  );
+  const onboardingGuardIndex = renderProjectOnboardingBody.indexOf(
+    "if (renderedProjectOnboardingKey === nextProjectOnboardingKey)",
+  );
+  const onboardingClassIndex = renderProjectOnboardingBody.indexOf(
+    "projectOnboarding.classList",
+  );
+  assert.ok(
+    onboardingKeyIndex !== -1 &&
+      onboardingGuardIndex > onboardingKeyIndex &&
+      onboardingGuardIndex < onboardingClassIndex,
+    "renderProjectOnboarding must return before unchanged onboarding DOM writes",
+  );
+
+  const updateActionAvailabilityBody = extractFunctionBody(appSource, "updateActionAvailability");
+  const actionKeyIndex = updateActionAvailabilityBody.indexOf(
+    "const nextActionAvailabilityKey = actionAvailabilityRenderKey();",
+  );
+  const actionGuardIndex = updateActionAvailabilityBody.indexOf(
+    "if (renderedActionAvailabilityKey === nextActionAvailabilityKey)",
+  );
+  const disabledIndex = updateActionAvailabilityBody.indexOf("addButton.disabled");
+  assert.ok(
+    actionKeyIndex !== -1 &&
+      actionGuardIndex > actionKeyIndex &&
+      actionGuardIndex < disabledIndex,
+    "updateActionAvailability must return before unchanged disabled-state DOM writes",
+  );
+});
+
+test("Static project chrome keys ignore workspace geometry and include visible transition state", () => {
+  const pickerKeyBody = extractFunctionBody(appSource, "projectPickerRenderKey");
+  assert.match(
+    pickerKeyBody,
+    /activeProjectTab\s*\(\s*\)/,
+    "Project Picker key must include visible active-tab state",
+  );
+  assert.match(
+    pickerKeyBody,
+    /projectError/,
+    "Project Picker key must include picker error text",
+  );
+  assert.match(
+    pickerKeyBody,
+    /recentProjectsRenderKey\s*\(/,
+    "Project Picker key must include Recent Projects only when visible",
+  );
+
+  const onboardingKeyBody = extractFunctionBody(appSource, "projectOnboardingRenderKey");
+  for (const field of ["kind", "project_root"]) {
+    assert.match(
+      onboardingKeyBody,
+      new RegExp(`\\b${field}\\b`),
+      `Project Onboarding key must include ${field}`,
+    );
+  }
+
+  const actionKeyBody = extractFunctionBody(appSource, "actionAvailabilityRenderKey");
+  assert.match(
+    actionKeyBody,
+    /activeProjectTab\s*\(\s*\)/,
+    "Action Availability key must include active-tab availability",
+  );
+
+  for (const keyBody of [pickerKeyBody, onboardingKeyBody, actionKeyBody]) {
+    for (const workspaceField of ["viewport", "windows", "geometry"]) {
+      assert.doesNotMatch(
+        keyBody,
+        new RegExp(`\\b${workspaceField}\\b`),
+        `Static project chrome keys must ignore ${workspaceField}`,
+      );
+    }
+  }
+});
+
 test("Sidebar Layers Agents counter filters non-agent preset windows", () => {
   // SPEC-2356 follow-up: recomputeOperatorTelemetry walked windowMap.values()
   // without checking preset, so every workspace window with data-agent-state

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -527,6 +527,10 @@ test("Window List skips unchanged row rebuilds after updating open state", () =>
   const keyIndex = renderWindowListBody.indexOf(
     "const nextWindowListKey = windowListRenderKey();",
   );
+  const closedGuardIndex = renderWindowListBody.indexOf("if (!windowListOpen)");
+  const closedSentinelIndex = renderWindowListBody.indexOf(
+    'renderedWindowListKey = "__closed__";',
+  );
   const guardIndex = renderWindowListBody.indexOf(
     "if (renderedWindowListKey === nextWindowListKey)",
   );
@@ -534,9 +538,32 @@ test("Window List skips unchanged row rebuilds after updating open state", () =>
 
   assert.notEqual(hiddenIndex, -1, "renderWindowList must update panel hidden state");
   assert.notEqual(ariaIndex, -1, "renderWindowList must update trigger aria-expanded");
+  assert.notEqual(closedGuardIndex, -1, "renderWindowList must have a closed fast path");
+  assert.notEqual(
+    closedSentinelIndex,
+    -1,
+    "closed Window List fast path must store a stable sentinel key",
+  );
+  assert.ok(
+    closedGuardIndex > hiddenIndex && closedGuardIndex > ariaIndex,
+    "closed Window List fast path must run after chrome hidden/expanded updates",
+  );
+  assert.ok(
+    closedGuardIndex < keyIndex,
+    "closed Window List fast path must return before key generation",
+  );
+  assert.ok(
+    closedSentinelIndex > closedGuardIndex && closedSentinelIndex < keyIndex,
+    "closed Window List fast path must store the sentinel before any key generation",
+  );
+  assert.match(
+    renderWindowListBody.slice(closedGuardIndex, keyIndex),
+    /return\s*;/,
+    "closed Window List fast path must return before windowListRenderKey()",
+  );
   assert.ok(
     keyIndex > hiddenIndex && keyIndex > ariaIndex,
-    "Window List key must run after open state updates",
+    "open Window List key must run after open state updates",
   );
   assert.ok(guardIndex > keyIndex, "renderWindowList must guard on the Window List key");
   assert.ok(

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -735,6 +735,35 @@ test("Window List skips unchanged row rebuilds after updating open state", () =>
   );
 });
 
+test("Window List row source rebuild avoids mapped intermediate arrays", () => {
+  const renderWindowListBody = extractFunctionBody(appSource, "renderWindowList");
+  assert.doesNotMatch(
+    renderWindowListBody,
+    /workspaceWindows\.map\s*\(/,
+    "Window List row rebuild must not allocate a mapped workspace-window lookup source",
+  );
+  assert.doesNotMatch(
+    renderWindowListBody,
+    /windowListEntries[\s\S]*?\.map\s*\(/,
+    "Window List row rebuild must not map backend entries before filtering",
+  );
+  assert.doesNotMatch(
+    renderWindowListBody,
+    /\.filter\s*\(/,
+    "Window List row rebuild must avoid chained filter allocation",
+  );
+  assert.match(
+    renderWindowListBody,
+    /for\s*\(\s*const\s+windowData\s+of\s+workspaceWindows\s*\)/,
+    "Window List row rebuild must build workspace lookups with a direct loop",
+  );
+  assert.match(
+    renderWindowListBody,
+    /for\s*\(\s*const\s+entry\s+of\s+windowListEntries\s*\)/,
+    "Window List row rebuild must derive server-backed entries with a direct loop",
+  );
+});
+
 test("Window List render key ignores viewport and includes row shell fields", () => {
   const keyBody = extractFunctionBody(appSource, "windowListRenderKey");
   assert.match(

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -825,7 +825,7 @@ test("Static project chrome renderers guard unchanged DOM writes", () => {
 
   const renderProjectPickerBody = extractFunctionBody(appSource, "renderProjectPicker");
   const pickerKeyIndex = renderProjectPickerBody.indexOf(
-    "const nextProjectPickerKey = projectPickerRenderKey();",
+    "const nextProjectPickerKey = projectPickerRenderKey(activeTab);",
   );
   const pickerGuardIndex = renderProjectPickerBody.indexOf(
     "if (renderedProjectPickerKey === nextProjectPickerKey)",
@@ -859,7 +859,7 @@ test("Static project chrome renderers guard unchanged DOM writes", () => {
 
   const updateActionAvailabilityBody = extractFunctionBody(appSource, "updateActionAvailability");
   const actionKeyIndex = updateActionAvailabilityBody.indexOf(
-    "const nextActionAvailabilityKey = actionAvailabilityRenderKey();",
+    "const nextActionAvailabilityKey = actionAvailabilityRenderKey(activeTab);",
   );
   const actionGuardIndex = updateActionAvailabilityBody.indexOf(
     "if (renderedActionAvailabilityKey === nextActionAvailabilityKey)",
@@ -877,7 +877,7 @@ test("Static project chrome keys ignore workspace geometry and include visible t
   const pickerKeyBody = extractFunctionBody(appSource, "projectPickerRenderKey");
   assert.match(
     pickerKeyBody,
-    /activeProjectTab\s*\(\s*\)/,
+    /activeTab/,
     "Project Picker key must include visible active-tab state",
   );
   assert.match(
@@ -903,7 +903,7 @@ test("Static project chrome keys ignore workspace geometry and include visible t
   const actionKeyBody = extractFunctionBody(appSource, "actionAvailabilityRenderKey");
   assert.match(
     actionKeyBody,
-    /activeProjectTab\s*\(\s*\)/,
+    /activeTab/,
     "Action Availability key must include active-tab availability",
   );
 
@@ -915,6 +915,51 @@ test("Static project chrome keys ignore workspace geometry and include visible t
         `Static project chrome keys must ignore ${workspaceField}`,
       );
     }
+  }
+});
+
+test("Static project chrome keys avoid JSON stringify allocation", () => {
+  for (const name of ["projectPickerRenderKey", "projectOnboardingRenderKey"]) {
+    const keyBody = extractFunctionBody(appSource, name);
+    assert.match(
+      keyBody,
+      /appendRenderKeyPart\s*\(/,
+      `${name} must append primitive fields directly`,
+    );
+    assert.doesNotMatch(
+      keyBody,
+      /JSON\.stringify\s*\(/,
+      `${name} must not serialize an object graph on every workspace_state`,
+    );
+  }
+});
+
+test("Static project chrome reuses the renderAppState active tab lookup", () => {
+  const renderAppStateBody = extractFunctionBody(appSource, "renderAppState");
+  const tabLookupIndex = renderAppStateBody.indexOf("const tab = activeProjectTab();");
+  const pickerCallIndex = renderAppStateBody.indexOf("renderProjectPicker(tab);");
+  const actionCallIndex = renderAppStateBody.indexOf("updateActionAvailability(tab);");
+  const onboardingCallIndex = renderAppStateBody.indexOf("renderProjectOnboarding(tab);");
+  const workspaceCallIndex = renderAppStateBody.indexOf(
+    "renderWorkspace(tab?.workspace || emptyWorkspace());",
+  );
+  assert.ok(
+    tabLookupIndex >= 0 &&
+      pickerCallIndex > tabLookupIndex &&
+      actionCallIndex > tabLookupIndex &&
+      onboardingCallIndex > tabLookupIndex &&
+      workspaceCallIndex > tabLookupIndex,
+    "renderAppState must resolve the active tab once and pass it through static chrome and workspace renderers",
+  );
+
+  const pickerKeyBody = extractFunctionBody(appSource, "projectPickerRenderKey");
+  const actionKeyBody = extractFunctionBody(appSource, "actionAvailabilityRenderKey");
+  for (const keyBody of [pickerKeyBody, actionKeyBody]) {
+    assert.doesNotMatch(
+      keyBody,
+      /activeProjectTab\s*\(\s*\)/,
+      "static chrome key helpers must not rescan activeProjectTab on the workspace_state hot path",
+    );
   }
 });
 

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -397,6 +397,113 @@ test("Workspace Windows render key ignores viewport and includes window shell fi
   );
 });
 
+test("Window List skips unchanged row rebuilds after updating open state", () => {
+  const renderWindowListBody = extractFunctionBody(appSource, "renderWindowList");
+  assert.match(
+    appSource,
+    /let\s+renderedWindowListKey\s*=/,
+    "app.js must track the last rendered Window List row key",
+  );
+  assert.match(
+    appSource,
+    /function\s+windowListRenderKey\s*\(/,
+    "app.js must define a Window List render key helper",
+  );
+
+  const hiddenIndex = renderWindowListBody.indexOf("windowListPanel.hidden");
+  const ariaIndex = renderWindowListBody.indexOf("aria-expanded");
+  const keyIndex = renderWindowListBody.indexOf(
+    "const nextWindowListKey = windowListRenderKey();",
+  );
+  const guardIndex = renderWindowListBody.indexOf(
+    "if (renderedWindowListKey === nextWindowListKey)",
+  );
+  const clearIndex = renderWindowListBody.indexOf("windowListPanel.innerHTML = \"\";");
+
+  assert.notEqual(hiddenIndex, -1, "renderWindowList must update panel hidden state");
+  assert.notEqual(ariaIndex, -1, "renderWindowList must update trigger aria-expanded");
+  assert.ok(
+    keyIndex > hiddenIndex && keyIndex > ariaIndex,
+    "Window List key must run after open state updates",
+  );
+  assert.ok(guardIndex > keyIndex, "renderWindowList must guard on the Window List key");
+  assert.ok(
+    guardIndex < clearIndex,
+    "unchanged Window List key must return before row clearing/rebuild",
+  );
+  assert.match(
+    renderWindowListBody.slice(guardIndex, clearIndex),
+    /return\s*;/,
+    "unchanged Window List key guard must return before clearing rows",
+  );
+
+  const toggleWindowListBody = extractFunctionBody(appSource, "toggleWindowList");
+  const invalidateIndex = toggleWindowListBody.indexOf("renderedWindowListKey = \"\";");
+  const renderIndex = toggleWindowListBody.indexOf("renderWindowList();");
+  const requestIndex = toggleWindowListBody.indexOf("requestWindowList();");
+  assert.notEqual(invalidateIndex, -1, "toggleWindowList must invalidate the Window List key");
+  assert.ok(
+    invalidateIndex < renderIndex && renderIndex < requestIndex,
+    "opening Window List must render current rows before requesting backend entries",
+  );
+});
+
+test("Window List render key ignores viewport and includes row shell fields", () => {
+  const keyBody = extractFunctionBody(appSource, "windowListRenderKey");
+  assert.match(
+    keyBody,
+    /active_tab_id/,
+    "Window List key must include active tab identity",
+  );
+  assert.match(
+    keyBody,
+    /windowListEntries/,
+    "Window List key must include server-provided window_list entries",
+  );
+  assert.match(
+    keyBody,
+    /activeWorkspace\s*\(\s*\)/,
+    "Window List key must include active workspace window identity/order",
+  );
+  assert.match(
+    keyBody,
+    /runtimeStateForWindow\s*\(/,
+    "Window List key must include runtime state used by status chips",
+  );
+  for (const field of [
+    "id",
+    "preset",
+    "title",
+    "dynamic_title",
+    "dynamic_title_detail",
+    "purpose_title",
+    "agent_id",
+    "agent_color",
+    "status",
+    "geometry",
+    "x",
+    "y",
+    "width",
+    "height",
+    "minimized",
+    "maximized",
+    "z_index",
+    "tab_group_id",
+    "tab_group_active",
+  ]) {
+    assert.match(
+      keyBody,
+      new RegExp(`\\b${field}\\b`),
+      `Window List key must include ${field}`,
+    );
+  }
+  assert.doesNotMatch(
+    keyBody,
+    /\bviewport\b/,
+    "Window List key must ignore viewport-only state",
+  );
+});
+
 test("Sidebar Layers Agents counter filters non-agent preset windows", () => {
   // SPEC-2356 follow-up: recomputeOperatorTelemetry walked windowMap.values()
   // without checking preset, so every workspace window with data-agent-state

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -323,7 +323,19 @@ test("viewport-only workspace_state skips unchanged window reconciliation", () =
     /function\s+workspaceWindowsRenderKey\s*\(/,
     "app.js must define a Workspace Windows render key helper",
   );
+  assert.match(
+    appSource,
+    /let\s+viewportDomApplied\s*=\s*false\s*;/,
+    "app.js must track whether the viewport DOM has been initialized",
+  );
 
+  const nextViewportIndex = renderWorkspaceBody.indexOf(
+    "const nextViewport = viewportSyncState.applyServerViewport",
+  );
+  const viewportChangedIndex = renderWorkspaceBody.indexOf(
+    "const viewportChanged = !sameViewportValues(viewport, nextViewport);",
+  );
+  const assignViewportIndex = renderWorkspaceBody.indexOf("viewport = nextViewport;");
   const applyViewportIndex = renderWorkspaceBody.indexOf("applyViewport();");
   const keyIndex = renderWorkspaceBody.indexOf(
     "const nextWorkspaceWindowsKey = workspaceWindowsRenderKey(workspace);",
@@ -336,8 +348,35 @@ test("viewport-only workspace_state skips unchanged window reconciliation", () =
   );
   const ensureIndex = renderWorkspaceBody.indexOf("ensureWindow(windowData)");
   const focusIndex = renderWorkspaceBody.indexOf("focusWindowLocally(topmostId)");
+  const applyCalls = [...renderWorkspaceBody.matchAll(/applyViewport\(\);/g)];
 
-  assert.notEqual(applyViewportIndex, -1, "renderWorkspace must apply viewport");
+  assert.notEqual(
+    nextViewportIndex,
+    -1,
+    "renderWorkspace must store the applied server viewport before DOM writes",
+  );
+  assert.ok(
+    viewportChangedIndex > nextViewportIndex,
+    "renderWorkspace must compare the current viewport with the applied server viewport",
+  );
+  assert.ok(
+    assignViewportIndex > viewportChangedIndex,
+    "renderWorkspace must compare before replacing the current viewport reference",
+  );
+  assert.equal(
+    applyCalls.length,
+    1,
+    "renderWorkspace must keep server viewport DOM writes behind one guarded apply call",
+  );
+  assert.ok(
+    applyViewportIndex > assignViewportIndex,
+    "changed server viewport must assign the new viewport before applying DOM writes",
+  );
+  assert.match(
+    renderWorkspaceBody.slice(assignViewportIndex, keyIndex),
+    /if\s*\(\s*!viewportDomApplied\s*\|\|\s*viewportChanged\s*\)\s*\{\s*applyViewport\(\);\s*\}/,
+    "unchanged server viewport must skip applyViewport only after the first DOM apply",
+  );
   assert.ok(keyIndex > applyViewportIndex, "window key guard must run after viewport");
   assert.ok(guardIndex > keyIndex, "renderWorkspace must guard on the window key");
   assert.ok(

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -351,6 +351,40 @@ test("viewport-only workspace_state skips unchanged window reconciliation", () =
   );
 });
 
+test("clamped no-op zoom returns before local viewport apply and persist work", () => {
+  const zoomBody = extractFunctionBody(appSource, "zoomCanvasAt");
+  assert.match(
+    appSource,
+    /function\s+sameViewportValues\s*\(/,
+    "app.js must define a semantic viewport equality helper",
+  );
+  const nextViewportIndex = zoomBody.indexOf("const nextViewport = {");
+  const guardIndex = zoomBody.indexOf("if (sameViewportValues(viewport, nextViewport))");
+  const assignIndex = zoomBody.indexOf("viewport = nextViewport;");
+  const recordIndex = zoomBody.indexOf("recordLocalViewportEdit();");
+  const applyIndex = zoomBody.indexOf("applyViewport();");
+  const persistIndex = zoomBody.indexOf("persistViewport();");
+
+  assert.notEqual(nextViewportIndex, -1, "zoomCanvasAt must compute next viewport first");
+  assert.ok(guardIndex > nextViewportIndex, "no-op guard must inspect the computed viewport");
+  assert.ok(
+    guardIndex < assignIndex
+      && guardIndex < recordIndex
+      && guardIndex < applyIndex
+      && guardIndex < persistIndex,
+    "clamped no-op zoom must return before assignment, local edit tracking, viewport writes, and persist scheduling",
+  );
+  assert.match(
+    zoomBody.slice(guardIndex, assignIndex),
+    /return\s*;/,
+    "same viewport guard must return before changed-zoom apply/persist sequence",
+  );
+  assert.ok(
+    assignIndex < recordIndex && recordIndex < applyIndex && applyIndex < persistIndex,
+    "changed zoom must still assign next viewport before the existing apply/persist sequence",
+  );
+});
+
 test("Workspace Windows render key ignores viewport and includes window shell fields", () => {
   const keyBody = extractFunctionBody(appSource, "workspaceWindowsRenderKey");
   assert.match(

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -695,7 +695,7 @@ test("Per-window renderer guards unchanged DOM writes after mount and preset syn
   const classIndex = ensureWindowBody.indexOf('classList.toggle("minimized"');
   const styleIndex = ensureWindowBody.indexOf("element.style.zIndex");
   const statusIndex = ensureWindowBody.indexOf("applyStatus");
-  const fitIndex = ensureWindowBody.indexOf("fitTerminal");
+  const fitIndex = ensureWindowBody.indexOf("scheduleTerminalFit");
 
   assert.notEqual(mountIndex, -1, "ensureWindow must keep preset/body mount logic");
   assert.ok(keyIndex > mountIndex, "per-window key must run after preset/body mounting");

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -594,6 +594,40 @@ test("Workspace Windows render key ignores viewport and includes window shell fi
   );
 });
 
+test("Workspace Windows render key avoids JSON stringify allocation", () => {
+  const keyBody = extractFunctionBody(appSource, "workspaceWindowsRenderKey");
+  assert.match(
+    appSource,
+    /function\s+appendRenderKeyPart\s*\(/,
+    "app.js must provide a primitive render-key append helper",
+  );
+  assert.match(
+    keyBody,
+    /appendRenderKeyPart\s*\(/,
+    "Workspace Windows key must append primitive key parts directly",
+  );
+  assert.doesNotMatch(
+    keyBody,
+    /JSON\.stringify\s*\(/,
+    "Workspace Windows key must not serialize a nested object graph",
+  );
+  assert.doesNotMatch(
+    keyBody,
+    /\bwindows\.map\s*\(/,
+    "Workspace Windows key must not allocate per-window map results",
+  );
+  assert.match(
+    keyBody,
+    /for\s*\(\s*const\s+windowData\s+of\s+windows\s*\)/,
+    "Workspace Windows key must walk windows with a direct loop",
+  );
+  assert.match(
+    keyBody,
+    /for\s*\(\s*const\s+windowId\s+of\s+allProjectWindowIds\s*\(\s*\)\s*\)/,
+    "Workspace Windows key must include mounted project window ids with a direct loop",
+  );
+});
+
 test("Window List skips unchanged row rebuilds after updating open state", () => {
   const renderWindowListBody = extractFunctionBody(appSource, "renderWindowList");
   assert.match(

--- a/crates/gwt/web/__tests__/socket-receive-dispatcher.test.mjs
+++ b/crates/gwt/web/__tests__/socket-receive-dispatcher.test.mjs
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   DEFAULT_COALESCE_KINDS,
@@ -7,6 +10,9 @@ import {
   coalesceEvents,
   createSocketReceiveDispatcher,
 } from "../socket-receive-dispatcher.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const dispatcherSource = readFileSync(resolve(here, "../socket-receive-dispatcher.js"), "utf8");
 
 function manualScheduler() {
   const pending = [];
@@ -441,4 +447,49 @@ test("dispatcher emits sanitized trace metadata for parse and receive timing", (
   assert.equal(traces[2].event_kind, "terminal_output");
   assert.equal(traces[2].duration_ms, 4);
   assert.equal(JSON.stringify(traces).includes("must-not-leak"), false);
+});
+
+test("dispatcher builds trace metadata lazily", () => {
+  assert.match(dispatcherSource, /function\s+trace\(\s*kind,\s*fieldsFactory/);
+  assert.doesNotMatch(
+    dispatcherSource,
+    /trace\(\s*["']ws_[^"']+["']\s*,\s*\{/,
+    "trace call sites must pass factories so inactive tracing skips field allocation",
+  );
+});
+
+test("dispatcher skips trace callbacks while shouldTrace is false", () => {
+  const traces = [];
+  const received = [];
+  const scheduler = manualScheduler();
+  let shouldTrace = false;
+  const dispatcher = createSocketReceiveDispatcher({
+    receive: (event) => received.push(event),
+    schedule: scheduler.schedule,
+    now: () => 0,
+    onTrace: (kind, fields) => traces.push({ kind, ...fields }),
+    shouldTrace: () => shouldTrace,
+  });
+
+  for (let i = 0; i < 25; i += 1) {
+    dispatcher.handle({
+      data: JSON.stringify({ kind: "terminal_output", id: "shell", data: String(i) }),
+    });
+  }
+  scheduler.runOnce();
+
+  assert.equal(received.length, 25);
+  assert.deepEqual(traces, [], "inactive tracing must not call onTrace");
+
+  shouldTrace = true;
+  dispatcher.handle({
+    data: JSON.stringify({ kind: "terminal_output", id: "shell", data: "active" }),
+  });
+  scheduler.runOnce();
+
+  assert.deepEqual(
+    traces.map((trace) => trace.kind),
+    ["ws_message", "ws_flush_start", "ws_receive", "ws_flush_end"],
+    "trace events must resume once shouldTrace returns true",
+  );
 });

--- a/crates/gwt/web/__tests__/socket-receive-dispatcher.test.mjs
+++ b/crates/gwt/web/__tests__/socket-receive-dispatcher.test.mjs
@@ -189,6 +189,73 @@ test("handle() accepts both WebSocket message events and pre-parsed payloads", (
   ]);
 });
 
+test("handle() defers string WebSocket JSON.parse until scheduled flush", () => {
+  const received = [];
+  const scheduler = manualScheduler();
+  const originalParse = JSON.parse;
+  let parseCalls = 0;
+  const dispatcher = createSocketReceiveDispatcher({
+    receive: (event) => received.push(event),
+    schedule: scheduler.schedule,
+    now: () => 0,
+  });
+
+  JSON.parse = (source, reviver) => {
+    parseCalls += 1;
+    return originalParse.call(JSON, source, reviver);
+  };
+  try {
+    dispatcher.handle({
+      data: JSON.stringify({ kind: "terminal_output", id: "shell", data: "0" }),
+    });
+
+    assert.equal(parseCalls, 0, "string handle() must not parse synchronously");
+    assert.equal(received.length, 0, "receive remains deferred until flush");
+    assert.equal(scheduler.pendingCount(), 1, "one frame is scheduled");
+
+    scheduler.runOnce();
+
+    assert.equal(parseCalls, 1, "flush parses the raw payload before receive()");
+    assert.deepEqual(received, [
+      { kind: "terminal_output", id: "shell", data: "0" },
+    ]);
+  } finally {
+    JSON.parse = originalParse;
+  }
+});
+
+test("string idempotent events coalesce before full JSON.parse", () => {
+  const received = [];
+  const scheduler = manualScheduler();
+  const originalParse = JSON.parse;
+  let parseCalls = 0;
+  const dispatcher = createSocketReceiveDispatcher({
+    receive: (event) => received.push(event),
+    schedule: scheduler.schedule,
+    now: () => 0,
+  });
+
+  JSON.parse = (source, reviver) => {
+    parseCalls += 1;
+    return originalParse.call(JSON, source, reviver);
+  };
+  try {
+    for (let i = 0; i < 25; i += 1) {
+      dispatcher.handle({
+        data: JSON.stringify({ kind: "workspace_state", revision: i }),
+      });
+    }
+
+    assert.equal(parseCalls, 0, "queued raw strings must not parse during handle()");
+    scheduler.runOnce();
+
+    assert.equal(parseCalls, 1, "only the latest coalesced state is parsed");
+    assert.deepEqual(received, [{ kind: "workspace_state", revision: 24 }]);
+  } finally {
+    JSON.parse = originalParse;
+  }
+});
+
 test("flushNow synchronously drains pending events without waiting for the scheduler", () => {
   const received = [];
   const scheduler = manualScheduler();

--- a/crates/gwt/web/__tests__/socket-receive-dispatcher.test.mjs
+++ b/crates/gwt/web/__tests__/socket-receive-dispatcher.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   DEFAULT_COALESCE_KINDS,
+  DEFAULT_MAX_STREAMED_BEFORE_STATE,
   coalesceEvents,
   createSocketReceiveDispatcher,
 } from "../socket-receive-dispatcher.js";
@@ -245,6 +246,84 @@ test("multiple streamed events maintain relative order, then idempotent follows"
     { kind: "workspace_state", n: 2 },
     { kind: "active_work_projection", v: 5 },
   ]);
+});
+
+test("idempotent state is delivered after a bounded streamed chunk during heavy backlog", () => {
+  const queue = [];
+  for (let i = 0; i < 500; i += 1) {
+    queue.push({ kind: "terminal_output", id: "shell", data: String(i) });
+  }
+  queue.push({ kind: "workspace_state", revision: 7 });
+
+  const coalesced = coalesceEvents(queue, DEFAULT_COALESCE_KINDS, {
+    maxStreamedBeforeState: DEFAULT_MAX_STREAMED_BEFORE_STATE,
+  });
+  const stateIndex = coalesced.findIndex(
+    (event) => event.kind === "workspace_state",
+  );
+  const streamed = coalesced.filter((event) => event.kind === "terminal_output");
+
+  assert.equal(stateIndex, DEFAULT_MAX_STREAMED_BEFORE_STATE);
+  assert.ok(500 / stateIndex >= 10);
+  assert.equal(streamed.length, 500);
+  assert.equal(streamed[0].data, "0");
+  assert.equal(streamed[499].data, "499");
+});
+
+test("small streamed bursts still flush before idempotent state", () => {
+  const queue = [];
+  for (let i = 0; i < 4; i += 1) {
+    queue.push({ kind: "terminal_output", id: "shell", data: String(i) });
+  }
+  queue.push({ kind: "workspace_state", revision: 1 });
+
+  const coalesced = coalesceEvents(queue, DEFAULT_COALESCE_KINDS, {
+    maxStreamedBeforeState: DEFAULT_MAX_STREAMED_BEFORE_STATE,
+  });
+
+  assert.deepEqual(
+    coalesced.map((event) => event.kind),
+    [
+      "terminal_output",
+      "terminal_output",
+      "terminal_output",
+      "terminal_output",
+      "workspace_state",
+    ],
+  );
+});
+
+test("dispatcher threads streamed chunk budget into receive order", () => {
+  const received = [];
+  const scheduler = manualScheduler();
+  const dispatcher = createSocketReceiveDispatcher({
+    receive: (event) => received.push(event),
+    schedule: scheduler.schedule,
+    now: () => 0,
+    maxStreamedBeforeState: 2,
+  });
+
+  for (let i = 0; i < 5; i += 1) {
+    dispatcher.enqueue({
+      kind: "terminal_output",
+      id: "shell",
+      data: String(i),
+    });
+  }
+  dispatcher.enqueue({ kind: "workspace_state", revision: 1 });
+  scheduler.runOnce();
+
+  assert.deepEqual(
+    received.map((event) => `${event.kind}:${event.data ?? event.revision}`),
+    [
+      "terminal_output:0",
+      "terminal_output:1",
+      "workspace_state:1",
+      "terminal_output:2",
+      "terminal_output:3",
+      "terminal_output:4",
+    ],
+  );
 });
 
 test("dispatcher delivers terminal_output ahead of pending workspace_state in the same flush", () => {

--- a/crates/gwt/web/__tests__/terminal-output-buffer.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-output-buffer.test.mjs
@@ -156,6 +156,35 @@ test("flush budget rolls excess chunks into later scheduled flushes without spli
   ]);
 });
 
+test("mergeChunks runs during the scheduled flush with original chunk order", () => {
+  const scheduler = manualScheduler();
+  const writes = [];
+  const mergeCalls = [];
+  const batcher = createTerminalOutputBatcher({
+    schedule: scheduler.schedule,
+    mergeChunks: (chunks, windowId) => {
+      mergeCalls.push({ windowId, chunks: [...chunks] });
+      return chunks.map((chunk) => chunk.toUpperCase()).join("|");
+    },
+    write: (windowId, text, done) => {
+      writes.push({ windowId, text });
+      done();
+    },
+  });
+
+  batcher.enqueue("agent-1", "ab");
+  batcher.enqueue("agent-1", "cd");
+
+  assert.deepEqual(mergeCalls, [], "merge must not run on enqueue");
+
+  scheduler.runOnce();
+
+  assert.deepEqual(mergeCalls, [
+    { windowId: "agent-1", chunks: ["ab", "cd"] },
+  ]);
+  assert.deepEqual(writes, [{ windowId: "agent-1", text: "AB|CD" }]);
+});
+
 test("defaults expose a bounded per-frame character budget", () => {
   assert.equal(DEFAULT_MAX_CHARS_PER_FLUSH, 65536);
 });

--- a/crates/gwt/web/__tests__/terminal-output-buffer.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-output-buffer.test.mjs
@@ -31,6 +31,42 @@ function manualScheduler() {
   };
 }
 
+function cursorScheduler() {
+  const pending = [];
+  let head = 0;
+  function compact() {
+    if (head > 32 && head * 2 >= pending.length) {
+      pending.splice(0, head);
+      head = 0;
+    }
+  }
+  return {
+    schedule: (cb) => {
+      pending.push(cb);
+      return pending.length - head;
+    },
+    runOnce() {
+      const cb = pending[head];
+      if (cb) {
+        head += 1;
+        compact();
+        cb();
+      }
+    },
+    runAll() {
+      while (head < pending.length) {
+        const cb = pending[head];
+        head += 1;
+        compact();
+        cb();
+      }
+    },
+    pendingCount() {
+      return pending.length - head;
+    },
+  };
+}
+
 test("same-window terminal chunks batch into one ordered xterm write", () => {
   const scheduler = manualScheduler();
   const writes = [];
@@ -162,6 +198,85 @@ test("multi-window terminal bursts respect the per-frame window budget", () => {
     { windowId: "agent-49", text: "chunk-49" },
   ]);
   assert.equal(scheduler.pendingCount(), 0);
+  assert.equal(batcher.pendingWindowCount(), 0);
+});
+
+test("large terminal output queues drain without per-chunk Array.shift", () => {
+  const scheduler = cursorScheduler();
+  const writes = [];
+  const batcher = createTerminalOutputBatcher({
+    schedule: scheduler.schedule,
+    maxCharsPerFlush: 10000,
+    write: (windowId, text, done) => {
+      writes.push({ windowId, text });
+      done();
+    },
+  });
+
+  const chunks = Array.from({ length: 2000 }, (_, index) => `${index},`);
+  for (const chunk of chunks) {
+    batcher.enqueue("agent-large", chunk);
+  }
+
+  assert.equal(scheduler.pendingCount(), 1);
+
+  const originalShift = Array.prototype.shift;
+  let shiftCalls = 0;
+  Array.prototype.shift = function patchedShift(...args) {
+    shiftCalls += 1;
+    return originalShift.apply(this, args);
+  };
+  try {
+    scheduler.runOnce();
+  } finally {
+    Array.prototype.shift = originalShift;
+  }
+
+  assert.equal(
+    shiftCalls,
+    0,
+    "large output backlog drain must not move the array once per chunk",
+  );
+  assert.deepEqual(writes, [
+    { windowId: "agent-large", text: chunks.join("") },
+  ]);
+  assert.equal(batcher.pendingCount("agent-large"), 0);
+  assert.equal(batcher.pendingWindowCount(), 0);
+});
+
+test("partial queue drains report only the unconsumed tail", () => {
+  const scheduler = cursorScheduler();
+  const writes = [];
+  const batcher = createTerminalOutputBatcher({
+    schedule: scheduler.schedule,
+    maxCharsPerFlush: 4,
+    write: (windowId, text, done) => {
+      writes.push({ windowId, text });
+      done();
+    },
+  });
+
+  batcher.enqueue("agent-tail", "aa");
+  batcher.enqueue("agent-tail", "bb");
+  batcher.enqueue("agent-tail", "cc");
+  batcher.enqueue("agent-tail", "dd");
+
+  scheduler.runOnce();
+
+  assert.deepEqual(writes, [{ windowId: "agent-tail", text: "aabb" }]);
+  assert.equal(batcher.pendingCount("agent-tail"), 2);
+  assert.equal(batcher.pendingCount(), 2);
+  assert.equal(batcher.pendingWindowCount(), 1);
+  assert.equal(scheduler.pendingCount(), 1);
+
+  scheduler.runOnce();
+
+  assert.deepEqual(writes, [
+    { windowId: "agent-tail", text: "aabb" },
+    { windowId: "agent-tail", text: "ccdd" },
+  ]);
+  assert.equal(batcher.pendingCount("agent-tail"), 0);
+  assert.equal(batcher.pendingCount(), 0);
   assert.equal(batcher.pendingWindowCount(), 0);
 });
 

--- a/crates/gwt/web/__tests__/terminal-output-buffer.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-output-buffer.test.mjs
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_MAX_CHARS_PER_FLUSH,
+  createTerminalOutputBatcher,
+} from "../terminal-output-buffer.js";
+
+function manualScheduler() {
+  const pending = [];
+  return {
+    schedule: (cb) => {
+      pending.push(cb);
+      return pending.length;
+    },
+    runOnce() {
+      const cb = pending.shift();
+      if (cb) cb();
+    },
+    runAll() {
+      while (pending.length > 0) {
+        const cb = pending.shift();
+        cb();
+      }
+    },
+    pendingCount() {
+      return pending.length;
+    },
+  };
+}
+
+test("same-window terminal chunks batch into one ordered xterm write", () => {
+  const scheduler = manualScheduler();
+  const writes = [];
+  const flushed = [];
+  const batcher = createTerminalOutputBatcher({
+    schedule: scheduler.schedule,
+    write: (windowId, text, done) => {
+      writes.push({ windowId, text });
+      done();
+    },
+    onFlush: (windowId) => flushed.push(windowId),
+  });
+
+  for (let i = 0; i < 500; i += 1) {
+    batcher.enqueue("agent-1", `${i},`);
+  }
+
+  assert.equal(writes.length, 0, "enqueue must not call xterm synchronously");
+  assert.equal(scheduler.pendingCount(), 1, "one frame handles the burst");
+
+  scheduler.runOnce();
+
+  assert.equal(writes.length, 1, "500 chunks should collapse to one write");
+  assert.equal(writes[0].windowId, "agent-1");
+  assert.equal(
+    writes[0].text,
+    Array.from({ length: 500 }, (_, i) => `${i},`).join(""),
+  );
+  assert.deepEqual(flushed, ["agent-1"]);
+});
+
+test("terminal output batching stays isolated per window", () => {
+  const scheduler = manualScheduler();
+  const writes = [];
+  const batcher = createTerminalOutputBatcher({
+    schedule: scheduler.schedule,
+    write: (windowId, text, done) => {
+      writes.push({ windowId, text });
+      done();
+    },
+  });
+
+  batcher.enqueue("agent-a", "a1");
+  batcher.enqueue("agent-b", "b1");
+  batcher.enqueue("agent-a", "a2");
+  batcher.enqueue("agent-b", "b2");
+
+  assert.equal(scheduler.pendingCount(), 2, "each window gets its own scheduled flush");
+  scheduler.runAll();
+
+  assert.deepEqual(writes, [
+    { windowId: "agent-a", text: "a1a2" },
+    { windowId: "agent-b", text: "b1b2" },
+  ]);
+});
+
+test("flushNow drains a window before its scheduled frame", () => {
+  const scheduler = manualScheduler();
+  const writes = [];
+  const flushed = [];
+  const batcher = createTerminalOutputBatcher({
+    schedule: scheduler.schedule,
+    write: (windowId, text, done) => {
+      writes.push({ windowId, text });
+      done();
+    },
+    onFlush: (windowId) => flushed.push(windowId),
+  });
+
+  batcher.enqueue("agent-1", "before");
+  assert.equal(batcher.flushNow("agent-1"), true);
+  assert.deepEqual(writes, [{ windowId: "agent-1", text: "before" }]);
+  assert.deepEqual(flushed, ["agent-1"]);
+
+  scheduler.runAll();
+  assert.equal(writes.length, 1, "stale scheduled frames must no-op after flushNow");
+});
+
+test("clear drops pending output for a window", () => {
+  const scheduler = manualScheduler();
+  const writes = [];
+  const batcher = createTerminalOutputBatcher({
+    schedule: scheduler.schedule,
+    write: (windowId, text, done) => {
+      writes.push({ windowId, text });
+      done();
+    },
+  });
+
+  batcher.enqueue("agent-1", "old");
+  batcher.enqueue("agent-2", "keep");
+  batcher.clear("agent-1");
+
+  scheduler.runAll();
+
+  assert.deepEqual(writes, [{ windowId: "agent-2", text: "keep" }]);
+  assert.equal(batcher.pendingCount("agent-1"), 0);
+});
+
+test("flush budget rolls excess chunks into later scheduled flushes without splitting chunks", () => {
+  const scheduler = manualScheduler();
+  const writes = [];
+  const batcher = createTerminalOutputBatcher({
+    schedule: scheduler.schedule,
+    maxCharsPerFlush: 5,
+    write: (windowId, text, done) => {
+      writes.push({ windowId, text });
+      done();
+    },
+  });
+
+  batcher.enqueue("agent-1", "ab");
+  batcher.enqueue("agent-1", "cd");
+  batcher.enqueue("agent-1", "ef");
+  batcher.enqueue("agent-1", "gh");
+
+  scheduler.runOnce();
+  assert.deepEqual(writes, [{ windowId: "agent-1", text: "abcd" }]);
+  assert.equal(scheduler.pendingCount(), 1, "remaining chunks schedule another frame");
+
+  scheduler.runOnce();
+  assert.deepEqual(writes, [
+    { windowId: "agent-1", text: "abcd" },
+    { windowId: "agent-1", text: "efgh" },
+  ]);
+});
+
+test("defaults expose a bounded per-frame character budget", () => {
+  assert.equal(DEFAULT_MAX_CHARS_PER_FLUSH, 65536);
+});

--- a/crates/gwt/web/__tests__/terminal-output-buffer.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-output-buffer.test.mjs
@@ -276,6 +276,88 @@ test("hidden terminal output remains queued without decode write or scheduler sp
   );
 });
 
+test("quiesced hidden terminal output does not reschedule until reveal", () => {
+  const scheduler = manualScheduler();
+  const writes = [];
+  const eligibility = new Map([["agent-hidden", false]]);
+  const batcher = createTerminalOutputBatcher({
+    schedule: scheduler.schedule,
+    canWrite: (windowId) => eligibility.get(windowId) !== false,
+    write: (windowId, text, done) => {
+      writes.push({ windowId, text });
+      done();
+    },
+  });
+
+  batcher.enqueue("agent-hidden", "hidden-a");
+  scheduler.runOnce();
+
+  assert.deepEqual(writes, []);
+  assert.equal(batcher.pendingCount("agent-hidden"), 1);
+  assert.equal(scheduler.pendingCount(), 0);
+
+  batcher.enqueue("agent-hidden", "hidden-b");
+  batcher.enqueue("agent-hidden", "hidden-c");
+
+  assert.equal(
+    scheduler.pendingCount(),
+    0,
+    "already-quiesced hidden output must not create empty scheduler frames",
+  );
+  assert.equal(batcher.pendingCount("agent-hidden"), 3);
+
+  eligibility.set("agent-hidden", true);
+  assert.equal(batcher.schedulePending("agent-hidden"), true);
+  assert.equal(scheduler.pendingCount(), 1);
+
+  scheduler.runOnce();
+
+  assert.deepEqual(writes, [
+    { windowId: "agent-hidden", text: "hidden-ahidden-bhidden-c" },
+  ]);
+  assert.equal(batcher.pendingCount("agent-hidden"), 0);
+  assert.equal(scheduler.pendingCount(), 0);
+});
+
+test("quiesced hidden terminal output does not block visible output scheduling", () => {
+  const scheduler = manualScheduler();
+  const writes = [];
+  const eligibility = new Map([
+    ["agent-hidden", false],
+    ["agent-visible", true],
+  ]);
+  const batcher = createTerminalOutputBatcher({
+    schedule: scheduler.schedule,
+    canWrite: (windowId) => eligibility.get(windowId) !== false,
+    write: (windowId, text, done) => {
+      writes.push({ windowId, text });
+      done();
+    },
+  });
+
+  batcher.enqueue("agent-hidden", "hidden-a");
+  scheduler.runOnce();
+  assert.equal(scheduler.pendingCount(), 0);
+
+  batcher.enqueue("agent-hidden", "hidden-b");
+  assert.equal(scheduler.pendingCount(), 0);
+
+  batcher.enqueue("agent-visible", "visible");
+
+  assert.equal(
+    scheduler.pendingCount(),
+    1,
+    "eligible output must still schedule while hidden output is quiesced",
+  );
+
+  scheduler.runOnce();
+
+  assert.deepEqual(writes, [{ windowId: "agent-visible", text: "visible" }]);
+  assert.equal(batcher.pendingCount("agent-hidden"), 2);
+  assert.equal(batcher.pendingWindowCount(), 1);
+  assert.equal(scheduler.pendingCount(), 0);
+});
+
 test("schedulePending resumes hidden queued output through the budgeted flush path", () => {
   const scheduler = manualScheduler();
   const writes = [];

--- a/crates/gwt/web/__tests__/terminal-output-buffer.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-output-buffer.test.mjs
@@ -76,13 +76,47 @@ test("terminal output batching stays isolated per window", () => {
   batcher.enqueue("agent-a", "a2");
   batcher.enqueue("agent-b", "b2");
 
-  assert.equal(scheduler.pendingCount(), 2, "each window gets its own scheduled flush");
+  assert.equal(scheduler.pendingCount(), 1, "one shared frame drains all windows");
   scheduler.runAll();
 
   assert.deepEqual(writes, [
     { windowId: "agent-a", text: "a1a2" },
     { windowId: "agent-b", text: "b1b2" },
   ]);
+});
+
+test("multi-window terminal bursts schedule one shared frame", () => {
+  const scheduler = manualScheduler();
+  const writes = [];
+  const batcher = createTerminalOutputBatcher({
+    schedule: scheduler.schedule,
+    write: (windowId, text, done) => {
+      writes.push({ windowId, text });
+      done();
+    },
+  });
+
+  for (let i = 0; i < 50; i += 1) {
+    const windowId = `agent-${i}`;
+    batcher.enqueue(windowId, `${windowId}:a`);
+    batcher.enqueue(windowId, `${windowId}:b`);
+  }
+
+  assert.equal(
+    scheduler.pendingCount(),
+    1,
+    "one shared frame should drain all pending terminal windows",
+  );
+
+  scheduler.runOnce();
+
+  assert.equal(writes.length, 50);
+  assert.deepEqual(writes.slice(0, 3), [
+    { windowId: "agent-0", text: "agent-0:aagent-0:b" },
+    { windowId: "agent-1", text: "agent-1:aagent-1:b" },
+    { windowId: "agent-2", text: "agent-2:aagent-2:b" },
+  ]);
+  assert.equal(scheduler.pendingCount(), 0);
 });
 
 test("flushNow drains a window before its scheduled frame", () => {

--- a/crates/gwt/web/__tests__/terminal-output-buffer.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-output-buffer.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   DEFAULT_MAX_CHARS_PER_FLUSH,
+  DEFAULT_MAX_TOTAL_CHARS_PER_FLUSH,
   DEFAULT_MAX_WINDOWS_PER_FLUSH,
   createTerminalOutputBatcher,
 } from "../terminal-output-buffer.js";
@@ -164,6 +165,77 @@ test("multi-window terminal bursts respect the per-frame window budget", () => {
   assert.equal(batcher.pendingWindowCount(), 0);
 });
 
+test("multi-window terminal bursts respect the aggregate per-frame character budget", () => {
+  const scheduler = manualScheduler();
+  const writes = [];
+  const batcher = createTerminalOutputBatcher({
+    schedule: scheduler.schedule,
+    maxWindowsPerFlush: 8,
+    maxTotalCharsPerFlush: 10,
+    write: (windowId, text, done) => {
+      writes.push({ windowId, text });
+      done();
+    },
+  });
+
+  batcher.enqueue("agent-0", "aaaaa");
+  batcher.enqueue("agent-1", "bbbbb");
+  batcher.enqueue("agent-2", "ccccc");
+  batcher.enqueue("agent-3", "ddddd");
+
+  scheduler.runOnce();
+
+  assert.deepEqual(writes, [
+    { windowId: "agent-0", text: "aaaaa" },
+    { windowId: "agent-1", text: "bbbbb" },
+  ]);
+  assert.equal(batcher.pendingWindowCount(), 2);
+  assert.equal(scheduler.pendingCount(), 1, "remaining text schedules one follow-up frame");
+
+  scheduler.runAll();
+
+  assert.deepEqual(writes, [
+    { windowId: "agent-0", text: "aaaaa" },
+    { windowId: "agent-1", text: "bbbbb" },
+    { windowId: "agent-2", text: "ccccc" },
+    { windowId: "agent-3", text: "ddddd" },
+  ]);
+  assert.equal(batcher.pendingWindowCount(), 0);
+});
+
+test("aggregate frame budget does not split a single oversized chunk", () => {
+  const scheduler = manualScheduler();
+  const writes = [];
+  const batcher = createTerminalOutputBatcher({
+    schedule: scheduler.schedule,
+    maxTotalCharsPerFlush: 10,
+    write: (windowId, text, done) => {
+      writes.push({ windowId, text });
+      done();
+    },
+  });
+
+  batcher.enqueue("agent-big", "xxxxxxxxxxxx");
+  batcher.enqueue("agent-small", "ok");
+  batcher.enqueue("agent-tail", "zz");
+
+  scheduler.runOnce();
+
+  assert.deepEqual(writes, [
+    { windowId: "agent-big", text: "xxxxxxxxxxxx" },
+  ]);
+  assert.equal(batcher.pendingWindowCount(), 2);
+  assert.equal(scheduler.pendingCount(), 1);
+
+  scheduler.runAll();
+
+  assert.deepEqual(writes, [
+    { windowId: "agent-big", text: "xxxxxxxxxxxx" },
+    { windowId: "agent-small", text: "ok" },
+    { windowId: "agent-tail", text: "zz" },
+  ]);
+});
+
 test("flushNow drains a window before its scheduled frame", () => {
   const scheduler = manualScheduler();
   const writes = [];
@@ -267,4 +339,5 @@ test("mergeChunks runs during the scheduled flush with original chunk order", ()
 test("defaults expose bounded per-frame budgets", () => {
   assert.equal(DEFAULT_MAX_CHARS_PER_FLUSH, 65536);
   assert.equal(DEFAULT_MAX_WINDOWS_PER_FLUSH, 8);
+  assert.equal(DEFAULT_MAX_TOTAL_CHARS_PER_FLUSH, DEFAULT_MAX_CHARS_PER_FLUSH);
 });

--- a/crates/gwt/web/__tests__/terminal-output-buffer.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-output-buffer.test.mjs
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   DEFAULT_MAX_CHARS_PER_FLUSH,
+  DEFAULT_MAX_WINDOWS_PER_FLUSH,
   createTerminalOutputBatcher,
 } from "../terminal-output-buffer.js";
 
@@ -108,7 +109,7 @@ test("multi-window terminal bursts schedule one shared frame", () => {
     "one shared frame should drain all pending terminal windows",
   );
 
-  scheduler.runOnce();
+  scheduler.runAll();
 
   assert.equal(writes.length, 50);
   assert.deepEqual(writes.slice(0, 3), [
@@ -117,6 +118,50 @@ test("multi-window terminal bursts schedule one shared frame", () => {
     { windowId: "agent-2", text: "agent-2:aagent-2:b" },
   ]);
   assert.equal(scheduler.pendingCount(), 0);
+});
+
+test("multi-window terminal bursts respect the per-frame window budget", () => {
+  const scheduler = manualScheduler();
+  const writes = [];
+  const batcher = createTerminalOutputBatcher({
+    schedule: scheduler.schedule,
+    maxWindowsPerFlush: 8,
+    write: (windowId, text, done) => {
+      writes.push({ windowId, text });
+      done();
+    },
+  });
+
+  for (let i = 0; i < 50; i += 1) {
+    batcher.enqueue(`agent-${i}`, `chunk-${i}`);
+  }
+
+  assert.equal(scheduler.pendingCount(), 1, "one shared frame is scheduled");
+
+  scheduler.runOnce();
+
+  assert.equal(writes.length, 8, "first frame writes only the configured window budget");
+  assert.equal(
+    batcher.pendingWindowCount(),
+    42,
+    "remaining windows stay pending for follow-up frames",
+  );
+  assert.equal(scheduler.pendingCount(), 1, "remaining windows schedule one follow-up frame");
+
+  scheduler.runAll();
+
+  assert.equal(writes.length, 50);
+  assert.deepEqual(writes.slice(0, 3), [
+    { windowId: "agent-0", text: "chunk-0" },
+    { windowId: "agent-1", text: "chunk-1" },
+    { windowId: "agent-2", text: "chunk-2" },
+  ]);
+  assert.deepEqual(writes.slice(-2), [
+    { windowId: "agent-48", text: "chunk-48" },
+    { windowId: "agent-49", text: "chunk-49" },
+  ]);
+  assert.equal(scheduler.pendingCount(), 0);
+  assert.equal(batcher.pendingWindowCount(), 0);
 });
 
 test("flushNow drains a window before its scheduled frame", () => {
@@ -219,6 +264,7 @@ test("mergeChunks runs during the scheduled flush with original chunk order", ()
   assert.deepEqual(writes, [{ windowId: "agent-1", text: "AB|CD" }]);
 });
 
-test("defaults expose a bounded per-frame character budget", () => {
+test("defaults expose bounded per-frame budgets", () => {
   assert.equal(DEFAULT_MAX_CHARS_PER_FLUSH, 65536);
+  assert.equal(DEFAULT_MAX_WINDOWS_PER_FLUSH, 8);
 });

--- a/crates/gwt/web/__tests__/terminal-output-buffer.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-output-buffer.test.mjs
@@ -236,6 +236,94 @@ test("aggregate frame budget does not split a single oversized chunk", () => {
   ]);
 });
 
+test("hidden terminal output remains queued without decode write or scheduler spin", () => {
+  const scheduler = manualScheduler();
+  const writes = [];
+  const mergeCalls = [];
+  const eligibility = new Map([
+    ["agent-hidden", false],
+    ["agent-visible", true],
+  ]);
+  const batcher = createTerminalOutputBatcher({
+    schedule: scheduler.schedule,
+    canWrite: (windowId) => eligibility.get(windowId) !== false,
+    mergeChunks: (chunks, windowId) => {
+      mergeCalls.push({ windowId, chunks: [...chunks] });
+      return chunks.join("");
+    },
+    write: (windowId, text, done) => {
+      writes.push({ windowId, text });
+      done();
+    },
+  });
+
+  batcher.enqueue("agent-hidden", "hidden-a");
+  batcher.enqueue("agent-hidden", "hidden-b");
+  batcher.enqueue("agent-visible", "visible");
+
+  scheduler.runOnce();
+
+  assert.deepEqual(mergeCalls, [
+    { windowId: "agent-visible", chunks: ["visible"] },
+  ]);
+  assert.deepEqual(writes, [{ windowId: "agent-visible", text: "visible" }]);
+  assert.equal(batcher.pendingCount("agent-hidden"), 2);
+  assert.equal(batcher.pendingWindowCount(), 1);
+  assert.equal(
+    scheduler.pendingCount(),
+    0,
+    "ineligible-only pending output must not schedule a follow-up spin",
+  );
+});
+
+test("schedulePending resumes hidden queued output through the budgeted flush path", () => {
+  const scheduler = manualScheduler();
+  const writes = [];
+  const eligibility = new Map([["agent-hidden", false]]);
+  const batcher = createTerminalOutputBatcher({
+    schedule: scheduler.schedule,
+    canWrite: (windowId) => eligibility.get(windowId) !== false,
+    maxCharsPerFlush: 6,
+    write: (windowId, text, done) => {
+      writes.push({ windowId, text });
+      done();
+    },
+  });
+
+  batcher.enqueue("agent-hidden", "aa");
+  batcher.enqueue("agent-hidden", "bb");
+  batcher.enqueue("agent-hidden", "cc");
+  batcher.enqueue("agent-hidden", "dd");
+  scheduler.runOnce();
+
+  assert.deepEqual(writes, []);
+  assert.equal(batcher.pendingCount("agent-hidden"), 4);
+  assert.equal(scheduler.pendingCount(), 0);
+
+  eligibility.set("agent-hidden", true);
+  assert.equal(batcher.schedulePending("agent-hidden"), true);
+  assert.equal(scheduler.pendingCount(), 1);
+
+  scheduler.runOnce();
+
+  assert.deepEqual(writes, [{ windowId: "agent-hidden", text: "aabbcc" }]);
+  assert.equal(
+    batcher.pendingCount("agent-hidden"),
+    1,
+    "existing per-window budget must still hold after reveal",
+  );
+  assert.equal(scheduler.pendingCount(), 1, "remaining chunks use one follow-up frame");
+
+  scheduler.runOnce();
+
+  assert.deepEqual(writes, [
+    { windowId: "agent-hidden", text: "aabbcc" },
+    { windowId: "agent-hidden", text: "dd" },
+  ]);
+  assert.equal(batcher.pendingCount("agent-hidden"), 0);
+  assert.equal(scheduler.pendingCount(), 0);
+});
+
 test("flushNow drains a window before its scheduled frame", () => {
   const scheduler = manualScheduler();
   const writes = [];

--- a/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
@@ -20,6 +20,7 @@ import {
   attachHostResizeReflow,
   classifyProjectWindowVisibility,
   createTerminalFitScheduler,
+  createTerminalViewportRefreshScheduler,
   elementHasLayoutBox,
   gateTerminalInputForReadiness,
   rearmRefreshOnVisible,
@@ -735,6 +736,93 @@ test("createTerminalFitScheduler coalesces same-window fits and preserves persis
   assert.equal(callbacks.length, 0);
 });
 
+test("createTerminalViewportRefreshScheduler budgets multi-terminal refreshes across frames", () => {
+  const callbacks = [];
+  const refreshCalls = [];
+  const scheduler = createTerminalViewportRefreshScheduler({
+    schedule: (callback) => {
+      callbacks.push(callback);
+      return callbacks.length;
+    },
+    canRefresh: () => true,
+    refresh: (id) => refreshCalls.push(id),
+    maxRefreshesPerFrame: 4,
+  });
+
+  for (let i = 0; i < 12; i += 1) {
+    scheduler.enqueue(`terminal-${i + 1}`);
+  }
+
+  assert.equal(callbacks.length, 1, "refresh burst must schedule one shared frame");
+
+  callbacks.shift()();
+  assert.deepEqual(
+    refreshCalls,
+    ["terminal-1", "terminal-2", "terminal-3", "terminal-4"],
+    "first frame must only run the configured refresh budget",
+  );
+  assert.equal(callbacks.length, 1, "remaining refreshes must share one follow-up frame");
+
+  callbacks.shift()();
+  assert.deepEqual(
+    refreshCalls,
+    [
+      "terminal-1",
+      "terminal-2",
+      "terminal-3",
+      "terminal-4",
+      "terminal-5",
+      "terminal-6",
+      "terminal-7",
+      "terminal-8",
+    ],
+    "second frame must continue in insertion order",
+  );
+  assert.equal(callbacks.length, 1, "third frame must be scheduled for the tail");
+
+  callbacks.shift()();
+  assert.deepEqual(
+    refreshCalls,
+    Array.from({ length: 12 }, (_, index) => `terminal-${index + 1}`),
+    "all queued terminals must eventually refresh exactly once",
+  );
+  assert.equal(callbacks.length, 0, "no extra frames after completion");
+  assert.equal(scheduler.pendingCount(), 0);
+});
+
+test("createTerminalViewportRefreshScheduler coalesces and marks ineligible windows pending", () => {
+  const callbacks = [];
+  const refreshCalls = [];
+  const pendingMarks = [];
+  const eligibility = new Map([
+    ["agent-1", true],
+    ["agent-2", false],
+  ]);
+  const scheduler = createTerminalViewportRefreshScheduler({
+    schedule: (callback) => {
+      callbacks.push(callback);
+      return callbacks.length;
+    },
+    canRefresh: (id) => eligibility.get(id) !== false,
+    refresh: (id) => refreshCalls.push(id),
+    markPending: (id) => pendingMarks.push(id),
+    maxRefreshesPerFrame: 4,
+  });
+
+  assert.equal(scheduler.enqueue("agent-1"), true);
+  assert.equal(scheduler.enqueue("agent-1"), true);
+  assert.equal(scheduler.enqueue("agent-2"), true);
+  assert.equal(callbacks.length, 1, "coalesced refreshes still share one frame");
+  assert.equal(scheduler.pendingCount(), 2);
+
+  callbacks.shift()();
+
+  assert.deepEqual(refreshCalls, ["agent-1"]);
+  assert.deepEqual(pendingMarks, ["agent-2"]);
+  assert.equal(scheduler.pendingCount(), 0);
+  assert.equal(callbacks.length, 0);
+});
+
 test("app.js wires the reflow controller for resize, transition, and predicate", () => {
   // Source-string contract retained per the memory — limited to wiring
   // detection so a future refactor that drops the import / call surfaces
@@ -751,8 +839,23 @@ test("app.js wires the reflow controller for resize, transition, and predicate",
   );
   assert.match(
     appSource,
+    /createTerminalViewportRefreshScheduler\(\{[\s\S]*?canRefresh:\s*canRefreshTerminalViewport[\s\S]*?refresh:\s*\(windowId\)\s*=>[\s\S]*?refreshTerminalViewport\(windowId\)[\s\S]*?markPending:\s*markTerminalViewportRefreshPending[\s\S]*?\}\)/,
+    "app.js must construct the shared terminal viewport refresh scheduler",
+  );
+  assert.match(
+    appSource,
     /function scheduleTerminalFit\(windowId,\s*persist = false\)[\s\S]*?terminalFitScheduler\.enqueue\(windowId,\s*\{\s*persist\s*\}\)/,
     "app.js must expose a scheduleTerminalFit wrapper over the shared fit scheduler",
+  );
+  assert.match(
+    appSource,
+    /function scheduleTerminalViewportRefresh\(windowId\)[\s\S]*?terminalViewportRefreshScheduler\.enqueue\(windowId\)/,
+    "app.js must route routine terminal viewport refreshes through the shared scheduler",
+  );
+  assert.match(
+    appSource,
+    /terminalViewportRefreshScheduler\?\.clear\(windowId\)/,
+    "removed terminal windows must be cleared from the shared viewport refresh scheduler",
   );
   assert.match(
     appSource,

--- a/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
@@ -19,6 +19,7 @@ import {
   attachContainerResizeReflow,
   attachHostResizeReflow,
   classifyProjectWindowVisibility,
+  createTerminalFitScheduler,
   elementHasLayoutBox,
   gateTerminalInputForReadiness,
   rearmRefreshOnVisible,
@@ -653,6 +654,87 @@ test("attachHostResizeReflow dispose cancels pending rAF (Issue #2903)", () => {
   assert.equal(fitCalls.length, 0, "no fits after dispose");
 });
 
+test("createTerminalFitScheduler budgets multi-terminal fits across frames", () => {
+  const callbacks = [];
+  const fitCalls = [];
+  const scheduler = createTerminalFitScheduler({
+    schedule: (callback) => {
+      callbacks.push(callback);
+      return callbacks.length;
+    },
+    fitTerminal: (id, persist) => fitCalls.push([id, persist]),
+    maxFitsPerFrame: 4,
+  });
+
+  for (let i = 0; i < 12; i += 1) {
+    scheduler.enqueue(`terminal-${i + 1}`, { persist: false });
+  }
+
+  assert.equal(callbacks.length, 1, "fit burst must schedule one shared frame");
+
+  callbacks.shift()();
+  assert.deepEqual(
+    fitCalls.map(([id]) => id),
+    ["terminal-1", "terminal-2", "terminal-3", "terminal-4"],
+    "first frame must only run the configured fit budget",
+  );
+  assert.equal(callbacks.length, 1, "remaining fits must share one follow-up frame");
+
+  callbacks.shift()();
+  assert.deepEqual(
+    fitCalls.map(([id]) => id),
+    [
+      "terminal-1",
+      "terminal-2",
+      "terminal-3",
+      "terminal-4",
+      "terminal-5",
+      "terminal-6",
+      "terminal-7",
+      "terminal-8",
+    ],
+    "second frame must continue in insertion order",
+  );
+  assert.equal(callbacks.length, 1, "third frame must be scheduled for the tail");
+
+  callbacks.shift()();
+  assert.deepEqual(
+    fitCalls.map(([id]) => id),
+    Array.from({ length: 12 }, (_, index) => `terminal-${index + 1}`),
+    "all queued terminals must eventually fit exactly once",
+  );
+  assert.equal(callbacks.length, 0, "no extra frames after completion");
+  assert.equal(scheduler.pendingCount(), 0);
+});
+
+test("createTerminalFitScheduler coalesces same-window fits and preserves persist=true", () => {
+  const callbacks = [];
+  const fitCalls = [];
+  const scheduler = createTerminalFitScheduler({
+    schedule: (callback) => {
+      callbacks.push(callback);
+      return callbacks.length;
+    },
+    fitTerminal: (id, persist) => fitCalls.push([id, persist]),
+    maxFitsPerFrame: 4,
+  });
+
+  assert.equal(scheduler.enqueue("agent-1", { persist: false }), true);
+  assert.equal(scheduler.enqueue("agent-1", { persist: true }), true);
+  assert.equal(scheduler.enqueue("agent-2", { persist: false }), true);
+  assert.equal(callbacks.length, 1, "coalesced requests still share one frame");
+  assert.equal(scheduler.pendingCount(), 2);
+
+  callbacks.shift()();
+
+  assert.deepEqual(fitCalls, [
+    ["agent-1", true],
+    ["agent-2", false],
+  ]);
+  assert.equal(scheduler.pendingCount(), 0);
+  assert.equal(callbacks.length, 0);
+});
+
 test("app.js wires the reflow controller for resize, transition, and predicate", () => {
   // Source-string contract retained per the memory — limited to wiring
   // detection so a future refactor that drops the import / call surfaces
@@ -664,8 +746,28 @@ test("app.js wires the reflow controller for resize, transition, and predicate",
   );
   assert.match(
     appSource,
-    /attachHostResizeReflow\(\{[\s\S]*?fitTerminal,\s*\n[\s\S]*?\}\)/,
-    "host resize fan-out must dispatch through the reflow controller",
+    /createTerminalFitScheduler\(\{\s*fitTerminal\s*\}\)/,
+    "app.js must construct the shared terminal fit scheduler from fitTerminal",
+  );
+  assert.match(
+    appSource,
+    /function scheduleTerminalFit\(windowId,\s*persist = false\)[\s\S]*?terminalFitScheduler\.enqueue\(windowId,\s*\{\s*persist\s*\}\)/,
+    "app.js must expose a scheduleTerminalFit wrapper over the shared fit scheduler",
+  );
+  assert.match(
+    appSource,
+    /attachHostResizeReflow\(\{[\s\S]*?fitTerminal:\s*scheduleTerminalFit[\s\S]*?\}\)/,
+    "host resize fan-out must route fit requests through the shared scheduler",
+  );
+  assert.match(
+    appSource,
+    /syncMaximizedWindowsToViewport[\s\S]*?scheduleTerminalFit\(windowData\.id,\s*false\)/,
+    "maximized viewport sync must route visual terminal fits through the shared scheduler",
+  );
+  assert.match(
+    appSource,
+    /scheduleTerminalFit\(windowData\.id,\s*shouldPersistTerminalGeometry\)/,
+    "workspace render geometry changes must route terminal fits through the shared scheduler",
   );
   assert.match(
     appSource,

--- a/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
+++ b/crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs
@@ -533,6 +533,37 @@ test("classifyProjectWindowVisibility keeps inactive project terminals hidden, n
   assert.deepEqual(result.removed, ["orphan::agent-1"]);
 });
 
+test("classifyProjectWindowVisibility accepts prebuilt id sets", () => {
+  const legacy = classifyProjectWindowVisibility({
+    activeWindowIds: ["tab-a::agent-1", "tab-a::board-1"],
+    allProjectWindowIds: [
+      "tab-a::agent-1",
+      "tab-a::board-1",
+      "tab-b::agent-1",
+    ],
+    mountedWindowIds: [
+      "tab-a::agent-1",
+      "tab-b::agent-1",
+      "orphan::agent-1",
+    ],
+  });
+  const fromSets = classifyProjectWindowVisibility({
+    activeWindowIdSet: new Set(["tab-a::agent-1", "tab-a::board-1"]),
+    allProjectWindowIdSet: new Set([
+      "tab-a::agent-1",
+      "tab-a::board-1",
+      "tab-b::agent-1",
+    ]),
+    mountedWindowIds: [
+      "tab-a::agent-1",
+      "tab-b::agent-1",
+      "orphan::agent-1",
+    ],
+  });
+
+  assert.deepEqual(fromSets, legacy);
+});
+
 test("attachHostResizeReflow throws when given a non-DOM window", () => {
   assert.throws(
     () =>

--- a/crates/gwt/web/__tests__/ui-trace-wiring.test.mjs
+++ b/crates/gwt/web/__tests__/ui-trace-wiring.test.mjs
@@ -15,8 +15,13 @@ const appSource = readFileSync(resolve(here, "../app.js"), "utf8");
 
 function fakeProfiler() {
   const calls = [];
+  let active = false;
   return {
     calls,
+    isActive() {
+      calls.push({ kind: "isActive" });
+      return active;
+    },
     measure(kind, fields, callback) {
       calls.push({ kind: "measure", event: kind, fields });
       return callback();
@@ -28,10 +33,16 @@ function fakeProfiler() {
       calls.push({ kind: "recordPointer", event: kind, pointerId: event.pointerId, fields });
     },
     start() {
+      active = true;
       calls.push({ kind: "start" });
       return { session_id: "trace-1", started_at: 1 };
     },
     stop() {
+      if (!active) {
+        calls.push({ kind: "stop" });
+        return null;
+      }
+      active = false;
       calls.push({ kind: "stop" });
       return { session_id: "trace-1", entries: [] };
     },
@@ -141,6 +152,22 @@ test("UI trace save payload keeps the wire kind in one place", () => {
   });
 });
 
+test("UI trace wiring exposes profiler active state", () => {
+  const profiler = fakeProfiler();
+  const wiring = createUiTraceWiring({
+    profiler,
+    send: () => {},
+    alert: () => {},
+    log: () => {},
+  });
+
+  assert.equal(wiring.isTracing(), false);
+  wiring.start();
+  assert.equal(wiring.isTracing(), true);
+  wiring.stop();
+  assert.equal(wiring.isTracing(), false);
+});
+
 test("app.js imports and instantiates the UI trace wiring module", () => {
   assert.match(
     appSource,
@@ -152,6 +179,10 @@ test("app.js imports and instantiates the UI trace wiring module", () => {
 test("WebSocket dispatcher forwards timing trace events through the wiring facade", () => {
   assert.match(appSource, /onTrace:\s*\(kind,\s*fields\)\s*=>/);
   assert.match(appSource, /traceUi\(kind,\s*fields\)/);
+});
+
+test("WebSocket dispatcher gates trace work through active UI trace state", () => {
+  assert.match(appSource, /shouldTrace:\s*uiTraceWiring\.isTracing/);
 });
 
 test("pointer diagnostics use centralized event constants", () => {

--- a/crates/gwt/web/__tests__/viewport-persist-throttle.test.mjs
+++ b/crates/gwt/web/__tests__/viewport-persist-throttle.test.mjs
@@ -259,3 +259,72 @@ test("payload always reflects the most recent value at flush time", () => {
   scheduler.advance(100);
   assert.deepEqual(sent, [{ x: 999, y: 999, zoom: 1.5 }]);
 });
+
+test("duplicate pending viewport payloads keep the existing timer and dispatch once", () => {
+  const sent = [];
+  const clock = manualClock();
+  const scheduler = manualScheduler();
+  const throttle = createViewportPersistThrottle({
+    send: (payload) => sent.push(payload),
+    tailMs: 100,
+    maxWaitMs: 500,
+    now: clock.nowFn,
+    setTimeoutImpl: scheduler.setTimeout,
+    clearTimeoutImpl: scheduler.clearTimeout,
+  });
+
+  throttle.schedule({ x: 10, y: 20, zoom: 1 });
+  clock.advance(30);
+  scheduler.advance(30);
+  throttle.schedule({ x: 10, y: 20, zoom: 1 });
+
+  assert.equal(
+    scheduler.pendingCount(),
+    1,
+    "duplicate pending payload must not create another active timer",
+  );
+
+  clock.advance(70);
+  scheduler.advance(70);
+  assert.deepEqual(sent, [{ x: 10, y: 20, zoom: 1 }]);
+  assert.equal(scheduler.pendingCount(), 0);
+});
+
+test("duplicate dispatched viewport payloads are no-ops until values change", () => {
+  const sent = [];
+  const clock = manualClock();
+  const scheduler = manualScheduler();
+  const throttle = createViewportPersistThrottle({
+    send: (payload) => sent.push(payload),
+    tailMs: 100,
+    maxWaitMs: 500,
+    now: clock.nowFn,
+    setTimeoutImpl: scheduler.setTimeout,
+    clearTimeoutImpl: scheduler.clearTimeout,
+  });
+
+  throttle.schedule({ x: 1, y: 2, zoom: 1 });
+  throttle.flushNow();
+  assert.deepEqual(sent, [{ x: 1, y: 2, zoom: 1 }]);
+
+  throttle.schedule({ x: 1, y: 2, zoom: 1 });
+  assert.deepEqual(
+    sent,
+    [{ x: 1, y: 2, zoom: 1 }],
+    "same values after dispatch must not send again",
+  );
+  assert.equal(
+    scheduler.pendingCount(),
+    0,
+    "same values after dispatch must not schedule a timer",
+  );
+
+  throttle.schedule({ x: 1, y: 2, zoom: 1.25 });
+  assert.equal(scheduler.pendingCount(), 1, "changed zoom must schedule");
+  clock.advance(100);
+  scheduler.advance(100);
+  assert.deepEqual(sent, [
+    { x: 1, y: 2, zoom: 1 },
+    { x: 1, y: 2, zoom: 1.25 },
+  ]);
+});

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -729,26 +729,35 @@
         });
       }
 
-      function projectPickerRenderKey() {
-        const shouldShow = !activeProjectTab();
-        return JSON.stringify({
-          visible: shouldShow,
-          error: projectError || "",
-          recent_projects: shouldShow ? recentProjectsRenderKey(appState) : "",
-        });
+      function projectPickerRenderKey(activeTab = activeProjectTab()) {
+        const shouldShow = !activeTab;
+        const parts = [];
+        appendRenderKeyPart(parts, "visible");
+        appendRenderKeyPart(parts, shouldShow);
+        appendRenderKeyPart(parts, "error");
+        appendRenderKeyPart(parts, projectError || "");
+        appendRenderKeyPart(parts, "recent_projects");
+        appendRenderKeyPart(
+          parts,
+          shouldShow ? recentProjectsRenderKey(appState) : "",
+        );
+        return parts.join("");
       }
 
       function projectOnboardingRenderKey(tab) {
         const visible = Boolean(tab && tab.kind !== "git");
-        return JSON.stringify({
-          visible,
-          kind: visible ? tab.kind || "" : "",
-          project_root: visible ? tab.project_root || "" : "",
-        });
+        const parts = [];
+        appendRenderKeyPart(parts, "visible");
+        appendRenderKeyPart(parts, visible);
+        appendRenderKeyPart(parts, "kind");
+        appendRenderKeyPart(parts, visible ? tab.kind || "" : "");
+        appendRenderKeyPart(parts, "project_root");
+        appendRenderKeyPart(parts, visible ? tab.project_root || "" : "");
+        return parts.join("");
       }
 
-      function actionAvailabilityRenderKey() {
-        return activeProjectTab() ? "active" : "empty";
+      function actionAvailabilityRenderKey(activeTab = activeProjectTab()) {
+        return activeTab ? "active" : "empty";
       }
       // SPEC-1934 US-6: state for the migration confirmation / progress modal.
       // `tabId` identifies which tab the active migration belongs to so a
@@ -1936,8 +1945,8 @@
         });
       }
 
-      function updateActionAvailability() {
-        const nextActionAvailabilityKey = actionAvailabilityRenderKey();
+      function updateActionAvailability(activeTab = activeProjectTab()) {
+        const nextActionAvailabilityKey = actionAvailabilityRenderKey(activeTab);
         if (renderedActionAvailabilityKey === nextActionAvailabilityKey) {
           return;
         }
@@ -2581,13 +2590,13 @@
         focusOpenProjectMenuItemAt(nextIndex);
       }
 
-      function renderProjectPicker() {
-        const nextProjectPickerKey = projectPickerRenderKey();
+      function renderProjectPicker(activeTab = activeProjectTab()) {
+        const nextProjectPickerKey = projectPickerRenderKey(activeTab);
         if (renderedProjectPickerKey === nextProjectPickerKey) {
           return;
         }
         renderedProjectPickerKey = nextProjectPickerKey;
-        const shouldShow = !activeProjectTab();
+        const shouldShow = !activeTab;
         projectPicker.classList.toggle("visible", shouldShow);
         projectPickerError.hidden = !projectError;
         projectPickerError.textContent = projectError;
@@ -2633,9 +2642,9 @@
               renderedProjectTabsKey = nextProjectTabsKey;
               renderProjectTabs();
             }
-            renderProjectPicker();
-            updateActionAvailability();
             const tab = activeProjectTab();
+            renderProjectPicker(tab);
+            updateActionAvailability(tab);
             renderProjectOnboarding(tab);
             renderWorkspace(tab?.workspace || emptyWorkspace());
             syncCurrentProjectWorkspaceIds(

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -495,6 +495,7 @@
       let renderedProjectPickerKey = "";
       let renderedProjectOnboardingKey = "";
       let renderedActionAvailabilityKey = "";
+      let renderedOperatorTelemetryKey = "";
 
       function projectTabsRenderKey(state) {
         return JSON.stringify({
@@ -3410,6 +3411,34 @@
       // Aggregates `data-agent-state` across all open windows and pushes the
       // counts into the bottom strip. We also expose agent count to the
       // sidebar layer for the "Quick" section's hint.
+      function operatorTelemetryRenderKey(counts) {
+        return JSON.stringify({
+          active: counts?.active ?? null,
+          idle: counts?.idle ?? null,
+          blocked: counts?.blocked ?? null,
+          done: counts?.done ?? null,
+          agents: counts?.agents ?? null,
+          branches: counts?.branches ?? null,
+          git: counts?.git ?? null,
+          hooks: counts?.hooks ?? null,
+          layers: counts?.layers ?? null,
+        });
+      }
+
+      function applyOperatorTelemetryCounts(counts) {
+        if (!window.__operatorShell?.applyTelemetryCounts) return;
+        const nextOperatorTelemetryKey = operatorTelemetryRenderKey(counts);
+        if (renderedOperatorTelemetryKey === nextOperatorTelemetryKey) {
+          return;
+        }
+        try {
+          window.__operatorShell.applyTelemetryCounts(counts);
+          renderedOperatorTelemetryKey = nextOperatorTelemetryKey;
+        } catch (e) {
+          console.warn("operator telemetry update failed", e);
+        }
+      }
+
       function recomputeOperatorTelemetry() {
         if (!window.__operatorShell?.applyTelemetryCounts) return;
         const counts = { active: 0, idle: 0, blocked: 0, done: 0, agents: 0 };
@@ -3456,11 +3485,7 @@
             counts.agents = Math.max(counts.agents, activeAgents + blockedAgents);
           }
         }
-        try {
-          window.__operatorShell.applyTelemetryCounts(counts);
-        } catch (e) {
-          console.warn("operator telemetry update failed", e);
-        }
+        applyOperatorTelemetryCounts(counts);
       }
 
       // ---- Provider usage & rate limits (SPEC-2970) ----
@@ -13822,15 +13847,11 @@
             syncBranchSelectionState(state);
             frontendUnits.branchesFileTreeSurface.renderBranches(event.id);
             // SPEC-2356 — feed git layer count into the Operator Status Strip.
-            try {
-              const branchesCount = Array.isArray(event.entries) ? event.entries.length : 0;
-              window.__operatorShell?.applyTelemetryCounts?.({
-                branches: branchesCount,
-                git: branchesCount,
-              });
-            } catch (e) {
-              console.warn("operator branch telemetry failed", e);
-            }
+            const branchesCount = Array.isArray(event.entries) ? event.entries.length : 0;
+            applyOperatorTelemetryCounts({
+              branches: branchesCount,
+              git: branchesCount,
+            });
             break;
           }
           case "profile_snapshot": {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -489,6 +489,10 @@
       let renderedRecentProjectsMenuKey = "";
       let renderedWorkspaceWindowsKey = "";
       let renderedWindowListKey = "";
+      let renderedAppVersionLabel = null;
+      let renderedProjectPickerKey = "";
+      let renderedProjectOnboardingKey = "";
+      let renderedActionAvailabilityKey = "";
 
       function projectTabsRenderKey(state) {
         return JSON.stringify({
@@ -596,6 +600,28 @@
           rows: entries.map(entryKey),
         });
       }
+
+      function projectPickerRenderKey() {
+        const shouldShow = !activeProjectTab();
+        return JSON.stringify({
+          visible: shouldShow,
+          error: projectError || "",
+          recent_projects: shouldShow ? recentProjectsRenderKey(appState) : "",
+        });
+      }
+
+      function projectOnboardingRenderKey(tab) {
+        const visible = Boolean(tab && tab.kind !== "git");
+        return JSON.stringify({
+          visible,
+          kind: visible ? tab.kind || "" : "",
+          project_root: visible ? tab.project_root || "" : "",
+        });
+      }
+
+      function actionAvailabilityRenderKey() {
+        return activeProjectTab() ? "active" : "empty";
+      }
       // SPEC-1934 US-6: state for the migration confirmation / progress modal.
       // `tabId` identifies which tab the active migration belongs to so a
       // multi-project frontend never mixes events from different repos.
@@ -668,6 +694,10 @@
 
       function renderAppVersion() {
         const label = formatVersionLabel();
+        if (renderedAppVersionLabel === label) {
+          return;
+        }
+        renderedAppVersionLabel = label;
         appVersionLabel.hidden = !label;
         appVersionLabel.textContent = label;
         appVersionLabel.title = label;
@@ -1760,7 +1790,12 @@
       }
 
       function updateActionAvailability() {
-        const hasActiveTab = Boolean(activeProjectTab());
+        const nextActionAvailabilityKey = actionAvailabilityRenderKey();
+        if (renderedActionAvailabilityKey === nextActionAvailabilityKey) {
+          return;
+        }
+        renderedActionAvailabilityKey = nextActionAvailabilityKey;
+        const hasActiveTab = nextActionAvailabilityKey === "active";
         addButton.disabled = !hasActiveTab;
         tileButton.disabled = !hasActiveTab;
         stackButton.disabled = !hasActiveTab;
@@ -2390,6 +2425,11 @@
       }
 
       function renderProjectPicker() {
+        const nextProjectPickerKey = projectPickerRenderKey();
+        if (renderedProjectPickerKey === nextProjectPickerKey) {
+          return;
+        }
+        renderedProjectPickerKey = nextProjectPickerKey;
         const shouldShow = !activeProjectTab();
         projectPicker.classList.toggle("visible", shouldShow);
         projectPickerError.hidden = !projectError;
@@ -2400,6 +2440,11 @@
       }
 
       function renderProjectOnboarding(tab) {
+        const nextProjectOnboardingKey = projectOnboardingRenderKey(tab);
+        if (renderedProjectOnboardingKey === nextProjectOnboardingKey) {
+          return;
+        }
+        renderedProjectOnboardingKey = nextProjectOnboardingKey;
         if (!tab || tab.kind === "git") {
           projectOnboarding.classList.remove("visible");
           return;

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -378,6 +378,7 @@
         idleMs: 300,
       });
       let viewportRasterTimer = null;
+      let viewportDomApplied = false;
       let launchWizard = null;
       let launchWizardOpenError = null;
       let activeWorkProjection = null;
@@ -2843,6 +2844,7 @@
           y: viewport.y,
           zoom: viewport.zoom,
         });
+        viewportDomApplied = true;
       }
 
       // Issue #2698 PR 2 (B1) — throttle the `update_viewport` WS
@@ -13341,10 +13343,14 @@
           UI_TRACE_EVENT.renderWorkspace,
           { windows: Array.isArray(workspace?.windows) ? workspace.windows.length : 0 },
           () => {
-            viewport = viewportSyncState.applyServerViewport(workspace.viewport, {
+            const nextViewport = viewportSyncState.applyServerViewport(workspace.viewport, {
               scopeKey: activeViewportScopeKey(),
             });
-            applyViewport();
+            const viewportChanged = !sameViewportValues(viewport, nextViewport);
+            viewport = nextViewport;
+            if (!viewportDomApplied || viewportChanged) {
+              applyViewport();
+            }
 
             const nextWorkspaceWindowsKey = workspaceWindowsRenderKey(workspace);
             if (renderedWorkspaceWindowsKey === nextWorkspaceWindowsKey) {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -2093,11 +2093,11 @@
       function renderWindowList() {
         windowListPanel.hidden = !windowListOpen;
         windowListButton.setAttribute("aria-expanded", windowListOpen ? "true" : "false");
-        const nextWindowListKey = windowListRenderKey();
         if (!windowListOpen) {
-          renderedWindowListKey = nextWindowListKey;
+          renderedWindowListKey = "__closed__";
           return;
         }
+        const nextWindowListKey = windowListRenderKey();
         if (renderedWindowListKey === nextWindowListKey) {
           return;
         }

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -2300,7 +2300,6 @@
               refreshBoardCurrentWorkspaceId();
             }
             renderWindowList();
-            renderActiveWorkOverview();
           },
         );
       }

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -51,6 +51,7 @@
         attachContainerResizeReflow,
         attachHostResizeReflow,
         classifyProjectWindowVisibility,
+        createTerminalFitScheduler,
         elementHasLayoutBox,
         gateTerminalInputForReadiness,
         rearmRefreshOnVisible,
@@ -184,6 +185,7 @@
       const detailMap = new Map();
       const windowRuntimeStateMap = new Map();
       const terminalMap = new Map();
+      let terminalFitScheduler = null;
       const terminalOutputBatcher = createTerminalOutputBatcher({
         mergeChunks: (chunks, windowId) => {
           const decoder = decoderMap.get(windowId);
@@ -2211,7 +2213,7 @@
           if (presetSurface(windowData.preset) === "terminal") {
             // Visual re-fit only (persist=false): never round-trip geometry from
             // the sync path, so this client cannot churn the shared state.
-            requestAnimationFrame(() => fitTerminal(windowData.id, false));
+            scheduleTerminalFit(windowData.id, false);
           }
         }
       }
@@ -3058,6 +3060,16 @@
           }
         );
       }
+
+      function scheduleTerminalFit(windowId, persist = false) {
+        if (!terminalFitScheduler) {
+          requestAnimationFrame(() => fitTerminal(windowId, persist));
+          return false;
+        }
+        return terminalFitScheduler.enqueue(windowId, { persist });
+      }
+
+      terminalFitScheduler = createTerminalFitScheduler({ fitTerminal });
 
       function scheduleTerminalResizeFit(windowId) {
         if (!terminalMap.has(windowId)) {
@@ -13283,9 +13295,7 @@
           presetSurface(windowData.preset) === "terminal" &&
           !windowData.minimized
         ) {
-          requestAnimationFrame(() =>
-            fitTerminal(windowData.id, shouldPersistTerminalGeometry),
-          );
+          scheduleTerminalFit(windowData.id, shouldPersistTerminalGeometry);
         }
       }
 
@@ -15475,7 +15485,7 @@
         window,
         terminalIds: () => terminalMap.keys(),
         canRefreshViewport: canRefreshTerminalViewport,
-        fitTerminal,
+        fitTerminal: scheduleTerminalFit,
         beforeFan: () => {
           frontendUnits.projectWorkspaceShell.renderWindowList();
           syncMaximizedWindowsToViewport();

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -488,6 +488,7 @@
       let renderedRecentProjectsKey = "";
       let renderedRecentProjectsMenuKey = "";
       let renderedWorkspaceWindowsKey = "";
+      let renderedWindowListKey = "";
 
       function projectTabsRenderKey(state) {
         return JSON.stringify({
@@ -538,6 +539,61 @@
             tab_group_id: windowData?.tab_group_id || "",
             tab_group_active: Boolean(windowData?.tab_group_active),
           })),
+        });
+      }
+
+      function windowListRenderKey() {
+        const workspace = activeWorkspace();
+        const workspaceWindows = workspace.windows || [];
+        const workspaceWindowMap = new Map(
+          workspaceWindows.map((windowData) => [windowData.id, windowData]),
+        );
+        const entries =
+          windowListEntries.length > 0
+            ? windowListEntries
+                .map((entry) => workspaceWindowMap.get(entry.id) || entry)
+                .filter(
+                  (entry) =>
+                    workspaceWindowMap.size === 0 || workspaceWindowMap.has(entry.id),
+                )
+            : workspaceWindows;
+        const entryKey = (entry) => {
+          const runtimeState = runtimeStateForWindow(entry);
+          return {
+            id: entry?.id || "",
+            preset: entry?.preset || "",
+            title: entry?.title || "",
+            dynamic_title: entry?.dynamic_title || "",
+            dynamic_title_detail: entry?.dynamic_title_detail || "",
+            purpose_title: entry?.purpose_title || "",
+            agent_id: entry?.agent_id || "",
+            agent_color: entry?.agent_color || "",
+            status: entry?.status || "",
+            runtime_state: runtimeState,
+            runtime_label: windowRuntimeLabel(runtimeState),
+            role_badge: windowRoleBadgeLabel(entry) || "",
+            display_title: windowDisplayTitle(entry),
+            title_tooltip: windowTitleTooltip(entry),
+            geometry: {
+              x: entry?.geometry?.x ?? 0,
+              y: entry?.geometry?.y ?? 0,
+              width: entry?.geometry?.width ?? 0,
+              height: entry?.geometry?.height ?? 0,
+            },
+            geometry_label: windowGeometryLabel(entry),
+            minimized: Boolean(entry?.minimized),
+            maximized: Boolean(entry?.maximized),
+            z_index: entry?.z_index ?? 0,
+            tab_group_id: entry?.tab_group_id || "",
+            tab_group_active: Boolean(entry?.tab_group_active),
+          };
+        };
+        return JSON.stringify({
+          open: Boolean(windowListOpen),
+          active_tab_id: appState?.active_tab_id || null,
+          window_list_entries: windowListEntries.map(entryKey),
+          active_window_ids: workspaceWindows.map((windowData) => windowData?.id || ""),
+          rows: entries.map(entryKey),
         });
       }
       // SPEC-1934 US-6: state for the migration confirmation / progress modal.
@@ -1913,9 +1969,15 @@
       function renderWindowList() {
         windowListPanel.hidden = !windowListOpen;
         windowListButton.setAttribute("aria-expanded", windowListOpen ? "true" : "false");
+        const nextWindowListKey = windowListRenderKey();
         if (!windowListOpen) {
+          renderedWindowListKey = nextWindowListKey;
           return;
         }
+        if (renderedWindowListKey === nextWindowListKey) {
+          return;
+        }
+        renderedWindowListKey = nextWindowListKey;
         const workspaceWindows = activeWorkspace().windows || [];
         const workspaceWindowMap = new Map(
           workspaceWindows.map((windowData) => [windowData.id, windowData]),
@@ -1984,6 +2046,7 @@
         }
         windowListOpen = !windowListOpen;
         windowListEntries = [];
+        renderedWindowListKey = "";
         renderWindowList();
         if (windowListOpen) {
           requestWindowList();

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1705,6 +1705,24 @@
         return ids;
       }
 
+      function allProjectWindowIdSet() {
+        const ids = new Set();
+        for (const tab of appState?.tabs || []) {
+          for (const windowData of tab.workspace?.windows || []) {
+            ids.add(windowData.id);
+          }
+        }
+        return ids;
+      }
+
+      function workspaceWindowIdSet(workspace) {
+        const ids = new Set();
+        for (const windowData of workspace?.windows || []) {
+          ids.add(windowData.id);
+        }
+        return ids;
+      }
+
       function workspaceWindowById(windowId) {
         return activeWorkspace().windows.find((windowData) => windowData.id === windowId) || null;
       }
@@ -13413,11 +13431,10 @@
             }
             renderedWorkspaceWindowsKey = nextWorkspaceWindowsKey;
 
-            const activeWindowIds = workspace.windows.map((windowData) => windowData.id);
-            const ids = new Set(activeWindowIds);
+            const activeWindowIdSet = workspaceWindowIdSet(workspace);
             const visibility = classifyProjectWindowVisibility({
-              activeWindowIds,
-              allProjectWindowIds: allProjectWindowIds(),
+              activeWindowIdSet,
+              allProjectWindowIdSet: allProjectWindowIdSet(),
               mountedWindowIds: windowMap.keys(),
             });
             for (const windowId of visibility.hidden) {
@@ -13500,7 +13517,7 @@
             scheduleMaximizedWindowsToViewportSync();
 
             const topmostId = topmostWindowId(workspace);
-            if (topmostId && ids.has(topmostId)) {
+            if (topmostId && activeWindowIdSet.has(topmostId)) {
               focusWindowLocally(topmostId);
               scheduleTerminalFocusActivation(topmostId, {
                 shouldPersistGeometry: false,

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -534,35 +534,68 @@
         );
       }
 
+      function appendRenderKeyPart(parts, value) {
+        const text = String(value ?? "");
+        parts.push(String(text.length), ":", text, "\u001f");
+      }
+
       function workspaceWindowsRenderKey(workspace) {
         const windows = workspace?.windows || [];
-        return JSON.stringify({
-          active_tab_id: appState?.active_tab_id || null,
-          active_window_ids: windows.map((windowData) => windowData?.id || ""),
-          all_project_window_ids: allProjectWindowIds(),
-          windows: windows.map((windowData) => ({
-            id: windowData?.id || "",
-            preset: windowData?.preset || "",
-            title: windowData?.title || "",
-            dynamic_title: windowData?.dynamic_title || "",
-            dynamic_title_detail: windowData?.dynamic_title_detail || "",
-            purpose_title: windowData?.purpose_title || "",
-            agent_id: windowData?.agent_id || "",
-            agent_color: windowData?.agent_color || "",
-            status: windowData?.status || "",
-            geometry: {
-              x: windowData?.geometry?.x ?? 0,
-              y: windowData?.geometry?.y ?? 0,
-              width: windowData?.geometry?.width ?? 0,
-              height: windowData?.geometry?.height ?? 0,
-            },
-            minimized: Boolean(windowData?.minimized),
-            maximized: Boolean(windowData?.maximized),
-            z_index: windowData?.z_index ?? 0,
-            tab_group_id: windowData?.tab_group_id || "",
-            tab_group_active: Boolean(windowData?.tab_group_active),
-          })),
-        });
+        const parts = [];
+        appendRenderKeyPart(parts, "active_tab_id");
+        appendRenderKeyPart(parts, appState?.active_tab_id || null);
+        appendRenderKeyPart(parts, "active_window_ids");
+        appendRenderKeyPart(parts, windows.length);
+        for (const windowData of windows) {
+          appendRenderKeyPart(parts, windowData?.id || "");
+        }
+        appendRenderKeyPart(parts, "all_project_window_ids");
+        for (const windowId of allProjectWindowIds()) {
+          appendRenderKeyPart(parts, windowId);
+        }
+        appendRenderKeyPart(parts, "windows");
+        appendRenderKeyPart(parts, windows.length);
+        for (const windowData of windows) {
+          const geometry = windowData?.geometry || {};
+          appendRenderKeyPart(parts, "id");
+          appendRenderKeyPart(parts, windowData?.id || "");
+          appendRenderKeyPart(parts, "preset");
+          appendRenderKeyPart(parts, windowData?.preset || "");
+          appendRenderKeyPart(parts, "title");
+          appendRenderKeyPart(parts, windowData?.title || "");
+          appendRenderKeyPart(parts, "dynamic_title");
+          appendRenderKeyPart(parts, windowData?.dynamic_title || "");
+          appendRenderKeyPart(parts, "dynamic_title_detail");
+          appendRenderKeyPart(parts, windowData?.dynamic_title_detail || "");
+          appendRenderKeyPart(parts, "purpose_title");
+          appendRenderKeyPart(parts, windowData?.purpose_title || "");
+          appendRenderKeyPart(parts, "agent_id");
+          appendRenderKeyPart(parts, windowData?.agent_id || "");
+          appendRenderKeyPart(parts, "agent_color");
+          appendRenderKeyPart(parts, windowData?.agent_color || "");
+          appendRenderKeyPart(parts, "status");
+          appendRenderKeyPart(parts, windowData?.status || "");
+          appendRenderKeyPart(parts, "geometry");
+          appendRenderKeyPart(parts, "x");
+          appendRenderKeyPart(parts, geometry.x ?? 0);
+          appendRenderKeyPart(parts, "y");
+          appendRenderKeyPart(parts, geometry.y ?? 0);
+          appendRenderKeyPart(parts, "width");
+          appendRenderKeyPart(parts, geometry.width ?? 0);
+          appendRenderKeyPart(parts, "height");
+          appendRenderKeyPart(parts, geometry.height ?? 0);
+          appendRenderKeyPart(parts, "minimized");
+          appendRenderKeyPart(parts, Boolean(windowData?.minimized));
+          appendRenderKeyPart(parts, "maximized");
+          appendRenderKeyPart(parts, Boolean(windowData?.maximized));
+          appendRenderKeyPart(parts, "z_index");
+          appendRenderKeyPart(parts, windowData?.z_index ?? 0);
+          appendRenderKeyPart(parts, "tab_group_id");
+          appendRenderKeyPart(parts, windowData?.tab_group_id || "");
+          appendRenderKeyPart(parts, "tab_group_active");
+          appendRenderKeyPart(parts, Boolean(windowData?.tab_group_active));
+        }
+        return parts.join("");
       }
 
       function windowListRenderKey() {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -510,6 +510,7 @@
       let renderedProjectOnboardingKey = "";
       let renderedActionAvailabilityKey = "";
       let renderedOperatorTelemetryKey = "";
+      let maximizedViewportSyncFrame = null;
 
       function projectTabsRenderKey(state) {
         return JSON.stringify({
@@ -2219,6 +2220,16 @@
             scheduleTerminalFit(windowData.id, false);
           }
         }
+      }
+
+      function scheduleMaximizedWindowsToViewportSync() {
+        if (maximizedViewportSyncFrame !== null) {
+          return;
+        }
+        maximizedViewportSyncFrame = requestAnimationFrame(() => {
+          maximizedViewportSyncFrame = null;
+          syncMaximizedWindowsToViewport();
+        });
       }
 
       function workspaceHasVisibleMaximizedWindow(workspace) {
@@ -13338,7 +13349,7 @@
             const nextWorkspaceWindowsKey = workspaceWindowsRenderKey(workspace);
             if (renderedWorkspaceWindowsKey === nextWorkspaceWindowsKey) {
               if (workspaceHasVisibleMaximizedWindow(workspace)) {
-                requestAnimationFrame(syncMaximizedWindowsToViewport);
+                scheduleMaximizedWindowsToViewportSync();
               }
               return;
             }
@@ -13428,7 +13439,7 @@
               });
             }
 
-            requestAnimationFrame(syncMaximizedWindowsToViewport);
+            scheduleMaximizedWindowsToViewportSync();
 
             const topmostId = topmostWindowId(workspace);
             if (topmostId && ids.has(topmostId)) {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -485,6 +485,8 @@
         recent_projects: [],
       };
       let renderedProjectTabsKey = "";
+      let renderedRecentProjectsKey = "";
+      let renderedRecentProjectsMenuKey = "";
 
       function projectTabsRenderKey(state) {
         return JSON.stringify({
@@ -495,6 +497,16 @@
             project_root: tab?.project_root || "",
           })),
         });
+      }
+
+      function recentProjectsRenderKey(state) {
+        return JSON.stringify(
+          (state?.recent_projects || []).map((project) => ({
+            title: project?.title || "",
+            kind: project?.kind || "",
+            path: project?.path || "",
+          })),
+        );
       }
       // SPEC-1934 US-6: state for the migration confirmation / progress modal.
       // `tabId` identifies which tab the active migration belongs to so a
@@ -2093,7 +2105,12 @@
         }
       }
 
-      function renderRecentProjects() {
+      function renderRecentProjects({ force = false } = {}) {
+        const nextKey = recentProjectsRenderKey(appState);
+        if (!force && renderedRecentProjectsKey === nextKey) {
+          return;
+        }
+        renderedRecentProjectsKey = nextKey;
         recentProjectList.replaceChildren();
         const recentProjects = appState?.recent_projects || [];
         if (recentProjects.length === 0) {
@@ -2122,16 +2139,19 @@
             recentProjectList.appendChild(row);
           }
         }
-
-        renderRecentProjectsIntoMenu();
       }
 
       // Issue #2684 — mirror Recent projects inside the split-button dropdown
       // so users can reach them without first closing every project tab.
-      function renderRecentProjectsIntoMenu() {
+      function renderRecentProjectsIntoMenu({ force = false } = {}) {
         if (!openProjectMenuRecent) {
           return;
         }
+        const nextKey = recentProjectsRenderKey(appState);
+        if (!force && renderedRecentProjectsMenuKey === nextKey) {
+          return;
+        }
+        renderedRecentProjectsMenuKey = nextKey;
         openProjectMenuRecent.replaceChildren();
         const recentProjects = appState?.recent_projects || [];
         if (recentProjects.length === 0) {
@@ -2182,7 +2202,7 @@
         if (!openProjectMenu || isOpenProjectMenuOpen()) {
           return;
         }
-        renderRecentProjectsIntoMenu();
+        renderRecentProjectsIntoMenu({ force: true });
         openProjectMenu.classList.add("open");
         openProjectMenu.setAttribute("aria-hidden", "false");
         openProjectMenuButton.setAttribute("aria-expanded", "true");
@@ -2270,7 +2290,9 @@
         projectPicker.classList.toggle("visible", shouldShow);
         projectPickerError.hidden = !projectError;
         projectPickerError.textContent = projectError;
-        renderRecentProjects();
+        if (shouldShow) {
+          renderRecentProjects();
+        }
       }
 
       function renderProjectOnboarding(tab) {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -52,6 +52,7 @@
         attachHostResizeReflow,
         classifyProjectWindowVisibility,
         createTerminalFitScheduler,
+        createTerminalViewportRefreshScheduler,
         elementHasLayoutBox,
         gateTerminalInputForReadiness,
         rearmRefreshOnVisible,
@@ -186,6 +187,7 @@
       const windowRuntimeStateMap = new Map();
       const terminalMap = new Map();
       let terminalFitScheduler = null;
+      let terminalViewportRefreshScheduler = null;
       const terminalOutputBatcher = createTerminalOutputBatcher({
         mergeChunks: (chunks, windowId) => {
           const decoder = decoderMap.get(windowId);
@@ -3245,24 +3247,28 @@
       function scheduleTerminalViewportRefresh(windowId) {
         const runtime = terminalMap.get(windowId);
         if (!runtime) {
-          return;
+          return false;
         }
         if (!canRefreshTerminalViewport(windowId)) {
-          runtime.viewportRefreshPending = true;
-          return;
+          markTerminalViewportRefreshPending(windowId);
+          return false;
         }
-        if (runtime.viewportRefreshFrame !== null) {
-          return;
+        if (!terminalViewportRefreshScheduler) {
+          requestAnimationFrame(() => {
+            if (!canRefreshTerminalViewport(windowId)) {
+              markTerminalViewportRefreshPending(windowId);
+              return;
+            }
+            const activeRuntime = terminalMap.get(windowId);
+            if (!activeRuntime) {
+              return;
+            }
+            activeRuntime.viewportRefreshPending = false;
+            refreshTerminalViewport(windowId);
+          });
+          return false;
         }
-        runtime.viewportRefreshFrame = requestAnimationFrame(() => {
-          runtime.viewportRefreshFrame = null;
-          if (!canRefreshTerminalViewport(windowId)) {
-            runtime.viewportRefreshPending = true;
-            return;
-          }
-          runtime.viewportRefreshPending = false;
-          refreshTerminalViewport(windowId);
-        });
+        return terminalViewportRefreshScheduler.enqueue(windowId);
       }
 
       function refreshTerminalViewport(windowId) {
@@ -3272,6 +3278,26 @@
         }
         runtime.terminal.refresh(0, runtime.terminal.rows - 1);
       }
+
+      function markTerminalViewportRefreshPending(windowId) {
+        const runtime = terminalMap.get(windowId);
+        if (runtime) {
+          runtime.viewportRefreshPending = true;
+        }
+      }
+
+      terminalViewportRefreshScheduler = createTerminalViewportRefreshScheduler({
+        canRefresh: canRefreshTerminalViewport,
+        refresh: (windowId) => {
+          const runtime = terminalMap.get(windowId);
+          if (!runtime) {
+            return;
+          }
+          runtime.viewportRefreshPending = false;
+          refreshTerminalViewport(windowId);
+        },
+        markPending: markTerminalViewportRefreshPending,
+      });
 
       function forceTerminalViewportRefresh(windowId, { shouldPersistGeometry = true } = {}) {
         const runtime = terminalMap.get(windowId);
@@ -3403,8 +3429,8 @@
           // Schedule one more viewport refresh on the next frame so the
           // post-fit cols/rows are reflected in the rendered buffer even
           // when xterm coalesces internal redraws. This keeps the prior
-          // `viewportRefreshFrame` re-arm path active for repeated
-          // activations.
+          // refresh re-arm behavior active for repeated activations while
+          // routing routine refresh work through the shared scheduler.
           scheduleTerminalViewportRefresh(windowId);
         });
       }
@@ -5562,7 +5588,6 @@
           terminal,
           fitAddon,
           cleanup,
-          viewportRefreshFrame: null,
           viewportRefreshPending: false,
           activationFrame: null,
           // SPEC-2008 Phase 26.A / FR-057: initial fit handshake state.
@@ -13341,12 +13366,10 @@
               const element = windowMap.get(windowId);
               if (!element) continue;
               const runtime = terminalMap.get(windowId);
-              if (runtime && runtime.viewportRefreshFrame !== null) {
-                cancelAnimationFrame(runtime.viewportRefreshFrame);
-              }
               if (runtime && runtime.activationFrame !== null) {
                 cancelAnimationFrame(runtime.activationFrame);
               }
+              terminalViewportRefreshScheduler?.clear(windowId);
               runtime?.cleanup?.();
               runtime?.terminal.dispose();
               terminalMap.delete(windowId);

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -185,6 +185,15 @@
       const windowRuntimeStateMap = new Map();
       const terminalMap = new Map();
       const terminalOutputBatcher = createTerminalOutputBatcher({
+        mergeChunks: (chunks, windowId) => {
+          const decoder = decoderMap.get(windowId);
+          if (!decoder) {
+            return "";
+          }
+          return chunks
+            .map((chunk) => decoder.decode(decodeBase64(chunk), { stream: true }))
+            .join("");
+        },
         write: (windowId, text, onWritten) => {
           const runtime = terminalMap.get(windowId);
           if (!runtime) {
@@ -5665,11 +5674,7 @@
               runtime.deferredWrites.push(base64);
               return;
             }
-            const decoder = decoderMap.get(windowId);
-            terminalOutputBatcher.enqueue(
-              windowId,
-              decoder.decode(decodeBase64(base64), { stream: true }),
-            );
+            terminalOutputBatcher.enqueue(windowId, base64);
           },
         );
       }

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -661,15 +661,22 @@
       }
 
       function windowRuntimeStatusRenderKey(windowId, runtimeState, effectiveDetail, windowData) {
-        return JSON.stringify({
-          id: windowId || "",
-          mounted: windowMap.has(windowId),
-          runtime_state: runtimeState || "",
-          detail: effectiveDetail || "",
-          preset: windowData?.preset || "",
-          runtime_visible: shouldShowRuntimeStatus(windowData),
-          agent_state: mapAgentTelemetryState(runtimeState),
-        });
+        const parts = [];
+        appendRenderKeyPart(parts, "id");
+        appendRenderKeyPart(parts, windowId || "");
+        appendRenderKeyPart(parts, "mounted");
+        appendRenderKeyPart(parts, windowMap.has(windowId));
+        appendRenderKeyPart(parts, "runtime_state");
+        appendRenderKeyPart(parts, runtimeState || "");
+        appendRenderKeyPart(parts, "detail");
+        appendRenderKeyPart(parts, effectiveDetail || "");
+        appendRenderKeyPart(parts, "preset");
+        appendRenderKeyPart(parts, windowData?.preset || "");
+        appendRenderKeyPart(parts, "runtime_visible");
+        appendRenderKeyPart(parts, shouldShowRuntimeStatus(windowData));
+        appendRenderKeyPart(parts, "agent_state");
+        appendRenderKeyPart(parts, mapAgentTelemetryState(runtimeState));
+        return parts.join("");
       }
 
       function windowElementRenderKey(windowData) {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -487,6 +487,7 @@
       let renderedProjectTabsKey = "";
       let renderedRecentProjectsKey = "";
       let renderedRecentProjectsMenuKey = "";
+      let renderedWorkspaceWindowsKey = "";
 
       function projectTabsRenderKey(state) {
         return JSON.stringify({
@@ -507,6 +508,37 @@
             path: project?.path || "",
           })),
         );
+      }
+
+      function workspaceWindowsRenderKey(workspace) {
+        const windows = workspace?.windows || [];
+        return JSON.stringify({
+          active_tab_id: appState?.active_tab_id || null,
+          active_window_ids: windows.map((windowData) => windowData?.id || ""),
+          all_project_window_ids: allProjectWindowIds(),
+          windows: windows.map((windowData) => ({
+            id: windowData?.id || "",
+            preset: windowData?.preset || "",
+            title: windowData?.title || "",
+            dynamic_title: windowData?.dynamic_title || "",
+            dynamic_title_detail: windowData?.dynamic_title_detail || "",
+            purpose_title: windowData?.purpose_title || "",
+            agent_id: windowData?.agent_id || "",
+            agent_color: windowData?.agent_color || "",
+            status: windowData?.status || "",
+            geometry: {
+              x: windowData?.geometry?.x ?? 0,
+              y: windowData?.geometry?.y ?? 0,
+              width: windowData?.geometry?.width ?? 0,
+              height: windowData?.geometry?.height ?? 0,
+            },
+            minimized: Boolean(windowData?.minimized),
+            maximized: Boolean(windowData?.maximized),
+            z_index: windowData?.z_index ?? 0,
+            tab_group_id: windowData?.tab_group_id || "",
+            tab_group_active: Boolean(windowData?.tab_group_active),
+          })),
+        });
       }
       // SPEC-1934 US-6: state for the migration confirmation / progress modal.
       // `tabId` identifies which tab the active migration belongs to so a
@@ -2002,6 +2034,15 @@
             requestAnimationFrame(() => fitTerminal(windowData.id, false));
           }
         }
+      }
+
+      function workspaceHasVisibleMaximizedWindow(workspace) {
+        return (workspace?.windows || []).some(
+          (windowData) =>
+            Boolean(windowData?.maximized) &&
+            !windowData?.minimized &&
+            visibleWindowData(windowData),
+        );
       }
 
       function renderProjectTabs() {
@@ -13008,6 +13049,15 @@
               scopeKey: activeViewportScopeKey(),
             });
             applyViewport();
+
+            const nextWorkspaceWindowsKey = workspaceWindowsRenderKey(workspace);
+            if (renderedWorkspaceWindowsKey === nextWorkspaceWindowsKey) {
+              if (workspaceHasVisibleMaximizedWindow(workspace)) {
+                requestAnimationFrame(syncMaximizedWindowsToViewport);
+              }
+              return;
+            }
+            renderedWorkspaceWindowsKey = nextWorkspaceWindowsKey;
 
             const activeWindowIds = workspace.windows.map((windowData) => windowData.id);
             const ids = new Set(activeWindowIds);

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -198,6 +198,7 @@
       });
       const windowMap = new Map();
       const renderedWindowElementKeys = new Map();
+      const renderedRuntimeStatusKeys = new Map();
       const fileTreeStateMap = new Map();
       const branchListStateMap = new Map();
       const profileStateMap = new Map();
@@ -599,6 +600,18 @@
           window_list_entries: windowListEntries.map(entryKey),
           active_window_ids: workspaceWindows.map((windowData) => windowData?.id || ""),
           rows: entries.map(entryKey),
+        });
+      }
+
+      function windowRuntimeStatusRenderKey(windowId, runtimeState, effectiveDetail, windowData) {
+        return JSON.stringify({
+          id: windowId || "",
+          mounted: windowMap.has(windowId),
+          runtime_state: runtimeState || "",
+          detail: effectiveDetail || "",
+          preset: windowData?.preset || "",
+          runtime_visible: shouldShowRuntimeStatus(windowData),
+          agent_state: mapAgentTelemetryState(runtimeState),
         });
       }
 
@@ -4367,6 +4380,17 @@
             ) {
               detailMap.delete(windowId);
             }
+            const effectiveDetail = detailMap.get(windowId) || "";
+            const nextRuntimeStatusKey = windowRuntimeStatusRenderKey(
+              windowId,
+              runtimeState,
+              effectiveDetail,
+              windowData,
+            );
+            if (renderedRuntimeStatusKeys.get(windowId) === nextRuntimeStatusKey) {
+              return;
+            }
+            renderedRuntimeStatusKeys.set(windowId, nextRuntimeStatusKey);
             const element = windowMap.get(windowId);
             if (!element) {
               renderWindowList();
@@ -4395,7 +4419,6 @@
             element.dataset.agentState = mapAgentTelemetryState(runtimeState);
             recomputeOperatorTelemetry();
             label.textContent = windowRuntimeLabel(runtimeState);
-            const effectiveDetail = detailMap.get(windowId);
             const statusTitle = effectiveDetail
               ? `${windowRuntimeLabel(runtimeState)}: ${effectiveDetail}`
               : windowRuntimeLabel(runtimeState);
@@ -13276,6 +13299,7 @@
               detailMap.delete(windowId);
               windowRuntimeStateMap.delete(windowId);
               renderedWindowElementKeys.delete(windowId);
+              renderedRuntimeStatusKeys.delete(windowId);
               pendingOutputMap.delete(windowId);
               pendingSnapshotMap.delete(windowId);
               terminalOutputBatcher.clear(windowId);

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -2580,11 +2580,9 @@
             const tab = activeProjectTab();
             renderProjectOnboarding(tab);
             renderWorkspace(tab?.workspace || emptyWorkspace());
-            const nextWorkspaceId = deriveCurrentProjectWorkspaceIds(tab?.workspace || {});
-            if (JSON.stringify(nextWorkspaceId) !== JSON.stringify(currentProjectWorkspaceId)) {
-              currentProjectWorkspaceId = nextWorkspaceId;
-              refreshBoardCurrentWorkspaceId();
-            }
+            syncCurrentProjectWorkspaceIds(
+              deriveCurrentProjectWorkspaceIds(tab?.workspace || {}),
+            );
             renderWindowList();
           },
         );
@@ -6999,7 +6997,10 @@
       // SPEC-2359 FR-098/101 + US-53: track every live assigned Work id for
       // the Board Work filter. Broadcast entries remain visible everywhere;
       // scoped entries match when their audience includes any active Work id.
+      const WORK_ID_KEY_SEPARATOR = "\u001f";
       let currentProjectWorkspaceId = [];
+      let currentProjectWorkspaceKey = "";
+      let activeWorkProjectionWorkspaceIds = [];
       function uniqueWorkIds(values) {
         const ids = [];
         for (const value of values || []) {
@@ -7008,12 +7009,19 @@
         }
         return ids;
       }
+      function workIdsKey(ids) {
+        return (ids || []).join(WORK_ID_KEY_SEPARATOR);
+      }
+      function cacheActiveWorkProjectionWorkspaceIds(projection) {
+        activeWorkProjectionWorkspaceIds = uniqueWorkIds(
+          Array.isArray(projection?.active_works)
+            ? projection.active_works.map((work) => work?.id)
+            : [],
+        );
+      }
       function deriveCurrentProjectWorkspaceIds(workspaceState) {
-        const activeWorkIds = Array.isArray(activeWorkProjection?.active_works)
-          ? activeWorkProjection.active_works.map((work) => work?.id)
-          : [];
-        if (activeWorkIds.length > 0) {
-          return uniqueWorkIds(activeWorkIds);
+        if (activeWorkProjectionWorkspaceIds.length > 0) {
+          return activeWorkProjectionWorkspaceIds;
         }
         const agents = workspaceState?.workspace?.agents
           || workspaceState?.agents
@@ -7028,6 +7036,17 @@
             )
             .map((agent) => agent.workspace_id),
         );
+      }
+      function syncCurrentProjectWorkspaceIds(nextIds) {
+        const ids = Array.isArray(nextIds) ? nextIds : [];
+        const nextKey = workIdsKey(ids);
+        if (nextKey === currentProjectWorkspaceKey) {
+          return false;
+        }
+        currentProjectWorkspaceId = ids;
+        currentProjectWorkspaceKey = nextKey;
+        refreshBoardCurrentWorkspaceId();
+        return true;
       }
       function refreshBoardCurrentWorkspaceId() {
         for (const state of boardStateMap.values()) {
@@ -13643,10 +13662,10 @@
             break;
           case "active_work_projection":
             activeWorkProjection = event.projection || null;
-            currentProjectWorkspaceId = deriveCurrentProjectWorkspaceIds(
-              activeWorkspace() || {},
+            cacheActiveWorkProjectionWorkspaceIds(activeWorkProjection);
+            syncCurrentProjectWorkspaceIds(
+              deriveCurrentProjectWorkspaceIds(activeWorkspace() || {}),
             );
-            refreshBoardCurrentWorkspaceId();
             renderActiveWorkOverview();
             workspaceOverviewSurface.renderWindows();
             recomputeOperatorTelemetry();

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -3646,17 +3646,26 @@
       // counts into the bottom strip. We also expose agent count to the
       // sidebar layer for the "Quick" section's hint.
       function operatorTelemetryRenderKey(counts) {
-        return JSON.stringify({
-          active: counts?.active ?? null,
-          idle: counts?.idle ?? null,
-          blocked: counts?.blocked ?? null,
-          done: counts?.done ?? null,
-          agents: counts?.agents ?? null,
-          branches: counts?.branches ?? null,
-          git: counts?.git ?? null,
-          hooks: counts?.hooks ?? null,
-          layers: counts?.layers ?? null,
-        });
+        const parts = [];
+        appendRenderKeyPart(parts, "active");
+        appendRenderKeyPart(parts, counts?.active ?? null);
+        appendRenderKeyPart(parts, "idle");
+        appendRenderKeyPart(parts, counts?.idle ?? null);
+        appendRenderKeyPart(parts, "blocked");
+        appendRenderKeyPart(parts, counts?.blocked ?? null);
+        appendRenderKeyPart(parts, "done");
+        appendRenderKeyPart(parts, counts?.done ?? null);
+        appendRenderKeyPart(parts, "agents");
+        appendRenderKeyPart(parts, counts?.agents ?? null);
+        appendRenderKeyPart(parts, "branches");
+        appendRenderKeyPart(parts, counts?.branches ?? null);
+        appendRenderKeyPart(parts, "git");
+        appendRenderKeyPart(parts, counts?.git ?? null);
+        appendRenderKeyPart(parts, "hooks");
+        appendRenderKeyPart(parts, counts?.hooks ?? null);
+        appendRenderKeyPart(parts, "layers");
+        appendRenderKeyPart(parts, counts?.layers ?? null);
+        return parts.join("");
       }
 
       function applyOperatorTelemetryCounts(counts) {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -484,6 +484,18 @@
         active_tab_id: null,
         recent_projects: [],
       };
+      let renderedProjectTabsKey = "";
+
+      function projectTabsRenderKey(state) {
+        return JSON.stringify({
+          active_tab_id: state?.active_tab_id || null,
+          tabs: (state?.tabs || []).map((tab) => ({
+            id: tab?.id || "",
+            title: tab?.title || "",
+            project_root: tab?.project_root || "",
+          })),
+        });
+      }
       // SPEC-1934 US-6: state for the migration confirmation / progress modal.
       // `tabId` identifies which tab the active migration belongs to so a
       // multi-project frontend never mixes events from different repos.
@@ -2288,7 +2300,11 @@
               recent_projects: [],
             };
             setVersionState(appState.app_version, versionState.latest);
-            renderProjectTabs();
+            const nextProjectTabsKey = projectTabsRenderKey(appState);
+            if (renderedProjectTabsKey !== nextProjectTabsKey) {
+              renderedProjectTabsKey = nextProjectTabsKey;
+              renderProjectTabs();
+            }
             renderProjectPicker();
             updateActionAvailability();
             const tab = activeProjectTab();

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -678,55 +678,98 @@
           windowData.maximized && !windowData.minimized
             ? maximizedGeometry(visibleBounds(), viewport.zoom)
             : null;
-        return JSON.stringify({
-          id: windowData.id,
-          preset: windowData.preset || "",
-          title: windowData.title || "",
-          dynamic_title: windowData.dynamic_title || "",
-          dynamic_title_detail: windowData.dynamic_title_detail || "",
-          purpose_title: windowData.purpose_title || "",
-          agent_id: windowData.agent_id || "",
-          agent_color: windowData.agent_color || "",
-          status: windowData.status || "",
-          runtime_state: runtimeStateForWindow(windowData),
-          detail: detailMap.get(windowData.id) || "",
-          display_title: windowDisplayTitle(windowData),
-          title_tooltip: windowTitleTooltip(windowData),
-          role_badge: windowRoleBadgeLabel(windowData),
-          geometry_revision: workspaceGeometryRevision(windowData),
-          geometry: {
-            x: geometry.x,
-            y: geometry.y,
-            width: geometry.width,
-            height: geometry.height,
-          },
-          minimized: Boolean(windowData.minimized),
-          maximized: Boolean(windowData.maximized),
-          z_index: windowData.z_index,
-          tab_group_id: windowData.tab_group_id || "",
-          tab_group_active: Boolean(windowData.tab_group_active),
-          maximized_fill: maximizedFill
-            ? {
-                x: maximizedFill.x,
-                y: maximizedFill.y,
-                width: maximizedFill.width,
-                height: maximizedFill.height,
-              }
-            : null,
-          tabs: windowTabsFor(windowData).map((tab) => ({
-            id: tab.id,
-            preset: tab.preset || "",
-            title: tab.title || "",
-            dynamic_title: tab.dynamic_title || "",
-            dynamic_title_detail: tab.dynamic_title_detail || "",
-            purpose_title: tab.purpose_title || "",
-            agent_id: tab.agent_id || "",
-            agent_color: tab.agent_color || "",
-            status: tab.status || "",
-            tab_group_id: tab.tab_group_id || "",
-            tab_group_active: Boolean(tab.tab_group_active),
-          })),
-        });
+        const tabGroupId = windowGroupId(windowData);
+        const parts = [];
+        appendRenderKeyPart(parts, "id");
+        appendRenderKeyPart(parts, windowData.id || "");
+        appendRenderKeyPart(parts, "preset");
+        appendRenderKeyPart(parts, windowData.preset || "");
+        appendRenderKeyPart(parts, "title");
+        appendRenderKeyPart(parts, windowData.title || "");
+        appendRenderKeyPart(parts, "dynamic_title");
+        appendRenderKeyPart(parts, windowData.dynamic_title || "");
+        appendRenderKeyPart(parts, "dynamic_title_detail");
+        appendRenderKeyPart(parts, windowData.dynamic_title_detail || "");
+        appendRenderKeyPart(parts, "purpose_title");
+        appendRenderKeyPart(parts, windowData.purpose_title || "");
+        appendRenderKeyPart(parts, "agent_id");
+        appendRenderKeyPart(parts, windowData.agent_id || "");
+        appendRenderKeyPart(parts, "agent_color");
+        appendRenderKeyPart(parts, windowData.agent_color || "");
+        appendRenderKeyPart(parts, "status");
+        appendRenderKeyPart(parts, windowData.status || "");
+        appendRenderKeyPart(parts, "runtime_state");
+        appendRenderKeyPart(parts, runtimeStateForWindow(windowData));
+        appendRenderKeyPart(parts, "detail");
+        appendRenderKeyPart(parts, detailMap.get(windowData.id) || "");
+        appendRenderKeyPart(parts, "display_title");
+        appendRenderKeyPart(parts, windowDisplayTitle(windowData));
+        appendRenderKeyPart(parts, "title_tooltip");
+        appendRenderKeyPart(parts, windowTitleTooltip(windowData));
+        appendRenderKeyPart(parts, "role_badge");
+        appendRenderKeyPart(parts, windowRoleBadgeLabel(windowData));
+        appendRenderKeyPart(parts, "geometry_revision");
+        appendRenderKeyPart(parts, workspaceGeometryRevision(windowData));
+        appendRenderKeyPart(parts, "geometry");
+        appendRenderKeyPart(parts, "x");
+        appendRenderKeyPart(parts, geometry.x ?? "");
+        appendRenderKeyPart(parts, "y");
+        appendRenderKeyPart(parts, geometry.y ?? "");
+        appendRenderKeyPart(parts, "width");
+        appendRenderKeyPart(parts, geometry.width ?? "");
+        appendRenderKeyPart(parts, "height");
+        appendRenderKeyPart(parts, geometry.height ?? "");
+        appendRenderKeyPart(parts, "minimized");
+        appendRenderKeyPart(parts, Boolean(windowData.minimized));
+        appendRenderKeyPart(parts, "maximized");
+        appendRenderKeyPart(parts, Boolean(windowData.maximized));
+        appendRenderKeyPart(parts, "z_index");
+        appendRenderKeyPart(parts, windowData.z_index ?? "");
+        appendRenderKeyPart(parts, "tab_group_id");
+        appendRenderKeyPart(parts, windowData.tab_group_id || "");
+        appendRenderKeyPart(parts, "tab_group_active");
+        appendRenderKeyPart(parts, Boolean(windowData.tab_group_active));
+        appendRenderKeyPart(parts, "maximized_fill");
+        appendRenderKeyPart(parts, Boolean(maximizedFill));
+        if (maximizedFill) {
+          appendRenderKeyPart(parts, "x");
+          appendRenderKeyPart(parts, maximizedFill.x);
+          appendRenderKeyPart(parts, "y");
+          appendRenderKeyPart(parts, maximizedFill.y);
+          appendRenderKeyPart(parts, "width");
+          appendRenderKeyPart(parts, maximizedFill.width);
+          appendRenderKeyPart(parts, "height");
+          appendRenderKeyPart(parts, maximizedFill.height);
+        }
+        appendRenderKeyPart(parts, "tabs");
+        for (const tab of activeWorkspace().windows || []) {
+          if (windowGroupId(tab) !== tabGroupId) {
+            continue;
+          }
+          appendRenderKeyPart(parts, "id");
+          appendRenderKeyPart(parts, tab.id || "");
+          appendRenderKeyPart(parts, "preset");
+          appendRenderKeyPart(parts, tab.preset || "");
+          appendRenderKeyPart(parts, "title");
+          appendRenderKeyPart(parts, tab.title || "");
+          appendRenderKeyPart(parts, "dynamic_title");
+          appendRenderKeyPart(parts, tab.dynamic_title || "");
+          appendRenderKeyPart(parts, "dynamic_title_detail");
+          appendRenderKeyPart(parts, tab.dynamic_title_detail || "");
+          appendRenderKeyPart(parts, "purpose_title");
+          appendRenderKeyPart(parts, tab.purpose_title || "");
+          appendRenderKeyPart(parts, "agent_id");
+          appendRenderKeyPart(parts, tab.agent_id || "");
+          appendRenderKeyPart(parts, "agent_color");
+          appendRenderKeyPart(parts, tab.agent_color || "");
+          appendRenderKeyPart(parts, "status");
+          appendRenderKeyPart(parts, tab.status || "");
+          appendRenderKeyPart(parts, "tab_group_id");
+          appendRenderKeyPart(parts, tab.tab_group_id || "");
+          appendRenderKeyPart(parts, "tab_group_active");
+          appendRenderKeyPart(parts, Boolean(tab.tab_group_active));
+        }
+        return parts.join("");
       }
 
       function projectPickerRenderKey(activeTab = activeProjectTab()) {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -70,6 +70,7 @@
         workspaceGeometryRevision,
       } from "/window-geometry-sync.js";
       import { createSocketReceiveDispatcher } from "/socket-receive-dispatcher.js";
+      import { createTerminalOutputBatcher } from "/terminal-output-buffer.js";
       import { createInteractionGuard } from "/interaction-guard.js";
       import { createCanvasWheelGestureClassifier } from "/canvas-wheel-gesture.js";
       import { createViewportPersistThrottle } from "/viewport-persist-throttle.js";
@@ -183,6 +184,18 @@
       const detailMap = new Map();
       const windowRuntimeStateMap = new Map();
       const terminalMap = new Map();
+      const terminalOutputBatcher = createTerminalOutputBatcher({
+        write: (windowId, text, onWritten) => {
+          const runtime = terminalMap.get(windowId);
+          if (!runtime) {
+            return;
+          }
+          runtime.terminal.write(text, onWritten);
+        },
+        onFlush: (windowId) => {
+          scheduleTerminalViewportRefresh(windowId);
+        },
+      });
       const windowMap = new Map();
       const fileTreeStateMap = new Map();
       const branchListStateMap = new Map();
@@ -5352,9 +5365,10 @@
               return;
             }
             const decoder = decoderMap.get(windowId);
-            runtime.terminal.write(decoder.decode(decodeBase64(base64), { stream: true }), () => {
-              scheduleTerminalViewportRefresh(windowId);
-            });
+            terminalOutputBatcher.enqueue(
+              windowId,
+              decoder.decode(decodeBase64(base64), { stream: true }),
+            );
           },
         );
       }
@@ -5377,6 +5391,7 @@
           pendingSnapshotMap.set(windowId, base64);
           return;
         }
+        terminalOutputBatcher.clear(windowId);
         const decoder = decoderMap.get(windowId);
         runtime.terminal.reset();
         runtime.terminal.write(decoder.decode(decodeBase64(base64)), () => {
@@ -12994,6 +13009,7 @@
               windowRuntimeStateMap.delete(windowId);
               pendingOutputMap.delete(windowId);
               pendingSnapshotMap.delete(windowId);
+              terminalOutputBatcher.clear(windowId);
               const profileState = profileStateMap.get(windowId);
               if (profileState) {
                 clearProfileSaveTimer(profileState);

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -2263,15 +2263,20 @@
         }
         renderedWindowListKey = nextWindowListKey;
         const workspaceWindows = activeWorkspace().windows || [];
-        const workspaceWindowMap = new Map(
-          workspaceWindows.map((windowData) => [windowData.id, windowData]),
-        );
-        const entries =
-          windowListEntries.length > 0
-            ? windowListEntries
-                .map((entry) => workspaceWindowMap.get(entry.id) || entry)
-                .filter((entry) => workspaceWindowMap.size === 0 || workspaceWindowMap.has(entry.id))
-            : workspaceWindows;
+        let entries = workspaceWindows;
+        if (windowListEntries.length > 0) {
+          const workspaceWindowMap = new Map();
+          for (const windowData of workspaceWindows) {
+            workspaceWindowMap.set(windowData.id, windowData);
+          }
+          entries = [];
+          for (const entry of windowListEntries) {
+            const workspaceEntry = workspaceWindowMap.get(entry.id);
+            if (workspaceWindowMap.size === 0 || workspaceEntry) {
+              entries.push(workspaceEntry || entry);
+            }
+          }
+        }
         windowListPanel.innerHTML = "";
         if (entries.length === 0) {
           const empty = document.createElement("div");

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -197,6 +197,7 @@
         },
       });
       const windowMap = new Map();
+      const renderedWindowElementKeys = new Map();
       const fileTreeStateMap = new Map();
       const branchListStateMap = new Map();
       const profileStateMap = new Map();
@@ -598,6 +599,63 @@
           window_list_entries: windowListEntries.map(entryKey),
           active_window_ids: workspaceWindows.map((windowData) => windowData?.id || ""),
           rows: entries.map(entryKey),
+        });
+      }
+
+      function windowElementRenderKey(windowData) {
+        const geometry = windowData.geometry || {};
+        const maximizedFill =
+          windowData.maximized && !windowData.minimized
+            ? maximizedGeometry(visibleBounds(), viewport.zoom)
+            : null;
+        return JSON.stringify({
+          id: windowData.id,
+          preset: windowData.preset || "",
+          title: windowData.title || "",
+          dynamic_title: windowData.dynamic_title || "",
+          dynamic_title_detail: windowData.dynamic_title_detail || "",
+          purpose_title: windowData.purpose_title || "",
+          agent_id: windowData.agent_id || "",
+          agent_color: windowData.agent_color || "",
+          status: windowData.status || "",
+          runtime_state: runtimeStateForWindow(windowData),
+          detail: detailMap.get(windowData.id) || "",
+          display_title: windowDisplayTitle(windowData),
+          title_tooltip: windowTitleTooltip(windowData),
+          role_badge: windowRoleBadgeLabel(windowData),
+          geometry_revision: workspaceGeometryRevision(windowData),
+          geometry: {
+            x: geometry.x,
+            y: geometry.y,
+            width: geometry.width,
+            height: geometry.height,
+          },
+          minimized: Boolean(windowData.minimized),
+          maximized: Boolean(windowData.maximized),
+          z_index: windowData.z_index,
+          tab_group_id: windowData.tab_group_id || "",
+          tab_group_active: Boolean(windowData.tab_group_active),
+          maximized_fill: maximizedFill
+            ? {
+                x: maximizedFill.x,
+                y: maximizedFill.y,
+                width: maximizedFill.width,
+                height: maximizedFill.height,
+              }
+            : null,
+          tabs: windowTabsFor(windowData).map((tab) => ({
+            id: tab.id,
+            preset: tab.preset || "",
+            title: tab.title || "",
+            dynamic_title: tab.dynamic_title || "",
+            dynamic_title_detail: tab.dynamic_title_detail || "",
+            purpose_title: tab.purpose_title || "",
+            agent_id: tab.agent_id || "",
+            agent_color: tab.agent_color || "",
+            status: tab.status || "",
+            tab_group_id: tab.tab_group_id || "",
+            tab_group_active: Boolean(tab.tab_group_active),
+          })),
         });
       }
 
@@ -13084,6 +13142,11 @@
           mountWindowBody(windowData, element);
         }
 
+        const nextWindowElementKey = windowElementRenderKey(windowData);
+        if (renderedWindowElementKeys.get(windowData.id) === nextWindowElementKey) {
+          return;
+        }
+
         element.querySelector(".title-text").textContent = windowDisplayTitle(windowData);
         const titleText = element.querySelector(".title-text");
         titleText.title = windowTitleTooltip(windowData);
@@ -13137,6 +13200,7 @@
         element.querySelector(".resize-handle").hidden =
           Boolean(windowData.minimized) || Boolean(windowData.maximized);
         applyStatus(windowData.id, windowData.status, detailMap.get(windowData.id));
+        renderedWindowElementKeys.set(windowData.id, windowElementRenderKey(windowData));
         if (
           (applyWorkspaceGeometry || Boolean(maximizedFill)) &&
           presetSurface(windowData.preset) === "terminal" &&
@@ -13202,6 +13266,7 @@
               decoderMap.delete(windowId);
               detailMap.delete(windowId);
               windowRuntimeStateMap.delete(windowId);
+              renderedWindowElementKeys.delete(windowId);
               pendingOutputMap.delete(windowId);
               pendingSnapshotMap.delete(windowId);
               terminalOutputBatcher.clear(windowId);

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -514,14 +514,21 @@
       let maximizedViewportSyncFrame = null;
 
       function projectTabsRenderKey(state) {
-        return JSON.stringify({
-          active_tab_id: state?.active_tab_id || null,
-          tabs: (state?.tabs || []).map((tab) => ({
-            id: tab?.id || "",
-            title: tab?.title || "",
-            project_root: tab?.project_root || "",
-          })),
-        });
+        const tabs = state?.tabs || [];
+        const parts = [];
+        appendRenderKeyPart(parts, "active_tab_id");
+        appendRenderKeyPart(parts, state?.active_tab_id || null);
+        appendRenderKeyPart(parts, "tabs");
+        appendRenderKeyPart(parts, tabs.length);
+        for (const tab of tabs) {
+          appendRenderKeyPart(parts, "id");
+          appendRenderKeyPart(parts, tab?.id || "");
+          appendRenderKeyPart(parts, "title");
+          appendRenderKeyPart(parts, tab?.title || "");
+          appendRenderKeyPart(parts, "project_root");
+          appendRenderKeyPart(parts, tab?.project_root || "");
+        }
+        return parts.join("");
       }
 
       function recentProjectsRenderKey(state) {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -205,6 +205,7 @@
           }
           runtime.terminal.write(text, onWritten);
         },
+        canWrite: canRefreshTerminalViewport,
         onFlush: (windowId) => {
           scheduleTerminalViewportRefresh(windowId);
         },
@@ -13357,6 +13358,7 @@
                 shouldHide: true,
                 hasTerminal: terminalMap.has(windowId),
                 onReveal: () => {
+                  terminalOutputBatcher.schedulePending(windowId);
                   rearmPendingTerminalViewportRefresh(windowId);
                   scheduleTerminalFocusActivation(windowId);
                 },
@@ -13419,6 +13421,7 @@
                 shouldHide: !visibleWindowData(windowData),
                 hasTerminal: terminalMap.has(windowData.id),
                 onReveal: () => {
+                  terminalOutputBatcher.schedulePending(windowData.id);
                   rearmPendingTerminalViewportRefresh(windowData.id);
                   scheduleTerminalFocusActivation(windowData.id);
                 },

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -608,56 +608,99 @@
       function windowListRenderKey() {
         const workspace = activeWorkspace();
         const workspaceWindows = workspace.windows || [];
-        const workspaceWindowMap = new Map(
-          workspaceWindows.map((windowData) => [windowData.id, windowData]),
-        );
-        const entries =
-          windowListEntries.length > 0
-            ? windowListEntries
-                .map((entry) => workspaceWindowMap.get(entry.id) || entry)
-                .filter(
-                  (entry) =>
-                    workspaceWindowMap.size === 0 || workspaceWindowMap.has(entry.id),
-                )
-            : workspaceWindows;
-        const entryKey = (entry) => {
+        const workspaceWindowMap = new Map();
+        for (const windowData of workspaceWindows) {
+          workspaceWindowMap.set(windowData.id, windowData);
+        }
+        const appendEntryKey = (parts, entry) => {
+          const geometry = entry?.geometry || {};
           const runtimeState = runtimeStateForWindow(entry);
-          return {
-            id: entry?.id || "",
-            preset: entry?.preset || "",
-            title: entry?.title || "",
-            dynamic_title: entry?.dynamic_title || "",
-            dynamic_title_detail: entry?.dynamic_title_detail || "",
-            purpose_title: entry?.purpose_title || "",
-            agent_id: entry?.agent_id || "",
-            agent_color: entry?.agent_color || "",
-            status: entry?.status || "",
-            runtime_state: runtimeState,
-            runtime_label: windowRuntimeLabel(runtimeState),
-            role_badge: windowRoleBadgeLabel(entry) || "",
-            display_title: windowDisplayTitle(entry),
-            title_tooltip: windowTitleTooltip(entry),
-            geometry: {
-              x: entry?.geometry?.x ?? 0,
-              y: entry?.geometry?.y ?? 0,
-              width: entry?.geometry?.width ?? 0,
-              height: entry?.geometry?.height ?? 0,
-            },
-            geometry_label: windowGeometryLabel(entry),
-            minimized: Boolean(entry?.minimized),
-            maximized: Boolean(entry?.maximized),
-            z_index: entry?.z_index ?? 0,
-            tab_group_id: entry?.tab_group_id || "",
-            tab_group_active: Boolean(entry?.tab_group_active),
-          };
+          appendRenderKeyPart(parts, "id");
+          appendRenderKeyPart(parts, entry?.id || "");
+          appendRenderKeyPart(parts, "preset");
+          appendRenderKeyPart(parts, entry?.preset || "");
+          appendRenderKeyPart(parts, "title");
+          appendRenderKeyPart(parts, entry?.title || "");
+          appendRenderKeyPart(parts, "dynamic_title");
+          appendRenderKeyPart(parts, entry?.dynamic_title || "");
+          appendRenderKeyPart(parts, "dynamic_title_detail");
+          appendRenderKeyPart(parts, entry?.dynamic_title_detail || "");
+          appendRenderKeyPart(parts, "purpose_title");
+          appendRenderKeyPart(parts, entry?.purpose_title || "");
+          appendRenderKeyPart(parts, "agent_id");
+          appendRenderKeyPart(parts, entry?.agent_id || "");
+          appendRenderKeyPart(parts, "agent_color");
+          appendRenderKeyPart(parts, entry?.agent_color || "");
+          appendRenderKeyPart(parts, "status");
+          appendRenderKeyPart(parts, entry?.status || "");
+          appendRenderKeyPart(parts, "runtime_state");
+          appendRenderKeyPart(parts, runtimeState);
+          appendRenderKeyPart(parts, "runtime_label");
+          appendRenderKeyPart(parts, windowRuntimeLabel(runtimeState));
+          appendRenderKeyPart(parts, "role_badge");
+          appendRenderKeyPart(parts, windowRoleBadgeLabel(entry) || "");
+          appendRenderKeyPart(parts, "display_title");
+          appendRenderKeyPart(parts, windowDisplayTitle(entry));
+          appendRenderKeyPart(parts, "title_tooltip");
+          appendRenderKeyPart(parts, windowTitleTooltip(entry));
+          appendRenderKeyPart(parts, "geometry");
+          appendRenderKeyPart(parts, "x");
+          appendRenderKeyPart(parts, geometry.x ?? 0);
+          appendRenderKeyPart(parts, "y");
+          appendRenderKeyPart(parts, geometry.y ?? 0);
+          appendRenderKeyPart(parts, "width");
+          appendRenderKeyPart(parts, geometry.width ?? 0);
+          appendRenderKeyPart(parts, "height");
+          appendRenderKeyPart(parts, geometry.height ?? 0);
+          appendRenderKeyPart(parts, "geometry_label");
+          appendRenderKeyPart(parts, windowGeometryLabel(entry));
+          appendRenderKeyPart(parts, "minimized");
+          appendRenderKeyPart(parts, Boolean(entry?.minimized));
+          appendRenderKeyPart(parts, "maximized");
+          appendRenderKeyPart(parts, Boolean(entry?.maximized));
+          appendRenderKeyPart(parts, "z_index");
+          appendRenderKeyPart(parts, entry?.z_index ?? 0);
+          appendRenderKeyPart(parts, "tab_group_id");
+          appendRenderKeyPart(parts, entry?.tab_group_id || "");
+          appendRenderKeyPart(parts, "tab_group_active");
+          appendRenderKeyPart(parts, Boolean(entry?.tab_group_active));
         };
-        return JSON.stringify({
-          open: Boolean(windowListOpen),
-          active_tab_id: appState?.active_tab_id || null,
-          window_list_entries: windowListEntries.map(entryKey),
-          active_window_ids: workspaceWindows.map((windowData) => windowData?.id || ""),
-          rows: entries.map(entryKey),
-        });
+        const parts = [];
+        appendRenderKeyPart(parts, "open");
+        appendRenderKeyPart(parts, Boolean(windowListOpen));
+        appendRenderKeyPart(parts, "active_tab_id");
+        appendRenderKeyPart(parts, appState?.active_tab_id || null);
+        appendRenderKeyPart(parts, "window_list_entries");
+        appendRenderKeyPart(parts, windowListEntries.length);
+        for (const entry of windowListEntries) {
+          appendEntryKey(parts, entry);
+        }
+        appendRenderKeyPart(parts, "active_window_ids");
+        appendRenderKeyPart(parts, workspaceWindows.length);
+        for (const windowData of workspaceWindows) {
+          appendRenderKeyPart(parts, windowData?.id || "");
+        }
+        appendRenderKeyPart(parts, "rows");
+        if (windowListEntries.length > 0) {
+          let rowCount = 0;
+          for (const entry of windowListEntries) {
+            if (workspaceWindowMap.size === 0 || workspaceWindowMap.has(entry.id)) {
+              rowCount += 1;
+            }
+          }
+          appendRenderKeyPart(parts, rowCount);
+          for (const entry of windowListEntries) {
+            if (workspaceWindowMap.size === 0 || workspaceWindowMap.has(entry.id)) {
+              appendEntryKey(parts, workspaceWindowMap.get(entry.id) || entry);
+            }
+          }
+        } else {
+          appendRenderKeyPart(parts, workspaceWindows.length);
+          for (const entry of workspaceWindows) {
+            appendEntryKey(parts, entry);
+          }
+        }
+        return parts.join("");
       }
 
       function windowRuntimeStatusRenderKey(windowId, runtimeState, effectiveDetail, windowData) {

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -2869,6 +2869,14 @@
         });
       }
 
+      function sameViewportValues(left, right) {
+        return left
+          && right
+          && left.x === right.x
+          && left.y === right.y
+          && left.zoom === right.zoom;
+      }
+
       function canvasCenterAnchor() {
         const rect = canvas.getBoundingClientRect();
         return {
@@ -2881,9 +2889,15 @@
         const clampedZoom = clampRange(nextZoom, 0.6, 2.4);
         const worldX = (anchorX - viewport.x) / viewport.zoom;
         const worldY = (anchorY - viewport.y) / viewport.zoom;
-        viewport.x = anchorX - worldX * clampedZoom;
-        viewport.y = anchorY - worldY * clampedZoom;
-        viewport.zoom = clampedZoom;
+        const nextViewport = {
+          x: anchorX - worldX * clampedZoom,
+          y: anchorY - worldY * clampedZoom,
+          zoom: clampedZoom,
+        };
+        if (sameViewportValues(viewport, nextViewport)) {
+          return;
+        }
+        viewport = nextViewport;
         recordLocalViewportEdit();
         applyViewport();
         persistViewport();

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -13328,7 +13328,7 @@
         element.querySelector(".resize-handle").hidden =
           Boolean(windowData.minimized) || Boolean(windowData.maximized);
         applyStatus(windowData.id, windowData.status, detailMap.get(windowData.id));
-        renderedWindowElementKeys.set(windowData.id, windowElementRenderKey(windowData));
+        renderedWindowElementKeys.set(windowData.id, nextWindowElementKey);
         if (
           (applyWorkspaceGeometry || Boolean(maximizedFill)) &&
           presetSurface(windowData.preset) === "terminal" &&

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -381,6 +381,7 @@
       let viewportDomApplied = false;
       let launchWizard = null;
       let launchWizardOpenError = null;
+      let launchWizardOpening = null;
       let activeWorkProjection = null;
       let pendingBoardEntryFocusId = null;
       let wizardWasOpen = false;
@@ -402,12 +403,14 @@
           }
           if (deferred.kind === "launch_wizard_state") {
             clearLaunchWizardPendingAction();
+            clearLaunchWizardOpening();
             if (deferred.wizard) {
               launchWizardOpenError = null;
             }
             launchWizard = deferred.wizard;
           } else if (deferred.kind === "launch_wizard_open_error") {
             clearLaunchWizardPendingAction();
+            clearLaunchWizardOpening();
             launchWizard = null;
             launchWizardOpenError = {
               title: deferred.title || "Launch Agent",
@@ -9376,6 +9379,7 @@
 
       function closeLaunchWizardLocal() {
         clearLaunchWizardPendingAction();
+        clearLaunchWizardOpening();
         launchWizard = null;
         launchWizardOpenError = null;
         // Issue #2698 PR 1 (B7) — local close wins over any pending
@@ -9399,6 +9403,22 @@
 
       function clearLaunchWizardPendingAction() {
         launchWizardPendingAction = null;
+      }
+
+      function openStartWorkPendingWizard() {
+        clearLaunchWizardPendingAction();
+        launchWizard = null;
+        launchWizardOpenError = null;
+        launchWizardOpening = {
+          title: "Start Work",
+          meta: "Work launch",
+          message: "Preparing Start Work...",
+        };
+        renderLaunchWizard();
+      }
+
+      function clearLaunchWizardOpening() {
+        launchWizardOpening = null;
       }
 
       function syncLaunchWizardPendingChrome(isPending) {
@@ -9439,7 +9459,7 @@
       }
 
       function renderLaunchWizard() {
-        if (!launchWizard && !launchWizardOpenError) {
+        if (!launchWizard && !launchWizardOpenError && !launchWizardOpening) {
           clearLaunchWizardPendingAction();
           syncLaunchWizardPendingChrome(false);
           const wasOpenBeforeClose = wizardModal.classList.contains("open");
@@ -9479,8 +9499,9 @@
         syncWizardDraftState();
         closeModal();
         const isLaunchActionPending = Boolean(launchWizardPendingAction);
+        const isLaunchOpeningPending = Boolean(launchWizardOpening);
         const isLaunchSubmitPending = launchWizardPendingAction?.kind === "submit";
-        syncLaunchWizardPendingChrome(isLaunchActionPending);
+        syncLaunchWizardPendingChrome(isLaunchActionPending || isLaunchOpeningPending);
         const wasOpenWizard = wizardModal.classList.contains("open");
         if (!wasOpenWizard) {
           // Capture trigger BEFORE flipping .open so render-driven focus
@@ -9499,6 +9520,33 @@
           // SPEC-2356 — trap Tab inside the wizard while it's open so
           // keyboard users can't escape into background content.
           wizardFocusTrapRelease = createFocusTrap(wizardDialog, { document });
+        }
+
+        if (launchWizardOpening) {
+          if (wizardTitle) {
+            wizardTitle.textContent = launchWizardOpening.title || "Start Work";
+          }
+          wizardMeta.textContent = launchWizardOpening.meta || "Work launch";
+          wizardBackButton.hidden = true;
+          wizardBackButton.disabled = true;
+          wizardSubmitButton.hidden = true;
+          wizardSubmitButton.disabled = true;
+          wizardCancelButton.textContent = "Cancel";
+          wizardCancelButton.disabled = true;
+          wizardError.hidden = true;
+          wizardError.textContent = "";
+          wizardSummary.innerHTML = "";
+          wizardBody.innerHTML = "";
+          const openingPanel = createNode("div", "launch-panel wizard-disabled");
+          openingPanel.appendChild(
+            createNode(
+              "div",
+              "launch-note launch-pending-note",
+              launchWizardOpening.message || "Preparing Start Work...",
+            ),
+          );
+          wizardBody.appendChild(openingPanel);
+          return;
         }
 
         if (launchWizardOpenError) {
@@ -14641,6 +14689,7 @@
               break;
             }
             clearLaunchWizardPendingAction();
+            clearLaunchWizardOpening();
             launchWizard = null;
             launchWizardOpenError = {
               title: event.title || "Launch Agent",
@@ -14666,6 +14715,7 @@
               break;
             }
             clearLaunchWizardPendingAction();
+            clearLaunchWizardOpening();
             if (event.wizard) {
               launchWizardOpenError = null;
             }
@@ -15818,6 +15868,7 @@
             return;
           case "start-work":
           case "spawn-agent":
+            openStartWorkPendingWizard();
             frontendUnits.socketTransport.send({
               kind: "open_start_work",
             });

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1551,6 +1551,7 @@
           onTrace: (kind, fields) => {
             traceUi(kind, fields);
           },
+          shouldTrace: uiTraceWiring.isTracing,
         });
         setConnectionState(true);
         send({ kind: "frontend_ready" });

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -4460,9 +4460,18 @@
       }
 
       function focusWindowLocally(windowId) {
+        const targetElement = windowMap.get(windowId);
+        if (focusedId === windowId && targetElement?.classList.contains("focused")) {
+          return;
+        }
+        const previousFocusedId = focusedId;
         focusedId = windowId;
-        for (const [id, element] of windowMap.entries()) {
-          element.classList.toggle("focused", id === windowId);
+        if (previousFocusedId && previousFocusedId !== windowId) {
+          const previousElement = windowMap.get(previousFocusedId);
+          previousElement?.classList.remove("focused");
+        }
+        if (targetElement) {
+          targetElement.classList.add("focused");
         }
       }
 

--- a/crates/gwt/web/project-tabs-renderer.js
+++ b/crates/gwt/web/project-tabs-renderer.js
@@ -123,23 +123,30 @@ export function renderProjectTabs({
   }
   const document = projectTabs.ownerDocument;
   const nextTabs = Array.isArray(tabs) ? tabs : [];
-  const nextIds = new Set(nextTabs.map((tab) => tab.id));
-
-  for (const button of projectTabs.querySelectorAll(
-    ".project-tab[data-project-tab-id]",
-  )) {
-    if (!nextIds.has(button.dataset.projectTabId)) {
-      button.remove();
-    }
+  const nextIds = new Set();
+  for (const tab of nextTabs) {
+    nextIds.add(tab.id);
   }
 
-  const existingButtons = new Map(
-    Array.from(
-      projectTabs.querySelectorAll(".project-tab[data-project-tab-id]"),
-    ).map((button) => [button.dataset.projectTabId, button]),
-  );
+  const existingButtons = new Map();
+  for (let index = projectTabs.children.length - 1; index >= 0; index -= 1) {
+    const button = projectTabs.children[index];
+    if (
+      !button.classList?.contains("project-tab") ||
+      !button.dataset?.projectTabId
+    ) {
+      continue;
+    }
+    const tabId = button.dataset.projectTabId;
+    if (!nextIds.has(tabId)) {
+      button.remove();
+      continue;
+    }
+    existingButtons.set(tabId, button);
+  }
 
-  nextTabs.forEach((tab, index) => {
+  for (let index = 0; index < nextTabs.length; index += 1) {
+    const tab = nextTabs[index];
     let button = existingButtons.get(tab.id);
     if (!button) {
       button = createTabButton(document, send, requestCloseProjectTab);
@@ -196,5 +203,5 @@ export function renderProjectTabs({
     if (current !== button) {
       projectTabs.insertBefore(button, current);
     }
-  });
+  }
 }

--- a/crates/gwt/web/socket-receive-dispatcher.js
+++ b/crates/gwt/web/socket-receive-dispatcher.js
@@ -12,10 +12,13 @@
 // - the queue is flushed on the next animation frame,
 // - idempotent global-state kinds (e.g. workspace_state) collapse to the
 //   latest occurrence, sparing redundant DOM mutations,
+// - long streamed-event backlogs deliver a bounded chunk before latest state so
+//   tab/project updates are not starved behind terminal output,
 // - per-frame time budget (default 8ms) bounds long tasks; remaining events
 //   defer to the next frame.
 
 const DEFAULT_BUDGET_MS = 8;
+export const DEFAULT_MAX_STREAMED_BEFORE_STATE = 32;
 
 // Idempotent kinds where only the latest occurrence carries information. Any
 // kind not in this set preserves original order and every occurrence.
@@ -41,6 +44,7 @@ export function createSocketReceiveDispatcher({
   now,
   budgetMs = DEFAULT_BUDGET_MS,
   coalesceKinds = DEFAULT_COALESCE_KINDS,
+  maxStreamedBeforeState = DEFAULT_MAX_STREAMED_BEFORE_STATE,
   onTrace,
 } = {}) {
   if (typeof receive !== "function") {
@@ -82,7 +86,9 @@ export function createSocketReceiveDispatcher({
     if (queue.length === 0) {
       return;
     }
-    const ready = coalesceEvents(queue, coalesceKinds);
+    const ready = coalesceEvents(queue, coalesceKinds, {
+      maxStreamedBeforeState,
+    });
     queue.length = 0;
     const start = nowImpl();
     trace("ws_flush_start", {
@@ -176,10 +182,15 @@ export function createSocketReceiveDispatcher({
   return { handle, enqueue, flushNow, pendingCount };
 }
 
-export function coalesceEvents(queue, coalesceKinds = DEFAULT_COALESCE_KINDS) {
+export function coalesceEvents(
+  queue,
+  coalesceKinds = DEFAULT_COALESCE_KINDS,
+  { maxStreamedBeforeState = DEFAULT_MAX_STREAMED_BEFORE_STATE } = {},
+) {
   if (!queue || queue.length <= 1) {
     return queue ? queue.slice() : [];
   }
+  const streamedChunkLimit = normalizeStreamedChunkLimit(maxStreamedBeforeState);
   const lastIndexByKind = new Map();
   for (let i = 0; i < queue.length; i += 1) {
     const event = queue[i];
@@ -212,5 +223,17 @@ export function coalesceEvents(queue, coalesceKinds = DEFAULT_COALESCE_KINDS) {
       streamed.push(event);
     }
   }
-  return streamed.concat(idempotent);
+  if (streamed.length <= streamedChunkLimit || idempotent.length === 0) {
+    return streamed.concat(idempotent);
+  }
+  return streamed
+    .slice(0, streamedChunkLimit)
+    .concat(idempotent, streamed.slice(streamedChunkLimit));
+}
+
+function normalizeStreamedChunkLimit(value) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return DEFAULT_MAX_STREAMED_BEFORE_STATE;
+  }
+  return Math.floor(value);
 }

--- a/crates/gwt/web/socket-receive-dispatcher.js
+++ b/crates/gwt/web/socket-receive-dispatcher.js
@@ -47,6 +47,7 @@ export function createSocketReceiveDispatcher({
   coalesceKinds = DEFAULT_COALESCE_KINDS,
   maxStreamedBeforeState = DEFAULT_MAX_STREAMED_BEFORE_STATE,
   onTrace,
+  shouldTrace,
 } = {}) {
   if (typeof receive !== "function") {
     throw new TypeError(
@@ -67,15 +68,31 @@ export function createSocketReceiveDispatcher({
     return Date.now();
   });
   const traceImpl = typeof onTrace === "function" ? onTrace : null;
+  const shouldTraceImpl = typeof shouldTrace === "function" ? shouldTrace : null;
 
   const queue = [];
   let scheduled = false;
 
-  function trace(kind, fields = {}) {
+  function traceActive() {
     if (!traceImpl) {
+      return false;
+    }
+    if (!shouldTraceImpl) {
+      return true;
+    }
+    try {
+      return Boolean(shouldTraceImpl());
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function trace(kind, fieldsFactory = () => ({})) {
+    if (!traceActive()) {
       return;
     }
     try {
+      const fields = fieldsFactory();
       traceImpl(kind, fields);
     } catch (_) {
       // Diagnostics must never affect the interactive event path.
@@ -92,9 +109,9 @@ export function createSocketReceiveDispatcher({
     });
     queue.length = 0;
     const start = nowImpl();
-    trace("ws_flush_start", {
+    trace("ws_flush_start", () => ({
       ready_count: ready.length,
-    });
+    }));
     let cursor = 0;
     while (cursor < ready.length) {
       const entry = ready[cursor];
@@ -103,18 +120,18 @@ export function createSocketReceiveDispatcher({
       try {
         const event = queuedEntryPayload(entry);
         receive(event);
-        trace("ws_receive", {
+        trace("ws_receive", () => ({
           event_kind: event && event.kind,
           duration_ms: nowImpl() - receiveStart,
           deferred_parse: entry && entry.type === "raw",
-        });
+        }));
       } catch (error) {
-        trace("ws_receive", {
+        trace("ws_receive", () => ({
           event_kind: eventKind,
           duration_ms: nowImpl() - receiveStart,
           threw: true,
           error_name: error && error.name,
-        });
+        }));
         console.warn(
           "[ws-dispatcher] receive threw for %s — continuing with remaining events",
           eventKind,
@@ -126,20 +143,20 @@ export function createSocketReceiveDispatcher({
         for (let i = ready.length - 1; i >= cursor; i -= 1) {
           queue.unshift(ready[i]);
         }
-        trace("ws_flush_defer", {
+        trace("ws_flush_defer", () => ({
           processed_count: cursor,
           remaining_count: ready.length - cursor,
           duration_ms: nowImpl() - start,
-        });
+        }));
         scheduled = true;
         scheduleImpl(flush);
         return;
       }
     }
-    trace("ws_flush_end", {
+    trace("ws_flush_end", () => ({
       processed_count: cursor,
       duration_ms: nowImpl() - start,
-    });
+    }));
   }
 
   function enqueue(event) {
@@ -154,11 +171,11 @@ export function createSocketReceiveDispatcher({
     const parseStart = nowImpl();
     if (messageEvent && typeof messageEvent.data === "string") {
       const entry = rawQueueEntry(messageEvent.data);
-      trace("ws_message", {
+      trace("ws_message", () => ({
         event_kind: entry.kind,
         parse_ms: nowImpl() - parseStart,
         deferred_parse: true,
-      });
+      }));
       queue.push(entry);
     } else if (
       messageEvent
@@ -166,10 +183,10 @@ export function createSocketReceiveDispatcher({
       && Object.hasOwn(messageEvent, "kind")
     ) {
       const entry = parsedQueueEntry(messageEvent);
-      trace("ws_message", {
+      trace("ws_message", () => ({
         event_kind: entry.kind,
         parse_ms: nowImpl() - parseStart,
-      });
+      }));
       queue.push(entry);
     } else {
       throw new TypeError(

--- a/crates/gwt/web/socket-receive-dispatcher.js
+++ b/crates/gwt/web/socket-receive-dispatcher.js
@@ -10,6 +10,7 @@
 // `createSocketReceiveDispatcher` wraps `receive` so:
 // - inbound events accumulate in a queue,
 // - the queue is flushed on the next animation frame,
+// - string payloads keep full JSON.parse work inside the scheduled flush budget,
 // - idempotent global-state kinds (e.g. workspace_state) collapse to the
 //   latest occurrence, sparing redundant DOM mutations,
 // - long streamed-event backlogs deliver a bounded chunk before latest state so
@@ -86,7 +87,7 @@ export function createSocketReceiveDispatcher({
     if (queue.length === 0) {
       return;
     }
-    const ready = coalesceEvents(queue, coalesceKinds, {
+    const ready = coalesceQueuedEntries(queue, coalesceKinds, {
       maxStreamedBeforeState,
     });
     queue.length = 0;
@@ -96,24 +97,27 @@ export function createSocketReceiveDispatcher({
     });
     let cursor = 0;
     while (cursor < ready.length) {
-      const event = ready[cursor];
+      const entry = ready[cursor];
+      const eventKind = queuedEntryKind(entry);
       const receiveStart = nowImpl();
       try {
+        const event = queuedEntryPayload(entry);
         receive(event);
         trace("ws_receive", {
           event_kind: event && event.kind,
           duration_ms: nowImpl() - receiveStart,
+          deferred_parse: entry && entry.type === "raw",
         });
       } catch (error) {
         trace("ws_receive", {
-          event_kind: event && event.kind,
+          event_kind: eventKind,
           duration_ms: nowImpl() - receiveStart,
           threw: true,
           error_name: error && error.name,
         });
         console.warn(
           "[ws-dispatcher] receive threw for %s — continuing with remaining events",
-          event && event.kind,
+          eventKind,
           error,
         );
       }
@@ -139,7 +143,7 @@ export function createSocketReceiveDispatcher({
   }
 
   function enqueue(event) {
-    queue.push(event);
+    queue.push(parsedQueueEntry(event));
     if (!scheduled) {
       scheduled = true;
       scheduleImpl(flush);
@@ -147,26 +151,35 @@ export function createSocketReceiveDispatcher({
   }
 
   function handle(messageEvent) {
-    let payload;
     const parseStart = nowImpl();
     if (messageEvent && typeof messageEvent.data === "string") {
-      payload = JSON.parse(messageEvent.data);
+      const entry = rawQueueEntry(messageEvent.data);
+      trace("ws_message", {
+        event_kind: entry.kind,
+        parse_ms: nowImpl() - parseStart,
+        deferred_parse: true,
+      });
+      queue.push(entry);
     } else if (
       messageEvent
       && typeof messageEvent === "object"
       && Object.hasOwn(messageEvent, "kind")
     ) {
-      payload = messageEvent;
+      const entry = parsedQueueEntry(messageEvent);
+      trace("ws_message", {
+        event_kind: entry.kind,
+        parse_ms: nowImpl() - parseStart,
+      });
+      queue.push(entry);
     } else {
       throw new TypeError(
         "createSocketReceiveDispatcher.handle expects a WebSocket message event or parsed payload",
       );
     }
-    trace("ws_message", {
-      event_kind: payload && payload.kind,
-      parse_ms: nowImpl() - parseStart,
-    });
-    enqueue(payload);
+    if (!scheduled) {
+      scheduled = true;
+      scheduleImpl(flush);
+    }
   }
 
   function flushNow() {
@@ -182,10 +195,69 @@ export function createSocketReceiveDispatcher({
   return { handle, enqueue, flushNow, pendingCount };
 }
 
+function parsedQueueEntry(event) {
+  return {
+    type: "parsed",
+    kind: event && event.kind,
+    payload: event,
+  };
+}
+
+const KIND_HINT_PATTERN = /"kind"\s*:\s*"([^"\\]*)"/;
+
+function rawQueueEntry(data) {
+  return {
+    type: "raw",
+    kind: extractKindHint(data),
+    payload: data,
+  };
+}
+
+function extractKindHint(data) {
+  if (typeof data !== "string") {
+    return "";
+  }
+  const match = KIND_HINT_PATTERN.exec(data);
+  return match ? match[1] : "";
+}
+
+function queuedEntryKind(entry) {
+  return entry && entry.kind;
+}
+
+function queuedEntryPayload(entry) {
+  if (entry && entry.type === "raw") {
+    return JSON.parse(entry.payload);
+  }
+  return entry ? entry.payload : entry;
+}
+
+function coalesceQueuedEntries(
+  queue,
+  coalesceKinds = DEFAULT_COALESCE_KINDS,
+  { maxStreamedBeforeState = DEFAULT_MAX_STREAMED_BEFORE_STATE } = {},
+) {
+  return coalesceByKind(queue, coalesceKinds, {
+    maxStreamedBeforeState,
+    kindFor: queuedEntryKind,
+  });
+}
+
 export function coalesceEvents(
   queue,
   coalesceKinds = DEFAULT_COALESCE_KINDS,
   { maxStreamedBeforeState = DEFAULT_MAX_STREAMED_BEFORE_STATE } = {},
+) {
+  return coalesceByKind(queue, coalesceKinds, {
+    maxStreamedBeforeState,
+    kindFor: (event) => event && event.kind,
+  });
+}
+
+function coalesceByKind(
+  queue,
+  coalesceKinds = DEFAULT_COALESCE_KINDS,
+  { maxStreamedBeforeState = DEFAULT_MAX_STREAMED_BEFORE_STATE, kindFor } = {},
 ) {
   if (!queue || queue.length <= 1) {
     return queue ? queue.slice() : [];
@@ -193,8 +265,7 @@ export function coalesceEvents(
   const streamedChunkLimit = normalizeStreamedChunkLimit(maxStreamedBeforeState);
   const lastIndexByKind = new Map();
   for (let i = 0; i < queue.length; i += 1) {
-    const event = queue[i];
-    const kind = event && event.kind;
+    const kind = kindFor(queue[i]);
     if (kind && coalesceKinds.has(kind)) {
       lastIndexByKind.set(kind, i);
     }
@@ -214,7 +285,7 @@ export function coalesceEvents(
   const idempotent = [];
   for (let i = 0; i < queue.length; i += 1) {
     const event = queue[i];
-    const kind = event && event.kind;
+    const kind = kindFor(event);
     if (kind && coalesceKinds.has(kind)) {
       if (lastIndexByKind.get(kind) === i) {
         idempotent.push(event);

--- a/crates/gwt/web/terminal-output-buffer.js
+++ b/crates/gwt/web/terminal-output-buffer.js
@@ -41,6 +41,25 @@ function defaultMergeChunks(chunks) {
   return chunks.join("");
 }
 
+function pendingChunkCount(entry) {
+  return Math.max(0, entry.chunks.length - entry.head);
+}
+
+function compactConsumedChunks(entry) {
+  if (entry.head <= 0) {
+    return;
+  }
+  if (entry.head >= entry.chunks.length) {
+    entry.chunks.length = 0;
+    entry.head = 0;
+    return;
+  }
+  if (entry.head >= 1024 && entry.head * 2 >= entry.chunks.length) {
+    entry.chunks.splice(0, entry.head);
+    entry.head = 0;
+  }
+}
+
 export function createTerminalOutputBatcher({
   schedule = defaultSchedule,
   write,
@@ -69,7 +88,7 @@ export function createTerminalOutputBatcher({
   function entryFor(windowId) {
     let entry = pendingByWindow.get(windowId);
     if (!entry) {
-      entry = { chunks: [] };
+      entry = { chunks: [], head: 0 };
       pendingByWindow.set(windowId, entry);
     }
     return entry;
@@ -106,17 +125,19 @@ export function createTerminalOutputBatcher({
       Number.isFinite(maxChars) && maxChars > 0
         ? Math.min(charsPerFlush, Math.floor(maxChars))
         : charsPerFlush;
-    while (entry.chunks.length > 0) {
-      const next = entry.chunks[0];
+    while (entry.head < entry.chunks.length) {
+      const next = entry.chunks[entry.head];
       if (chunks.length > 0 && chars + next.length > charLimit) {
         break;
       }
-      chunks.push(entry.chunks.shift());
+      chunks.push(next);
+      entry.head += 1;
       chars += next.length;
       if (chars >= charLimit) {
         break;
       }
     }
+    compactConsumedChunks(entry);
     return chunks;
   }
 
@@ -186,14 +207,15 @@ export function createTerminalOutputBatcher({
     if (!entry) {
       return { flushed: false, chars: 0 };
     }
-    if (entry.chunks.length === 0) {
+    if (pendingChunkCount(entry) === 0) {
       pendingByWindow.delete(windowId);
       quiescedWindows.delete(windowId);
       return { flushed: false, chars: 0 };
     }
     const chunks = takeFlushChunks(entry, maxChars);
-    if (entry.chunks.length === 0) {
+    if (pendingChunkCount(entry) === 0) {
       pendingByWindow.delete(windowId);
+      quiescedWindows.delete(windowId);
     }
     let text = "";
     try {
@@ -242,11 +264,12 @@ export function createTerminalOutputBatcher({
 
   function pendingCount(windowId) {
     if (windowId !== undefined) {
-      return pendingByWindow.get(windowId)?.chunks.length || 0;
+      const entry = pendingByWindow.get(windowId);
+      return entry ? pendingChunkCount(entry) : 0;
     }
     let count = 0;
     for (const entry of pendingByWindow.values()) {
-      count += entry.chunks.length;
+      count += pendingChunkCount(entry);
     }
     return count;
   }

--- a/crates/gwt/web/terminal-output-buffer.js
+++ b/crates/gwt/web/terminal-output-buffer.js
@@ -7,6 +7,7 @@
 
 export const DEFAULT_MAX_CHARS_PER_FLUSH = 65536;
 export const DEFAULT_MAX_WINDOWS_PER_FLUSH = 8;
+export const DEFAULT_MAX_TOTAL_CHARS_PER_FLUSH = DEFAULT_MAX_CHARS_PER_FLUSH;
 
 function defaultSchedule(callback) {
   if (typeof requestAnimationFrame === "function") {
@@ -29,6 +30,13 @@ function normalizeMaxWindowsPerFlush(value) {
   return Math.floor(value);
 }
 
+function normalizeMaxTotalCharsPerFlush(value) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return DEFAULT_MAX_TOTAL_CHARS_PER_FLUSH;
+  }
+  return Math.floor(value);
+}
+
 function defaultMergeChunks(chunks) {
   return chunks.join("");
 }
@@ -39,6 +47,7 @@ export function createTerminalOutputBatcher({
   onFlush,
   maxCharsPerFlush = DEFAULT_MAX_CHARS_PER_FLUSH,
   maxWindowsPerFlush = DEFAULT_MAX_WINDOWS_PER_FLUSH,
+  maxTotalCharsPerFlush = DEFAULT_MAX_TOTAL_CHARS_PER_FLUSH,
   mergeChunks = defaultMergeChunks,
 } = {}) {
   if (typeof write !== "function") {
@@ -48,6 +57,7 @@ export function createTerminalOutputBatcher({
   const onFlushImpl = typeof onFlush === "function" ? onFlush : null;
   const charsPerFlush = normalizeMaxCharsPerFlush(maxCharsPerFlush);
   const windowsPerFlush = normalizeMaxWindowsPerFlush(maxWindowsPerFlush);
+  const totalCharsPerFlush = normalizeMaxTotalCharsPerFlush(maxTotalCharsPerFlush);
   const mergeChunksImpl =
     typeof mergeChunks === "function" ? mergeChunks : defaultMergeChunks;
   const pendingByWindow = new Map();
@@ -84,17 +94,21 @@ export function createTerminalOutputBatcher({
     return true;
   }
 
-  function takeFlushChunks(entry) {
+  function takeFlushChunks(entry, maxChars = charsPerFlush) {
     const chunks = [];
     let chars = 0;
+    const charLimit =
+      Number.isFinite(maxChars) && maxChars > 0
+        ? Math.min(charsPerFlush, Math.floor(maxChars))
+        : charsPerFlush;
     while (entry.chunks.length > 0) {
       const next = entry.chunks[0];
-      if (chunks.length > 0 && chars + next.length > charsPerFlush) {
+      if (chunks.length > 0 && chars + next.length > charLimit) {
         break;
       }
       chunks.push(entry.chunks.shift());
       chars += next.length;
-      if (chars >= charsPerFlush) {
+      if (chars >= charLimit) {
         break;
       }
     }
@@ -120,14 +134,21 @@ export function createTerminalOutputBatcher({
     }
     let flushed = false;
     let windowsFlushed = 0;
+    let charsFlushed = 0;
     for (const windowId of Array.from(pendingByWindow.keys())) {
       if (windowsFlushed >= windowsPerFlush) {
+        break;
+      }
+      if (windowsFlushed > 0 && charsFlushed >= totalCharsPerFlush) {
         break;
       }
       if (!pendingByWindow.has(windowId)) {
         continue;
       }
-      flushed = flushWindow(windowId) || flushed;
+      const remainingChars = Math.max(1, totalCharsPerFlush - charsFlushed);
+      const result = flushWindow(windowId, remainingChars);
+      flushed = result.flushed || flushed;
+      charsFlushed += result.chars;
       windowsFlushed += 1;
     }
     if (pendingByWindow.size > 0) {
@@ -136,16 +157,16 @@ export function createTerminalOutputBatcher({
     return flushed;
   }
 
-  function flushWindow(windowId) {
+  function flushWindow(windowId, maxChars = charsPerFlush) {
     const entry = pendingByWindow.get(windowId);
     if (!entry) {
-      return false;
+      return { flushed: false, chars: 0 };
     }
     if (entry.chunks.length === 0) {
       pendingByWindow.delete(windowId);
-      return false;
+      return { flushed: false, chars: 0 };
     }
-    const chunks = takeFlushChunks(entry);
+    const chunks = takeFlushChunks(entry, maxChars);
     if (entry.chunks.length === 0) {
       pendingByWindow.delete(windowId);
     }
@@ -154,23 +175,24 @@ export function createTerminalOutputBatcher({
       text = mergeChunksImpl(chunks, windowId);
     } catch (error) {
       console.warn("[terminal-output-buffer] merge failed for %s", windowId, error);
-      return false;
+      return { flushed: false, chars: 0 };
     }
     if (!text) {
-      return false;
+      return { flushed: false, chars: 0 };
     }
     try {
       write(windowId, text, () => notifyFlushed(windowId));
     } catch (error) {
       console.warn("[terminal-output-buffer] write failed for %s", windowId, error);
     }
-    return true;
+    return { flushed: true, chars: text.length };
   }
 
   function flushNow(windowId) {
     let flushed = false;
     while (pendingByWindow.has(windowId)) {
-      if (!flushWindow(windowId)) {
+      const result = flushWindow(windowId);
+      if (!result.flushed) {
         break;
       }
       flushed = true;

--- a/crates/gwt/web/terminal-output-buffer.js
+++ b/crates/gwt/web/terminal-output-buffer.js
@@ -41,22 +41,23 @@ export function createTerminalOutputBatcher({
   const mergeChunksImpl =
     typeof mergeChunks === "function" ? mergeChunks : defaultMergeChunks;
   const pendingByWindow = new Map();
+  let scheduled = false;
 
   function entryFor(windowId) {
     let entry = pendingByWindow.get(windowId);
     if (!entry) {
-      entry = { chunks: [], scheduled: false };
+      entry = { chunks: [] };
       pendingByWindow.set(windowId, entry);
     }
     return entry;
   }
 
-  function scheduleWindow(windowId, entry) {
-    if (entry.scheduled) {
+  function scheduleFlush() {
+    if (scheduled) {
       return;
     }
-    entry.scheduled = true;
-    scheduleImpl(() => flushWindow(windowId));
+    scheduled = true;
+    scheduleImpl(flushPending);
   }
 
   function enqueue(windowId, text) {
@@ -69,7 +70,7 @@ export function createTerminalOutputBatcher({
     }
     const entry = entryFor(windowId);
     entry.chunks.push(normalized);
-    scheduleWindow(windowId, entry);
+    scheduleFlush();
     return true;
   }
 
@@ -102,12 +103,26 @@ export function createTerminalOutputBatcher({
     }
   }
 
+  function flushPending() {
+    scheduled = false;
+    if (pendingByWindow.size === 0) {
+      return false;
+    }
+    let flushed = false;
+    for (const windowId of Array.from(pendingByWindow.keys())) {
+      flushed = flushWindow(windowId) || flushed;
+    }
+    if (pendingByWindow.size > 0) {
+      scheduleFlush();
+    }
+    return flushed;
+  }
+
   function flushWindow(windowId) {
     const entry = pendingByWindow.get(windowId);
     if (!entry) {
       return false;
     }
-    entry.scheduled = false;
     if (entry.chunks.length === 0) {
       pendingByWindow.delete(windowId);
       return false;
@@ -115,8 +130,6 @@ export function createTerminalOutputBatcher({
     const chunks = takeFlushChunks(entry);
     if (entry.chunks.length === 0) {
       pendingByWindow.delete(windowId);
-    } else {
-      scheduleWindow(windowId, entry);
     }
     let text = "";
     try {

--- a/crates/gwt/web/terminal-output-buffer.js
+++ b/crates/gwt/web/terminal-output-buffer.js
@@ -49,6 +49,7 @@ export function createTerminalOutputBatcher({
   maxWindowsPerFlush = DEFAULT_MAX_WINDOWS_PER_FLUSH,
   maxTotalCharsPerFlush = DEFAULT_MAX_TOTAL_CHARS_PER_FLUSH,
   mergeChunks = defaultMergeChunks,
+  canWrite,
 } = {}) {
   if (typeof write !== "function") {
     throw new TypeError("createTerminalOutputBatcher requires a write callback");
@@ -60,6 +61,7 @@ export function createTerminalOutputBatcher({
   const totalCharsPerFlush = normalizeMaxTotalCharsPerFlush(maxTotalCharsPerFlush);
   const mergeChunksImpl =
     typeof mergeChunks === "function" ? mergeChunks : defaultMergeChunks;
+  const canWriteImpl = typeof canWrite === "function" ? canWrite : () => true;
   const pendingByWindow = new Map();
   let scheduled = false;
 
@@ -145,16 +147,28 @@ export function createTerminalOutputBatcher({
       if (!pendingByWindow.has(windowId)) {
         continue;
       }
+      if (!canWriteImpl(windowId)) {
+        continue;
+      }
       const remainingChars = Math.max(1, totalCharsPerFlush - charsFlushed);
       const result = flushWindow(windowId, remainingChars);
       flushed = result.flushed || flushed;
       charsFlushed += result.chars;
       windowsFlushed += 1;
     }
-    if (pendingByWindow.size > 0) {
+    if (hasEligiblePendingWindow()) {
       scheduleFlush();
     }
     return flushed;
+  }
+
+  function hasEligiblePendingWindow() {
+    for (const windowId of pendingByWindow.keys()) {
+      if (canWriteImpl(windowId)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   function flushWindow(windowId, maxChars = charsPerFlush) {
@@ -204,6 +218,14 @@ export function createTerminalOutputBatcher({
     return pendingByWindow.delete(windowId);
   }
 
+  function schedulePending(windowId) {
+    if (!pendingByWindow.has(windowId)) {
+      return false;
+    }
+    scheduleFlush();
+    return true;
+  }
+
   function pendingCount(windowId) {
     if (windowId !== undefined) {
       return pendingByWindow.get(windowId)?.chunks.length || 0;
@@ -223,6 +245,7 @@ export function createTerminalOutputBatcher({
     enqueue,
     flushNow,
     clear,
+    schedulePending,
     pendingCount,
     pendingWindowCount,
   };

--- a/crates/gwt/web/terminal-output-buffer.js
+++ b/crates/gwt/web/terminal-output-buffer.js
@@ -21,11 +21,16 @@ function normalizeMaxCharsPerFlush(value) {
   return Math.floor(value);
 }
 
+function defaultMergeChunks(chunks) {
+  return chunks.join("");
+}
+
 export function createTerminalOutputBatcher({
   schedule = defaultSchedule,
   write,
   onFlush,
   maxCharsPerFlush = DEFAULT_MAX_CHARS_PER_FLUSH,
+  mergeChunks = defaultMergeChunks,
 } = {}) {
   if (typeof write !== "function") {
     throw new TypeError("createTerminalOutputBatcher requires a write callback");
@@ -33,6 +38,8 @@ export function createTerminalOutputBatcher({
   const scheduleImpl = typeof schedule === "function" ? schedule : defaultSchedule;
   const onFlushImpl = typeof onFlush === "function" ? onFlush : null;
   const charsPerFlush = normalizeMaxCharsPerFlush(maxCharsPerFlush);
+  const mergeChunksImpl =
+    typeof mergeChunks === "function" ? mergeChunks : defaultMergeChunks;
   const pendingByWindow = new Map();
 
   function entryFor(windowId) {
@@ -111,7 +118,13 @@ export function createTerminalOutputBatcher({
     } else {
       scheduleWindow(windowId, entry);
     }
-    const text = chunks.join("");
+    let text = "";
+    try {
+      text = mergeChunksImpl(chunks, windowId);
+    } catch (error) {
+      console.warn("[terminal-output-buffer] merge failed for %s", windowId, error);
+      return false;
+    }
     if (!text) {
       return false;
     }

--- a/crates/gwt/web/terminal-output-buffer.js
+++ b/crates/gwt/web/terminal-output-buffer.js
@@ -1,0 +1,163 @@
+// SPEC-1939 Phase 24 — per-terminal output batching.
+//
+// WebSocket receive dispatch is already rAF/budget bounded, but xterm still
+// pays per `write()` call once terminal_output reaches app.js. This helper
+// batches decoded text per window so dense PTY bursts produce one xterm write
+// per frame for normal chunk sizes while preserving per-window ordering.
+
+export const DEFAULT_MAX_CHARS_PER_FLUSH = 65536;
+
+function defaultSchedule(callback) {
+  if (typeof requestAnimationFrame === "function") {
+    return requestAnimationFrame(callback);
+  }
+  return setTimeout(callback, 0);
+}
+
+function normalizeMaxCharsPerFlush(value) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return DEFAULT_MAX_CHARS_PER_FLUSH;
+  }
+  return Math.floor(value);
+}
+
+export function createTerminalOutputBatcher({
+  schedule = defaultSchedule,
+  write,
+  onFlush,
+  maxCharsPerFlush = DEFAULT_MAX_CHARS_PER_FLUSH,
+} = {}) {
+  if (typeof write !== "function") {
+    throw new TypeError("createTerminalOutputBatcher requires a write callback");
+  }
+  const scheduleImpl = typeof schedule === "function" ? schedule : defaultSchedule;
+  const onFlushImpl = typeof onFlush === "function" ? onFlush : null;
+  const charsPerFlush = normalizeMaxCharsPerFlush(maxCharsPerFlush);
+  const pendingByWindow = new Map();
+
+  function entryFor(windowId) {
+    let entry = pendingByWindow.get(windowId);
+    if (!entry) {
+      entry = { chunks: [], scheduled: false };
+      pendingByWindow.set(windowId, entry);
+    }
+    return entry;
+  }
+
+  function scheduleWindow(windowId, entry) {
+    if (entry.scheduled) {
+      return;
+    }
+    entry.scheduled = true;
+    scheduleImpl(() => flushWindow(windowId));
+  }
+
+  function enqueue(windowId, text) {
+    if (windowId === null || windowId === undefined || text === "") {
+      return false;
+    }
+    const normalized = String(text);
+    if (!normalized) {
+      return false;
+    }
+    const entry = entryFor(windowId);
+    entry.chunks.push(normalized);
+    scheduleWindow(windowId, entry);
+    return true;
+  }
+
+  function takeFlushChunks(entry) {
+    const chunks = [];
+    let chars = 0;
+    while (entry.chunks.length > 0) {
+      const next = entry.chunks[0];
+      if (chunks.length > 0 && chars + next.length > charsPerFlush) {
+        break;
+      }
+      chunks.push(entry.chunks.shift());
+      chars += next.length;
+      if (chars >= charsPerFlush) {
+        break;
+      }
+    }
+    return chunks;
+  }
+
+  function notifyFlushed(windowId) {
+    if (!onFlushImpl) {
+      return;
+    }
+    try {
+      onFlushImpl(windowId);
+    } catch (_) {
+      // Refresh callbacks are best-effort UI maintenance and must not break
+      // the terminal output drain.
+    }
+  }
+
+  function flushWindow(windowId) {
+    const entry = pendingByWindow.get(windowId);
+    if (!entry) {
+      return false;
+    }
+    entry.scheduled = false;
+    if (entry.chunks.length === 0) {
+      pendingByWindow.delete(windowId);
+      return false;
+    }
+    const chunks = takeFlushChunks(entry);
+    if (entry.chunks.length === 0) {
+      pendingByWindow.delete(windowId);
+    } else {
+      scheduleWindow(windowId, entry);
+    }
+    const text = chunks.join("");
+    if (!text) {
+      return false;
+    }
+    try {
+      write(windowId, text, () => notifyFlushed(windowId));
+    } catch (error) {
+      console.warn("[terminal-output-buffer] write failed for %s", windowId, error);
+    }
+    return true;
+  }
+
+  function flushNow(windowId) {
+    let flushed = false;
+    while (pendingByWindow.has(windowId)) {
+      if (!flushWindow(windowId)) {
+        break;
+      }
+      flushed = true;
+    }
+    return flushed;
+  }
+
+  function clear(windowId) {
+    return pendingByWindow.delete(windowId);
+  }
+
+  function pendingCount(windowId) {
+    if (windowId !== undefined) {
+      return pendingByWindow.get(windowId)?.chunks.length || 0;
+    }
+    let count = 0;
+    for (const entry of pendingByWindow.values()) {
+      count += entry.chunks.length;
+    }
+    return count;
+  }
+
+  function pendingWindowCount() {
+    return pendingByWindow.size;
+  }
+
+  return {
+    enqueue,
+    flushNow,
+    clear,
+    pendingCount,
+    pendingWindowCount,
+  };
+}

--- a/crates/gwt/web/terminal-output-buffer.js
+++ b/crates/gwt/web/terminal-output-buffer.js
@@ -63,6 +63,7 @@ export function createTerminalOutputBatcher({
     typeof mergeChunks === "function" ? mergeChunks : defaultMergeChunks;
   const canWriteImpl = typeof canWrite === "function" ? canWrite : () => true;
   const pendingByWindow = new Map();
+  const quiescedWindows = new Set();
   let scheduled = false;
 
   function entryFor(windowId) {
@@ -92,7 +93,9 @@ export function createTerminalOutputBatcher({
     }
     const entry = entryFor(windowId);
     entry.chunks.push(normalized);
-    scheduleFlush();
+    if (!quiescedWindows.has(windowId) || hasSchedulablePendingWindow()) {
+      scheduleFlush();
+    }
     return true;
   }
 
@@ -147,7 +150,11 @@ export function createTerminalOutputBatcher({
       if (!pendingByWindow.has(windowId)) {
         continue;
       }
+      if (quiescedWindows.has(windowId)) {
+        continue;
+      }
       if (!canWriteImpl(windowId)) {
+        quiescedWindows.add(windowId);
         continue;
       }
       const remainingChars = Math.max(1, totalCharsPerFlush - charsFlushed);
@@ -156,14 +163,17 @@ export function createTerminalOutputBatcher({
       charsFlushed += result.chars;
       windowsFlushed += 1;
     }
-    if (hasEligiblePendingWindow()) {
+    if (hasSchedulablePendingWindow()) {
       scheduleFlush();
     }
     return flushed;
   }
 
-  function hasEligiblePendingWindow() {
+  function hasSchedulablePendingWindow() {
     for (const windowId of pendingByWindow.keys()) {
+      if (quiescedWindows.has(windowId)) {
+        continue;
+      }
       if (canWriteImpl(windowId)) {
         return true;
       }
@@ -178,6 +188,7 @@ export function createTerminalOutputBatcher({
     }
     if (entry.chunks.length === 0) {
       pendingByWindow.delete(windowId);
+      quiescedWindows.delete(windowId);
       return { flushed: false, chars: 0 };
     }
     const chunks = takeFlushChunks(entry, maxChars);
@@ -204,6 +215,7 @@ export function createTerminalOutputBatcher({
 
   function flushNow(windowId) {
     let flushed = false;
+    quiescedWindows.delete(windowId);
     while (pendingByWindow.has(windowId)) {
       const result = flushWindow(windowId);
       if (!result.flushed) {
@@ -215,6 +227,7 @@ export function createTerminalOutputBatcher({
   }
 
   function clear(windowId) {
+    quiescedWindows.delete(windowId);
     return pendingByWindow.delete(windowId);
   }
 
@@ -222,6 +235,7 @@ export function createTerminalOutputBatcher({
     if (!pendingByWindow.has(windowId)) {
       return false;
     }
+    quiescedWindows.delete(windowId);
     scheduleFlush();
     return true;
   }

--- a/crates/gwt/web/terminal-output-buffer.js
+++ b/crates/gwt/web/terminal-output-buffer.js
@@ -6,6 +6,7 @@
 // per frame for normal chunk sizes while preserving per-window ordering.
 
 export const DEFAULT_MAX_CHARS_PER_FLUSH = 65536;
+export const DEFAULT_MAX_WINDOWS_PER_FLUSH = 8;
 
 function defaultSchedule(callback) {
   if (typeof requestAnimationFrame === "function") {
@@ -21,6 +22,13 @@ function normalizeMaxCharsPerFlush(value) {
   return Math.floor(value);
 }
 
+function normalizeMaxWindowsPerFlush(value) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return DEFAULT_MAX_WINDOWS_PER_FLUSH;
+  }
+  return Math.floor(value);
+}
+
 function defaultMergeChunks(chunks) {
   return chunks.join("");
 }
@@ -30,6 +38,7 @@ export function createTerminalOutputBatcher({
   write,
   onFlush,
   maxCharsPerFlush = DEFAULT_MAX_CHARS_PER_FLUSH,
+  maxWindowsPerFlush = DEFAULT_MAX_WINDOWS_PER_FLUSH,
   mergeChunks = defaultMergeChunks,
 } = {}) {
   if (typeof write !== "function") {
@@ -38,6 +47,7 @@ export function createTerminalOutputBatcher({
   const scheduleImpl = typeof schedule === "function" ? schedule : defaultSchedule;
   const onFlushImpl = typeof onFlush === "function" ? onFlush : null;
   const charsPerFlush = normalizeMaxCharsPerFlush(maxCharsPerFlush);
+  const windowsPerFlush = normalizeMaxWindowsPerFlush(maxWindowsPerFlush);
   const mergeChunksImpl =
     typeof mergeChunks === "function" ? mergeChunks : defaultMergeChunks;
   const pendingByWindow = new Map();
@@ -109,8 +119,16 @@ export function createTerminalOutputBatcher({
       return false;
     }
     let flushed = false;
+    let windowsFlushed = 0;
     for (const windowId of Array.from(pendingByWindow.keys())) {
+      if (windowsFlushed >= windowsPerFlush) {
+        break;
+      }
+      if (!pendingByWindow.has(windowId)) {
+        continue;
+      }
       flushed = flushWindow(windowId) || flushed;
+      windowsFlushed += 1;
     }
     if (pendingByWindow.size > 0) {
       scheduleFlush();

--- a/crates/gwt/web/terminal-viewport-reflow.js
+++ b/crates/gwt/web/terminal-viewport-reflow.js
@@ -5,6 +5,7 @@
 // source-string contracts).
 
 export const DEFAULT_MAX_TERMINAL_FITS_PER_FRAME = 4;
+export const DEFAULT_MAX_TERMINAL_REFRESHES_PER_FRAME = 4;
 
 function defaultScheduleFrame(callback) {
   if (typeof requestAnimationFrame === "function") {
@@ -16,6 +17,13 @@ function defaultScheduleFrame(callback) {
 function normalizeMaxTerminalFitsPerFrame(value) {
   if (!Number.isFinite(value) || value <= 0) {
     return DEFAULT_MAX_TERMINAL_FITS_PER_FRAME;
+  }
+  return Math.floor(value);
+}
+
+function normalizeMaxTerminalRefreshesPerFrame(value) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return DEFAULT_MAX_TERMINAL_REFRESHES_PER_FRAME;
   }
   return Math.floor(value);
 }
@@ -86,6 +94,91 @@ export function createTerminalFitScheduler({
 
   return {
     enqueue,
+    flushPending,
+    pendingCount,
+  };
+}
+
+/**
+ * Coalesce terminal viewport refresh requests through one bounded frame queue.
+ *
+ * xterm refresh is render work. Terminal output, scroll, and visibility paths
+ * can request refreshes for many terminals before paint; this scheduler keeps
+ * each window refreshed at most once per burst while limiting how many refresh
+ * calls run in one frame.
+ */
+export function createTerminalViewportRefreshScheduler({
+  schedule = defaultScheduleFrame,
+  canRefresh,
+  refresh,
+  markPending,
+  maxRefreshesPerFrame = DEFAULT_MAX_TERMINAL_REFRESHES_PER_FRAME,
+} = {}) {
+  if (typeof refresh !== "function") {
+    throw new TypeError("createTerminalViewportRefreshScheduler requires a refresh callback");
+  }
+  const scheduleImpl = typeof schedule === "function" ? schedule : defaultScheduleFrame;
+  const canRefreshImpl = typeof canRefresh === "function" ? canRefresh : () => true;
+  const markPendingImpl = typeof markPending === "function" ? markPending : () => {};
+  const refreshesPerFrame = normalizeMaxTerminalRefreshesPerFrame(maxRefreshesPerFrame);
+  const pending = new Set();
+  let scheduled = false;
+
+  function scheduleFlush() {
+    if (scheduled) {
+      return;
+    }
+    scheduled = true;
+    scheduleImpl(flushPending);
+  }
+
+  function enqueue(windowId) {
+    if (windowId === null || windowId === undefined || windowId === "") {
+      return false;
+    }
+    pending.add(String(windowId));
+    scheduleFlush();
+    return true;
+  }
+
+  function clear(windowId) {
+    if (windowId === null || windowId === undefined || windowId === "") {
+      return false;
+    }
+    return pending.delete(String(windowId));
+  }
+
+  function flushPending() {
+    scheduled = false;
+    let refreshed = 0;
+    for (const windowId of Array.from(pending.values())) {
+      if (refreshed >= refreshesPerFrame) {
+        break;
+      }
+      if (!pending.has(windowId)) {
+        continue;
+      }
+      pending.delete(windowId);
+      if (!canRefreshImpl(windowId)) {
+        markPendingImpl(windowId);
+        continue;
+      }
+      refresh(windowId);
+      refreshed += 1;
+    }
+    if (pending.size > 0) {
+      scheduleFlush();
+    }
+    return refreshed;
+  }
+
+  function pendingCount() {
+    return pending.size;
+  }
+
+  return {
+    enqueue,
+    clear,
     flushPending,
     pendingCount,
   };

--- a/crates/gwt/web/terminal-viewport-reflow.js
+++ b/crates/gwt/web/terminal-viewport-reflow.js
@@ -339,6 +339,13 @@ function idSet(values) {
   return set;
 }
 
+function providedIdSet(value) {
+  if (!value || typeof value.has !== "function" || typeof value[Symbol.iterator] !== "function") {
+    return null;
+  }
+  return value;
+}
+
 /**
  * Classify mounted workspace windows during a project-tab render.
  *
@@ -350,11 +357,13 @@ function idSet(values) {
  */
 export function classifyProjectWindowVisibility({
   activeWindowIds,
+  activeWindowIdSet,
   allProjectWindowIds,
+  allProjectWindowIdSet,
   mountedWindowIds,
 }) {
-  const active = idSet(activeWindowIds);
-  const all = idSet(allProjectWindowIds);
+  const active = providedIdSet(activeWindowIdSet) || idSet(activeWindowIds);
+  const all = providedIdSet(allProjectWindowIdSet) || idSet(allProjectWindowIds);
   const visible = Array.from(active);
   const hidden = [];
   const removed = [];

--- a/crates/gwt/web/terminal-viewport-reflow.js
+++ b/crates/gwt/web/terminal-viewport-reflow.js
@@ -4,6 +4,93 @@
 // window interaction features must be covered by behavior tests, not just
 // source-string contracts).
 
+export const DEFAULT_MAX_TERMINAL_FITS_PER_FRAME = 4;
+
+function defaultScheduleFrame(callback) {
+  if (typeof requestAnimationFrame === "function") {
+    return requestAnimationFrame(callback);
+  }
+  return setTimeout(callback, 0);
+}
+
+function normalizeMaxTerminalFitsPerFrame(value) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return DEFAULT_MAX_TERMINAL_FITS_PER_FRAME;
+  }
+  return Math.floor(value);
+}
+
+/**
+ * Coalesce terminal viewport fit requests through one bounded frame queue.
+ *
+ * Fitting an xterm terminal can force render/measure work and optionally
+ * persist PTY geometry. Render and resize paths can request many fits before
+ * the next paint; this scheduler keeps those fits ordered while preventing one
+ * frame from draining every terminal in a large workspace.
+ */
+export function createTerminalFitScheduler({
+  schedule = defaultScheduleFrame,
+  fitTerminal,
+  maxFitsPerFrame = DEFAULT_MAX_TERMINAL_FITS_PER_FRAME,
+} = {}) {
+  if (typeof fitTerminal !== "function") {
+    throw new TypeError("createTerminalFitScheduler requires a fitTerminal callback");
+  }
+  const scheduleImpl = typeof schedule === "function" ? schedule : defaultScheduleFrame;
+  const fitsPerFrame = normalizeMaxTerminalFitsPerFrame(maxFitsPerFrame);
+  const pending = new Map();
+  let scheduled = false;
+
+  function scheduleFlush() {
+    if (scheduled) {
+      return;
+    }
+    scheduled = true;
+    scheduleImpl(flushPending);
+  }
+
+  function enqueue(windowId, { persist = false } = {}) {
+    if (windowId === null || windowId === undefined || windowId === "") {
+      return false;
+    }
+    const id = String(windowId);
+    const existing = pending.get(id);
+    pending.set(id, { persist: Boolean(existing?.persist || persist) });
+    scheduleFlush();
+    return true;
+  }
+
+  function flushPending() {
+    scheduled = false;
+    let flushed = 0;
+    for (const [windowId, state] of Array.from(pending.entries())) {
+      if (flushed >= fitsPerFrame) {
+        break;
+      }
+      if (!pending.has(windowId)) {
+        continue;
+      }
+      pending.delete(windowId);
+      fitTerminal(windowId, state.persist);
+      flushed += 1;
+    }
+    if (pending.size > 0) {
+      scheduleFlush();
+    }
+    return flushed;
+  }
+
+  function pendingCount() {
+    return pending.size;
+  }
+
+  return {
+    enqueue,
+    flushPending,
+    pendingCount,
+  };
+}
+
 /**
  * Attach a host `window.resize` listener that refreshes every visible
  * terminal viewport. The caller supplies the terminal id iterator,

--- a/crates/gwt/web/ui-trace-wiring.js
+++ b/crates/gwt/web/ui-trace-wiring.js
@@ -72,6 +72,13 @@ export function createUiTraceWiring({
     return profiler.measure(kind, fields, callback);
   }
 
+  function isTracing() {
+    if (typeof profiler.isActive !== "function") {
+      return false;
+    }
+    return Boolean(profiler.isActive());
+  }
+
   function start() {
     const trace = profiler.start();
     log(`[ui-trace] started ${trace.session_id}`);
@@ -105,6 +112,7 @@ export function createUiTraceWiring({
   }
 
   return {
+    isTracing,
     registerPalette,
     start,
     stop,

--- a/crates/gwt/web/viewport-persist-throttle.js
+++ b/crates/gwt/web/viewport-persist-throttle.js
@@ -38,8 +38,37 @@ export function createViewportPersistThrottle({
 
   let timerId = null;
   let firstPendingAt = 0;
-  let latestPayload;
+  let latestX;
+  let latestY;
+  let latestZoom;
+  let lastDispatchedX;
+  let lastDispatchedY;
+  let lastDispatchedZoom;
+  let hasLastDispatched = false;
   let hasPending = false;
+
+  function sameViewportPayload(payload, x, y, zoom, hasValue) {
+    return hasValue
+      && payload
+      && typeof payload === "object"
+      && payload.x === x
+      && payload.y === y
+      && payload.zoom === zoom;
+  }
+
+  function storePendingPayload(payload) {
+    latestX = payload.x;
+    latestY = payload.y;
+    latestZoom = payload.zoom;
+  }
+
+  function latestPayloadSnapshot() {
+    return {
+      x: latestX,
+      y: latestY,
+      zoom: latestZoom,
+    };
+  }
 
   function clearTimer() {
     if (timerId !== null) {
@@ -53,15 +82,32 @@ export function createViewportPersistThrottle({
     if (!hasPending) {
       return;
     }
-    const payload = latestPayload;
+    const payload = latestPayloadSnapshot();
     hasPending = false;
-    latestPayload = undefined;
     firstPendingAt = 0;
     send(payload);
+    lastDispatchedX = payload.x;
+    lastDispatchedY = payload.y;
+    lastDispatchedZoom = payload.zoom;
+    hasLastDispatched = true;
   }
 
   function schedule(payload) {
-    latestPayload = payload;
+    if (sameViewportPayload(payload, latestX, latestY, latestZoom, hasPending)) {
+      return;
+    }
+    if (
+      sameViewportPayload(
+        payload,
+        lastDispatchedX,
+        lastDispatchedY,
+        lastDispatchedZoom,
+        hasLastDispatched,
+      )
+    ) {
+      return;
+    }
+    storePendingPayload(payload);
     if (!hasPending) {
       hasPending = true;
       firstPendingAt = nowFn();
@@ -78,11 +124,14 @@ export function createViewportPersistThrottle({
     if (!hasPending) {
       return;
     }
-    const payload = latestPayload;
+    const payload = latestPayloadSnapshot();
     hasPending = false;
-    latestPayload = undefined;
     firstPendingAt = 0;
     send(payload);
+    lastDispatchedX = payload.x;
+    lastDispatchedY = payload.y;
+    lastDispatchedZoom = payload.zoom;
+    hasLastDispatched = true;
   }
 
   function hasPendingValue() {

--- a/scripts/check-frontend-bundle.sh
+++ b/scripts/check-frontend-bundle.sh
@@ -16,6 +16,7 @@ node --check crates/gwt/web/window-docking.js
 node --check crates/gwt/web/update-cta.js
 node --check crates/gwt/web/terminal-context-menu.js
 node --check crates/gwt/web/terminal-wheel-scroll.js
+node --check crates/gwt/web/terminal-output-buffer.js
 node --check crates/gwt/web/canvas-wheel-gesture.js
 node --check crates/gwt/web/window-geometry-sync.js
 node --check crates/gwt/web/custom-agent-env-editor.js

--- a/scripts/run-frontend-unit-tests.sh
+++ b/scripts/run-frontend-unit-tests.sh
@@ -24,6 +24,7 @@ bash scripts/run-node-tests-with-linkedom.sh \
   crates/gwt/web/__tests__/terminal-context-menu.test.mjs \
   crates/gwt/web/__tests__/terminal-copy-shortcut.test.mjs \
   crates/gwt/web/__tests__/terminal-wheel-scroll.test.mjs \
+  crates/gwt/web/__tests__/terminal-output-buffer.test.mjs \
   crates/gwt/web/__tests__/canvas-wheel-gesture.test.mjs \
   crates/gwt/web/__tests__/terminal-viewport-reflow.test.mjs \
   crates/gwt/web/__tests__/window-geometry-sync.test.mjs \

--- a/tasks/memory.md
+++ b/tasks/memory.md
@@ -6690,3 +6690,10 @@ Type: workflow
 Context: 「Claude Code の使用量が怪しい」調査で Explore サブエージェントが『月$8,462の従量課金』『cacheを5分TTLで毎ターン破壊』『cache_read 11億/per-turn 966k』『無限リトライループ・264回暴走起動』と報告したが全て実データで反証された。実際は ~/.claude/.credentials.json が subscriptionType=max / rateLimitTier=default_claude_max_20x で ANTHROPIC_API_KEY 未設定（ドル従量課金ゼロ・Maxサブスク枠）、cacheは ephemeral_1h TTL、11億はメインとサブエージェント(subagents/配下)の二重計上、retryは有限(100ms bootstrap完了待ち)、264回は1791行の2日間テスト集中だった。真因は Opus 4.8 + 1M context(per-turn最大995k)常用 × 長大セッション × subagent多用で gwt が Opus の81%。
 Learning: 使用量/コスト調査でサブエージェントの定量報告は誇張・二重計上・誤前提を含みやすく鵜呑み厳禁。(1)課金体系は ~/.claude/.credentials.json の subscriptionType/rateLimitTier と ANTHROPIC_API_KEY 有無で先に確定する(サブスク枠かAPI従量かで結論が真逆)。(2)transcript集計はメインセッションとサブエージェント(subagents/*.jsonl)を分離し各assistant messageを1回だけ model別 group_by する。(3)per-turnの input+cache_read が context window(200k/1M)を超えたら集計バグのサイン。
 Future Action: 使用量調査では結論前に自分で credentials 種別確認と jq による model別/二重計上排除の集計を実行し、エージェントの数値と断定を一次データで裏取りする。
+
+## 2026-06-06 — Guard SPEC section edits against empty stdin writes
+
+Type: lesson
+Context: While completing SPEC-1939 Phase 34, a perl pipeline used backtick-delimited text and failed before producing content, but gwtd issue spec 1939 --edit tasks -f - still consumed empty stdin and wrote a 0-byte tasks section. The section was restored from the cached artifact comment before handoff.
+Learning: Piping generated content directly into gwtd issue spec --edit is unsafe when the generator can fail; pipefail does not prevent the receiving command from accepting empty stdin.
+Future Action: For SPEC section rewrites, generate to a temporary file first, assert expected byte/line count and required anchors, show tail/readback, and only then pass the verified file to gwtd issue spec --edit.


### PR DESCRIPTION
## Summary

- Browser hot paths now skip unchanged redraws, payloads, terminal writes, viewport updates, and duplicate persistence work to reduce CPU, memory, and I/O pressure during normal operation.
- WebSocket receive, terminal output, terminal fit/refresh, and viewport persistence are budgeted or deferred so large event bursts do not block tab switching or other UI interactions.
- Start Work now opens its wizard immediately and defers `origin/develop` preparation until final launch materialization, removing the visible click-to-modal delay.

## Changes

- `crates/gwt/web/app.js`: adds render-key guards, local pending Start Work wizard rendering, deferred socket parsing, reduced redundant UI updates, and lower-allocation workspace/project chrome paths.
- `crates/gwt/web/terminal-output-buffer.js`: batches terminal output per frame, avoids repeated queue shifting, and keeps hidden terminal output quiesced until reveal.
- `crates/gwt/web/terminal-viewport-reflow.js` and `crates/gwt/web/viewport-persist-throttle.js`: add frame budgets, coalescing, layout-box checks, and throttled viewport persistence.
- `crates/gwt/web/project-tabs-renderer.js` and `crates/gwt/src/app_runtime/*`: reduce redundant project tab/window/status broadcasts, duplicate persistence writes, and unchanged state fan-out.
- `crates/gwt/src/launch_runtime.rs` and `crates/gwt/src/app_runtime/wizard.rs`: move Start Work `origin/develop` preparation out of wizard open and into final launch materialization.
- `crates/gwt/web/__tests__`, `crates/gwt/playwright/tests`, and `crates/gwt/src/embedded_web.rs`: add regression coverage for redraw guards, dispatch budgets, terminal buffering, viewport throttling, project tabs, Start Work immediacy, and embedded bundle contracts.

## Testing

- [x] `git diff --check` — PASS.
- [x] `cargo fmt -- --check` — PASS.
- [x] `bash scripts/run-frontend-unit-tests.sh` — PASS, 706 tests.
- [x] `cargo test -p gwt-core -p gwt --all-features` — PASS.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — PASS.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — PASS.
- [x] Fresh isolated browser smoke after merging `origin/develop` — PASS; Start Work opened `#wizard-modal` in the same JS turn (`immediateOpen=true`, `clickTurnMs=1.2`, title `Start Work`, pending text `Preparing Start Work...`).
- [x] User visual verification — confirmed on 2026-06-07.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — the branch reduces existing browser hot-path work and preserves existing UX contracts with regression coverage.
- Known blockers: None.
- Remaining acceptance: None for this PR scope; further performance tuning can continue as follow-up measurement work.

## Closing Issues

- None

## Related Issues / Links

- #2014

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (N/A — no user-facing docs change)
- [x] Migration/backfill plan included (N/A — no schema/data migration)
- [x] CHANGELOG impact considered (patch-level performance/bug-fix changes; no breaking change)

## Context

- This PR follows the browser responsiveness/performance work for SPEC #2014: reduce memory churn, CPU usage, I/O, and interaction stalls that made tab switching and Start Work/Launch Agent feel unresponsive.

## Risk / Impact

- **Affected areas**: WebView rendering, terminal output scheduling, viewport persistence, project tabs/window state, workspace state broadcasting, Start Work launch wizard open/launch flow.
- **Rollback plan**: revert this PR; the changes are local to browser/runtime hot paths and do not introduce persistent schema changes.

## Screenshots

- N/A — this is a responsiveness and scheduling change. Visual behavior was verified through fresh browser smoke and user confirmation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added terminal output batching to reduce performance overhead during high-volume output streams.
  * Project Index Status now reports coverage scope indicating whether scanning covered current worktree, all worktrees, or partial subset.
  * UI trace system now exposes active/inactive tracing state.

* **Performance**
  * Viewport updates are deduplicated to prevent redundant persistence broadcasts.
  * Terminal refresh and fit operations batch across animation frames with configurable per-frame limits.
  * App rendering uses memoized keys to skip redundant DOM updates for project tabs, window lists, and telemetry.

* **Bug Fixes**
  * Suppressed redundant runtime state transition events reaching the frontend.
  * Improved Start Work base-branch selection and deferred remote branch preparation until launch time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->