### PR TITLE
test(gwt): pin remaining fake gh rustc spawn in env tests

### DIFF
--- a/crates/gwt/src/cli/env/tests.rs
+++ b/crates/gwt/src/cli/env/tests.rs
@@ -129,7 +129,11 @@ match args.as_slice() {
     let source_path = bin_dir.join("gh.rs");
     fs::write(&source_path, source).expect("write fake gh source");
     let output_path = bin_dir.join(format!("gh{}", env::consts::EXE_SUFFIX));
+    // Pin the child's working directory: parallel tests may set the
+    // process-wide CWD to a tempdir that gets dropped, and rustc refuses to
+    // start from a deleted CWD ("Current directory is invalid", #3006).
     let status = std::process::Command::new("rustc")
+        .current_dir(bin_dir)
         .arg(&source_path)
         .arg("-o")
         .arg(&output_path)


### PR DESCRIPTION
## Summary

- PR #3012 の Codex レビュー指摘（"Pin every fake gh rustc spawn"）への対応。#3006 の CWD race 修正が `cli/test_support.rs` 側のみで、`cli/env/tests.rs` に重複する fake gh compiler が ambient CWD のまま `rustc` を spawn しており同じ flake が残るため、同一の `current_dir(bin_dir)` 固定を適用する。

## Changes

- `crates/gwt/src/cli/env/tests.rs`: fake gh compiler の rustc spawn に `.current_dir(bin_dir)` を明示（test_support.rs と同一パターン・同一コメント）

## Testing

- [x] `cargo test -p gwt --lib cli::env` — 6 passed / 0 failed
- [x] `cargo test -p gwt --all-features` — 1838 passed / 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` / `cargo fmt --check` — clean
- User Verification Result: n/a（テスト infra のみの変更で UI 影響なし）

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — テストコードのみの 4 行変更
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None（#3006 は PR #3012 で close 済み。本 PR は残存箇所の補完）

## Related Issues / Links

- PR #3012 — 指摘元の Codex レビュースレッド
- #3006 — 元の flake 報告

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (if user-facing change) — N/A: テストのみ
- [ ] Migration/backfill plan included (if schema/data change) — N/A
- [x] CHANGELOG impact considered — test (リリース対象外タイプ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
