### PR TITLE
fix(launch-wizard): align Claude default effort with Claude Code model defaults

### DIFF
--- a/.gwt/work/memory.md
+++ b/.gwt/work/memory.md
@@ -6802,3 +6802,10 @@ Type: failure-pattern
 Context: SPEC-1939 Phase 67 investigated >100% CPU in the installed GWT.app while a fresh target/debug/gwt checkout was idle.
 Learning: Current-checkout smoke passing is insufficient when the running installed app uses an older binary/runtime runner; compare installed/current hashes, runtime manifest runner hash, child runner processes, and recent log storm counters.
 Future Action: For future CPU or log-storm reports, run gwtd diagnostics cpu --json against the live machine before declaring the checkout fixed, and explicitly record whether installed app/runtime remain stale.
+
+## 2026-06-10 — 新モデル追加時は per-model default effort も Claude Code docs で確認する
+
+Type: lesson
+Context: PR #3007 で Fable 5 をモデル候補に追加した際、opus と同じ reasoning ladder (xHigh default) を共有させたが、Codex レビューで Fable 5 の Claude Code 既定 effort は high だと指摘された。検証の結果 Opus 4.8 / Sonnet 4.6 の既定も high で、gwt の xHigh/medium 既定は旧バージョン (Opus 4.7 時代) の stale な引き継ぎだった。
+Learning: Claude Code の既定 effort はモデル世代ごとに変わる (4.7=xhigh, 4.8/Fable5/Sonnet4.6=high)。モデル候補の追加・ラベル更新時にラベルだけ追従して既定値の追従が漏れると、ユーザーが意図せず高コスト effort で起動する。
+Future Action: launch_wizard のモデル一覧や既定値を更新する際は https://code.claude.com/docs/en/model-config#adjust-effort-level の "The default effort is ..." を必ず確認し、CLAUDE_*_REASONING_OPTIONS の is_default と説明文 "(... default)" を同時に更新する。

--- a/crates/gwt-agent/src/claude_capabilities.rs
+++ b/crates/gwt-agent/src/claude_capabilities.rs
@@ -3,7 +3,7 @@
 //! `ultracode` is a Claude Code *session setting* (not an effort level): it
 //! sends `xhigh` to the model and additionally enables dynamic workflow
 //! orchestration. It is available only on models that support `xhigh`
