### PR TITLE
fix(launch-wizard): default Claude reasoning to Auto and delegate effort to Claude Code

### DIFF
--- a/.gwt/work/memory.md
+++ b/.gwt/work/memory.md
@@ -6809,3 +6809,17 @@ Type: lesson
 Context: PR #3007 で Fable 5 をモデル候補に追加した際、opus と同じ reasoning ladder (xHigh default) を共有させたが、Codex レビューで Fable 5 の Claude Code 既定 effort は high だと指摘された。検証の結果 Opus 4.8 / Sonnet 4.6 の既定も high で、gwt の xHigh/medium 既定は旧バージョン (Opus 4.7 時代) の stale な引き継ぎだった。
 Learning: Claude Code の既定 effort はモデル世代ごとに変わる (4.7=xhigh, 4.8/Fable5/Sonnet4.6=high)。モデル候補の追加・ラベル更新時にラベルだけ追従して既定値の追従が漏れると、ユーザーが意図せず高コスト effort で起動する。
 Future Action: launch_wizard のモデル一覧や既定値を更新する際は https://code.claude.com/docs/en/model-config#adjust-effort-level の "The default effort is ..." を必ず確認し、CLAUDE_*_REASONING_OPTIONS の is_default と説明文 "(... default)" を同時に更新する。
+
+## 2026-06-10 — effort 既定はハードコードせず Auto（非 export）で Claude Code に委譲する
+
+Type: decision
+Context: PR #3009 で既定 effort を docs の high に揃えた直後、Codex レビューが「AWS platform では opus→Opus 4.7（既定 xhigh）に解決されるため high 固定は不一致」と指摘。provider・モデル世代ごとに既定が異なるため、gwt 側のハードコードはどの値でも何処かで stale になる。
+Learning: Claude の effort 既定は reasoning=auto（CLAUDE_CODE_EFFORT_LEVEL 非 export）にして Claude Code 自身の per-model 既定に委譲するのが構造的な解。値の追従更新が不要になり、stale 既定バグのクラスごと消える。
+Future Action: launch オプションの「既定値」を gwt 側に持たせる前に、CLI 側に既定解決を委譲できるか（フラグ/環境変数を渡さない選択肢）を先に検討する。
+
+## 2026-06-10 — wizard slider の E2E は focusout で interaction guard を解放してから assert する
+
+Type: failure-pattern
+Context: launch-wizard-controls-live.spec.ts の ArrowRight→summary assert が常に失敗。WS 送信・backend 適用は正常で、frontend の wizardInteractionGuard（SPEC-2014 2026-05-29）が slider focus 中の launch_wizard_state 再レンダリングを focusout まで defer していた。Playwright の press は focus を残すため summary が永遠に古いままになり、後続 probe の echo も全て deferred に飲まれて「backend が死んだ」ように見えた。
+Learning: guard は <select> と .launch-range__input の focus/pointer 中に activate され focusout/Escape で release される。slider 操作後の backend 反映を assert する E2E は blur() などで guard を先に解放する必要がある。
+Future Action: wizard の <select>/slider を操作する E2E・自動検証では、操作後に blur または別要素クリックを挟んでから backend 反映を assert する。「アクションが無視される」症状を見たら interaction guard の defer を最初に疑う。

