### PR TITLE
fix(windows): prefer Bun for Claude placeholder wrappers

### DIFF
--- a/crates/gwt-terminal/src/pty/windows_spawn.rs
+++ b/crates/gwt-terminal/src/pty/windows_spawn.rs
@@ -536,7 +536,7 @@ fn resolve_bun_placeholder_target(
     let cli_wrapper = package_root.join("cli-wrapper.cjs");
     if cli_wrapper.is_file() {
         return Some(WindowsSpawnTarget {
-            command: locate_node_runtime(env, remove_env),
+            command: locate_bun_runtime(env, remove_env),
             args_prefix: vec![cli_wrapper.display().to_string()],
         });
     }
@@ -599,10 +599,6 @@ fn locate_bun_runtime(env: &HashMap<String, String>, remove_env: &[String]) -> S
         return found;
     }
     "bun".to_string()
-}
-
-fn locate_node_runtime(env: &HashMap<String, String>, remove_env: &[String]) -> String {
-    find_executable_on_path("node.exe", env, remove_env).unwrap_or_else(|| "node".to_string())
 }
 
 fn find_executable_on_path(
@@ -1291,6 +1287,47 @@ mod tests {
             "expected cli-wrapper.cjs as first arg"
         );
         assert_eq!(normalized.args[1], "--version");
+    }
+
+    #[test]
+    fn claude_placeholder_stub_prefers_bun_runtime_when_node_is_absent() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let (bin_exe, _pkg_root, cli_wrapper) = fake_bun_install(
+            temp.path(),
+            "@anthropic-ai/claude-code",
+            "claude",
+            r#"{"bin":{"claude":"bin/claude.exe"}}"#,
+            "cli-wrapper.cjs",
+        );
+        std::fs::write(
+            &bin_exe,
+            "echo \"Error: claude native binary not installed.\" >&2\nexit 1\n",
+        )
+        .expect("write placeholder stub");
+        let bun_bin_dir = temp.path().join(".bun").join("bin");
+        std::fs::create_dir_all(&bun_bin_dir).expect("bun bin");
+        let bun_exe = bun_bin_dir.join("bun.exe");
+        std::fs::write(&bun_exe, b"MZ\x00").expect("bun.exe");
+
+        let mut env = HashMap::new();
+        env.insert("PATH".to_string(), bun_bin_dir.display().to_string());
+        env.insert("PATHEXT".to_string(), ".COM;.EXE;.BAT;.CMD".to_string());
+        env.insert(
+            "USERPROFILE".to_string(),
+            temp.path().join("no_bun").display().to_string(),
+        );
+
+        let normalized = normalized_config(
+            bin_exe.display().to_string().as_str(),
+            vec!["--version".to_string()],
+            env,
+        );
+
+        assert_eq!(normalized.command, bun_exe.display().to_string());
+        assert_eq!(
+            normalized.args,
+            vec![cli_wrapper.display().to_string(), "--version".to_string()]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Prefer Bun's runtime for Claude Code placeholder wrappers when Node is absent, so Bun-managed Windows installs do not fail with a missing `node` command.
- Stabilize the full-status refresh cooldown regression test by fixing its expected request before the background probe can update shared state.

## Changes

- `crates/gwt-terminal/src/pty/windows_spawn.rs`: Uses the existing Bun-aware runtime resolver for Bun placeholder `cli-wrapper.cjs` targets and adds regression coverage for Node-absent/Bun-present installs.
- `crates/gwt/src/project_index_bootstrap.rs`: Fixes a race in the cooldown test expectation that could fail on fast Linux CI runners.

## Testing

- [x] `cargo fmt -- --check` - PASS.
- [x] `git diff --check` - PASS.
- [x] `bunx commitlint --from origin/develop --to HEAD` - PASS.
- [x] `cargo test -p gwt-terminal` - PASS, 72 tests passed.
- [x] `cargo clippy -p gwt-terminal --all-targets --all-features -- -D warnings` - PASS.
- [x] `cargo test -p gwt --bin gwt project_index_bootstrap::tests::repeated_full_status_refresh_inside_cooldown_reuses_cached_status_probe -- --nocapture` - PASS.
- [x] GitHub CI for PR #3031 - PASS: Build, Check (Windows), Check (macOS), Test (Rust), Test (Rust, Windows), Test (Python runner), Cargo Deny, Clippy & Rustfmt, Commit Message Lint.
- [ ] `cargo test -p gwt --bin gwt` - FAIL locally on Windows, 523 passed / 16 failed in unrelated existing Board/env-lock/PATH tests after the focused CI failure test passed.

## PR Readiness

- State: Draft
- Releaseable slice: No; focused fixes and CI are complete, but full local verification is still blocked by unrelated Windows-local failures.
- Known blockers: Local Windows `cargo test -p gwt --bin gwt` has unrelated failures outside this follow-up diff.
- Remaining acceptance: Resolve or formally route the unrelated local full-gate failures before marking ready.

## Closing Issues

- None

## Related Issues / Links

- #2014
- #3027

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `svelte-check`) - Rust fmt and targeted clippy passed; `svelte-check` is not applicable.
- [x] Documentation updated (if user-facing change) - N/A, no user docs change.
- [x] Migration/backfill plan included (if schema/data change) - N/A, no schema or data migration.
- [x] CHANGELOG impact considered (breaking change flagged in commit) - Patch fix, no breaking change.

## Context

- Follow-up to review feedback on #3027: the placeholder wrapper path should not require Node when Bun is the available package runtime.

## Risk / Impact

- **Affected areas**: Windows command normalization for Bun-managed Claude Code installs and one timing-sensitive project-index test.
- **Rollback plan**: Revert this PR; Bun-managed Claude placeholder wrappers without Node may again fail to launch through the wrapper path.