-//! (Opus 4.7 / 4.8) and requires Claude Code >= 2.1.154 with workflows
+//! (Opus 4.7 / 4.8, Fable 5) and requires Claude Code >= 2.1.154 with workflows
 //! enabled. These helpers determine, before launch, whether the installed
 //! Claude Code can actually use ultracode so the Launch Wizard only offers it
 //! when usable.

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -3755,14 +3755,14 @@ const CLAUDE_OPUS_REASONING_OPTIONS: [ReasoningDisplayOption; 7] = [
     ReasoningDisplayOption {
         label: "High",
         stored_value: "high",
-        description: "Deeper reasoning for complex work",
-        is_default: false,
+        description: "Balances tokens and intelligence (Fable 5 / Opus 4.8 default)",
+        is_default: true,
     },
     ReasoningDisplayOption {
         label: "xHigh",
         stored_value: "xhigh",
-        description: "Best results for most coding tasks (Opus 4.8 default)",
-        is_default: true,
+        description: "Deeper reasoning at higher token spend",
+        is_default: false,
     },
     ReasoningDisplayOption {
         label: "Max",
@@ -3795,13 +3795,13 @@ const CLAUDE_SONNET_REASONING_OPTIONS: [ReasoningDisplayOption; 4] = [
         label: "Medium",
         stored_value: "medium",
         description: "Balanced reasoning for everyday work",
-        is_default: true,
+        is_default: false,
     },
     ReasoningDisplayOption {
         label: "High",
         stored_value: "high",
-        description: "Deeper reasoning for complex work",
-        is_default: false,
+        description: "Deeper reasoning for complex work (Sonnet 4.6 default)",
+        is_default: true,
     },
 ];
 
@@ -8518,7 +8518,7 @@ mod tests {
             .expect("opus options must contain ultracode");
         assert!(
             !ultra.is_default,
-            "ultracode must be opt-in; xhigh stays the Opus default"
+            "ultracode must be opt-in; high stays the Opus-tier default"
         );
     }
 
@@ -8537,12 +8537,14 @@ mod tests {
     }
 
     #[test]
-    fn claude_opus_reasoning_default_is_xhigh() {
+    fn claude_opus_reasoning_default_is_high() {
+        // Claude Code model-config docs: default effort is `high` on
+        // Fable 5 / Opus 4.8 (`xhigh` was the Opus 4.7 default).
         let default = super::CLAUDE_OPUS_REASONING_OPTIONS
             .iter()
             .find(|option| option.is_default)
             .expect("Opus reasoning options must have a default row");
-        assert_eq!(default.stored_value, "xhigh");
+        assert_eq!(default.stored_value, "high");
     }
 
     fn claude_state(model: &str, ultracode_supported: bool) -> LaunchWizardState {
@@ -8591,7 +8593,7 @@ mod tests {
     }
 
     #[test]
-    fn fable_reasoning_matches_opus_ladder_with_xhigh_default() {
+    fn fable_reasoning_matches_opus_ladder_with_high_default() {
         let values = claude_reasoning_values(&claude_state("fable", true));
         assert_eq!(
             values,
@@ -8603,7 +8605,7 @@ mod tests {
             .iter()
             .find(|option| option.is_default)
             .map(|option| option.stored_value);
-        assert_eq!(default, Some("xhigh"));
+        assert_eq!(default, Some("high"));
     }
 
     #[test]
@@ -8633,12 +8635,14 @@ mod tests {
     }
 
     #[test]
-    fn claude_sonnet_reasoning_default_is_medium() {
+    fn claude_sonnet_reasoning_default_is_high() {
+        // Claude Code model-config docs: default effort is `high` on
+        // Sonnet 4.6.
         let default = super::CLAUDE_SONNET_REASONING_OPTIONS
             .iter()
             .find(|option| option.is_default)
             .expect("Sonnet reasoning options must have a default row");
-        assert_eq!(default.stored_value, "medium");
+        assert_eq!(default.stored_value, "high");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- PR #3007 の Codex レビュー指摘（Fable 5 の既定 effort は `xhigh` ではなく `high`）を起点に、Claude の既定 effort を Claude Code model-config docs に追従させる（SPEC-2014 2026-06-10 追記）。
- docs 検証の結果、Fable 5 だけでなく Opus 4.8 / Sonnet 4.6 の既定も `high` であり、gwt の opus-tier=`xhigh` / sonnet=`medium` は旧バージョン（Opus 4.7 時代）の stale な既定だったため、3 モデルまとめて `high` に揃える（opus 追従はユーザー承認済み、sonnet は同一根拠での docs 追従）。

## Context

- Claude Code model-config docs: "The default effort is `high` on Fable 5, Opus 4.8, Opus 4.6, and Sonnet 4.6, and `xhigh` on Opus 4.7." (<https://code.claude.com/docs/en/model-config#adjust-effort-level>)
- gwt の `xhigh` 既定は xhigh が既定だった Opus 4.7 で導入され、Opus 4.8 への更新時にラベル "(Opus 4.8 default)" のみ追従して既定値の追従が漏れていた。

## Changes

- `crates/gwt/src/launch_wizard.rs`:
  - `CLAUDE_OPUS_REASONING_OPTIONS`: 既定を `xhigh` → `high` に変更。説明文を docs 準拠に更新（High: "Balances tokens and intelligence (Fable 5 / Opus 4.8 default)"、xHigh: "Deeper reasoning at higher token spend"）
  - `CLAUDE_SONNET_REASONING_OPTIONS`: 既定を `medium` → `high` に変更（High: "(Sonnet 4.6 default)"）
  - Codex の既定（medium）は対象外で不変。`xhigh`/`max`/`ultracode` は選択肢として残る
  - テスト: 既定値 assert を `high` に更新（opus / sonnet / fable）
- `crates/gwt-agent/src/claude_capabilities.rs`: ultracode doc comment に Fable 5 を追記
- `.gwt/work/memory.md`: 再発防止 memory（モデル更新時は per-model default effort を docs で確認）を追加

## Testing

- [x] `cargo test -p gwt-core -p gwt-agent -p gwt --all-features` — 2731 passed / 0 failed（TDD: 既定値テスト 3 件を RED で確認後 GREEN 化）
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — warning なし
- [x] `cargo fmt --check` — 差分なし
- [x] ユーザー視覚検証 — fresh isolated gwt の Launch Wizard で Default (Opus 4.8) / fable / opus / sonnet すべての Reasoning 初期値が High になることを確認（**User Verification Result: confirmed**）
- 補足: 検証中に #3006 と同根の flake（`with_fake_gh` 系、今回は `gh_wrappers_tolerate_resolve_failure_after_remote_state_changes`）が 1 回発生。#3006 に追記済み。再実行で全件 green。

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — 既定値（新規選択時の初期値）の変更のみで、ユーザーが明示選択した effort の永続化・resume・levels の選択肢は不変
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- PR #3007 — 指摘元の Codex レビュースレッド（本 PR で対応）
- SPEC-2014 (#2014) — 2026-06-10 追記「Claude 既定 effort を Claude Code model defaults に追従」
- #3006 — 検証中に再観測した既存テスト flake（スコープ外）

## Risk / Impact

- **Affected areas**: Launch Wizard の Claude reasoning 初期値のみ。新規起動の既定が xhigh→high（opus/fable）、medium→high（sonnet）に変わる
- **Rollback plan**: 該当 const の `is_default` を戻すだけで復元可能（1 commit revert）

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (if user-facing change) — N/A: README に effort 既定の記載なし、SPEC-2014 は更新済み
- [ ] Migration/backfill plan included (if schema/data change) — N/A: schema/data 変更なし
- [x] CHANGELOG impact considered (breaking change flagged in commit) — fix (patch)、breaking change なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended ultracode session support to include Fable 5 model

* **Updates**
  * Corrected default reasoning effort levels for Claude Opus and Sonnet models from "xhigh" to "high" to align with Claude Code's actual platform defaults, ensuring users receive appropriate default performance settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->