--- a/crates/gwt/playwright/tests/launch-wizard-controls-live.spec.ts
+++ b/crates/gwt/playwright/tests/launch-wizard-controls-live.spec.ts
@@ -71,27 +71,37 @@ test.describe.serial("Launch Wizard setting controls (live backend)", () => {
       await model.selectOption("sonnet");
     }
 
+    // Auto is the default: the slider starts suspended and the effort is
+    // delegated to Claude Code's own per-model default.
     const range = wizard.locator(".launch-range__input");
     await expect(range).toBeVisible();
+    await expect(range).toBeDisabled();
+    await expect(effortSummaryValue(page)).toHaveText("auto");
+
+    const auto = wizard.locator('[data-reasoning-auto] input[type="checkbox"]');
+    await expect(auto).toHaveCount(1);
+    await expect(auto).toBeChecked();
+
+    // Turning Auto off re-enables the slider parked at the middle ordinal
+    // stop (Medium for Sonnet's Low / Medium / High scale).
+    await auto.setChecked(false);
     await expect(range).toBeEnabled();
     await expect(effortSummaryValue(page)).toHaveText("medium");
 
     // ArrowRight snaps from Medium to High and reports the stored value.
-    await range.focus();
-    await page.keyboard.press("ArrowRight");
+    // While the slider keeps focus, the wizardInteractionGuard (SPEC-2014
+    // 2026-05-29) defers backend re-renders so the drag/keyboard interaction
+    // is not destroyed mid-step; the coalesced state flushes on focusout.
+    // Blur the slider to release the guard before asserting the summary.
+    await range.press("ArrowRight");
+    await range.blur();
     await expect(effortSummaryValue(page)).toHaveText("high");
 
-    // Auto is a separate toggle, not a slider stop: enabling it suspends the
-    // slider and reports "auto".
-    const auto = wizard.locator('[data-reasoning-auto] input[type="checkbox"]');
-    await expect(auto).toHaveCount(1);
+    // Auto is a separate toggle, not a slider stop: re-enabling it suspends
+    // the slider and reports "auto" again.
     await auto.setChecked(true);
     await expect(range).toBeDisabled();
     await expect(effortSummaryValue(page)).toHaveText("auto");
-
-    await auto.setChecked(false);
-    await expect(range).toBeEnabled();
-    await expect(effortSummaryValue(page)).not.toHaveText("auto");
   });
 });
 

--- a/crates/gwt/src/cli/test_support.rs
+++ b/crates/gwt/src/cli/test_support.rs
@@ -189,7 +189,11 @@ fn main() -> ExitCode {
     let source_path = bin_dir.join("gh.rs");
     fs::write(&source_path, source).expect("write fake gh source");
     let output_path = bin_dir.join(format!("gh{}", env::consts::EXE_SUFFIX));
+    // Pin the child's working directory: parallel tests may set the
+    // process-wide CWD to a tempdir that gets dropped, and rustc refuses to
+    // start from a deleted CWD ("Current directory is invalid", #3006).
     let status = std::process::Command::new("rustc")
+        .current_dir(bin_dir)
         .arg(&source_path)
         .arg("-o")
         .arg(&output_path)

--- a/crates/gwt/src/launch_wizard.rs
+++ b/crates/gwt/src/launch_wizard.rs
@@ -3733,12 +3733,17 @@ const GEMINI_MODEL_OPTIONS: [ModelDisplayOption; 7] = [
     },
 ];
 
