### PR TITLE
fix(window-tabs): prevent activation flicker

### DIFF
--- a/crates/gwt/playwright/tests/_helpers/embedded-frontend.ts
+++ b/crates/gwt/playwright/tests/_helpers/embedded-frontend.ts
@@ -40,6 +40,7 @@ const ROOT_MODULES = new Set([
   "operator-shell.js",
   "project-clone-modal.js",
   "project-tabs-renderer.js",
+  "window-tabs-renderer.js",
   // SPEC-3015 — generated protocol enum contract + extracted window runtime
   // state helpers.
   "protocol-enums.js",

--- a/crates/gwt/src/embedded_web.rs
+++ b/crates/gwt/src/embedded_web.rs
@@ -92,6 +92,10 @@ root_js_modules! {
     // project tab id so status-only workspace refreshes do not rebuild the
     // whole tab strip.
     "project-tabs-renderer.js" => "renderProjectTabs",
+    // SPEC-2008 Phase 34 — stable window tab renderer. Keeps grouped-window
+    // tab DOM keyed by window id so active-tab switches do not blank/rebuild
+    // the tab strip or disturb the terminal body.
+    "window-tabs-renderer.js" => "renderWindowTabs",
     // SPEC-1939 Phase 12 / T-IDX-106 — Settings.Index tab renderer.
     "index-settings-panel.js" => "renderIndexSettingsPanel",
     // SPEC-2008 Phase 24 — terminal viewport reflow primitives.

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -15,6 +15,10 @@ const projectTabsRendererSource = readFileSync(
   resolve(here, "../project-tabs-renderer.js"),
   "utf8",
 );
+const windowTabsRendererSource = readFileSync(
+  resolve(here, "../window-tabs-renderer.js"),
+  "utf8",
+);
 const branchCleanupSource = readFileSync(resolve(here, "../branch-cleanup-modal.js"), "utf8");
 const branchListStateSource = readFileSync(resolve(here, "../branch-list-state.js"), "utf8");
 const windowDockingSource = readFileSync(resolve(here, "../window-docking.js"), "utf8");
@@ -1177,7 +1181,7 @@ test("workspace windows expose draggable tab docking affordances", () => {
     "expected tab drag outside a group to send detach_window_tab",
   );
   assert.match(
-    appSource,
+    `${appSource}\n${windowTabsRendererSource}`,
     /kind:\s*"activate_window_tab"/,
     "expected tab click to activate a grouped window tab",
   );
@@ -1195,6 +1199,52 @@ test("workspace windows expose draggable tab docking affordances", () => {
     inlineStyle,
     /\.workspace-window\.dock-target\s+\.window-tab-strip::before/,
     "expected dockable targets to expose a tab insertion indicator",
+  );
+});
+
+test("Window tab activation updates tab chrome in place without remounting terminal body", () => {
+  assert.match(
+    appSource,
+    /from\s+"\/window-tabs-renderer\.js"/,
+    "app.js must use the extracted stable window tab renderer",
+  );
+  const renderTabsBody = extractFunctionBody(appSource, "renderWindowTabs");
+  assert.match(
+    renderTabsBody,
+    /renderWindowTabsView\(\{/,
+    "window tab chrome updates must be delegated to the stable renderer",
+  );
+  assert.doesNotMatch(
+    renderTabsBody,
+    /innerHTML\s*=/,
+    "window tab activation must not clear and rebuild the tab strip",
+  );
+  assert.doesNotMatch(
+    windowTabsRendererSource,
+    /innerHTML\s*=/,
+    "stable window tab renderer must update keyed tab nodes in place",
+  );
+  assert.match(
+    windowTabsRendererSource,
+    /dataset\.windowTabId/,
+    "stable window tab renderer must key DOM nodes by window id",
+  );
+
+  const ensureWindowBody = extractFunctionBody(appSource, "ensureWindow");
+  const mountCalls =
+    ensureWindowBody.match(/mountWindowBody\(windowData,\s*element\)/g) || [];
+  assert.equal(
+    mountCalls.length,
+    1,
+    "terminal body mounting must remain limited to the preset-change path",
+  );
+  const mountIndex = ensureWindowBody.indexOf("mountWindowBody(windowData, element);");
+  const renderKeyIndex = ensureWindowBody.indexOf(
+    "const nextWindowElementKey = windowElementRenderKey(windowData);",
+  );
+  assert.ok(
+    mountIndex !== -1 && renderKeyIndex !== -1 && mountIndex < renderKeyIndex,
+    "window render-key updates, including tab_group_active changes, must run after the body mount guard",
   );
 });
 

--- a/crates/gwt/web/__tests__/window-tabs-renderer.test.mjs
+++ b/crates/gwt/web/__tests__/window-tabs-renderer.test.mjs
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseHTML } from "linkedom";
+
+import { renderWindowTabs } from "../window-tabs-renderer.js";
+
+const DEFAULT_TABS = [
+  { id: "win-1", title: "Agent One", preset: "codex" },
+  { id: "win-2", title: "Agent Two", preset: "claude" },
+];
+
+function setupDom() {
+  const { document } = parseHTML('<div class="window-tab-strip"></div>');
+  return {
+    strip: document.querySelector(".window-tab-strip"),
+  };
+}
+
+function render(deps = {}) {
+  const { strip = setupDom().strip, sends = [], drags = [] } = deps;
+  renderWindowTabs({
+    strip,
+    tabs: deps.tabs ?? DEFAULT_TABS,
+    activeWindowId: deps.activeWindowId ?? "win-1",
+    tooltipForWindow:
+      deps.tooltipForWindow ?? ((tab) => `Tooltip for ${tab.title}`),
+    send: deps.send ?? ((payload) => sends.push(payload)),
+    onTabDragStart:
+      deps.onTabDragStart ?? ((event, id) => drags.push(["start", id])),
+    onTabDrag: deps.onTabDrag ?? ((event, id) => drags.push(["drag", id])),
+    onTabDragEnd:
+      deps.onTabDragEnd ?? ((event, id) => drags.push(["end", id])),
+  });
+  return { strip, sends, drags };
+}
+
+test("renderWindowTabs preserves tab DOM across active-tab changes", () => {
+  const { strip } = setupDom();
+
+  render({ strip });
+  const firstItem = strip.querySelector('[data-window-tab-id="win-1"]');
+  const secondItem = strip.querySelector('[data-window-tab-id="win-2"]');
+  const firstButton = firstItem.querySelector(".window-tab");
+  const secondButton = secondItem.querySelector(".window-tab");
+  const firstClose = firstItem.querySelector(".window-tab-close");
+
+  render({
+    strip,
+    activeWindowId: "win-2",
+    tabs: [
+      { id: "win-1", title: "Agent One Updated", preset: "codex" },
+      { id: "win-2", title: "Agent Two", preset: "claude" },
+    ],
+  });
+
+  assert.equal(
+    strip.querySelector('[data-window-tab-id="win-1"]'),
+    firstItem,
+    "window tab item must be updated in place instead of recreated",
+  );
+  assert.equal(
+    strip.querySelector('[data-window-tab-id="win-2"]'),
+    secondItem,
+    "active tab changes must not recreate sibling tab items",
+  );
+  assert.equal(firstItem.querySelector(".window-tab"), firstButton);
+  assert.equal(secondItem.querySelector(".window-tab"), secondButton);
+  assert.equal(firstItem.querySelector(".window-tab-close"), firstClose);
+  assert.equal(firstButton.textContent, "Agent One Updated");
+  assert.equal(firstButton.title, "Tooltip for Agent One Updated");
+  assert.equal(
+    firstButton.getAttribute("aria-label"),
+    "Activate Agent One Updated",
+  );
+  assert.equal(
+    firstClose.getAttribute("aria-label"),
+    "Close Agent One Updated",
+  );
+  assert.equal(firstButton.getAttribute("aria-current"), null);
+  assert.equal(secondButton.getAttribute("aria-current"), "page");
+  assert.equal(firstButton.classList.contains("active"), false);
+  assert.equal(secondButton.classList.contains("active"), true);
+  assert.equal(secondButton.draggable, true);
+});
+
+test("renderWindowTabs keeps one activate/close binding per stable tab node", () => {
+  const { strip } = setupDom();
+  const sends = [];
+
+  render({ strip, sends });
+  render({ strip, sends, activeWindowId: "win-2" });
+  render({ strip, sends, activeWindowId: "win-1" });
+
+  const firstButton = strip.querySelector(
+    '[data-window-tab-id="win-1"] .window-tab',
+  );
+  firstButton.dispatchEvent(
+    new firstButton.ownerDocument.defaultView.Event("click", {
+      bubbles: true,
+    }),
+  );
+
+  const secondClose = strip.querySelector(
+    '[data-window-tab-id="win-2"] .window-tab-close',
+  );
+  secondClose.dispatchEvent(
+    new secondClose.ownerDocument.defaultView.Event("click", {
+      bubbles: true,
+    }),
+  );
+
+  assert.deepEqual(sends, [
+    { kind: "activate_window_tab", id: "win-1" },
+    { kind: "close_window", id: "win-2" },
+  ]);
+});
+
+test("renderWindowTabs reorders and removes tabs without rebuilding kept nodes", () => {
+  const { strip } = setupDom();
+
+  render({ strip });
+  const firstItem = strip.querySelector('[data-window-tab-id="win-1"]');
+
+  render({
+    strip,
+    activeWindowId: "win-3",
+    tabs: [
+      { id: "win-3", title: "Agent Three", preset: "agent" },
+      { id: "win-1", title: "Agent One", preset: "codex" },
+    ],
+  });
+
+  assert.equal(strip.children.length, 2);
+  assert.equal(strip.children[0].dataset.windowTabId, "win-3");
+  assert.equal(strip.children[1], firstItem);
+  assert.equal(strip.querySelector('[data-window-tab-id="win-2"]'), null);
+});
+
+test("renderWindowTabs drag callbacks read the current tab id after rerender", () => {
+  const { strip } = setupDom();
+  const drags = [];
+
+  render({ strip, drags });
+  render({
+    strip,
+    drags,
+    tabs: [
+      { id: "win-1", title: "Agent One Updated", preset: "codex" },
+      { id: "win-2", title: "Agent Two", preset: "claude" },
+    ],
+  });
+
+  const firstButton = strip.querySelector(
+    '[data-window-tab-id="win-1"] .window-tab',
+  );
+  const event = (type) =>
+    new firstButton.ownerDocument.defaultView.Event(type, { bubbles: true });
+  firstButton.dispatchEvent(event("dragstart"));
+  firstButton.dispatchEvent(event("drag"));
+  firstButton.dispatchEvent(event("dragend"));
+
+  assert.deepEqual(drags, [
+    ["start", "win-1"],
+    ["drag", "win-1"],
+    ["end", "win-1"],
+  ]);
+});

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -38,6 +38,7 @@
         renderProjectTabs as renderProjectTabsView,
         updateProjectTabDot as updateProjectTabDotView,
       } from "/project-tabs-renderer.js";
+      import { renderWindowTabs as renderWindowTabsView } from "/window-tabs-renderer.js";
       import { renderCloseProjectTabConfirmModal } from "/close-project-tab-confirm-modal.js";
       import { renderIndexSettingsPanel } from "/index-settings-panel.js";
       import { renderCustomAgentEnvEditor } from "/custom-agent-env-editor.js";
@@ -4553,46 +4554,28 @@
       function renderWindowTabs(windowData, element) {
         const strip = element.querySelector(".window-tab-strip");
         if (!strip) return;
-        const tabs = windowTabsFor(windowData);
-        strip.innerHTML = "";
-        for (const tab of tabs) {
-          const tabItem = document.createElement("div");
-          tabItem.className = "window-tab-item";
-          const tabButton = document.createElement("button");
-          tabButton.type = "button";
-          tabButton.className = "window-tab";
-          tabButton.draggable = true;
-          tabButton.dataset.windowTabId = tab.id;
-          tabButton.setAttribute("aria-label", `Activate ${tab.title}`);
-          if (tab.id === windowData.id || tab.tab_group_active) {
-            tabButton.classList.add("active");
-            tabButton.setAttribute("aria-current", "page");
-          }
-          tabButton.textContent = tab.title;
-          // Native tooltip with the full window title (or dynamic detail) so a
-          // tab truncated by max-width still reveals its title on hover. Mirrors
-          // the titlebar (titleText.title) and window-list row tooltips.
-          tabButton.title = windowTitleTooltip(tab);
-          tabButton.addEventListener("click", (event) => {
-            event.stopPropagation();
-            send({ kind: "activate_window_tab", id: tab.id });
-          });
-          tabButton.addEventListener("dragstart", (event) => {
+        renderWindowTabsView({
+          strip,
+          tabs: windowTabsFor(windowData),
+          activeWindowId: windowData.id,
+          tooltipForWindow: windowTitleTooltip,
+          send,
+          onTabDragStart: (event, tabId) => {
             windowTabDragState = {
-              id: tab.id,
+              id: tabId,
               docked: false,
               lastClientPoint: clientPointFromDragEvent(
                 event,
                 canvas.getBoundingClientRect(),
               ),
             };
-            event.dataTransfer?.setData("text/plain", tab.id);
+            event.dataTransfer?.setData("text/plain", tabId);
             if (event.dataTransfer) {
               event.dataTransfer.effectAllowed = "move";
             }
-          });
-          tabButton.addEventListener("drag", trackWindowTabDragPoint);
-          tabButton.addEventListener("dragend", (event) => {
+          },
+          onTabDrag: trackWindowTabDragPoint,
+          onTabDragEnd: (event) => {
             const drag = windowTabDragState;
             trackWindowTabDragPoint(event);
             windowTabDragState = null;
@@ -4606,20 +4589,8 @@
               id: drag.id,
               geometry,
             });
-          });
-          const closeButton = document.createElement("button");
-          closeButton.type = "button";
-          closeButton.className = "window-tab-close";
-          closeButton.setAttribute("aria-label", `Close ${tab.title}`);
-          closeButton.textContent = "×";
-          closeButton.addEventListener("click", (event) => {
-            event.stopPropagation();
-            send({ kind: "close_window", id: tab.id });
-          });
-          tabItem.appendChild(tabButton);
-          tabItem.appendChild(closeButton);
-          strip.appendChild(tabItem);
-        }
+          },
+        });
       }
 
       function handleTitlebarClick(windowId) {

--- a/crates/gwt/web/window-tabs-renderer.js
+++ b/crates/gwt/web/window-tabs-renderer.js
@@ -1,0 +1,159 @@
+function ensureChild(parent, selector, create) {
+  const existing = parent.querySelector(selector);
+  if (existing) {
+    return existing;
+  }
+  const child = create(parent.ownerDocument);
+  parent.appendChild(child);
+  return child;
+}
+
+function tabTitle(tab) {
+  return String(tab?.title || "Window");
+}
+
+function tabIdFromItem(item) {
+  return item?.dataset?.windowTabId || "";
+}
+
+function itemActions(item) {
+  return item.__windowTabActions || {};
+}
+
+function createTabButton(document, item) {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "window-tab";
+  button.draggable = true;
+
+  button.addEventListener("click", (event) => {
+    event.stopPropagation();
+    const id = tabIdFromItem(item);
+    itemActions(item).send?.({ kind: "activate_window_tab", id });
+  });
+  button.addEventListener("dragstart", (event) => {
+    itemActions(item).onTabDragStart?.(event, tabIdFromItem(item));
+  });
+  button.addEventListener("drag", (event) => {
+    itemActions(item).onTabDrag?.(event, tabIdFromItem(item));
+  });
+  button.addEventListener("dragend", (event) => {
+    itemActions(item).onTabDragEnd?.(event, tabIdFromItem(item));
+  });
+
+  return button;
+}
+
+function createCloseButton(document, item) {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "window-tab-close";
+  button.textContent = "×";
+  button.addEventListener("click", (event) => {
+    event.stopPropagation();
+    const id = tabIdFromItem(item);
+    itemActions(item).send?.({ kind: "close_window", id });
+  });
+  return button;
+}
+
+function createTabItem(document, actions) {
+  const item = document.createElement("div");
+  item.className = "window-tab-item";
+  item.__windowTabActions = actions;
+  item.appendChild(createTabButton(document, item));
+  item.appendChild(createCloseButton(document, item));
+  return item;
+}
+
+function updateTabItem(item, tab, { activeWindowId, tooltipForWindow, actions }) {
+  const title = tabTitle(tab);
+  const active = tab.id === activeWindowId || Boolean(tab.tab_group_active);
+  item.__windowTabActions = actions;
+  item.dataset.windowTabId = tab.id;
+
+  const tabButton = ensureChild(item, ".window-tab", (document) =>
+    createTabButton(document, item),
+  );
+  tabButton.type = "button";
+  tabButton.className = "window-tab";
+  tabButton.draggable = true;
+  tabButton.dataset.windowTabId = tab.id;
+  tabButton.setAttribute("aria-label", `Activate ${title}`);
+  tabButton.classList.toggle("active", active);
+  if (active) {
+    tabButton.setAttribute("aria-current", "page");
+  } else {
+    tabButton.removeAttribute("aria-current");
+  }
+  tabButton.textContent = title;
+  tabButton.title =
+    typeof tooltipForWindow === "function" ? tooltipForWindow(tab) : title;
+
+  const closeButton = ensureChild(item, ".window-tab-close", (document) =>
+    createCloseButton(document, item),
+  );
+  closeButton.type = "button";
+  closeButton.className = "window-tab-close";
+  closeButton.setAttribute("aria-label", `Close ${title}`);
+  closeButton.textContent = "×";
+}
+
+export function renderWindowTabs({
+  strip,
+  tabs,
+  activeWindowId,
+  tooltipForWindow,
+  send,
+  onTabDragStart,
+  onTabDrag,
+  onTabDragEnd,
+}) {
+  if (!strip) {
+    return;
+  }
+  const document = strip.ownerDocument;
+  const nextTabs = Array.isArray(tabs) ? tabs : [];
+  const nextIds = new Set(nextTabs.map((tab) => tab.id));
+  const actions = {
+    send,
+    onTabDragStart,
+    onTabDrag,
+    onTabDragEnd,
+  };
+
+  const existingItems = new Map();
+  for (let index = strip.children.length - 1; index >= 0; index -= 1) {
+    const item = strip.children[index];
+    if (
+      !item.classList?.contains("window-tab-item") ||
+      !item.dataset?.windowTabId
+    ) {
+      continue;
+    }
+    const id = item.dataset.windowTabId;
+    if (!nextIds.has(id)) {
+      item.remove();
+      continue;
+    }
+    existingItems.set(id, item);
+  }
+
+  for (let index = 0; index < nextTabs.length; index += 1) {
+    const tab = nextTabs[index];
+    let item = existingItems.get(tab.id);
+    if (!item) {
+      item = createTabItem(document, actions);
+    }
+    updateTabItem(item, tab, {
+      activeWindowId,
+      tooltipForWindow,
+      actions,
+    });
+
+    const current = strip.children[index] || null;
+    if (current !== item) {
+      strip.insertBefore(item, current);
+    }
+  }
+}

--- a/scripts/check-frontend-bundle.sh
+++ b/scripts/check-frontend-bundle.sh
@@ -1,34 +1,52 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-node --check crates/gwt/web/app.js
-node --check crates/gwt/web/branch-cleanup-modal.js
-node --check crates/gwt/web/branch-list-state.js
-node --check crates/gwt/web/migration-modal.js
-node --check crates/gwt/web/project-clone-modal.js
-node --check crates/gwt/web/board-surface.js
-node --check crates/gwt/web/workspace-kanban-surface.js
-node --check crates/gwt/web/theme-manager.js
-node --check crates/gwt/web/theme-toggle.js
-node --check crates/gwt/web/hotkey.js
-node --check crates/gwt/web/operator-shell.js
-node --check crates/gwt/web/focus-trap.js
-node --check crates/gwt/web/window-docking.js
-node --check crates/gwt/web/update-cta.js
-node --check crates/gwt/web/terminal-context-menu.js
-node --check crates/gwt/web/terminal-wheel-scroll.js
-node --check crates/gwt/web/terminal-output-buffer.js
-node --check crates/gwt/web/canvas-wheel-gesture.js
-node --check crates/gwt/web/window-geometry-sync.js
-node --check crates/gwt/web/custom-agent-env-editor.js
-node --check crates/gwt/web/socket-receive-dispatcher.js
-node --check crates/gwt/web/interaction-guard.js
-node --check crates/gwt/web/viewport-persist-throttle.js
-node --check crates/gwt/web/viewport-sync.js
-node --check crates/gwt/web/project-tabs-renderer.js
-node --check crates/gwt/web/clone-modal-focus-guard.js
-node --check crates/gwt/web/ui-trace-profiler.js
-node --check crates/gwt/web/ui-trace-wiring.js
-node --check crates/gwt/web/close-project-tab-confirm-modal.js
-node --check crates/gwt/web/release-notes-window.js
-node --check crates/gwt/web/console-window.js
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMPDIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+printf '{"private":true,"type":"module"}\n' > "$TMPDIR/package.json"
+ln -s "$ROOT/crates" "$TMPDIR/crates"
+
+cd "$TMPDIR"
+
+node_check() {
+  node --preserve-symlinks --preserve-symlinks-main --check "$1"
+}
+
+node_check crates/gwt/web/app.js
+node_check crates/gwt/web/branch-cleanup-modal.js
+node_check crates/gwt/web/branch-list-state.js
+node_check crates/gwt/web/migration-modal.js
+node_check crates/gwt/web/project-clone-modal.js
+node_check crates/gwt/web/board-surface.js
+node_check crates/gwt/web/workspace-kanban-surface.js
+node_check crates/gwt/web/theme-manager.js
+node_check crates/gwt/web/theme-toggle.js
+node_check crates/gwt/web/hotkey.js
+node_check crates/gwt/web/operator-shell.js
+node_check crates/gwt/web/focus-trap.js
+node_check crates/gwt/web/window-docking.js
+node_check crates/gwt/web/update-cta.js
+node_check crates/gwt/web/terminal-context-menu.js
+node_check crates/gwt/web/terminal-wheel-scroll.js
+node_check crates/gwt/web/terminal-output-buffer.js
+node_check crates/gwt/web/canvas-wheel-gesture.js
+node_check crates/gwt/web/window-geometry-sync.js
+node_check crates/gwt/web/custom-agent-env-editor.js
+node_check crates/gwt/web/socket-receive-dispatcher.js
+node_check crates/gwt/web/interaction-guard.js
+node_check crates/gwt/web/viewport-persist-throttle.js
+node_check crates/gwt/web/viewport-sync.js
+node_check crates/gwt/web/project-tabs-renderer.js
+node_check crates/gwt/web/window-tabs-renderer.js
+node_check crates/gwt/web/clone-modal-focus-guard.js
+node_check crates/gwt/web/ui-trace-profiler.js
+node_check crates/gwt/web/ui-trace-wiring.js
+node_check crates/gwt/web/close-project-tab-confirm-modal.js
+node_check crates/gwt/web/release-notes-window.js
+node_check crates/gwt/web/console-window.js

--- a/scripts/run-frontend-unit-tests.sh
+++ b/scripts/run-frontend-unit-tests.sh
@@ -40,6 +40,7 @@ bash scripts/run-node-tests-with-linkedom.sh \
   crates/gwt/web/__tests__/viewport-persist-throttle.test.mjs \
   crates/gwt/web/__tests__/viewport-sync.test.mjs \
   crates/gwt/web/__tests__/project-tabs-renderer.test.mjs \
+  crates/gwt/web/__tests__/window-tabs-renderer.test.mjs \
   crates/gwt/web/__tests__/project-tab-style.test.mjs \
   crates/gwt/web/__tests__/playwright-embedded-routes.test.mjs \
   crates/gwt/web/__tests__/viewport-persist-wiring.test.mjs \

--- a/scripts/run-node-tests-with-linkedom.sh
+++ b/scripts/run-node-tests-with-linkedom.sh
@@ -10,7 +10,9 @@ cleanup() {
 trap cleanup EXIT
 
 printf '{"private":true,"type":"module"}\n' > "$TMPDIR/package.json"
-bun install --cwd "$TMPDIR" linkedom@0.18.12 >/dev/null
+if ! bun install --cwd "$TMPDIR" linkedom@0.18.12 >/dev/null 2>"$TMPDIR/bun-install.err"; then
+  npm install --prefix "$TMPDIR" linkedom@0.18.12 >/dev/null
+fi
 
 ln -s "$ROOT/crates" "$TMPDIR/crates"
 

--- a/scripts/run-visual-tests.sh
+++ b/scripts/run-visual-tests.sh
@@ -5,7 +5,6 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PLAYWRIGHT_VERSION="${GWT_PLAYWRIGHT_VERSION:-1.49.1}"
 PLAYWRIGHT_DEPS_DIR="${GWT_PLAYWRIGHT_DEPS_DIR:-${TMPDIR:-/tmp}/gwt-playwright-${PLAYWRIGHT_VERSION}}"
 PLAYWRIGHT_NODE_MODULES="${PLAYWRIGHT_DEPS_DIR}/node_modules"
-PLAYWRIGHT_BIN="${PLAYWRIGHT_NODE_MODULES}/.bin/playwright"
 PLAYWRIGHT_RESOLVER="${PLAYWRIGHT_DEPS_DIR}/resolve-playwright.cjs"
 RUN_DIR="$(mktemp -d)"
 
@@ -16,14 +15,41 @@ trap cleanup EXIT
 
 mkdir -p "${PLAYWRIGHT_DEPS_DIR}"
 
-if [[ ! -x "${PLAYWRIGHT_BIN}" ]]; then
+resolve_playwright_bin() {
+  local base="${PLAYWRIGHT_NODE_MODULES}/.bin/playwright"
+  local candidate
+  for candidate in "$base" "${base}.exe" "${base}.cmd"; do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+install_playwright_deps() {
+  if command -v bun >/dev/null 2>&1 && bun install --silent; then
+    return 0
+  fi
+  npm install --silent --no-audit --no-fund --package-lock=false
+}
+
+PLAYWRIGHT_BIN="$(resolve_playwright_bin || true)"
+
+if [[ -z "${PLAYWRIGHT_BIN}" ]]; then
   cat >"${PLAYWRIGHT_DEPS_DIR}/package.json" <<JSON
 {"private":true,"dependencies":{"@playwright/test":"${PLAYWRIGHT_VERSION}"}}
 JSON
   (
     cd "${PLAYWRIGHT_DEPS_DIR}"
-    bun install --silent
+    install_playwright_deps
   )
+  PLAYWRIGHT_BIN="$(resolve_playwright_bin || true)"
+fi
+
+if [[ -z "${PLAYWRIGHT_BIN}" ]]; then
+  echo "[FAIL] Playwright binary was not installed in ${PLAYWRIGHT_NODE_MODULES}/.bin" >&2
+  exit 1
 fi
 
 cat >"${PLAYWRIGHT_RESOLVER}" <<'JS'

--- a/scripts/test_release_assets.cjs
+++ b/scripts/test_release_assets.cjs
@@ -197,19 +197,25 @@ run("frontend bundle check keeps the GUI front door explicit", () => {
   // expressed as required substrings so future modules can extend the chain
   // without rewriting the test, while still keeping the legacy SPEC-2008
   // surfaces (app, branch-cleanup-modal, migration-modal) wired up.
+  assert.ok(
+    bundleScript.includes("node --check") ||
+      bundleScript.includes("--check \"$1\""),
+    "check-frontend-bundle.sh must call node with --check"
+  );
   for (const required of [
-    "node --check crates/gwt/web/app.js",
-    "node --check crates/gwt/web/branch-cleanup-modal.js",
-    "node --check crates/gwt/web/migration-modal.js",
-    "node --check crates/gwt/web/theme-manager.js",
-    "node --check crates/gwt/web/theme-toggle.js",
-    "node --check crates/gwt/web/hotkey.js",
-    "node --check crates/gwt/web/operator-shell.js",
-    "node --check crates/gwt/web/focus-trap.js",
+    "crates/gwt/web/app.js",
+    "crates/gwt/web/branch-cleanup-modal.js",
+    "crates/gwt/web/migration-modal.js",
+    "crates/gwt/web/theme-manager.js",
+    "crates/gwt/web/theme-toggle.js",
+    "crates/gwt/web/hotkey.js",
+    "crates/gwt/web/operator-shell.js",
+    "crates/gwt/web/focus-trap.js",
   ]) {
     assert.ok(
-      bundleScript.includes(required),
-      `check-frontend-bundle.sh must include "${required}"`
+      bundleScript.includes(`node --check ${required}`) ||
+        bundleScript.includes(`node_check ${required}`),
+      `check-frontend-bundle.sh must include a node syntax check for "${required}"`
     );
   }
 });


### PR DESCRIPTION
## Summary

- Preserve window tab DOM nodes across active-tab changes so terminal panes do not remount or flash when users switch grouped Agent tabs.
- Add focused renderer coverage and embedded asset registration for the new stable tab-strip renderer.
- Harden frontend verification scripts so module-aware bundle checks and Windows/WSL Playwright setup stay covered by release contracts.

## Changes

- `crates/gwt/web/window-tabs-renderer.js`: adds a keyed in-place renderer that updates tab label, tooltip, active state, ARIA state, close action, and drag callbacks without rebuilding retained tab buttons.
- `crates/gwt/web/app.js`: delegates grouped window tab rendering to the stable renderer while preserving activation, close, dock, and detach behavior.
- `crates/gwt/web/__tests__/window-tabs-renderer.test.mjs`: covers DOM preservation, single handler binding, reorder/removal behavior, and current drag callback state.
- `crates/gwt/web/__tests__/operator-chrome-structure.test.mjs`: locks the app import and renderer contract so tab activation does not return to destructive `innerHTML` rebuilding.
- `crates/gwt/src/embedded_web.rs` and `crates/gwt/playwright/tests/_helpers/embedded-frontend.ts`: register and serve `/window-tabs-renderer.js` for embedded/runtime and Playwright routes.
- `scripts/check-frontend-bundle.sh`, `scripts/run-node-tests-with-linkedom.sh`, `scripts/run-frontend-unit-tests.sh`, and `scripts/run-visual-tests.sh`: include the new module in frontend checks and make Windows/WSL test dependency setup more robust.
- `scripts/test_release_assets.cjs`: accepts the module-aware `node_check <path>` bundle syntax-check helper while preserving the release contract that the GUI front door is checked.

## Testing

- [x] `bash scripts/check-frontend-bundle.sh` — PASS.
- [x] `bash scripts/run-frontend-unit-tests.sh` — PASS, 753 tests passed.
- [x] `cargo test -p gwt embedded_web --all-features` — PASS, 104 tests passed.
- [x] `cargo fmt --check` — PASS.
- [x] `git diff --check` — PASS.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — PASS.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — PASS.
- [x] `node scripts/test_release_assets.cjs` — PASS.
- [x] `bash scripts/check-release-flow.sh` — PASS.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — PASS for new commits.
- [x] Manual visual smoke: launched a fresh debug GUI at `http://127.0.0.1:55350/`; the user confirmed the grouped Agent tab switching behavior with `OK` on 2026-06-10.
- [ ] `bash scripts/run-visual-tests.sh` — blocked by WSL Playwright host dependencies missing `libnss3`, `libnspr4`, and `libasound2t64`; `sudo -n apt-get install ...` failed because sudo requires a password.
- [ ] `cargo test -p gwt-core -p gwt --all-features` — fails 5 existing Windows/env-sensitive tests outside this frontend diff: `cli::tray::autostart::tests::legacy_launch_agent_path_is_user_scoped`, `cli::tray::lock::tests::second_acquire_for_same_user_reports_already_running`, `cli::tray::lock::tests::set_url_updates_lock_payload_in_place`, `cli::workspace::tests::workspace_update_agent_session_uses_stored_project_state_root`, and `cli::workspace::tests::workspace_update_repairs_split_agent_title_into_canonical_root`.

## PR Readiness

- State: Draft
- Releaseable slice: No for Ready review because the pre-PR gate still has local tooling/full-suite blockers, although the window-tab UX slice itself is implemented and user-confirmed.
- Known blockers: WSL Playwright browser host dependencies are missing, and the broad Windows cargo suite still fails 5 baseline tray/workspace tests unrelated to the frontend tab renderer diff.
- Remaining acceptance: Install/fix the Playwright host dependencies, rerun `bash scripts/run-visual-tests.sh`, resolve or classify the 5 full-suite cargo failures, then promote to Ready only after the pre-PR gate is clean.

## Closing Issues

- None

## Related Issues / Links

- #2008

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`; no `svelte-check` in this checkout)
- [x] Documentation updated (N/A: no README/user command docs changed; SPEC #2008 Phase 34 carries the acceptance notes)
- [x] Migration/backfill plan included (N/A: no schema or data migration)
- [x] CHANGELOG impact considered (patch-level fix, no breaking change)

## Context

- Tab activation inside grouped Agent windows rebuilt the tab strip nodes and produced visible redraw/flicker during normal use.
- The fix keeps tab-strip DOM identity stable across activation updates and limits rerendering to state synchronization.

## Risk / Impact

- **Affected areas**: grouped window tabs, Agent terminal tab activation, tab close, tab drag/dock/detach, embedded frontend asset routing, frontend test runners.
- **Rollback plan**: revert the window tab renderer commit and the related frontend verification script commits; no persisted data migration is involved.

## Screenshots

| Before | After |
|--------|-------|
| User-provided MP4 showed visible redraw/flicker on every grouped Agent tab switch. | Fresh debug GUI at `http://127.0.0.1:55350/` was manually checked by the user and confirmed with `OK`. |
