### PR TITLE
fix(update): avoid UAC installer detection in Windows self-update helper spawn

### DIFF
--- a/.gwt/work/memory.md
+++ b/.gwt/work/memory.md
@@ -6836,3 +6836,10 @@ Type: failure-pattern
 Context: launch-wizard-controls-live.spec.ts の ArrowRight→summary assert が常に失敗。WS 送信・backend 適用は正常で、frontend の wizardInteractionGuard（SPEC-2014 2026-05-29）が slider focus 中の launch_wizard_state 再レンダリングを focusout まで defer していた。Playwright の press は focus を残すため summary が永遠に古いままになり、後続 probe の echo も全て deferred に飲まれて「backend が死んだ」ように見えた。
 Learning: guard は <select> と .launch-range__input の focus/pointer 中に activate され focusout/Escape で release される。slider 操作後の backend 反映を assert する E2E は blur() などで guard を先に解放する必要がある。
 Future Action: wizard の <select>/slider を操作する E2E・自動検証では、操作後に blur または別要素クリックを挟んでから backend 反映を assert する。「アクションが無視される」症状を見たら interaction guard の defer を最初に疑う。
+
+## 2026-06-10 — Windows 配布 exe には asInvoker manifest を必ず埋め込む
+
+Type: decision
+Context: Windows 自動更新で helper exe (gwt-update-helper.exe) の spawn が os error 740 で失敗 (#3018)。manifest 無しの exe は名前に update/setup/install/patch を含むと UAC Installer Detection で昇格要求され、CreateProcess は昇格できず ERROR_ELEVATION_REQUIRED になる。EnableInstallerDetection は Windows Home 既定有効でマシン依存再現。
+Learning: rustc は exe にデフォルト manifest を埋め込まない。winresource も set_manifest 明示時のみ。Microsoft 規定の対処は requestedExecutionLevel=asInvoker の manifest 埋め込みで、これが installer detection の off-switch になる。
+Future Action: Windows 向けバイナリを追加・リネームする際は (1) build.rs の set_manifest が適用されるか、(2) exe / 一時コピーの名前に installer-detection キーワードを含めないかを確認する。自己更新系の修正は実行中バイナリ側に効くため E2E は 2 リリース跨ぎになる前提で検証計画を立てる。

--- a/crates/gwt-core/src/update.rs
+++ b/crates/gwt-core/src/update.rs
@@ -829,14 +829,10 @@ impl UpdateManager {
             .join(format!("v{}", latest.trim().trim_start_matches('v')));
         fs::create_dir_all(&update_dir).map_err(|e| format!("Failed to create update dir: {e}"))?;
 
-        #[cfg(windows)]
-        let helper_name = "gwt-update-helper.exe".to_string();
-        #[cfg(not(windows))]
-        let helper_name = current_exe
-            .file_name()
-            .and_then(|s| s.to_str())
-            .map(|s| format!("{s}.update-helper"))
-            .unwrap_or_else(|| "gwt.update-helper".to_string());
+        let helper_name = helper_file_name(
+            cfg!(windows),
+            current_exe.file_name().and_then(|s| s.to_str()),
+        );
         let helper_path = update_dir.join(helper_name);
 
         fs::copy(current_exe, &helper_path)
@@ -1086,6 +1082,24 @@ pub fn internal_run_installer(
     {
         let _ = (target_exe, installer, installer_kind, args_file);
         Err("installer updates are not supported on this platform".to_string())
+    }
+}
+
+/// File name for the self-copy spawned to apply an update (#3018).
+///
+/// The Windows name must not contain UAC installer-detection keywords
+/// ("update", "setup", "install", "patch"): gwt.exe spawns this copy via
+/// CreateProcess, which cannot elevate, so a keyword match on a
+/// manifest-less executable fails with ERROR_ELEVATION_REQUIRED (os error
+/// 740) on machines where EnableInstallerDetection is on (Windows Home
+/// default).
+fn helper_file_name(windows: bool, current_exe_file_name: Option<&str>) -> String {
+    if windows {
+        "gwt-restart-helper.exe".to_string()
+    } else {
+        current_exe_file_name
+            .map(|s| format!("{s}.update-helper"))
+            .unwrap_or_else(|| "gwt.update-helper".to_string())
     }
 }
 
@@ -2316,6 +2330,32 @@ mod tests {
             &args_path,
         )
         .expect("spawn installer helper");
+    }
+
+    #[test]
+    fn windows_helper_file_name_avoids_uac_installer_detection_keywords() {
+        // #3018: spawning a manifest-less exe whose name matches UAC
+        // installer-detection keywords fails with os error 740.
+        let name = helper_file_name(true, Some("gwt.exe")).to_lowercase();
+        for keyword in ["update", "setup", "install", "patch"] {
+            assert!(
+                !name.contains(keyword),
+                "windows helper name {name:?} contains UAC installer-detection keyword {keyword:?}"
+            );
+        }
+        assert!(name.ends_with(".exe"));
+    }
+
+    #[test]
+    fn non_windows_helper_file_name_derives_from_current_exe() {
+        assert_eq!(
+            helper_file_name(false, Some("gwt")),
+            "gwt.update-helper".to_string()
+        );
+        assert_eq!(
+            helper_file_name(false, None),
+            "gwt.update-helper".to_string()
+        );
     }
 
     #[test]

--- a/crates/gwt/build.rs
+++ b/crates/gwt/build.rs
@@ -8,6 +8,21 @@ fn main() {
     resource.set("ProductName", "GWT");
     resource.set("CompanyName", "GWT Contributors");
     resource.set("LegalCopyright", "Copyright (c) GWT Contributors");
+    // #3018: without an embedded manifest declaring requestedExecutionLevel,
+    // UAC installer detection treats keyword-named copies of these binaries
+    // (e.g. the self-update helper) as legacy installers and CreateProcess
+    // fails with ERROR_ELEVATION_REQUIRED (os error 740).
+    resource.set_manifest(
+        r#"<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+<trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+        <requestedPrivileges>
+            <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+        </requestedPrivileges>
+    </security>
+</trustInfo>
+</assembly>"#,
+    );
 
     if let Err(error) = resource.compile() {
         panic!("failed to compile Windows resources: {error}");


### PR DESCRIPTION
## Summary

- Windows の自動更新で「Restart now」を押すと installer helper の spawn が `要求された操作には管理者特権が必要です。(os error 740)` で失敗する問題を修正する（#3018）。
- 原因は、manifest を持たない gwt.exe のコピー `gwt-update-helper.exe`（名前に "update" を含む）が UAC Installer Detection によりレガシーインストーラー扱いされ、昇格できない CreateProcess が ERROR_ELEVATION_REQUIRED で失敗すること。`EnableInstallerDetection` は Windows Home 既定有効のためマシン依存で再現する。
- MSI は `Scope="perUser"`（LocalAppData）であり本来昇格不要。manifest 埋め込み（Microsoft 規定の対処）と helper 名のキーワード回避の両方を入れる。

## Changes

- `crates/gwt/build.rs`: winresource `set_manifest` で `requestedExecutionLevel level="asInvoker"` の application manifest を gwt.exe / gwtd.exe に埋め込み。manifest を持つ exe は UAC Installer Detection の対象外になる。
- `crates/gwt-core/src/update.rs`: helper 名生成を `helper_file_name()` に抽出し、Windows helper 名を `gwt-update-helper.exe` → `gwt-restart-helper.exe` に変更（installer-detection キーワード update/setup/install/patch の回避）。非 Windows の `.update-helper` suffix は変更なし。キーワード回避を assert する単体テスト 2 件を追加。

## Testing

- [x] `cargo test -p gwt-core -p gwt --all-features` — 全 PASS（gwt-core 954 + gwt 545 + 統合スイート、base sync 後に再実行済み）
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — PASS
- [x] `cargo fmt --all -- --check` — PASS
- [x] TDD: `windows_helper_file_name_avoids_uac_installer_detection_keywords` を RED（旧名で fail）→ rename で GREEN を確認
- [ ] Windows 実機 E2E — リリース後にしか検証不可（下記 Remaining acceptance 参照）

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — 既存挙動の変更は helper ファイル名と embedded manifest のみで、単独でマージ・配信可能。非 Windows 経路は無変更。
- Known blockers: None
- Remaining acceptance: Windows 実機での E2E 確認は構造上 2 リリース跨ぎ（修正版を手動インストール → その次のリリースへの自動更新が 740 なしで成功することを確認）。配信 blocker ではなく、リリース後の観測タスクとして Issue #3018 に手順を記載済み。
- User Verification Result: skipped(リリース前に実機検証不可能 — ユーザーが明示的に Skip — proceed to PR を選択。次回リリースで E2E 確認)

## Closing Issues

- Closes #3018

## Related Issues / Links

- #3019（MSI インストール完了フィードバック UI、別対応）
- #2820（Windows MSI 診断スクリプト、同根の「画面が出ない」UX 報告）
- [Microsoft Learn: UAC settings and configuration](https://learn.microsoft.com/en-us/windows/security/application-security/application-control/user-account-control/settings-and-configuration)（`EnableInstallerDetection` は Home 既定有効）
- [rust-lang/rust#10512](https://github.com/rust-lang/rust/issues/10512)（manifest 無し exe は名前キーワードで UAC installer detection の対象）

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated — N/A: ユーザー向け挙動の変更はなし（修正のみ）
- [ ] Migration/backfill plan included — N/A: schema/data 変更なし
- [x] CHANGELOG impact considered（`fix:` patch リリース、breaking change なし）

## Risk / Impact

- **Affected areas**: Windows 自動更新の helper spawn 経路、Windows バイナリの embedded resources（manifest 追加）。
- **Rollback plan**: 本 PR の revert のみで戻る。manifest は最小構成（trustInfo/asInvoker のみ）で longPathAware 等は含めず、既存挙動への副作用を避けている。
- 制約: 修正は実行中バイナリ側に効くため、既存の 9.54.0 利用者の「修正版への自動更新」は依然 740 で失敗する。修正版を一度手動インストールすれば以降の自動更新から解消する。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows update helper executable naming scheme for better system compatibility.
  * Added application manifest configuration to Windows builds to properly define execution context requirements.

* **Tests**
  * Added unit tests validating Windows update helper filename conventions and non-Windows fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->