+// Auto is the default: gwt skips the CLAUDE_CODE_EFFORT_LEVEL export so
+// Claude Code applies its own per-model default effort (`high` on
+// Fable 5 / Opus 4.8, `xhigh` on Opus 4.7). Hardcoding a level here goes
+// stale whenever a model generation changes its default, and the `opus`
+// alias resolves to different generations per provider.
 const CLAUDE_OPUS_REASONING_OPTIONS: [ReasoningDisplayOption; 7] = [
     ReasoningDisplayOption {
         label: "Auto",
         stored_value: "auto",
-        description: "Let the model choose the effort",
-        is_default: false,
+        description: "Follow Claude Code's default effort for the model",
+        is_default: true,
     },
     ReasoningDisplayOption {
         label: "Low",
@@ -3756,7 +3761,7 @@ const CLAUDE_OPUS_REASONING_OPTIONS: [ReasoningDisplayOption; 7] = [
         label: "High",
         stored_value: "high",
         description: "Balances tokens and intelligence (Fable 5 / Opus 4.8 default)",
-        is_default: true,
+        is_default: false,
     },
     ReasoningDisplayOption {
         label: "xHigh",
@@ -3782,8 +3787,8 @@ const CLAUDE_SONNET_REASONING_OPTIONS: [ReasoningDisplayOption; 4] = [
     ReasoningDisplayOption {
         label: "Auto",
         stored_value: "auto",
-        description: "Let the model choose the effort",
-        is_default: false,
+        description: "Follow Claude Code's default effort for the model",
+        is_default: true,
     },
     ReasoningDisplayOption {
         label: "Low",
@@ -3801,7 +3806,7 @@ const CLAUDE_SONNET_REASONING_OPTIONS: [ReasoningDisplayOption; 4] = [
         label: "High",
         stored_value: "high",
         description: "Deeper reasoning for complex work (Sonnet 4.6 default)",
-        is_default: true,
+        is_default: false,
     },
 ];
 
@@ -8518,7 +8523,7 @@ mod tests {
             .expect("opus options must contain ultracode");
         assert!(
             !ultra.is_default,
-            "ultracode must be opt-in; high stays the Opus-tier default"
+            "ultracode must be opt-in; auto stays the Opus-tier default"
         );
     }
 
@@ -8537,14 +8542,16 @@ mod tests {
     }
 
     #[test]
-    fn claude_opus_reasoning_default_is_high() {
-        // Claude Code model-config docs: default effort is `high` on
-        // Fable 5 / Opus 4.8 (`xhigh` was the Opus 4.7 default).
+    fn claude_opus_reasoning_default_is_auto() {
+        // Defaulting to Auto skips the CLAUDE_CODE_EFFORT_LEVEL export so
+        // Claude Code applies its own per-model default (`high` on
+        // Fable 5 / Opus 4.8, `xhigh` on Opus 4.7) regardless of which
+        // model the alias resolves to on the user's provider.
         let default = super::CLAUDE_OPUS_REASONING_OPTIONS
             .iter()
             .find(|option| option.is_default)
             .expect("Opus reasoning options must have a default row");
-        assert_eq!(default.stored_value, "high");
+        assert_eq!(default.stored_value, "auto");
     }
 
     fn claude_state(model: &str, ultracode_supported: bool) -> LaunchWizardState {
@@ -8593,7 +8600,7 @@ mod tests {
     }
 
     #[test]
-    fn fable_reasoning_matches_opus_ladder_with_high_default() {
+    fn fable_reasoning_matches_opus_ladder_with_auto_default() {
         let values = claude_reasoning_values(&claude_state("fable", true));
         assert_eq!(
             values,
@@ -8605,7 +8612,7 @@ mod tests {
             .iter()
             .find(|option| option.is_default)
             .map(|option| option.stored_value);
-        assert_eq!(default, Some("high"));
+        assert_eq!(default, Some("auto"));
     }
 
     #[test]
@@ -8635,14 +8642,14 @@ mod tests {
     }
 
     #[test]
-    fn claude_sonnet_reasoning_default_is_high() {
-        // Claude Code model-config docs: default effort is `high` on
-        // Sonnet 4.6.
+    fn claude_sonnet_reasoning_default_is_auto() {
+        // Auto delegates the default effort to Claude Code itself
+        // (`high` on Sonnet 4.6 per the model-config docs).
         let default = super::CLAUDE_SONNET_REASONING_OPTIONS
             .iter()
             .find(|option| option.is_default)
             .expect("Sonnet reasoning options must have a default row");
-        assert_eq!(default.stored_value, "high");
+        assert_eq!(default.stored_value, "auto");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- PR #3009 の Codex レビュー指摘（AWS platform では `opus`→Opus 4.7 に解決され既定 `xhigh` のため、共有既定 `high` は環境によって Claude Code 本体と不一致）を受け、Claude の reasoning 既定を **Auto**（`CLAUDE_CODE_EFFORT_LEVEL` 非 export）に変更し、effort 既定の解決を Claude Code 自身の per-model 既定へ委譲する（SPEC-2014 2026-06-10 追記、ユーザー承認済み）。
- CodeRabbit 指摘の live E2E 期待値の陳腐化（sonnet 初期 `medium` assert）を解消し、wizardInteractionGuard の defer 設計に整合する形で spec を更新する。
- 併せて既存テスト flake #3006（fake gh compile の CWD race）を根本修正する。

## Context

- effort 既定は provider・モデル世代で異なる（Anthropic API: Opus 4.8/Fable 5=high、AWS platform: Opus 4.7=xhigh）。gwt 側のハードコードはどの値でも何処かの環境で stale になるため、値の追従ではなく委譲が構造的な解。
- E2E 調査の過程で、スライダーへのキー入力後に summary が更新されない事象を深掘りし、原因は SPEC-2014 2026-05-29 設計の wizardInteractionGuard（slider focus 中は `launch_wizard_state` 再レンダリングを defer、focusout で flush）であることを特定。実装のバグではなく、spec 側が focus を残したまま assert していたことが原因。

## Changes

- `crates/gwt/src/launch_wizard.rs`:
  - `CLAUDE_OPUS_REASONING_OPTIONS` / `CLAUDE_SONNET_REASONING_OPTIONS` の既定を `Auto` に変更（Codex の既定 medium は不変）
  - Auto の説明文を "Follow Claude Code's default effort for the model" に更新。委譲の設計理由をコメントで明記
  - テスト: 既定値 assert を auto に更新（opus / sonnet / fable）
- `crates/gwt/playwright/tests/launch-wizard-controls-live.spec.ts`: Auto 既定の初期状態（Auto ON・スライダー suspend）を検証し、Auto OFF→中央段 park→ArrowRight→`blur()` で guard 解放→summary 反映の順に修正
- `crates/gwt/src/cli/test_support.rs`: fake gh compile の rustc spawn に `.current_dir(bin_dir)` を明示（並列テストの CWD 無効化 race を解消、#3006）
- `.gwt/work/memory.md`: 再発防止 memory 2 件（既定値は委譲で解く / interaction guard と E2E assert の整合）

## Testing

- [x] `cargo test -p gwt-core -p gwt-agent -p gwt --all-features` — 2731 passed / 0 failed（base sync 後 `-p gwt` 再実行 1838 passed / 0 failed）
- [x] `cargo clippy --all-targets --all-features -- -D warnings` / `cargo fmt --check` — clean
- [x] Playwright live E2E `launch-wizard-controls-live.spec.ts` — fresh isolated gwt + `GWT_PLAYWRIGHT_BASE_URL` + `GWT_PLAYWRIGHT_PROJECT_ROOT` で **2 passed**（Target / Reasoning）
- [x] ユーザー視覚検証 — fresh isolated gwt で Claude 選択時に Auto トグル ON・スライダー suspend を確認（**User Verification Result: confirmed**）

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — 既定値（新規選択時の初期値）の変更のみ。明示選択した effort の export・永続化・選択肢は不変で、Auto は既存実装済みの選択肢
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- Closes #3006

## Related Issues / Links

- PR #3009 — 指摘元の Codex / CodeRabbit レビュースレッド（本 PR で対応）
- SPEC-2014 (#2014) — 2026-06-10 追記「Claude reasoning 既定を Auto（Claude Code 既定への委譲）に変更」
- #3010 — fable の version gating（スコープ外・別対応）

## Risk / Impact

- **Affected areas**: Launch Wizard の Claude reasoning 初期値のみ（high 固定 → Auto）。Auto 起動時は Claude Code 側の既定（ユーザーの settings.json の effortLevel があればそれ）が適用される
- **Rollback plan**: 該当 const の `is_default` を戻すだけで復元可能（1 commit revert）

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (if user-facing change) — N/A: README に effort 既定の記載なし、SPEC-2014 は更新済み
- [ ] Migration/backfill plan included (if schema/data change) — N/A: schema/data 変更なし
- [x] CHANGELOG impact considered (breaking change flagged in commit) — fix (patch)、breaking change なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Default reasoning effort is now set to "auto," allowing it to align with Claude Code's per-model defaults instead of a fixed value.

* **Tests**
  * Updated launch wizard E2E tests to verify auto toggle and slider interaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->