### PR TITLE
fix: show Starting instead of Not Started for agent windows

### DIFF
--- a/crates/gwt/playwright/tests/text-first-ui-live.spec.ts
+++ b/crates/gwt/playwright/tests/text-first-ui-live.spec.ts
@@ -53,20 +53,20 @@ test.describe("Text-first UI live readability", () => {
                         tab_group_active: false,
                       },
                       {
-                        id: "text-first-not-started-agent",
+                        id: "text-first-starting-agent",
                         title: "Codex",
                         preset: "codex",
                         geometry: { x: 880, y: 120, width: 520, height: 360 },
                         z_index: 12,
-                        status: "not_started",
+                        status: "starting",
                         minimized: false,
                         maximized: false,
                         pre_maximize_geometry: null,
                         persist: true,
                         purpose_title: null,
                         dynamic_title: "Codex",
-                        dynamic_title_detail: "Readable not-started transcript",
-                        agent_id: "agent-not-started",
+                        dynamic_title_detail: "Readable starting transcript",
+                        agent_id: "agent-starting",
                         agent_color: "cyan",
                         tab_group_id: null,
                         tab_group_active: false,
@@ -87,7 +87,7 @@ test.describe("Text-first UI live readability", () => {
     await page.locator(`#op-theme-toggle [data-theme-value="${theme}"]`).click();
     await expect(page.locator("html")).toHaveAttribute("data-theme", theme);
 
-    for (const id of ["text-first-idle-agent", "text-first-not-started-agent"]) {
+    for (const id of ["text-first-idle-agent", "text-first-starting-agent"]) {
       const workspaceWindow = page.locator(`.workspace-window[data-id="${id}"]`);
       await expect(workspaceWindow).toBeVisible();
       await expect(workspaceWindow).toHaveCSS("opacity", "1");
@@ -96,6 +96,13 @@ test.describe("Text-first UI live readability", () => {
         "rgba(0, 0, 0, 0)",
       );
     }
+
+    // US-69: a pre-lifecycle agent surfaces as "Starting" (not "Not Started").
+    await expect(
+      page.locator(
+        '.workspace-window[data-id="text-first-starting-agent"] .status-label',
+      ),
+    ).toHaveText("Starting");
 
     await page.screenshot({
       path: testInfo.outputPath(`text-first-${theme}-window.png`),

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -14478,7 +14478,7 @@ exit 1
             .find(|window| window.id == "tab-1::agent-1")
             .unwrap();
 
-        assert_eq!(window.status, WindowProcessStatus::NotStarted);
+        assert_eq!(window.status, WindowProcessStatus::Starting);
         assert_eq!(tab.running_agent_count, 0);
         assert!(tab.running_agents.is_empty());
     }
@@ -14502,7 +14502,7 @@ exit 1
             .find(|window| window.id == "tab-1::agent-1")
             .unwrap();
 
-        assert_eq!(window.status, WindowProcessStatus::NotStarted);
+        assert_eq!(window.status, WindowProcessStatus::Starting);
     }
 
     #[test]

--- a/crates/gwt/src/cli/hook/runtime_state.rs
+++ b/crates/gwt/src/cli/hook/runtime_state.rs
@@ -43,7 +43,7 @@ pub struct RuntimeState {
 pub fn status_for_event(event: &str) -> Option<&'static str> {
     match window_state_for_hook_event(event)? {
         crate::persistence::WindowState::Running => Some("Running"),
-        crate::persistence::WindowState::NotStarted => Some("NotStarted"),
+        crate::persistence::WindowState::Starting => Some("Starting"),
         crate::persistence::WindowState::Idle => Some("Idle"),
         crate::persistence::WindowState::Waiting => Some("Waiting"),
         crate::persistence::WindowState::Stopped => Some("Stopped"),

--- a/crates/gwt/src/cli/pane.rs
+++ b/crates/gwt/src/cli/pane.rs
@@ -389,7 +389,7 @@ fn resolve_window_id<'a>(
 fn status_label(status: WindowState) -> &'static str {
     match status {
         WindowState::Running => "running",
-        WindowState::NotStarted => "not-started",
+        WindowState::Starting => "starting",
         WindowState::Idle => "idle",
         WindowState::Waiting => "waiting",
         WindowState::Stopped => "stopped",
@@ -507,13 +507,13 @@ mod tests {
     }
 
     #[test]
-    fn render_pane_list_labels_pre_lifecycle_agents_not_started() {
+    fn render_pane_list_labels_pre_lifecycle_agents_starting() {
         let mut windows = vec![window("tab-1::codex-1", WindowPreset::Codex, Some("codex"))];
-        windows[0].status = WindowState::NotStarted;
+        windows[0].status = WindowState::Starting;
 
         let rendered = render_pane_list(&windows);
 
-        assert!(rendered.contains("tab-1::codex-1\tnot-started\tcodex"));
+        assert!(rendered.contains("tab-1::codex-1\tstarting\tcodex"));
     }
 
     #[test]

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -1850,21 +1850,21 @@ mod tests {
     }
 
     #[test]
-    fn embedded_web_agent_runtime_maps_not_started_separately() {
+    fn embedded_web_agent_runtime_maps_starting_separately() {
         let js = app_js();
         let html = frontend_styles_bundle();
 
         assert!(
-            js.contains("not_started: \"Not Started\""),
-            "expected embedded js to expose a Not Started runtime label",
+            js.contains("starting: \"Starting\""),
+            "expected embedded js to expose a Starting runtime label (US-69)",
         );
         assert!(
-            js.contains("case \"not_started\":") && js.contains("return \"not_started\";"),
-            "expected embedded js to keep pre-lifecycle agent telemetry separate",
+            js.contains("case \"starting\":") && js.contains("return \"not_started\";"),
+            "expected the starting runtime state to map onto the separate not_started telemetry rim",
         );
         assert!(
-            html.contains(".status-chip.not_started .status-dot"),
-            "expected embedded html to define a not_started status chip variant",
+            html.contains(".status-chip.starting .status-dot"),
+            "expected embedded html to define a starting status chip variant",
         );
     }
 

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -4465,7 +4465,7 @@ fn runtime_target_value(target: gwt_agent::LaunchRuntimeTarget) -> &'static str 
 fn window_status_wire(status: crate::WindowProcessStatus) -> &'static str {
     match status {
         crate::WindowProcessStatus::Running => "running",
-        crate::WindowProcessStatus::NotStarted => "not_started",
+        crate::WindowProcessStatus::Starting => "starting",
         crate::WindowProcessStatus::Idle => "idle",
         crate::WindowProcessStatus::Waiting => "waiting",
         crate::WindowProcessStatus::Stopped => "stopped",

--- a/crates/gwt/src/persistence.rs
+++ b/crates/gwt/src/persistence.rs
@@ -34,10 +34,17 @@ pub fn default_canvas_viewport() -> CanvasViewport {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WindowState {
-    #[serde(alias = "starting", alias = "ready")]
+    #[serde(alias = "ready")]
     Running,
-    #[serde(alias = "not-started", alias = "notStarted", alias = "NotStarted")]
-    NotStarted,
+    // US-69: renamed from `NotStarted`. Serializes to "starting"; legacy
+    // `not_started` spellings remain accepted for backward compatibility.
+    #[serde(
+        alias = "not_started",
+        alias = "not-started",
+        alias = "notStarted",
+        alias = "NotStarted"
+    )]
+    Starting,
     Idle,
     Waiting,
     #[serde(alias = "exited")]
@@ -48,8 +55,6 @@ pub enum WindowState {
 pub type WindowProcessStatus = WindowState;
 
 impl WindowState {
-    #[allow(non_upper_case_globals)]
-    pub const Starting: Self = Self::Running;
     #[allow(non_upper_case_globals)]
     pub const Ready: Self = Self::Running;
     #[allow(non_upper_case_globals)]
@@ -1219,10 +1224,10 @@ mod tests {
         let error = serde_json::from_str::<WindowState>(r#""error""#).expect("error");
 
         assert_eq!(waiting, WindowState::Waiting);
-        assert_eq!(not_started, WindowState::NotStarted);
+        assert_eq!(not_started, WindowState::Starting);
         assert_eq!(
             serde_json::to_string(&not_started).expect("serialize not started"),
-            r#""not_started""#
+            r#""starting""#
         );
         assert_eq!(idle, WindowState::Idle);
         assert_eq!(
@@ -1239,12 +1244,40 @@ mod tests {
         let legacy_exited =
             serde_json::from_str::<WindowState>(r#""exited""#).expect("legacy exited");
 
-        assert_eq!(legacy_starting, WindowState::Running);
+        // US-69: "starting" is now the canonical Starting variant (no longer Running).
+        assert_eq!(legacy_starting, WindowState::Starting);
         assert_eq!(legacy_ready, WindowState::Running);
         assert_eq!(legacy_exited, WindowState::Stopped);
         assert_eq!(
             serde_json::to_string(&WindowState::Waiting).expect("serialize"),
             r#""waiting""#
         );
+    }
+
+    #[test]
+    fn window_state_starting_variant_serializes_and_accepts_legacy_not_started() {
+        // US-69: NotStarted renamed to Starting; canonical serialized form is "starting".
+        assert_eq!(
+            serde_json::to_string(&WindowState::Starting).expect("serialize starting"),
+            r#""starting""#
+        );
+        // "starting" round-trips back to the Starting variant.
+        assert_eq!(
+            serde_json::from_str::<WindowState>(r#""starting""#).expect("starting"),
+            WindowState::Starting
+        );
+        // Backward compatibility: every legacy not_started spelling deserializes to Starting.
+        for legacy in [
+            r#""not_started""#,
+            r#""not-started""#,
+            r#""notStarted""#,
+            r#""NotStarted""#,
+        ] {
+            assert_eq!(
+                serde_json::from_str::<WindowState>(legacy).expect("legacy not_started"),
+                WindowState::Starting,
+                "legacy {legacy} should map to Starting",
+            );
+        }
     }
 }

--- a/crates/gwt/src/window_state.rs
+++ b/crates/gwt/src/window_state.rs
@@ -26,7 +26,7 @@ pub fn compose_window_state_with_active_session(
         return hook_state.unwrap_or(if has_active_agent_session {
             WindowState::Idle
         } else {
-            WindowState::NotStarted
+            WindowState::Starting
         });
     }
     pty_state
@@ -72,9 +72,9 @@ pub fn window_state_for_hook_event(event: &str) -> Option<WindowState> {
 
 fn parse_runtime_status(status: &str) -> Option<WindowState> {
     match status.trim().to_ascii_lowercase().as_str() {
-        "running" | "starting" | "ready" => Some(WindowState::Running),
-        "notstarted" | "not_started" | "not-started" | "not started" => {
-            Some(WindowState::NotStarted)
+        "running" | "ready" => Some(WindowState::Running),
+        "starting" | "notstarted" | "not_started" | "not-started" | "not started" => {
+            Some(WindowState::Starting)
         }
         "idle" => Some(WindowState::Idle),
         "waiting" | "waitinginput" | "waiting_input" => Some(WindowState::Waiting),
@@ -144,7 +144,7 @@ mod tests {
         );
         assert_eq!(
             compose_window_state(WindowState::Running, WindowPreset::Agent, None),
-            WindowState::NotStarted
+            WindowState::Starting
         );
         assert_eq!(
             compose_window_state(
@@ -186,11 +186,11 @@ mod tests {
     }
 
     #[test]
-    fn compose_window_state_defaults_live_agent_without_hook_state_to_not_started() {
+    fn compose_window_state_defaults_live_agent_without_hook_state_to_starting() {
         let composed = compose_window_state(WindowState::Running, WindowPreset::Agent, None);
 
-        assert_eq!(composed, WindowState::NotStarted);
-        assert_eq!(serde_json::to_string(&composed).unwrap(), "\"not_started\"");
+        assert_eq!(composed, WindowState::Starting);
+        assert_eq!(serde_json::to_string(&composed).unwrap(), "\"starting\"");
     }
 
     #[test]

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -2164,17 +2164,19 @@
 
       const WINDOW_RUNTIME_STATE_LABELS = Object.freeze({
         running: "Running",
-        not_started: "Not Started",
+        starting: "Starting",
         idle: "Idle",
         waiting: "Waiting",
         stopped: "Stopped",
         error: "Error",
       });
 
+      // US-69: the pre-lifecycle state is now `starting`. Legacy `not_started`
+      // spellings (and the older `starting`→running conflation) normalize to it.
       const LEGACY_WINDOW_RUNTIME_STATE_ALIASES = Object.freeze({
-        starting: "running",
-        notstarted: "not_started",
-        "not-started": "not_started",
+        not_started: "starting",
+        notstarted: "starting",
+        "not-started": "starting",
         ready: "idle",
         exited: "stopped",
       });
@@ -4393,10 +4395,9 @@
       // `idle` until the design language explicitly handles them.
       function mapAgentTelemetryState(runtimeState) {
         switch (runtimeState) {
-          case "starting":
           case "running":
             return "active";
-          case "not_started":
+          case "starting":
             return "not_started";
           case "ready":
           case "idle":
@@ -4424,7 +4425,7 @@
               detailMap.set(windowId, detail);
             } else if (
               runtimeState === "running" ||
-              runtimeState === "not_started" ||
+              runtimeState === "starting" ||
               runtimeState === "idle" ||
               runtimeState === "waiting"
             ) {

--- a/crates/gwt/web/project-tabs-renderer.js
+++ b/crates/gwt/web/project-tabs-renderer.js
@@ -60,9 +60,9 @@ function createTabButton(document, send, requestCloseProjectTab) {
 const AGENT_WINDOW_PRESETS = new Set(["agent", "claude", "codex"]);
 
 const LEGACY_WINDOW_RUNTIME_STATE_ALIASES = Object.freeze({
-  starting: "running",
-  notstarted: "not_started",
-  "not-started": "not_started",
+  not_started: "starting",
+  notstarted: "starting",
+  "not-started": "starting",
   ready: "idle",
   exited: "stopped",
 });

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -759,7 +759,7 @@ body {
   background: var(--color-state-active);
 }
 
-.status-chip.not_started .status-dot {
+.status-chip.starting .status-dot {
   background: var(--color-state-idle);
 }
 

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -2300,9 +2300,8 @@ kbd.op-kbd {
   font-size: var(--type-xs);
   letter-spacing: var(--tracking-mono);
 }
-:root[data-theme] .status-chip.starting,
 :root[data-theme] .status-chip.running { color: var(--color-state-active); border-color: var(--color-state-active); }
-:root[data-theme] .status-chip.not_started,
+:root[data-theme] .status-chip.starting,
 :root[data-theme] .status-chip.ready,
 :root[data-theme] .status-chip.idle,
 :root[data-theme] .status-chip.waiting { color: var(--color-state-idle); border-color: var(--color-state-idle); }


### PR DESCRIPTION
## Summary

- Rename the agent window pre-lifecycle status from "Not Started" to "Starting" so a freshly launched agent reads as launching instead of failed/untouched (SPEC-2359 US-69, FR-370〜374).
- Rename is end-to-end: enum variant, wire value, CSS class, `gwtd pane` CLI output, and the GUI label all move to `starting`; legacy `not_started` spellings stay accepted via serde aliases for backward compatibility.

## Changes

- `crates/gwt/src/persistence.rs`: `WindowState::NotStarted` → `Starting` (serializes to `"starting"`, aliases `not_started`/`not-started`/`notStarted`/`NotStarted`); removed the colliding `pub const Starting: Self = Self::Running` and the `"starting"` alias on `Running`; round-trip tests updated + new legacy-alias test.
- `crates/gwt/src/window_state.rs`: `compose_window_state_with_active_session` and `parse_runtime_status` now produce `WindowState::Starting`; `"starting"` parses to `Starting` (no longer `Running`).
- `crates/gwt/src/launch_wizard.rs` / `crates/gwt/src/cli/pane.rs` / `crates/gwt/src/cli/hook/runtime_state.rs`: wire/CLI/hook status strings unified to `starting` / `Starting`.
- `crates/gwt/src/app_runtime/mod.rs`: pre-lifecycle normalization tests updated to expect `Starting`.
- `crates/gwt/src/embedded_web.rs`: embedded-asset contract test now pins the `Starting` label, the `starting`→`not_started` telemetry mapping, and the `.status-chip.starting` CSS variant.
- `crates/gwt/web/app.js`: label map exposes `starting: "Starting"`; legacy aliases map `not_started` spellings to `starting` and the old `starting`→`running` conflation is removed; telemetry mapper routes `starting` to the existing `not_started` rim; `applyStatus` detail-clear list updated.
- `crates/gwt/web/project-tabs-renderer.js`: same legacy-alias inversion, so a starting agent no longer lights the tab dot as running.
- `crates/gwt/web/styles/app.css` / `crates/gwt/web/styles/components.css`: `.status-chip.not_started` → `.status-chip.starting`, keeping the idle (dim) visual; `starting` removed from the active-color group.
- `crates/gwt/playwright/tests/text-first-ui-live.spec.ts`: fixture uses canonical `starting` status and asserts the chip label text is `Starting`.

## Testing

- [x] `cargo test -p gwt-core -p gwt --all-features` — all test binaries pass (61 green, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — pass
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/run-frontend-unit-tests.sh` — 738 tests pass (includes telemetry-state contract and project-tabs-renderer suites)
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — builds
- [x] Manual: fresh isolated `target/debug/gwt` (browser-served), real Start Work → agent launch succeeded; pre-lifecycle agent window renders chip label `Starting` (class `.status-chip.starting`, telemetry rim unchanged) and a running agent renders `Running`; user visually confirmed
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — exit 0

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — self-contained rename with serde-alias backward compatibility; no protocol break, no behavior change beyond the label/state vocabulary
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- #2359 (SPEC-2359 US-69 / FR-370〜374 / SC-247〜250)

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (if user-facing change) — N/A: README does not document individual status labels
- [ ] Migration/backfill plan included (if schema/data change) — N/A: serde aliases keep old persisted `not_started` values loading; legacy on-disk `"starting"` (defensive alias only, never written by released code) now maps to the new Starting state, which is the accepted migration recorded in SPEC-2359 FR-372
- [x] CHANGELOG impact considered (breaking change flagged in commit) — `fix:` patch release, no breaking change

## Risk / Impact

- **Affected areas**: agent window status chip (GUI), `gwtd pane` status strings, persisted window-state vocabulary (`workspace.json` / session state), launch wizard wire values
- **Rollback plan**: revert the single commit; old code still parses `"starting"` (legacy alias on `Running`) and `"not_started"`, so persisted state remains loadable after rollback


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent windows now display a distinct "Starting" status state with proper styling and label rendering.

* **Style**
  * Updated CSS styling for the starting state status indicator.

* **Tests**
  * Updated test cases to verify the new Starting state behavior across UI, runtime, and serialization layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->