### PR TITLE
feat(launch-wizard): add Fable 5 to Claude model options

### DIFF
--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -3297,7 +3297,8 @@ impl LaunchWizardState {
     fn current_reasoning_options(&self) -> Vec<ReasoningDisplayOption> {
         if self.agent_is_codex() {
             CODEX_REASONING_OPTIONS.to_vec()
-        } else if self.effective_agent_id() == "claude" && is_claude_opus_model(self.model.as_str())
+        } else if self.effective_agent_id() == "claude"
+            && is_claude_opus_tier_model(self.model.as_str())
         {
             let mut options = CLAUDE_OPUS_REASONING_OPTIONS.to_vec();
             // `ultracode` is opt-in and only usable on Opus 4.7/4.8 with a
@@ -3649,18 +3650,24 @@ fn default_launch_path(
 
 const CLAUDE_DEFAULT_MODEL_LABEL: &str = "Default (Opus 4.8)";
 
-fn is_claude_opus_model(model: &str) -> bool {
-    model == CLAUDE_DEFAULT_MODEL_LABEL || model == "opus"
+// Fable 5 shares the Opus 4.7/4.8 effort surface (low..max), so both models
+// use the same opus-tier reasoning ladder.
+fn is_claude_opus_tier_model(model: &str) -> bool {
+    model == CLAUDE_DEFAULT_MODEL_LABEL || model == "opus" || model == "fable"
 }
 
 fn is_claude_effort_capable_model(model: &str) -> bool {
-    is_claude_opus_model(model) || model == "sonnet"
+    is_claude_opus_tier_model(model) || model == "sonnet"
 }
 
-const CLAUDE_MODEL_OPTIONS: [ModelDisplayOption; 4] = [
+const CLAUDE_MODEL_OPTIONS: [ModelDisplayOption; 5] = [
     ModelDisplayOption {
         label: CLAUDE_DEFAULT_MODEL_LABEL,
         description: "Most capable for complex work",
+    },
+    ModelDisplayOption {
+        label: "fable",
+        description: "Most capable for the hardest, longest-running tasks",
     },
     ModelDisplayOption {
         label: "opus",
@@ -3766,7 +3773,7 @@ const CLAUDE_OPUS_REASONING_OPTIONS: [ReasoningDisplayOption; 7] = [
     ReasoningDisplayOption {
         label: "Ultracode",
         stored_value: "ultracode",
-        description: "Top-tier effort plus dynamic workflow orchestration (Opus only)",
+        description: "Top-tier effort plus dynamic workflow orchestration (Opus-tier only)",
         is_default: false,
     },
 ];
@@ -7805,8 +7812,10 @@ mod tests {
             .iter()
             .any(|option| option.value == "continue"));
 
-        assert!(current_model_options("claude").contains(&"sonnet"));
-        assert!(current_model_options("claude").contains(&"Default (Opus 4.8)"));
+        assert_eq!(
+            current_model_options("claude"),
+            vec!["Default (Opus 4.8)", "fable", "opus", "sonnet", "haiku"]
+        );
         assert_eq!(
             current_model_options("codex"),
             vec!["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"]
@@ -8536,7 +8545,7 @@ mod tests {
         assert_eq!(default.stored_value, "xhigh");
     }
 
-    fn opus_state(ultracode_supported: bool) -> LaunchWizardState {
+    fn claude_state(model: &str, ultracode_supported: bool) -> LaunchWizardState {
         let agent_options = vec![AgentOption {
             id: "claude".to_string(),
             name: "Claude Code".to_string(),
@@ -8551,13 +8560,13 @@ mod tests {
         // field at render time — see `current_reasoning_options`).
         ctx.ultracode_supported = ultracode_supported;
         let mut state = LaunchWizardState::open_with(ctx, agent_options, Vec::new());
-        // Drive current_reasoning_options() down the Claude Opus branch.
+        // Drive current_reasoning_options() down the requested Claude model branch.
         state.agent_id = "claude".to_string();
-        state.model = "opus".to_string();
+        state.model = model.to_string();
         state
     }
 
-    fn opus_reasoning_values(state: &LaunchWizardState) -> Vec<&'static str> {
+    fn claude_reasoning_values(state: &LaunchWizardState) -> Vec<&'static str> {
         state
             .current_reasoning_options()
             .iter()
@@ -8567,18 +8576,49 @@ mod tests {
 
     #[test]
     fn opus_reasoning_includes_ultracode_when_supported() {
-        let values = opus_reasoning_values(&opus_state(true));
+        let values = claude_reasoning_values(&claude_state("opus", true));
         assert!(values.contains(&"ultracode"));
         assert_eq!(values.last(), Some(&"ultracode"));
     }
 
     #[test]
     fn opus_reasoning_excludes_ultracode_when_unsupported() {
-        let values = opus_reasoning_values(&opus_state(false));
+        let values = claude_reasoning_values(&claude_state("opus", false));
         assert!(!values.contains(&"ultracode"));
         // Common levels remain intact when ultracode is gated out.
         assert!(values.contains(&"xhigh"));
         assert!(values.contains(&"max"));
+    }
+
+    #[test]
+    fn fable_reasoning_matches_opus_ladder_with_xhigh_default() {
+        let values = claude_reasoning_values(&claude_state("fable", true));
+        assert_eq!(
+            values,
+            ["auto", "low", "medium", "high", "xhigh", "max", "ultracode"]
+        );
+        let state = claude_state("fable", true);
+        let default = state
+            .current_reasoning_options()
+            .iter()
+            .find(|option| option.is_default)
+            .map(|option| option.stored_value);
+        assert_eq!(default, Some("xhigh"));
+    }
+
+    #[test]
+    fn fable_reasoning_excludes_ultracode_when_unsupported() {
+        let values = claude_reasoning_values(&claude_state("fable", false));
+        assert!(!values.contains(&"ultracode"));
+        assert!(values.contains(&"xhigh"));
+        assert!(values.contains(&"max"));
+    }
+
+    #[test]
+    fn fable_is_effort_capable_for_launch() {
+        let mut state = claude_state("fable", true);
+        state.reasoning = "xhigh".to_string();
+        assert_eq!(state.reasoning_level_for_launch(), Some("xhigh"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Claude Code v2.1.170 でリリースされた新モデル Fable 5 (alias: `fable`) を Launch Wizard の Claude モデル候補に追加し、Claude Code の `/model` 一覧と同じ順序（`Default (Opus 4.8)` の直後）で選択できるようにする（SPEC-2014 2026-06-10 追記）。
- Fable 5 は Opus 4.7/4.8 と同じ effort surface（low/medium/high/xhigh/max）を持つため、opus-tier 判定を共有して同一の reasoning ladder（xHigh デフォルト、Ultracode は gate 付き）を提示する。

## Changes

- `crates/gwt/src/launch_wizard.rs`:
  - `CLAUDE_MODEL_OPTIONS` を 4→5 要素に拡張し、`fable`（"Most capable for the hardest, longest-running tasks"）を `Default (Opus 4.8)` の直後に挿入
  - `is_claude_opus_model` を `is_claude_opus_tier_model` にリネームし `fable` を opus-tier 判定に追加（`is_claude_effort_capable_model` と `current_reasoning_options` が自動追従）
  - Ultracode 説明文を `(Opus only)` → `(Opus-tier only)` に更新
  - テスト: モデル候補順序の assert、fable の reasoning ladder / ultracode gate / effort-capable テストを追加（テストヘルパー `opus_state` を `claude_state(model, ...)` に一般化）

## Testing

- [x] `cargo test -p gwt-core -p gwt --all-features` — 2382 passed / 0 failed（TDD: fable テスト 4 件を RED で確認後 GREEN 化）
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — warning なし
- [x] `cargo fmt --check` — 差分なし
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — 成功
- [x] ユーザー視覚検証 — fresh isolated gwt の Launch Wizard で Model 候補が `Default (Opus 4.8) / fable / opus / sonnet / haiku` の順に表示され、fable 選択時の Reasoning スライダーが opus と同一（6 段・xHigh デフォルト）であることを確認（**User Verification Result: confirmed**）
- 補足: 検証 1 回目に既存 flake `cli::pr::tests::gh_wrappers_parse_successful_responses`（並列テストの CWD race、本変更と無関係）が 1 件発生。#3006 として登録済み。再実行で全件 green。

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — モデル候補の追加のみで既存挙動（Default 非送出・opus/sonnet/haiku の選択・effort 受け渡し）は不変
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- SPEC-2014 (#2014) — Launch Wizard。2026-06-10 追記として受け入れシナリオを追加済み
- #3006 — pre-PR 検証中に観測した既存テスト flake（本 PR のスコープ外）

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (if user-facing change) — N/A: モデル候補は Wizard 内の動的表示で、README にモデル一覧の記載なし
- [ ] Migration/backfill plan included (if schema/data change) — N/A: schema/data 変更なし
- [x] CHANGELOG impact considered (breaking change flagged in commit) — feat (minor)、breaking change なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
