### PR TITLE
fix(index): harden cpu diagnostics

### DIFF
--- a/.gwt/work/memory.md
+++ b/.gwt/work/memory.md
@@ -6774,3 +6774,10 @@ Type: lesson
 Context: PR #3001 の Linux Test (Rust) で workspace_projection::tests::resolve_workspace_id_for_session_returns_none_when_session_missing が save_workspace_projection(...).unwrap() の ENOENT で失敗した。
 Learning: 同じ test binary 内で HOME を一時ディレクトリに差し替えるテストがある場合、HOME を変更しないテストでも gwt_home()/gwt_workspace_*_for_repo_path() を読むなら env_lock が必要。読み手が lock を取らないと、差し替えテストの TempDir drop と write_atomic の create/open が競合する。
 Future Action: HOME/USERPROFILE/XDG_CONFIG_HOME/GIT_CONFIG_GLOBAL など process-wide env から path を導くテストを追加・変更するときは、env を変更する側だけでなく読む側にも crate::test_support::env_lock() を適用する。
+
+## 2026-06-09 — Installed app/runtime staleness can hide CPU regressions
+
+Type: failure-pattern
+Context: SPEC-1939 Phase 67 investigated >100% CPU in the installed GWT.app while a fresh target/debug/gwt checkout was idle.
+Learning: Current-checkout smoke passing is insufficient when the running installed app uses an older binary/runtime runner; compare installed/current hashes, runtime manifest runner hash, child runner processes, and recent log storm counters.
+Future Action: For future CPU or log-storm reports, run gwtd diagnostics cpu --json against the live machine before declaring the checkout fixed, and explicitly record whether installed app/runtime remain stale.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,6 +1287,7 @@ dependencies = [
  "gwt-github",
  "gwt-skills",
  "gwt-terminal",
+ "hex",
  "ignore",
  "image",
  "libc",

--- a/crates/gwt-core/src/runtime.rs
+++ b/crates/gwt-core/src/runtime.rs
@@ -72,6 +72,17 @@ pub fn project_index_runner_path() -> PathBuf {
     project_index_runner_path_from(&crate::paths::gwt_home())
 }
 
+/// Return this binary's bundled project-index runner content hash without
+/// mutating the shared runtime directory.
+pub fn bundled_project_index_runner_hash() -> String {
+    content_hash(RUNNER_SOURCE)
+}
+
+/// Return the shared project-index runtime manifest path.
+pub fn project_index_runtime_manifest_path() -> PathBuf {
+    crate::paths::gwt_runtime_dir().join(RUNTIME_MANIFEST_FILE)
+}
+
 /// Return the Python executable for this binary's content-addressed index venv.
 pub fn project_index_python_path() -> PathBuf {
     project_index_python_path_from(&crate::paths::gwt_home())

--- a/crates/gwt/Cargo.toml
+++ b/crates/gwt/Cargo.toml
@@ -53,6 +53,7 @@ regex.workspace = true
 rfd = "0.17"
 reqwest.workspace = true
 sha2.workspace = true
+hex.workspace = true
 notify.workspace = true
 notify-debouncer-mini.workspace = true
 chardetng.workspace = true

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -9,6 +9,7 @@ mod actions;
 mod board;
 mod build;
 pub mod daemon;
+mod diagnostics;
 mod discuss;
 pub(crate) mod discussion;
 mod env;
@@ -33,10 +34,12 @@ mod workspace;
 use std::io::{self};
 
 pub use board::{BoardCommand, BoardPostCommand};
+pub use diagnostics::DiagnosticsCommand;
 pub use discussion::DiscussionCommand;
 pub(crate) use env::ClientRef;
 pub use env::{dispatch, CliEnv, DefaultCliEnv, TestEnv};
 use gwt_github::{ApiError, SpecOpsError};
+pub use index::{IndexCommand, IndexScope};
 pub use memory::MemoryCommand;
 
 /// Compact linked PR summary used by `gwtd issue linked-prs`.
@@ -132,6 +135,7 @@ pub enum CliCommand {
     Board(BoardCommand),
     Hook(HookCommand),
     Index(IndexCommand),
+    Diagnostics(DiagnosticsCommand),
     Memory(MemoryCommand),
     Discuss(DiscussCommand),
     Discussion(DiscussionCommand),
@@ -318,15 +322,6 @@ pub enum ActionsCommand {
     JobLogs { job_id: u64 },
 }
 
-/// SPEC-1942 family enum for `gwtd index ...`.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum IndexCommand {
-    /// `gwtd index status`.
-    Status,
-    /// `gwtd index rebuild [--scope <scope>]`.
-    Rebuild { scope: IndexScope },
-}
-
 /// SPEC-1942 family enum for `gwtd hook ...` and `gwtd __internal daemon-hook ...`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HookCommand {
@@ -371,18 +366,6 @@ pub enum PaneCommand {
     /// `gwtd pane close <id>` / `gwtd pane stop <id>`.
     Close { id: String },
 }
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum IndexScope {
-    All,
-    Issues,
-    Specs,
-    Memory,
-    Discussions,
-    Board,
-    Files,
-    FilesDocs,
-}
-
 /// Sub-action for `gwtd discuss ...` (SPEC-1935 FR-014p).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiscussAction {
@@ -419,7 +402,7 @@ impl std::fmt::Display for CliParseError {
         match self {
             CliParseError::Usage => write!(
                 f,
-                "usage: gwtd issue spec <n> [--section <name>|--rename <title>|--edit <name> (-f <file>|--json [-f <file>] [--replace])] | gwtd issue spec list [--phase <p>] [--state open|closed] | gwtd issue spec create (--title <t> -f <file> | --json --title <t> [-f <file>] | --help) [--label <l>]* | gwtd issue view|comments|linked-prs <n> [--refresh] | gwtd issue create --title <t> -f <file> [--label <l>]* | gwtd issue comment <n> -f <file> | gwtd pr current|create --base <b> [--head <h>] --title <t> -f <file> [--label <l>]* [--draft]|edit <n> [--title <t>] [-f <file>] [--add-label <l>]*|view <n>|comment <n> -f <file>|reviews <n>|review-threads <n>|review-threads reply-and-resolve <n> -f <file>|checks <n> | gwtd actions logs --run <id> | gwtd actions job-logs --job <id> | gwtd board show [--json] [--workspace <id>|--all] | gwtd board post --kind <kind> (--body <text> | -f <file>) [--title-summary <text>] [--parent <id>] [--topic <t>]* [--owner <n>]* [--target <id>]* [--mention <kind:id>]* [--broadcast] | gwtd memory add [--date <yyyy-mm-dd>] [--type lesson|decision|workflow|failure-pattern] --title <text> --context <text> --learning <text> --future-action <text> | gwtd discussion update [fields] | gwtd lessons add ... | gwtd workspace update [--title-summary <text>] [fields] | gwtd workspace candidates --agent-session <id> | gwtd workspace join --agent-session <id> --workspace <id> | gwtd workspace create --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--split-from <id>] [--boundary <text>] | gwtd workspace ensure --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--topic <t>] [--boundary <text>] | gwtd pane list|read <id> [--lines <n>]|close <id> | gwtd index status|rebuild [--scope all|issues|specs|memory|discussions|board|files|files-docs]"
+                "usage: gwtd issue spec <n> [--section <name>|--rename <title>|--edit <name> (-f <file>|--json [-f <file>] [--replace])] | gwtd issue spec list [--phase <p>] [--state open|closed] | gwtd issue spec create (--title <t> -f <file> | --json --title <t> [-f <file>] | --help) [--label <l>]* | gwtd issue view|comments|linked-prs <n> [--refresh] | gwtd issue create --title <t> -f <file> [--label <l>]* | gwtd issue comment <n> -f <file> | gwtd pr current|create --base <b> [--head <h>] --title <t> -f <file> [--label <l>]* [--draft]|edit <n> [--title <t>] [-f <file>] [--add-label <l>]*|view <n>|comment <n> -f <file>|reviews <n>|review-threads <n>|review-threads reply-and-resolve <n> -f <file>|checks <n> | gwtd actions logs --run <id> | gwtd actions job-logs --job <id> | gwtd board show [--json] [--workspace <id>|--all] | gwtd board post --kind <kind> (--body <text> | -f <file>) [--title-summary <text>] [--parent <id>] [--topic <t>]* [--owner <n>]* [--target <id>]* [--mention <kind:id>]* [--broadcast] | gwtd memory add [--date <yyyy-mm-dd>] [--type lesson|decision|workflow|failure-pattern] --title <text> --context <text> --learning <text> --future-action <text> | gwtd discussion update [fields] | gwtd lessons add ... | gwtd workspace update [--title-summary <text>] [fields] | gwtd workspace candidates --agent-session <id> | gwtd workspace join --agent-session <id> --workspace <id> | gwtd workspace create --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--split-from <id>] [--boundary <text>] | gwtd workspace ensure --agent-session <id> --title-summary <text> [--current-focus <text>] [--spec <n>|--issue <n>] [--topic <t>] [--boundary <text>] | gwtd pane list|read <id> [--lines <n>]|close <id> | gwtd index status|rebuild [--scope all|issues|specs|memory|discussions|board|files|files-docs] | gwtd diagnostics cpu --json"
             ),
             CliParseError::InvalidNumber(s) => write!(f, "invalid issue number: {s}"),
             CliParseError::MissingFlag(flag) => write!(f, "missing required flag: {flag}"),
@@ -539,6 +522,7 @@ pub fn should_dispatch_cli(args: &[String]) -> bool {
                     | "update"
                     | "__internal"
                     | "index"
+                    | "diagnostics"
                     | "memory"
                     | "lessons"
                     | "discuss"
@@ -581,6 +565,11 @@ pub fn parse_board_args(args: &[String]) -> Result<CliCommand, CliParseError> {
 /// Parse an argv slice into a `gwtd index ...` [`CliCommand`].
 pub fn parse_index_args(args: &[String]) -> Result<CliCommand, CliParseError> {
     index::parse(args).map(CliCommand::Index)
+}
+
+/// Parse an argv slice into a `gwtd diagnostics ...` [`CliCommand`].
+pub fn parse_diagnostics_args(args: &[String]) -> Result<CliCommand, CliParseError> {
+    diagnostics::parse(args).map(CliCommand::Diagnostics)
 }
 
 /// Parse an argv slice into a `gwtd memory ...` / `gwtd lessons ...` [`CliCommand`].
@@ -758,6 +747,7 @@ pub fn run<E: CliEnv>(env: &mut E, cmd: CliCommand) -> Result<i32, SpecOpsError>
         CliCommand::Hook(HookCommand::InternalDaemon { name, rest }) => {
             return hook::run_daemon_hook(env, &name, &rest);
         }
+        CliCommand::Diagnostics(inner) => diagnostics::run(env, inner, &mut out)?,
         CliCommand::Update(UpdateCommand::CheckOnly) => {
             std::process::exit(update::run(update::UpdateRunMode::CheckOnly));
         }

--- a/crates/gwt/src/cli/diagnostics.rs
+++ b/crates/gwt/src/cli/diagnostics.rs
@@ -1,0 +1,456 @@
+//! `gwtd diagnostics ...` family module.
+
+use std::{
+    cmp::Reverse,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use gwt_github::{client::ApiError, SpecOpsError};
+use serde::Serialize;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use super::{CliEnv, CliParseError};
+
+const CPU_DIAGNOSTICS_SCHEMA_VERSION: u32 = 1;
+const RECENT_LOG_FILE_LIMIT: usize = 16;
+const RECENT_LOG_LINES_PER_FILE: usize = 2_000;
+
+/// SPEC-1939 Phase 67 family enum for `gwtd diagnostics ...`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiagnosticsCommand {
+    /// `gwtd diagnostics cpu --json`.
+    Cpu { json: bool },
+}
+
+pub fn parse(args: &[String]) -> Result<DiagnosticsCommand, CliParseError> {
+    let (head, rest) = args.split_first().ok_or(CliParseError::Usage)?;
+    match head.as_str() {
+        "cpu" if rest == ["--json"] => Ok(DiagnosticsCommand::Cpu { json: true }),
+        "cpu" => Err(CliParseError::Usage),
+        other => Err(CliParseError::UnknownSubcommand(other.to_string())),
+    }
+}
+
+pub fn run<E: CliEnv>(
+    env: &mut E,
+    cmd: DiagnosticsCommand,
+    out: &mut String,
+) -> Result<i32, SpecOpsError> {
+    match cmd {
+        DiagnosticsCommand::Cpu { json: true } => {
+            let diagnostics = collect_cpu_diagnostics(env.repo_path());
+            let rendered = serde_json::to_string_pretty(&diagnostics).map_err(unexpected_error)?;
+            out.push_str(&rendered);
+            out.push('\n');
+            Ok(0)
+        }
+        DiagnosticsCommand::Cpu { json: false } => Err(unexpected_error("json output is required")),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CpuDiagnostics {
+    pub schema_version: u32,
+    pub repo_path: String,
+    pub gwt_processes: Vec<ProcessSnapshot>,
+    pub runner_processes: Vec<ProcessSnapshot>,
+    pub binaries: BinaryDiagnostics,
+    pub runtime: RuntimeDiagnostics,
+    pub recent_logs: LogBudgetDiagnostics,
+    pub stale: StaleDiagnostics,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct ProcessSnapshot {
+    pub pid: u32,
+    pub ppid: Option<u32>,
+    pub cpu_percent: Option<f64>,
+    pub elapsed: Option<String>,
+    pub command: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct FileHash {
+    pub path: String,
+    pub sha256_16: String,
+    pub size_bytes: u64,
+    pub modified_unix_seconds: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BinaryDiagnostics {
+    pub installed_gwt: Option<FileHash>,
+    pub installed_gwtd: Option<FileHash>,
+    pub current_gwt: Option<FileHash>,
+    pub current_gwtd: Option<FileHash>,
+    pub current_exe: Option<FileHash>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RuntimeDiagnostics {
+    pub runtime_dir: String,
+    pub manifest_path: String,
+    pub manifest_runner_path: Option<String>,
+    pub manifest_runner_hash: Option<String>,
+    pub legacy_runner_path: String,
+    pub legacy_runner_hash: Option<String>,
+    pub bundled_runner_hash: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct LogBudgetDiagnostics {
+    pub inspected_files: usize,
+    pub inspected_lines: usize,
+    pub status_completed_info: usize,
+    pub hook_live_204_info: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct StaleDiagnostics {
+    pub installed_gwt_differs_from_current: Option<bool>,
+    pub installed_gwtd_differs_from_current: Option<bool>,
+    pub runtime_manifest_stale: Option<bool>,
+    pub legacy_runner_stale: Option<bool>,
+    pub status_or_hook_log_storm: bool,
+}
+
+pub fn collect_cpu_diagnostics(repo_path: &Path) -> CpuDiagnostics {
+    let snapshots = collect_process_snapshots();
+    let gwt_processes = snapshots
+        .iter()
+        .filter(|snapshot| is_gwt_process(snapshot))
+        .cloned()
+        .collect();
+    let runner_processes = snapshots
+        .iter()
+        .filter(|snapshot| is_chroma_runner_process(snapshot))
+        .cloned()
+        .collect();
+    let binaries = collect_binary_diagnostics();
+    let runtime = collect_runtime_diagnostics();
+    let recent_logs = collect_recent_log_budget(
+        &gwt_core::paths::gwt_projects_dir(),
+        RECENT_LOG_FILE_LIMIT,
+        RECENT_LOG_LINES_PER_FILE,
+    );
+    let stale = StaleDiagnostics {
+        installed_gwt_differs_from_current: hashes_differ(
+            binaries.installed_gwt.as_ref(),
+            binaries.current_gwt.as_ref(),
+        ),
+        installed_gwtd_differs_from_current: hashes_differ(
+            binaries.installed_gwtd.as_ref(),
+            binaries.current_gwtd.as_ref(),
+        ),
+        runtime_manifest_stale: runtime
+            .manifest_runner_hash
+            .as_ref()
+            .map(|hash| hash != &runtime.bundled_runner_hash),
+        legacy_runner_stale: runtime
+            .legacy_runner_hash
+            .as_ref()
+            .map(|hash| hash != &runtime.bundled_runner_hash),
+        status_or_hook_log_storm: recent_logs.status_completed_info > 100
+            || recent_logs.hook_live_204_info > 100,
+    };
+
+    CpuDiagnostics {
+        schema_version: CPU_DIAGNOSTICS_SCHEMA_VERSION,
+        repo_path: repo_path.display().to_string(),
+        gwt_processes,
+        runner_processes,
+        binaries,
+        runtime,
+        recent_logs,
+        stale,
+    }
+}
+
+fn collect_process_snapshots() -> Vec<ProcessSnapshot> {
+    let output = match Command::new("ps")
+        .args(["axww", "-o", "pid=,ppid=,%cpu=,etime=,command="])
+        .output()
+    {
+        Ok(output) if output.status.success() => output,
+        _ => return Vec::new(),
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_process_snapshots(&stdout)
+}
+
+fn parse_process_snapshots(text: &str) -> Vec<ProcessSnapshot> {
+    text.lines()
+        .filter_map(parse_process_snapshot_line)
+        .collect()
+}
+
+fn parse_process_snapshot_line(line: &str) -> Option<ProcessSnapshot> {
+    let mut parts = line.split_whitespace();
+    let pid = parts.next()?.parse().ok()?;
+    let ppid = parts.next().and_then(|value| value.parse().ok());
+    let cpu_percent = parts.next().and_then(|value| value.parse().ok());
+    let elapsed = parts.next().map(ToString::to_string);
+    let command = parts.collect::<Vec<_>>().join(" ");
+    if command.is_empty() {
+        return None;
+    }
+    Some(ProcessSnapshot {
+        pid,
+        ppid,
+        cpu_percent,
+        elapsed,
+        command,
+    })
+}
+
+fn is_gwt_process(snapshot: &ProcessSnapshot) -> bool {
+    let command = snapshot.command.as_str();
+    if command.contains("chroma_index_runner") || command.contains("/gwtd") {
+        return false;
+    }
+    command.contains("/GWT.app/Contents/MacOS/gwt")
+        || command.contains("/target/debug/gwt")
+        || command.contains("/target/release/gwt")
+}
+
+fn is_chroma_runner_process(snapshot: &ProcessSnapshot) -> bool {
+    snapshot.command.contains("chroma_index_runner")
+}
+
+fn collect_binary_diagnostics() -> BinaryDiagnostics {
+    let current_exe_path = std::env::current_exe().ok();
+    let current_gwtd_path = current_gwtd_candidate(current_exe_path.as_deref());
+    let current_gwt_path = current_gwt_candidate(current_exe_path.as_deref());
+    BinaryDiagnostics {
+        installed_gwt: hash_file(Path::new("/Applications/GWT.app/Contents/MacOS/gwt")),
+        installed_gwtd: hash_file(Path::new("/Applications/GWT.app/Contents/MacOS/gwtd")),
+        current_gwt: current_gwt_path.as_deref().and_then(hash_file),
+        current_gwtd: current_gwtd_path.as_deref().and_then(hash_file),
+        current_exe: current_exe_path.as_deref().and_then(hash_file),
+    }
+}
+
+fn current_gwt_candidate(current_exe: Option<&Path>) -> Option<PathBuf> {
+    let current_exe = current_exe?;
+    match current_exe.file_name().and_then(|name| name.to_str()) {
+        Some("gwt") => Some(current_exe.to_path_buf()),
+        Some("gwtd") => Some(current_exe.with_file_name("gwt")),
+        _ => None,
+    }
+}
+
+fn current_gwtd_candidate(current_exe: Option<&Path>) -> Option<PathBuf> {
+    let current_exe = current_exe?;
+    match current_exe.file_name().and_then(|name| name.to_str()) {
+        Some("gwtd") => Some(current_exe.to_path_buf()),
+        Some("gwt") => Some(current_exe.with_file_name("gwtd")),
+        _ => None,
+    }
+}
+
+fn collect_runtime_diagnostics() -> RuntimeDiagnostics {
+    let runtime_dir = gwt_core::paths::gwt_runtime_dir();
+    let manifest_path = gwt_core::runtime::project_index_runtime_manifest_path();
+    let legacy_runner_path = gwt_core::paths::gwt_runtime_runner_path();
+    let manifest = read_runtime_manifest_runner(&runtime_dir, &manifest_path);
+    RuntimeDiagnostics {
+        runtime_dir: runtime_dir.display().to_string(),
+        manifest_path: manifest_path.display().to_string(),
+        manifest_runner_path: manifest
+            .runner_path
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        manifest_runner_hash: manifest.runner_hash,
+        legacy_runner_path: legacy_runner_path.display().to_string(),
+        legacy_runner_hash: hash_file(&legacy_runner_path).map(|file| file.sha256_16),
+        bundled_runner_hash: gwt_core::runtime::bundled_project_index_runner_hash(),
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct RuntimeManifestRunner {
+    runner_path: Option<PathBuf>,
+    runner_hash: Option<String>,
+}
+
+fn read_runtime_manifest_runner(runtime_dir: &Path, manifest_path: &Path) -> RuntimeManifestRunner {
+    let Ok(bytes) = fs::read(manifest_path) else {
+        return RuntimeManifestRunner::default();
+    };
+    let Ok(value) = serde_json::from_slice::<Value>(&bytes) else {
+        return RuntimeManifestRunner::default();
+    };
+    let runner = value.get("runner");
+    let runner_hash = runner
+        .and_then(|runner| runner.get("sha256_16"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    let runner_path = runner
+        .and_then(|runner| runner.get("path"))
+        .and_then(Value::as_str)
+        .map(PathBuf::from)
+        .map(|path| {
+            if path.is_absolute() {
+                path
+            } else {
+                runtime_dir.join(path)
+            }
+        });
+    RuntimeManifestRunner {
+        runner_path,
+        runner_hash,
+    }
+}
+
+fn collect_recent_log_budget(
+    projects_dir: &Path,
+    file_limit: usize,
+    lines_per_file: usize,
+) -> LogBudgetDiagnostics {
+    let mut files = Vec::new();
+    collect_project_log_files(projects_dir, &mut files);
+    files.sort_by_key(|(modified, _)| Reverse(*modified));
+
+    let mut diagnostics = LogBudgetDiagnostics::default();
+    for (_modified, path) in files.into_iter().take(file_limit) {
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        diagnostics.inspected_files += 1;
+        let lines = content.lines().rev().take(lines_per_file);
+        count_log_budget_from_lines(lines, &mut diagnostics);
+    }
+    diagnostics
+}
+
+fn collect_project_log_files(dir: &Path, files: &mut Vec<(SystemTime, PathBuf)>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        collect_log_files_in_dir(&path.join("logs"), files);
+    }
+}
+
+fn collect_log_files_in_dir(log_dir: &Path, files: &mut Vec<(SystemTime, PathBuf)>) {
+    let Ok(entries) = fs::read_dir(log_dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if !name.starts_with("gwt.log.") {
+            continue;
+        }
+        let modified = entry
+            .metadata()
+            .and_then(|metadata| metadata.modified())
+            .unwrap_or(UNIX_EPOCH);
+        files.push((modified, path));
+    }
+}
+
+fn count_log_budget_from_lines<'a>(
+    lines: impl Iterator<Item = &'a str>,
+    diagnostics: &mut LogBudgetDiagnostics,
+) {
+    for line in lines {
+        diagnostics.inspected_lines += 1;
+        if line.contains("project index status runner completed for worktree") {
+            diagnostics.status_completed_info += 1;
+        }
+        if line.contains("/internal/hook-live") && line.contains("\"status\":204") {
+            diagnostics.hook_live_204_info += 1;
+        }
+    }
+}
+
+fn hash_file(path: &Path) -> Option<FileHash> {
+    let bytes = fs::read(path).ok()?;
+    let mut hasher = Sha256::new();
+    hasher.update(&bytes);
+    let metadata = fs::metadata(path).ok()?;
+    Some(FileHash {
+        path: path.display().to_string(),
+        sha256_16: hex::encode(hasher.finalize())[..16].to_string(),
+        size_bytes: metadata.len(),
+        modified_unix_seconds: metadata
+            .modified()
+            .ok()
+            .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+            .map(|duration| duration.as_secs()),
+    })
+}
+
+fn hashes_differ(left: Option<&FileHash>, right: Option<&FileHash>) -> Option<bool> {
+    Some(left?.sha256_16 != right?.sha256_16)
+}
+
+fn unexpected_error(err: impl ToString) -> SpecOpsError {
+    SpecOpsError::from(ApiError::Unexpected(err.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(items: &[&str]) -> Vec<String> {
+        items.iter().map(|item| (*item).to_string()).collect()
+    }
+
+    #[test]
+    fn parses_diagnostics_cpu_json() {
+        assert_eq!(
+            parse(&s(&["cpu", "--json"])).unwrap(),
+            DiagnosticsCommand::Cpu { json: true }
+        );
+        assert!(parse(&s(&["cpu"])).is_err());
+    }
+
+    #[test]
+    fn parses_ps_output_and_classifies_gwt_processes() {
+        let text = "\
+  935     1 100.2 02:17:18 /Applications/GWT.app/Contents/MacOS/gwt
+936 935 78.4 00:00:05 /Users/me/.gwt/runtime/venvs/chroma/bin/python /Users/me/.gwt/runtime/runners/chroma_index_runner-abc.py --action status
+1200 1 0.0 00:01:00 /Users/me/project/target/debug/gwtd diagnostics cpu --json
+";
+        let snapshots = parse_process_snapshots(text);
+        assert_eq!(snapshots.len(), 3);
+        assert_eq!(snapshots[0].pid, 935);
+        assert_eq!(snapshots[0].cpu_percent, Some(100.2));
+        assert!(is_gwt_process(&snapshots[0]));
+        assert!(is_chroma_runner_process(&snapshots[1]));
+        assert!(!is_gwt_process(&snapshots[2]));
+    }
+
+    #[test]
+    fn counts_recent_status_and_hook_live_log_lines() {
+        let mut diagnostics = LogBudgetDiagnostics::default();
+        count_log_budget_from_lines(
+            [
+                r#"{"message":"project index status runner completed for worktree"}"#,
+                r#"{"method":"POST","path":"/internal/hook-live","status":204}"#,
+                r#"{"method":"POST","path":"/internal/hook-live","status":500}"#,
+            ]
+            .into_iter(),
+            &mut diagnostics,
+        );
+
+        assert_eq!(diagnostics.inspected_lines, 3);
+        assert_eq!(diagnostics.status_completed_info, 1);
+        assert_eq!(diagnostics.hook_live_204_info, 1);
+    }
+}

--- a/crates/gwt/src/cli/env/mod.rs
+++ b/crates/gwt/src/cli/env/mod.rs
@@ -182,6 +182,7 @@ pub fn dispatch<E: CliEnv>(env: &mut E, args: &[String]) -> i32 {
         "actions" => parse_actions_args(&rest),
         "board" => parse_board_args(&rest),
         "index" => super::parse_index_args(&rest),
+        "diagnostics" => super::parse_diagnostics_args(&rest),
         "memory" | "lessons" => parse_memory_args(&rest),
         "discussion" => parse_discussion_args(&rest),
         "hook" => parse_hook_args(&rest),

--- a/crates/gwt/src/cli/family_split_tests.rs
+++ b/crates/gwt/src/cli/family_split_tests.rs
@@ -8,8 +8,9 @@ use super::*;
 #[test]
 fn cli_command_family_split_round_trip_parses() {
     use crate::cli::{
-        ActionsCommand, BoardCommand, CliCommand, DiscussCommand, HookCommand, IndexCommand,
-        IssueCommand, MemoryCommand, PaneCommand, PrCommand, UpdateCommand, WorkspaceCommand,
+        ActionsCommand, BoardCommand, CliCommand, DiagnosticsCommand, DiscussCommand, HookCommand,
+        IndexCommand, IssueCommand, MemoryCommand, PaneCommand, PrCommand, UpdateCommand,
+        WorkspaceCommand,
     };
 
     fn s(value: &str) -> String {
@@ -84,6 +85,13 @@ fn cli_command_family_split_round_trip_parses() {
             scope: IndexScope::All
         })
     ));
+
+    // gwtd diagnostics cpu --json
+    let cmd = parse_diagnostics_args(&[s("cpu"), s("--json")]).expect("parse diagnostics cpu");
+    assert_eq!(
+        cmd,
+        CliCommand::Diagnostics(DiagnosticsCommand::Cpu { json: true })
+    );
 
     // gwtd memory add ...
     let cmd = parse_memory_args(&[

--- a/crates/gwt/src/cli/index/mod.rs
+++ b/crates/gwt/src/cli/index/mod.rs
@@ -14,7 +14,7 @@ pub mod runtime;
 
 use gwt_github::{client::ApiError, SpecOpsError};
 
-use super::{CliEnv, CliParseError, IndexCommand, IndexScope};
+use super::{CliEnv, CliParseError};
 
 use audit::{
     audit_log_dir, audit_rebuild_result, audit_rebuild_start, audit_runner_progress, audit_status,
@@ -24,6 +24,27 @@ use runtime::{
     format_runner_failure, parse_runner_json, rebuild_actions, render_index_status,
     resolve_index_context, run_runner_rebuild, run_runner_status,
 };
+
+/// SPEC-1942 family enum for `gwtd index ...`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IndexCommand {
+    /// `gwtd index status`.
+    Status,
+    /// `gwtd index rebuild [--scope <scope>]`.
+    Rebuild { scope: IndexScope },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexScope {
+    All,
+    Issues,
+    Specs,
+    Memory,
+    Discussions,
+    Board,
+    Files,
+    FilesDocs,
+}
 
 pub fn parse(args: &[String]) -> Result<IndexCommand, CliParseError> {
     let (head, rest) = args.split_first().ok_or(CliParseError::Usage)?;

--- a/crates/gwt/src/project_index_bootstrap.rs
+++ b/crates/gwt/src/project_index_bootstrap.rs
@@ -18,6 +18,7 @@ pub enum ProjectIndexBootstrapRequest {
 }
 
 const FULL_STATUS_RETRY_DELAY: Duration = Duration::from_millis(100);
+const FULL_STATUS_COOLDOWN: Duration = Duration::from_secs(10);
 
 type BootstrapFn = dyn Fn(&Path) -> Result<(), String> + Send + Sync + 'static;
 type StatusProbeFn = dyn Fn(&Path) -> gwt::ProjectIndexStatusView + Send + Sync + 'static;
@@ -52,10 +53,27 @@ pub enum IndexInFlightKey {
     },
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct ProjectIndexBootstrapService {
     in_flight: Arc<Mutex<HashSet<IndexInFlightKey>>>,
-    last_full_status: Arc<Mutex<HashMap<PathBuf, gwt::ProjectIndexStatusView>>>,
+    last_full_status: Arc<Mutex<HashMap<PathBuf, FullStatusCacheEntry>>>,
+    full_status_cooldown: Duration,
+}
+
+#[derive(Clone)]
+struct FullStatusCacheEntry {
+    refreshed_at: Instant,
+    status: gwt::ProjectIndexStatusView,
+}
+
+impl Default for ProjectIndexBootstrapService {
+    fn default() -> Self {
+        Self {
+            in_flight: Arc::default(),
+            last_full_status: Arc::default(),
+            full_status_cooldown: FULL_STATUS_COOLDOWN,
+        }
+    }
 }
 
 impl ProjectIndexBootstrapService {
@@ -67,6 +85,14 @@ impl ProjectIndexBootstrapService {
     #[cfg(test)]
     pub(crate) fn new_for_test() -> Self {
         Self::default()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_for_test_with_full_status_cooldown(full_status_cooldown: Duration) -> Self {
+        Self {
+            full_status_cooldown,
+            ..Self::default()
+        }
     }
 
     pub(crate) fn spawn(
@@ -153,6 +179,9 @@ impl ProjectIndexBootstrapService {
                 worktree = %project_root_label,
                 "project index full status refresh waiting for startup bootstrap"
             );
+            return ProjectIndexBootstrapRequest::AlreadyRunning;
+        }
+        if self.full_status_cached_recently(&project_key, &project_root_label) {
             return ProjectIndexBootstrapRequest::AlreadyRunning;
         }
         let key = IndexInFlightKey::FullStatus {
@@ -331,23 +360,70 @@ impl ProjectIndexBootstrapService {
         status: gwt::ProjectIndexStatusView,
     ) -> bool {
         let key = normalize_project_root(project_key);
+        let mut changed = true;
         if let Ok(mut last) = self.last_full_status.lock() {
-            if last.get(&key) == Some(&status) {
+            if last.get(&key).map(|entry| &entry.status) == Some(&status) {
                 tracing::debug!(
                     target: "gwt::index",
                     worktree = %project_root_label,
                     state = %status.state,
                     "skipping unchanged project index full status broadcast"
                 );
-                return false;
+                changed = false;
             }
-            last.insert(key, status.clone());
+            last.insert(
+                key,
+                FullStatusCacheEntry {
+                    refreshed_at: Instant::now(),
+                    status: status.clone(),
+                },
+            );
+        }
+        if !changed {
+            return false;
         }
         proxy.send(UserEvent::ProjectIndexStatus {
             project_root: project_root_label.to_string(),
             status,
         });
         true
+    }
+
+    fn full_status_cached_recently(&self, project_key: &Path, project_root_label: &str) -> bool {
+        if self.full_status_cooldown.is_zero() {
+            return false;
+        }
+        let key = normalize_project_root(project_key);
+        let Ok(last) = self.last_full_status.lock() else {
+            return false;
+        };
+        let Some(entry) = last.get(&key) else {
+            return false;
+        };
+        let elapsed = entry.refreshed_at.elapsed();
+        if elapsed >= self.full_status_cooldown {
+            return false;
+        }
+        tracing::debug!(
+            target: "gwt::index",
+            worktree = %project_root_label,
+            elapsed_ms = elapsed.as_millis() as u64,
+            cooldown_ms = self.full_status_cooldown.as_millis() as u64,
+            "skipping fresh project index full status refresh"
+        );
+        true
+    }
+
+    fn invalidate_full_status(&self, project_root: &Path) {
+        let key = normalize_project_root(project_root);
+        if let Ok(mut last) = self.last_full_status.lock() {
+            last.remove(&key);
+        }
+    }
+
+    #[cfg(test)]
+    fn invalidate_full_status_for_test(&self, project_root: &Path) {
+        self.invalidate_full_status(project_root);
     }
 
     #[cfg(test)]
@@ -489,7 +565,7 @@ impl ProjectIndexBootstrapService {
         let project_key = normalize_project_root(&project_root);
         let project_root_label = project_key.display().to_string();
         let key = IndexInFlightKey::Rebuild {
-            project_root: project_key,
+            project_root: project_key.clone(),
             scope,
             worktree_hash: worktree_hash.clone(),
         };
@@ -503,9 +579,12 @@ impl ProjectIndexBootstrapService {
             );
             return ProjectIndexBootstrapRequest::AlreadyRunning;
         }
+        self.invalidate_full_status(&project_key);
 
         let in_flight = self.in_flight.clone();
         let key_for_thread = key.clone();
+        let service_for_thread = self.clone();
+        let project_key_for_thread = project_key.clone();
         let spawn_result = thread::Builder::new()
             .name("gwt-index-rebuild".to_string())
             .spawn(move || {
@@ -514,6 +593,7 @@ impl ProjectIndexBootstrapService {
                     key: key_for_thread,
                 };
                 rebuild();
+                service_for_thread.invalidate_full_status(&project_key_for_thread);
             });
 
         match spawn_result {
@@ -558,6 +638,7 @@ impl ProjectIndexBootstrapService {
             ));
         }
         let result = body();
+        self.invalidate_full_status(project_root);
         self.release(&key);
         result
     }
@@ -1057,8 +1138,10 @@ mod tests {
     }
 
     #[test]
-    fn repeated_full_status_refresh_suppresses_unchanged_status_broadcast() {
-        let service = super::ProjectIndexBootstrapService::new_for_test();
+    fn repeated_full_status_refresh_inside_cooldown_reuses_cached_status_probe() {
+        let service = super::ProjectIndexBootstrapService::new_for_test_with_full_status_cooldown(
+            Duration::from_secs(60),
+        );
         let temp = tempdir().expect("tempdir");
         let expected_project_root = dunce::canonicalize(temp.path())
             .unwrap_or_else(|_| temp.path().to_path_buf())
@@ -1082,7 +1165,12 @@ mod tests {
                 }),
                 Duration::from_millis(5),
             );
-            assert_eq!(request, super::ProjectIndexBootstrapRequest::Spawned);
+            let expected_request = if status_probe_calls.load(Ordering::SeqCst) == 0 {
+                super::ProjectIndexBootstrapRequest::Spawned
+            } else {
+                super::ProjectIndexBootstrapRequest::AlreadyRunning
+            };
+            assert_eq!(request, expected_request);
             wait_for_project_status_detail(&events, &expected_project_root, "unchanged full table");
             for _ in 0..100 {
                 if service.full_status_is_idle_for_test(temp.path()) {
@@ -1092,7 +1180,11 @@ mod tests {
             }
         }
 
-        assert_eq!(status_probe_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            status_probe_calls.load(Ordering::SeqCst),
+            1,
+            "a repeated full-status refresh inside the cooldown must not start another aggregate status probe"
+        );
         let recorded = events.lock().expect("events");
         let full_status_events = recorded
             .iter()
@@ -1108,6 +1200,54 @@ mod tests {
         assert_eq!(
             full_status_events, 1,
             "unchanged full status payload should not be re-broadcast"
+        );
+    }
+
+    #[test]
+    fn invalidating_full_status_cache_allows_next_refresh_after_rebuild() {
+        let service = super::ProjectIndexBootstrapService::new_for_test_with_full_status_cooldown(
+            Duration::from_secs(60),
+        );
+        let temp = tempdir().expect("tempdir");
+        let expected_project_root = dunce::canonicalize(temp.path())
+            .unwrap_or_else(|_| temp.path().to_path_buf())
+            .display()
+            .to_string();
+        let (proxy, events) = AppEventProxy::stub();
+        let status_probe_calls = Arc::new(AtomicUsize::new(0));
+
+        for detail in ["first full table", "second full table"] {
+            let calls = status_probe_calls.clone();
+            let detail = detail.to_string();
+            let detail_for_probe = detail.clone();
+            let request = service.spawn_full_status_refresh_with_retry(
+                proxy.clone(),
+                temp.path().to_path_buf(),
+                Arc::new(|_project_root: &Path| Ok(())),
+                Arc::new(move |_project_root: &Path| {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    gwt::ProjectIndexStatusView::new(
+                        gwt::ProjectIndexStatusState::Ready,
+                        &detail_for_probe,
+                    )
+                }),
+                Duration::from_millis(5),
+            );
+            assert_eq!(request, super::ProjectIndexBootstrapRequest::Spawned);
+            wait_for_project_status_detail(&events, &expected_project_root, &detail);
+            for _ in 0..100 {
+                if service.full_status_is_idle_for_test(temp.path()) {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            service.invalidate_full_status_for_test(temp.path());
+        }
+
+        assert_eq!(
+            status_probe_calls.load(Ordering::SeqCst),
+            2,
+            "rebuild/repair invalidation must let the next full-status refresh probe again"
         );
     }
 


### PR DESCRIPTION
## Summary

- Add CPU diagnostics for installed/runtime drift so high CPU reports can be tied to the running app instead of only the checkout.
- Cool down repeated full-status refreshes so unchanged aggregate Project Index probes do not keep spawning inside the refresh window.

## Changes

- `crates/gwt/src/cli/diagnostics.rs`: adds `gwtd diagnostics cpu --json` with process, binary hash, runtime hash, and recent log budget diagnostics.
- `crates/gwt/src/cli.rs` and `crates/gwt/src/cli/env/mod.rs`: wires the new diagnostics command family into the `gwtd` CLI dispatch surface.
- `crates/gwt-core/src/runtime.rs`: exposes bundled Project Index runner hash and runtime manifest path for diagnostics without mutating the runtime directory.
- `crates/gwt/src/project_index_bootstrap.rs`: adds a 10-second full-status cooldown plus rebuild invalidation so cached status suppresses duplicate aggregate probes only until repair/rebuild changes the data.
- `.gwt/work/memory.md`: records the installed app/runtime staleness lesson for future CPU incident triage.

## Testing

- [x] `cargo fmt -- --check` - passed.
- [x] `cargo test -p gwt --all-features diagnostics::tests` - passed.
- [x] `cargo test -p gwt --all-features project_index_bootstrap::tests` - passed.
- [x] `cargo test -p gwt --test cli_file_size_test --all-features` - passed.
- [x] `cargo test -p gwt-core -p gwt --all-features -- --test-threads=1` - passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` - passed.
- [x] `target/debug/gwtd diagnostics cpu --json` - passed and reported stale installed/runtime hashes plus recent log storm counters.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` - passed.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes - the diagnostics command is additive and the cooldown is scoped to repeated full-status refreshes with rebuild invalidation.
- Known blockers: None
- Remaining acceptance: None
- User Verification Result: n/a - no GUI or visual surface changed; the new CLI output was verified by command execution.

## Closing Issues

- None

## Related Issues / Links

- #1939

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (N/A - no user-facing docs surface changed)
- [x] Migration/backfill plan included (N/A - no schema or data migration)
- [x] CHANGELOG impact considered (patch fix; no breaking change)

## Context

- SPEC-1939 Phase 67 follows up on a production `/Applications/GWT.app` CPU spike where the fresh checkout was idle but the installed app/runtime runner was stale.

## Risk / Impact

- **Affected areas**: `gwtd diagnostics`, Project Index full-status refresh scheduling, runtime hash reporting.
- **Rollback plan**: revert this PR; the diagnostics command is additive and the cooldown state is in-memory only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `gwtd diagnostics cpu` command with JSON output to report CPU metrics, process snapshots, binary hashes, and staleness indicators.

* **Bug Fixes**
  * Optimized project index status refresh with cooldown mechanism to prevent excessive status probes and improve responsiveness.

* **Documentation**
  * Added failure pattern documentation: installed app staleness can mask CPU regressions and log budget issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->