### PR TITLE
feat(workspace): cross-machine 復元・canonical grouping・Remote/derived Done・一括 Clean Up (SPEC-2359 W16)

### DIFF
--- a/crates/gwt-core/src/lib.rs
+++ b/crates/gwt-core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod skill_state;
 pub mod test_support;
 pub mod update;
 pub mod usage;
+pub mod work_events_intake;
 pub mod workspace_projection;
 pub mod workspace_projection_migration;
 pub mod worktree_hash;

--- a/crates/gwt-core/src/paths.rs
+++ b/crates/gwt-core/src/paths.rs
@@ -199,6 +199,19 @@ pub fn gwt_workspace_work_events_closed_path_for_repo_path(repo_path: &Path) -> 
     gwt_workspace_work_events_closed_path(&repo_hash)
 }
 
+/// SPEC-2359 W-16 (FR-387): fingerprint cache for the cross-machine work
+/// events intake (`source → blob oid / content sha256`). Pure optimization —
+/// deleting it only costs re-reading sources (dedup is event-id based).
+pub fn gwt_workspace_work_events_intake_state_path(repo_hash: &RepoHash) -> PathBuf {
+    gwt_project_dir(repo_hash).join("project-state/work-events-intake.json")
+}
+
+/// Return the intake fingerprint cache path for a repository path.
+pub fn gwt_workspace_work_events_intake_state_path_for_repo_path(repo_path: &Path) -> PathBuf {
+    let repo_hash = project_scope_hash(repo_path);
+    gwt_workspace_work_events_intake_state_path(&repo_hash)
+}
+
 /// Resolve the main worktree root (git common dir) for a repository or linked
 /// worktree path.
 ///
@@ -840,6 +853,15 @@ mod tests {
         let repo_local = gwt_repo_local_work_events_path(&repo);
         assert_ne!(closed, in_work_home);
         assert_ne!(closed, repo_local);
+    }
+
+    #[test]
+    fn gwt_workspace_work_events_intake_state_path_uses_project_state_dir() {
+        let repo_hash = compute_repo_hash("git@github.com:akiojin/gwt.git");
+        let path = gwt_workspace_work_events_intake_state_path(&repo_hash);
+        assert!(path
+            .to_string_lossy()
+            .ends_with("project-state/work-events-intake.json"));
     }
 
     #[test]

--- a/crates/gwt-core/src/process.rs
+++ b/crates/gwt-core/src/process.rs
@@ -142,6 +142,91 @@ pub fn run_git_logged(
     result
 }
 
+/// SPEC-2359 W-16 (FR-387): `run_git_logged` variant that pipes `stdin`
+/// into the child — required by `git cat-file --batch-check`, which reads
+/// its object list from stdin so one spawn resolves many blobs.
+pub fn run_git_logged_with_stdin(
+    args: &[&str],
+    current_dir: Option<&std::path::Path>,
+    stdin: &[u8],
+) -> std::io::Result<std::process::Output> {
+    use std::io::Write;
+
+    let spawn_id = next_git_spawn_id();
+    let label = format!("git {}", args.join(" "));
+    let started_at = std::time::Instant::now();
+
+    tracing::info!(
+        target: "gwt.process.summary",
+        kind = "git",
+        spawn_id = spawn_id,
+        label = %label,
+        phase = "start",
+        "process start",
+    );
+    push_command_banner_to_hub(
+        crate::process_console::ProcessKind::Git,
+        spawn_id,
+        &label,
+        current_dir,
+    );
+
+    let mut command = hidden_command("git");
+    command.args(args);
+    if let Some(dir) = current_dir {
+        command.current_dir(dir);
+    }
+    command
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    let result = (|| {
+        let mut child = command.spawn()?;
+        if let Some(mut pipe) = child.stdin.take() {
+            pipe.write_all(stdin)?;
+        }
+        child.wait_with_output()
+    })();
+
+    let (exit_code, success, stdout_lines, stderr_lines) = match &result {
+        Ok(output) => {
+            forward_git_lines(spawn_id, &output.stdout, &output.stderr);
+            let stdout_lines = String::from_utf8_lossy(&output.stdout).lines().count() as u64;
+            let stderr_lines = String::from_utf8_lossy(&output.stderr).lines().count() as u64;
+            (
+                output.status.code(),
+                output.status.success(),
+                stdout_lines,
+                stderr_lines,
+            )
+        }
+        Err(_) => (None, false, 0, 0),
+    };
+
+    let duration_ms = started_at.elapsed().as_millis() as u64;
+    push_command_summary_to_hub(
+        crate::process_console::ProcessKind::Git,
+        spawn_id,
+        exit_code,
+        duration_ms,
+    );
+    tracing::info!(
+        target: "gwt.process.summary",
+        kind = "git",
+        spawn_id = spawn_id,
+        label = %label,
+        phase = "end",
+        exit_code = exit_code.map(|c| c as i64),
+        duration_ms = duration_ms,
+        stdout_lines = stdout_lines,
+        stderr_lines = stderr_lines,
+        success = success,
+        "process end",
+    );
+
+    result
+}
+
 /// Shared helper: push a synthetic banner line (the command string
 /// prefixed with `$ `) as the first line of a new spawn. Used by
 /// `run_git_logged` and `spawn_logged` so the Console window can render

--- a/crates/gwt-core/src/work_events_intake.rs
+++ b/crates/gwt-core/src/work_events_intake.rs
@@ -1,0 +1,479 @@
+//! SPEC-2359 W-16 (FR-387/FR-388): cross-machine Work skeleton intake.
+//!
+//! A permanently-installed, idempotent consumer that merges `events.jsonl`
+//! content from any source (local worktree filesystems, the base branch,
+//! fetched `origin/*` refs) into the home works projection. Replaces the
+//! one-shot `rebuild_work_items_from_events_for_repo` migration gate.
+//!
+//! Contract (plan §Architecture Decisions 3):
+//! - dedup is the diff against the FULL event-id set already inside
+//!   works.json — deleting the intake state cache never breaks idempotence
+//!   (SC-260);
+//! - close kinds {Pause, Done, Discard} are never ingested from ANY source
+//!   (defence against contaminated logs, #3023; close state is owned by the
+//!   machine-local close log per FR-384);
+//! - malformed lines are skipped leniently (warn, keep going);
+//! - terminal (Done / Discarded) items never apply events stamped at or
+//!   before their close time (no re-open, no `updated_at` rollback);
+//! - only works.json is written — sessions / current.json / journal.jsonl
+//!   are untouched (SC-261).
+
+use std::collections::{BTreeMap, HashSet};
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{GwtError, Result};
+use crate::workspace_projection::{
+    load_workspace_work_items_from_path, save_workspace_work_items_projection_to_path,
+    WorkspaceWorkEvent, WorkspaceWorkEventKind, WorkspaceWorkItemsProjection,
+};
+
+/// Per-run accounting so callers (and tests) can see what happened.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct WorkEventsIntakeReport {
+    pub applied: usize,
+    pub skipped_duplicate: usize,
+    pub skipped_close_kind: usize,
+    pub skipped_invalid: usize,
+    pub skipped_terminal: usize,
+}
+
+impl WorkEventsIntakeReport {
+    pub fn changed(&self) -> bool {
+        self.applied > 0
+    }
+}
+
+fn is_close_kind(kind: WorkspaceWorkEventKind) -> bool {
+    matches!(
+        kind,
+        WorkspaceWorkEventKind::Pause
+            | WorkspaceWorkEventKind::Done
+            | WorkspaceWorkEventKind::Discard
+    )
+}
+
+/// The moment a terminal item closed: `completed_at` when recorded, else its
+/// last update. Events at or before this instant must not re-apply.
+fn terminal_close_time(
+    item: &crate::workspace_projection::WorkspaceWorkItem,
+) -> Option<DateTime<Utc>> {
+    item.is_terminal()
+        .then(|| item.completed_at.unwrap_or(item.updated_at))
+}
+
+/// Ingest one source's raw `events.jsonl` content into the works projection
+/// at `work_items_path`. Pure file-paths API (#3022): no HOME resolution.
+pub fn ingest_work_events_content(
+    work_items_path: &Path,
+    content: &str,
+) -> Result<WorkEventsIntakeReport> {
+    let mut report = WorkEventsIntakeReport::default();
+    let mut projection = load_workspace_work_items_from_path(work_items_path)?
+        .unwrap_or_else(|| WorkspaceWorkItemsProjection::empty(Utc::now()));
+
+    let mut seen_event_ids: HashSet<String> = projection
+        .work_items
+        .iter()
+        .flat_map(|item| item.events.iter().map(|event| event.id.clone()))
+        .collect();
+
+    let mut incoming: Vec<WorkspaceWorkEvent> = Vec::new();
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let event: WorkspaceWorkEvent = match serde_json::from_str(line) {
+            Ok(event) => event,
+            Err(error) => {
+                report.skipped_invalid += 1;
+                tracing::warn!(%error, "work events intake: skipping malformed line");
+                continue;
+            }
+        };
+        if is_close_kind(event.kind) {
+            report.skipped_close_kind += 1;
+            continue;
+        }
+        if !seen_event_ids.insert(event.id.clone()) {
+            // Covers both already-ingested events and duplicate lines inside
+            // one source (git union-merge artifacts).
+            report.skipped_duplicate += 1;
+            continue;
+        }
+        incoming.push(event);
+    }
+    if incoming.is_empty() {
+        return Ok(report);
+    }
+    incoming.sort_by_key(|event| event.updated_at);
+
+    for event in incoming {
+        let terminal_cutoff = projection
+            .work_items
+            .iter()
+            .find(|item| item.id == event.work_item_id)
+            .and_then(terminal_close_time);
+        if let Some(closed_at) = terminal_cutoff {
+            if event.updated_at <= closed_at {
+                report.skipped_terminal += 1;
+                continue;
+            }
+        }
+        projection.apply_event(event);
+        report.applied += 1;
+    }
+
+    if report.applied > 0 {
+        projection.updated_at = Utc::now();
+        save_workspace_work_items_projection_to_path(work_items_path, &projection)?;
+    }
+    Ok(report)
+}
+
+/// Fingerprint cache mapping a source key (worktree path / ref name) to the
+/// last-ingested content fingerprint (git blob oid or content sha256). A pure
+/// optimization: deleting the file only costs re-reading sources, never
+/// correctness (dedup is event-id based).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkEventsIntakeState {
+    #[serde(default)]
+    pub sources: BTreeMap<String, String>,
+}
+
+impl WorkEventsIntakeState {
+    /// True when `source` already ingested content with `fingerprint`.
+    pub fn is_current(&self, source: &str, fingerprint: &str) -> bool {
+        self.sources.get(source).map(String::as_str) == Some(fingerprint)
+    }
+
+    pub fn record(&mut self, source: impl Into<String>, fingerprint: impl Into<String>) {
+        self.sources.insert(source.into(), fingerprint.into());
+    }
+}
+
+/// Load the intake state; missing or corrupt files yield the default state
+/// (the cache is advisory).
+pub fn load_work_events_intake_state(path: &Path) -> WorkEventsIntakeState {
+    let Ok(body) = std::fs::read_to_string(path) else {
+        return WorkEventsIntakeState::default();
+    };
+    serde_json::from_str(&body).unwrap_or_default()
+}
+
+pub fn save_work_events_intake_state(path: &Path, state: &WorkEventsIntakeState) -> Result<()> {
+    let body = serde_json::to_vec_pretty(state)
+        .map_err(|error| GwtError::Other(format!("work events intake state: {error}")))?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    crate::workspace_projection::write_atomic(path, &body)
+}
+
+/// Content sha256 used as the fingerprint for filesystem sources (git blob
+/// oids serve the same purpose for ref sources).
+pub fn content_fingerprint(content: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workspace_projection::{WorkspaceStatusCategory, WorkspaceWorkItemsProjection};
+    use chrono::TimeZone;
+
+    fn event_json(id: &str, work_id: &str, kind: &str, updated_at: &str, extra: &str) -> String {
+        format!(
+            "{{\"id\":\"{id}\",\"work_item_id\":\"{work_id}\",\"kind\":\"{kind}\",\"updated_at\":\"{updated_at}\"{extra}}}"
+        )
+    }
+
+    #[test]
+    fn ingest_restores_work_skeleton_from_source_content() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let works = tmp.path().join("works.json");
+        let content = [
+            event_json(
+                "evt-1",
+                "work-feature-aaaa1111",
+                "start",
+                "2026-06-01T10:00:00Z",
+                ",\"title\":\"feature work\",\"intent\":\"build it\",\"status_category\":\"active\",\"board_entry_id\":\"board-1\",\"execution_container\":{\"branch\":\"work/feature\"}",
+            ),
+            event_json(
+                "evt-2",
+                "work-feature-aaaa1111",
+                "update",
+                "2026-06-02T11:00:00Z",
+                ",\"summary\":\"halfway\"",
+            ),
+        ]
+        .join("\n");
+
+        let report = ingest_work_events_content(&works, &content).expect("ingest");
+        assert_eq!(report.applied, 2);
+
+        let projection = load_workspace_work_items_from_path(&works)
+            .expect("load")
+            .expect("projection exists");
+        assert_eq!(projection.work_items.len(), 1);
+        let item = &projection.work_items[0];
+        assert_eq!(item.id, "work-feature-aaaa1111");
+        assert_eq!(item.title, "feature work");
+        assert_eq!(item.intent.as_deref(), Some("build it"));
+        assert_eq!(item.summary.as_deref(), Some("halfway"));
+        assert_eq!(
+            item.created_at,
+            chrono::Utc.with_ymd_and_hms(2026, 6, 1, 10, 0, 0).unwrap()
+        );
+        assert_eq!(
+            item.updated_at,
+            chrono::Utc.with_ymd_and_hms(2026, 6, 2, 11, 0, 0).unwrap()
+        );
+        assert!(item
+            .execution_containers
+            .iter()
+            .any(|container| container.branch.as_deref() == Some("work/feature")));
+        assert!(item.board_refs.iter().any(|entry| entry == "board-1"));
+    }
+
+    /// SC-260: re-ingesting the same source is a no-op, with or without any
+    /// intake state cache — dedup rides the works.json event-id set.
+    #[test]
+    fn double_ingest_is_idempotent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let works = tmp.path().join("works.json");
+        let content = event_json(
+            "evt-1",
+            "work-x-bbbb2222",
+            "start",
+            "2026-06-01T10:00:00Z",
+            ",\"title\":\"x\",\"status_category\":\"active\"",
+        );
+
+        let first = ingest_work_events_content(&works, &content).expect("first ingest");
+        assert_eq!(first.applied, 1);
+        let second = ingest_work_events_content(&works, &content).expect("second ingest");
+        assert_eq!(second.applied, 0);
+        assert_eq!(second.skipped_duplicate, 1);
+
+        let projection = load_workspace_work_items_from_path(&works)
+            .expect("load")
+            .expect("projection");
+        assert_eq!(projection.work_items.len(), 1);
+        assert_eq!(projection.work_items[0].events.len(), 1);
+    }
+
+    /// Close kinds are never ingested from any source (#3023 defence +
+    /// FR-384: close state is machine-local).
+    #[test]
+    fn close_kinds_are_never_ingested() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let works = tmp.path().join("works.json");
+        let content = [
+            event_json(
+                "evt-1",
+                "work-x-cccc3333",
+                "start",
+                "2026-06-01T10:00:00Z",
+                ",\"title\":\"x\",\"status_category\":\"active\"",
+            ),
+            event_json(
+                "evt-2",
+                "work-x-cccc3333",
+                "pause",
+                "2026-06-01T11:00:00Z",
+                "",
+            ),
+            event_json(
+                "evt-3",
+                "work-x-cccc3333",
+                "done",
+                "2026-06-01T12:00:00Z",
+                "",
+            ),
+            event_json(
+                "evt-4",
+                "work-x-cccc3333",
+                "discard",
+                "2026-06-01T13:00:00Z",
+                "",
+            ),
+        ]
+        .join("\n");
+
+        let report = ingest_work_events_content(&works, &content).expect("ingest");
+        assert_eq!(report.applied, 1);
+        assert_eq!(report.skipped_close_kind, 3);
+
+        let projection = load_workspace_work_items_from_path(&works)
+            .expect("load")
+            .expect("projection");
+        let item = &projection.work_items[0];
+        assert!(!item.is_terminal(), "close kinds must not close the item");
+        assert_ne!(item.status_category, WorkspaceStatusCategory::Done);
+    }
+
+    #[test]
+    fn malformed_lines_are_skipped_leniently() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let works = tmp.path().join("works.json");
+        let content = format!(
+            "not json at all\n{{\"id\":\"broken\"}}\n{}",
+            event_json(
+                "evt-1",
+                "work-x-dddd4444",
+                "start",
+                "2026-06-01T10:00:00Z",
+                ",\"title\":\"x\",\"status_category\":\"active\"",
+            )
+        );
+
+        let report = ingest_work_events_content(&works, &content).expect("ingest");
+        assert_eq!(report.applied, 1);
+        assert_eq!(report.skipped_invalid, 2);
+    }
+
+    /// Terminal items never apply events stamped at or before their close
+    /// time: no re-open, no `updated_at` rollback (re-ingest of a Backfill
+    /// committed elsewhere after the local close, FR-380 note).
+    #[test]
+    fn terminal_items_skip_events_at_or_before_close_time() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let works = tmp.path().join("works.json");
+        let closed_at = chrono::Utc.with_ymd_and_hms(2026, 6, 5, 12, 0, 0).unwrap();
+        let mut projection = WorkspaceWorkItemsProjection::empty(closed_at);
+        let mut done = crate::workspace_projection::WorkspaceWorkEvent::new(
+            WorkspaceWorkEventKind::Done,
+            "work-x-eeee5555",
+            closed_at,
+        );
+        done.status_category = Some(WorkspaceStatusCategory::Done);
+        done.title = Some("closed work".to_string());
+        projection.apply_event(done);
+        save_workspace_work_items_projection_to_path(&works, &projection).expect("seed");
+
+        let content = [
+            // Before the close: must be skipped.
+            event_json(
+                "evt-old",
+                "work-x-eeee5555",
+                "update",
+                "2026-06-04T10:00:00Z",
+                ",\"summary\":\"stale\"",
+            ),
+            // After the close: applies through normal apply_event semantics.
+            event_json(
+                "evt-new",
+                "work-x-eeee5555",
+                "update",
+                "2026-06-06T10:00:00Z",
+                ",\"summary\":\"fresh\"",
+            ),
+        ]
+        .join("\n");
+
+        let report = ingest_work_events_content(&works, &content).expect("ingest");
+        assert_eq!(report.skipped_terminal, 1);
+        assert_eq!(report.applied, 1);
+
+        let projection = load_workspace_work_items_from_path(&works)
+            .expect("load")
+            .expect("projection");
+        let item = &projection.work_items[0];
+        assert!(
+            item.updated_at >= closed_at,
+            "updated_at must never roll back behind the close time"
+        );
+        assert_ne!(item.summary.as_deref(), Some("stale"));
+    }
+
+    /// Union-merge artifacts: the same event id appearing twice within one
+    /// source content applies once.
+    #[test]
+    fn duplicate_event_ids_within_one_source_dedup() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let works = tmp.path().join("works.json");
+        let line = event_json(
+            "evt-1",
+            "work-x-ffff6666",
+            "start",
+            "2026-06-01T10:00:00Z",
+            ",\"title\":\"x\",\"status_category\":\"active\"",
+        );
+        let content = format!("{line}\n{line}");
+
+        let report = ingest_work_events_content(&works, &content).expect("ingest");
+        assert_eq!(report.applied, 1);
+        assert_eq!(report.skipped_duplicate, 1);
+    }
+
+    /// SC-261: intake writes works.json only — sibling state files are
+    /// untouched byte-for-byte.
+    #[test]
+    fn ingest_leaves_sessions_current_and_journal_untouched() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let works = tmp.path().join("works.json");
+        let current = tmp.path().join("current.json");
+        let journal = tmp.path().join("journal.jsonl");
+        std::fs::write(&current, b"{\"current\":true}").expect("seed current");
+        std::fs::write(&journal, b"{\"entry\":1}\n").expect("seed journal");
+
+        let content = event_json(
+            "evt-1",
+            "work-x-aaaa7777",
+            "start",
+            "2026-06-01T10:00:00Z",
+            ",\"title\":\"x\",\"status_category\":\"active\"",
+        );
+        ingest_work_events_content(&works, &content).expect("ingest");
+
+        assert_eq!(
+            std::fs::read(&current).expect("current"),
+            b"{\"current\":true}"
+        );
+        assert_eq!(
+            std::fs::read(&journal).expect("journal"),
+            b"{\"entry\":1}\n"
+        );
+    }
+
+    #[test]
+    fn intake_state_roundtrip_and_lenient_load() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join("work-events-intake.json");
+
+        // Missing file → default.
+        assert_eq!(
+            load_work_events_intake_state(&path),
+            WorkEventsIntakeState::default()
+        );
+
+        let mut state = WorkEventsIntakeState::default();
+        state.record("origin/work/x", "blob-oid-1");
+        save_work_events_intake_state(&path, &state).expect("save");
+        let loaded = load_work_events_intake_state(&path);
+        assert!(loaded.is_current("origin/work/x", "blob-oid-1"));
+        assert!(!loaded.is_current("origin/work/x", "blob-oid-2"));
+
+        // Corrupt file → default (advisory cache).
+        std::fs::write(&path, b"{ not json").expect("corrupt");
+        assert_eq!(
+            load_work_events_intake_state(&path),
+            WorkEventsIntakeState::default()
+        );
+    }
+
+    #[test]
+    fn content_fingerprint_is_stable_sha256() {
+        assert_eq!(content_fingerprint("abc"), content_fingerprint("abc"));
+        assert_ne!(content_fingerprint("abc"), content_fingerprint("abd"));
+        assert_eq!(content_fingerprint("abc").len(), 64);
+    }
+}

--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -106,6 +106,25 @@ pub fn canonical_work_id(
     ))
 }
 
+/// SPEC-2359 W16-4 (FR-391): derived "Done-equivalent" classification for a
+/// merged-and-stale Workspace. PURE display state: callers must never record
+/// a close event from this verdict (US-61 — explicit user close only); the
+/// flag clears by itself when the Workspace is updated after the merge.
+///
+/// `merge_reference_time` is the branch tip committer time (proxy for the
+/// unknown squash-merge instant — plan decision 8). `None` (unknown) never
+/// classifies as Done.
+pub fn derive_merged_done_equivalent(
+    merged_into_base: bool,
+    last_updated_at: DateTime<Utc>,
+    merge_reference_time: Option<DateTime<Utc>>,
+) -> bool {
+    let Some(reference) = merge_reference_time else {
+        return false;
+    };
+    merged_into_base && last_updated_at <= reference
+}
+
 /// SPEC-2359 W16-2 (FR-389): the Workspace grouping key for one Work item —
 /// derived at view-assembly time, never stored (plan decision 6). Works that
 /// share a canonical branch (any spelling: `X`, `origin/X`,
@@ -5939,6 +5958,31 @@ mod tests {
             "first Done timestamp must be preserved on idempotent Done re-apply"
         );
         assert_eq!(item.updated_at, t2, "updated_at should still advance");
+    }
+
+    #[test]
+    fn derive_merged_done_equivalent_classifies_only_merged_and_stale() {
+        let merged_at = chrono::Utc.with_ymd_and_hms(2026, 6, 10, 12, 0, 0).unwrap();
+        let before = merged_at - chrono::Duration::hours(1);
+        let after = merged_at + chrono::Duration::hours(1);
+
+        // merged ∧ stale (no update after the merge) → Done-equivalent.
+        assert!(derive_merged_done_equivalent(true, before, Some(merged_at)));
+        assert!(derive_merged_done_equivalent(
+            true,
+            merged_at,
+            Some(merged_at)
+        ));
+        // updated after the merge → back to Active/Paused (FR-391).
+        assert!(!derive_merged_done_equivalent(true, after, Some(merged_at)));
+        // unmerged → never.
+        assert!(!derive_merged_done_equivalent(
+            false,
+            before,
+            Some(merged_at)
+        ));
+        // unknown merge reference → never.
+        assert!(!derive_merged_done_equivalent(true, before, None));
     }
 
     #[test]

--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -106,6 +106,33 @@ pub fn canonical_work_id(
     ))
 }
 
+/// SPEC-2359 W16-2 (FR-389): the Workspace grouping key for one Work item —
+/// derived at view-assembly time, never stored (plan decision 6). Works that
+/// share a canonical branch (any spelling: `X`, `origin/X`,
+/// `refs/remotes/origin/X`) group under one Workspace row; worktree-only
+/// items key on the canonical worktree identity; everything else (legacy
+/// `workspace-<millis>` / bare-UUID items without containers) keeps its own
+/// `item.id` as the key so old rows never vanish.
+pub fn workspace_group_key_for_item(project_root: &Path, item: &WorkspaceWorkItem) -> String {
+    let branch = item
+        .execution_containers
+        .iter()
+        .find_map(|container| container.branch.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if let Some(key) = canonical_work_id(project_root, branch, None) {
+        return key;
+    }
+    let worktree = item
+        .execution_containers
+        .iter()
+        .find_map(|container| container.worktree_path.as_deref());
+    if let Some(key) = canonical_work_id(project_root, None, worktree) {
+        return key;
+    }
+    item.id.clone()
+}
+
 fn canonical_work_branch_identity(branch: &str) -> String {
     if let Some(name) = branch.strip_prefix("refs/remotes/") {
         return name.strip_prefix("origin/").unwrap_or(name).to_string();
@@ -5912,6 +5939,61 @@ mod tests {
             "first Done timestamp must be preserved on idempotent Done re-apply"
         );
         assert_eq!(item.updated_at, t2, "updated_at should still advance");
+    }
+
+    #[test]
+    fn workspace_group_key_groups_same_branch_across_spellings_and_ids() {
+        let project_root = Path::new("/tmp/repo");
+        let now = chrono::Utc::now();
+        let mut item_a = WorkspaceWorkItem {
+            id: "work-session-aaaa".to_string(),
+            title: "a".to_string(),
+            intent: None,
+            summary: None,
+            status_category: WorkspaceStatusCategory::Active,
+            owner: None,
+            created_at: now,
+            updated_at: now,
+            completed_at: None,
+            agents: Vec::new(),
+            execution_containers: vec![WorkspaceExecutionContainerRef {
+                branch: Some("work/x".to_string()),
+                worktree_path: None,
+                pr_number: None,
+                pr_url: None,
+                pr_state: None,
+            }],
+            board_refs: Vec::new(),
+            related_work_item_ids: Vec::new(),
+            events: Vec::new(),
+            discarded: false,
+        };
+        let mut item_b = item_a.clone();
+        item_b.id = "work-session-bbbb".to_string();
+        item_b.execution_containers[0].branch = Some("origin/work/x".to_string());
+        let mut item_c = item_a.clone();
+        item_c.id = "work-x-12345678".to_string();
+        item_c.execution_containers[0].branch = Some("refs/remotes/origin/work/x".to_string());
+
+        let key_a = workspace_group_key_for_item(project_root, &item_a);
+        let key_b = workspace_group_key_for_item(project_root, &item_b);
+        let key_c = workspace_group_key_for_item(project_root, &item_c);
+        assert_eq!(key_a, key_b, "origin/X spelling groups with X");
+        assert_eq!(key_a, key_c, "refs/remotes/origin/X spelling groups with X");
+
+        // Branchless legacy items keep their own id (adapter: old rows never
+        // vanish and never merge into each other).
+        item_a.execution_containers.clear();
+        item_a.id = "workspace-1748822400000".to_string();
+        assert_eq!(
+            workspace_group_key_for_item(project_root, &item_a),
+            "workspace-1748822400000"
+        );
+        item_a.id = "0f5e2c1a-aaaa-bbbb-cccc-1234567890ab".to_string();
+        assert_eq!(
+            workspace_group_key_for_item(project_root, &item_a),
+            "0f5e2c1a-aaaa-bbbb-cccc-1234567890ab"
+        );
     }
 
     #[test]

--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -1344,14 +1344,14 @@ pub struct WorkspaceWorkItemsProjection {
 }
 
 impl WorkspaceWorkItemsProjection {
-    fn empty(updated_at: DateTime<Utc>) -> Self {
+    pub fn empty(updated_at: DateTime<Utc>) -> Self {
         Self {
             updated_at,
             work_items: Vec::new(),
         }
     }
 
-    fn apply_event(&mut self, event: WorkspaceWorkEvent) {
+    pub fn apply_event(&mut self, event: WorkspaceWorkEvent) {
         let existing_index = self
             .work_items
             .iter()
@@ -2500,15 +2500,18 @@ pub fn rebuild_work_items_from_events_paths(
     Ok(WorkspaceWorkItemsRebuildOutcome::Applied)
 }
 
-/// SPEC-2359 US-37: Convenience wrapper for the daemon bootstrap hook.
-/// Resolves the project-scoped paths and invokes
-/// [`rebuild_work_items_from_events_paths`].
+/// SPEC-2359 US-37 — SUPERSEDED by the W-16 intake consumer
+/// (`work_events_intake` + the gwt-side `work_events_ingest` orchestrator).
+/// The bootstrap no longer calls this; the permanently-installed idempotent
+/// intake covers the same repo-local source plus worktree filesystems and
+/// fetched `origin/*` refs. The `work_items.migration.json` marker file is
+/// no longer read but is intentionally left on disk. Kept for tests and as
+/// a manual recovery tool.
 ///
 /// SPEC-2359 Phase W-15 (FR-384) caveat: close-kind events recorded after
 /// W-15 live only in the home close log (`work-events-closed.jsonl`). A
-/// future marker version bump that replays solely the repo-local log would
-/// resurrect closed Work — any such replay must also merge the home close
-/// log (the W-16 intake consumer supersedes this rebuild entirely).
+/// replay of solely the repo-local log would resurrect closed Work — any
+/// such replay must also merge the home close log.
 pub fn rebuild_work_items_from_events_for_repo(
     repo_path: &Path,
 ) -> Result<WorkspaceWorkItemsRebuildOutcome> {
@@ -3215,7 +3218,7 @@ fn first_nonempty_line(value: &str) -> Option<String> {
         .map(str::to_string)
 }
 
-fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
+pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }

--- a/crates/gwt-git/src/blob.rs
+++ b/crates/gwt-git/src/blob.rs
@@ -1,0 +1,169 @@
+//! SPEC-2359 W-16 (FR-387): checkout-free blob access for the cross-machine
+//! work events intake.
+//!
+//! Spawn budget (plan §Architecture Decisions 4): one `cat-file
+//! --batch-check` resolves the `events.jsonl` blob oid for ANY number of
+//! refs (object list rides stdin), and only blobs that have not been
+//! ingested yet pay an extra `cat-file blob` read.
+
+use std::path::Path;
+
+use gwt_core::{GwtError, Result};
+
+/// Resolve the blob oid of `path_in_tree` for each commit sha in `commits`,
+/// in ONE `git cat-file --batch-check` spawn. Returns one entry per input
+/// commit, `None` when the commit's tree has no such path.
+pub fn events_blob_oids_batch(
+    repo_path: &Path,
+    commits: &[String],
+    path_in_tree: &str,
+) -> Result<Vec<Option<String>>> {
+    if commits.is_empty() {
+        return Ok(Vec::new());
+    }
+    let stdin: String = commits
+        .iter()
+        .map(|sha| format!("{sha}:{path_in_tree}\n"))
+        .collect();
+    let output = gwt_core::process::run_git_logged_with_stdin(
+        &["cat-file", "--batch-check"],
+        Some(repo_path),
+        stdin.as_bytes(),
+    )
+    .map_err(|error| GwtError::Git(format!("cat-file --batch-check: {error}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(GwtError::Git(format!("cat-file --batch-check: {stderr}")));
+    }
+    // One output line per input line, in order:
+    //   `<oid> <type> <size>` for resolvable objects,
+    //   `<spec> missing` (or `... ambiguous`) otherwise.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let oids: Vec<Option<String>> = stdout
+        .lines()
+        .map(|line| {
+            let mut parts = line.split_whitespace();
+            let first = parts.next()?.to_string();
+            let second = parts.next()?;
+            (second == "blob").then_some(first)
+        })
+        .collect();
+    if oids.len() != commits.len() {
+        return Err(GwtError::Git(format!(
+            "cat-file --batch-check: expected {} lines, got {}",
+            commits.len(),
+            oids.len()
+        )));
+    }
+    Ok(oids)
+}
+
+/// Read a blob's full content by oid — no checkout, no worktree access.
+pub fn read_blob(repo_path: &Path, oid: &str) -> Result<String> {
+    let output = gwt_core::process::run_git_logged(&["cat-file", "blob", oid], Some(repo_path))
+        .map_err(|error| GwtError::Git(format!("cat-file blob: {error}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(GwtError::Git(format!("cat-file blob {oid}: {stderr}")));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn run(cmd: &mut Command) {
+        let output = cmd.output().expect("git command should run");
+        assert!(
+            output.status.success(),
+            "git command failed: {}\nstderr: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_repo() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path();
+        run(Command::new("git")
+            .args(["init", "--initial-branch=main"])
+            .current_dir(path));
+        run(Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(path));
+        run(Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(path));
+        run(Command::new("git")
+            .args(["commit", "--allow-empty", "-m", "init"])
+            .current_dir(path));
+        dir
+    }
+
+    fn head_sha(repo: &std::path::Path) -> String {
+        let output = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(repo)
+            .output()
+            .expect("rev-parse");
+        String::from_utf8_lossy(&output.stdout).trim().to_string()
+    }
+
+    #[test]
+    fn batch_resolves_events_blob_oids_and_reads_without_checkout() {
+        let dir = init_repo();
+        let repo = dir.path();
+
+        // Commit with .gwt/work/events.jsonl on a side branch.
+        run(Command::new("git")
+            .args(["checkout", "-b", "work/with-events"])
+            .current_dir(repo));
+        std::fs::create_dir_all(repo.join(".gwt/work")).expect("mk .gwt/work");
+        std::fs::write(repo.join(".gwt/work/events.jsonl"), "{\"id\":\"evt-1\"}\n")
+            .expect("write events");
+        run(Command::new("git")
+            .args(["add", ".gwt/work/events.jsonl"])
+            .current_dir(repo));
+        run(Command::new("git")
+            .args(["commit", "-m", "events"])
+            .current_dir(repo));
+        let with_events = head_sha(repo);
+
+        // Back to main (no events file) and drop the working copy so a
+        // successful read proves checkout-free access.
+        run(Command::new("git")
+            .args(["checkout", "main"])
+            .current_dir(repo));
+        let without_events = head_sha(repo);
+        assert!(
+            !repo.join(".gwt/work/events.jsonl").exists(),
+            "fixture: main checkout must not carry the events file"
+        );
+
+        let oids = events_blob_oids_batch(
+            repo,
+            &[with_events, without_events],
+            ".gwt/work/events.jsonl",
+        )
+        .expect("batch-check");
+        assert_eq!(oids.len(), 2);
+        let blob_oid = oids[0].as_deref().expect("events blob resolves");
+        assert!(oids[1].is_none(), "ref without events.jsonl yields None");
+
+        let content = read_blob(repo, blob_oid).expect("read blob");
+        assert_eq!(content, "{\"id\":\"evt-1\"}\n");
+    }
+
+    #[test]
+    fn batch_with_no_commits_spawns_nothing_and_returns_empty() {
+        let dir = init_repo();
+        let oids =
+            events_blob_oids_batch(dir.path(), &[], ".gwt/work/events.jsonl").expect("empty");
+        assert!(oids.is_empty());
+    }
+}

--- a/crates/gwt-git/src/lib.rs
+++ b/crates/gwt-git/src/lib.rs
@@ -3,6 +3,7 @@
 //! Provides repository discovery, branch listing, worktree management,
 //! GitHub Issue/PR tracking, diff helpers, and commit log queries.
 
+pub mod blob;
 pub mod branch;
 pub mod commit;
 pub mod diff;

--- a/crates/gwt-git/src/refs.rs
+++ b/crates/gwt-git/src/refs.rs
@@ -51,6 +51,39 @@ pub fn list_existing_refs(repo_path: &Path, candidates: &[&str]) -> Result<HashS
     Ok(existing)
 }
 
+/// SPEC-2359 W-16 (FR-387): enumerate every `refs/remotes/origin/*` ref with
+/// its commit sha in ONE `for-each-ref` spawn. `origin/HEAD` (a symref) is
+/// skipped. The pair feeds `blob::events_blob_oids_batch` so the intake can
+/// read `events.jsonl` from fetched branches without checking anything out.
+pub fn list_origin_refs_with_commit(repo_path: &Path) -> Result<Vec<(String, String)>> {
+    let output = gwt_core::process::run_git_logged(
+        &[
+            "for-each-ref",
+            "--format=%(refname)\t%(objectname)",
+            "refs/remotes/origin/",
+        ],
+        Some(repo_path),
+    )
+    .map_err(|error| GwtError::Git(format!("for-each-ref origin: {error}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(GwtError::Git(format!("for-each-ref origin: {stderr}")));
+    }
+    let refs = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let (refname, sha) = line.split_once('\t')?;
+            let refname = refname.trim();
+            let sha = sha.trim();
+            if refname.is_empty() || sha.is_empty() || refname == "refs/remotes/origin/HEAD" {
+                return None;
+            }
+            Some((refname.to_string(), sha.to_string()))
+        })
+        .collect();
+    Ok(refs)
+}
+
 #[cfg(test)]
 mod tests {
     use std::process::Command;
@@ -97,6 +130,31 @@ mod tests {
         run(Command::new("git")
             .args(["update-ref", refname, "HEAD"])
             .current_dir(repo));
+    }
+
+    #[test]
+    fn list_origin_refs_with_commit_lists_refname_sha_pairs_excluding_head() {
+        let dir = init_repo();
+        let repo = dir.path();
+        create_remote_tracking_ref(repo, "refs/remotes/origin/develop");
+        create_remote_tracking_ref(repo, "refs/remotes/origin/work/x");
+        // origin/HEAD symref must be skipped.
+        run(Command::new("git")
+            .args([
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                "refs/remotes/origin/develop",
+            ])
+            .current_dir(repo));
+
+        let refs = list_origin_refs_with_commit(repo).expect("list origin refs");
+        let names: Vec<&str> = refs.iter().map(|(name, _)| name.as_str()).collect();
+        assert!(names.contains(&"refs/remotes/origin/develop"));
+        assert!(names.contains(&"refs/remotes/origin/work/x"));
+        assert!(!names.contains(&"refs/remotes/origin/HEAD"));
+        for (_, sha) in &refs {
+            assert_eq!(sha.len(), 40, "full object sha expected: {sha}");
+        }
     }
 
     #[test]

--- a/crates/gwt-git/src/refs.rs
+++ b/crates/gwt-git/src/refs.rs
@@ -84,6 +84,39 @@ pub fn list_origin_refs_with_commit(repo_path: &Path) -> Result<Vec<(String, Str
     Ok(refs)
 }
 
+/// SPEC-2359 W16-4 (FR-391): committer time (unix seconds) of every local
+/// branch tip and every `origin/*` tip, in ONE `for-each-ref` spawn. Keys
+/// are short ref names (`work/x`, `origin/work/x`). Used as the
+/// merge-reference-time proxy for the derived Done classification.
+pub fn branch_tip_committer_times(
+    repo_path: &Path,
+) -> Result<std::collections::HashMap<String, i64>> {
+    let output = gwt_core::process::run_git_logged(
+        &[
+            "for-each-ref",
+            "--format=%(refname:short)\t%(committerdate:unix)",
+            "refs/heads/",
+            "refs/remotes/origin/",
+        ],
+        Some(repo_path),
+    )
+    .map_err(|error| GwtError::Git(format!("for-each-ref tip times: {error}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(GwtError::Git(format!("for-each-ref tip times: {stderr}")));
+    }
+    let times = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let (name, unix) = line.split_once('\t')?;
+            let name = name.trim();
+            let unix: i64 = unix.trim().parse().ok()?;
+            (!name.is_empty()).then(|| (name.to_string(), unix))
+        })
+        .collect();
+    Ok(times)
+}
+
 #[cfg(test)]
 mod tests {
     use std::process::Command;
@@ -130,6 +163,22 @@ mod tests {
         run(Command::new("git")
             .args(["update-ref", refname, "HEAD"])
             .current_dir(repo));
+    }
+
+    #[test]
+    fn branch_tip_committer_times_lists_local_and_origin_tips() {
+        let dir = init_repo();
+        let repo = dir.path();
+        create_branch(repo, "work/x");
+        create_remote_tracking_ref(repo, "refs/remotes/origin/work/y");
+
+        let times = branch_tip_committer_times(repo).expect("tip times");
+        assert!(times.contains_key("main"));
+        assert!(times.contains_key("work/x"));
+        assert!(times.contains_key("origin/work/y"));
+        for time in times.values() {
+            assert!(*time > 1_500_000_000, "plausible unix committer time");
+        }
     }
 
     #[test]

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -2409,6 +2409,7 @@ fn active_work_items_from_projection(
                 closed_at: None,
                 session_agent_total: 0,
                 merged_into_base: false,
+                workspace_key: None,
                 updated_at: row_updated_at,
             }
         })
@@ -2493,6 +2494,7 @@ fn append_paused_work_items(
             closed_at: None,
             session_agent_total: 0,
             merged_into_base: false,
+            workspace_key: None,
             // FR-403: paused/backfill rows carry the record's last update.
             updated_at: work.updated_at.clone(),
         });
@@ -3148,6 +3150,77 @@ fn attach_registry_sessions_to_active_works(
             .unwrap_or_default()
     };
     active_works.sort_by_key(|work| std::cmp::Reverse(row_sort_key(work)));
+}
+
+/// SPEC-2359 W16-2 (FR-389 / SC-259): assign every row its Workspace
+/// grouping key (canonical branch identity → canonical worktree identity →
+/// own id) and merge rows that share a key into ONE Workspace row. The
+/// newest row is the representative; agents concatenate (the identity
+/// collapse downstream dedups), numeric counts sum, and `merged_into_base`
+/// ORs. Old branchless ids keep their own key, so legacy rows never vanish
+/// or fuse.
+fn assign_and_merge_workspace_groups(
+    active_works: &mut Vec<gwt::ActiveWorkItemView>,
+    project_root: &Path,
+) {
+    for work in active_works.iter_mut() {
+        let branch = work
+            .branch
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let worktree = work.worktree_path.as_deref().map(std::path::Path::new);
+        let key = gwt_core::workspace_projection::canonical_work_id(project_root, branch, None)
+            .or_else(|| {
+                gwt_core::workspace_projection::canonical_work_id(project_root, None, worktree)
+            })
+            .unwrap_or_else(|| work.id.clone());
+        work.workspace_key = Some(key);
+    }
+
+    let mut merged: Vec<gwt::ActiveWorkItemView> = Vec::with_capacity(active_works.len());
+    let mut index_by_key: HashMap<String, usize> = HashMap::new();
+    for work in active_works.drain(..) {
+        let key = work
+            .workspace_key
+            .clone()
+            .unwrap_or_else(|| work.id.clone());
+        match index_by_key.get(&key) {
+            Some(&slot) => {
+                let target = &mut merged[slot];
+                let newer = work.updated_at > target.updated_at;
+                let mut agents = std::mem::take(&mut target.agents);
+                agents.extend(work.agents.iter().cloned());
+                let active_agents = target.active_agents + work.active_agents;
+                let blocked_agents = target.blocked_agents + work.blocked_agents;
+                let session_agent_total = target.session_agent_total + work.session_agent_total;
+                let merged_into_base = target.merged_into_base || work.merged_into_base;
+                if newer {
+                    let key = target.workspace_key.clone();
+                    *target = work;
+                    target.workspace_key = key;
+                }
+                target.agents = agents;
+                target.active_agents = active_agents;
+                target.blocked_agents = blocked_agents;
+                target.session_agent_total = session_agent_total;
+                target.merged_into_base = merged_into_base;
+                if target.branch.is_none() {
+                    // keep any branch the group knows about
+                    target.branch = merged_branch_fallback(&target.agents);
+                }
+            }
+            None => {
+                index_by_key.insert(key, merged.len());
+                merged.push(work);
+            }
+        }
+    }
+    *active_works = merged;
+}
+
+fn merged_branch_fallback(agents: &[gwt::ActiveWorkAgentView]) -> Option<String> {
+    agents.iter().find_map(|agent| agent.branch.clone())
 }
 
 /// SPEC-2359 W-15 (FR-386): flag rows whose branch is merged into a base on
@@ -3882,8 +3955,21 @@ impl AppRuntime {
             return;
         }
         let proxy = self.proxy.clone();
+        // Resolve the home-projection paths on the calling thread: HOME is
+        // process-global and parallel unit tests scope it per test
+        // (ScopedEnvVar, #3022) — a late resolution inside the worker would
+        // race those scopes and write into another test's home.
+        let work_items_path =
+            gwt_core::paths::gwt_workspace_work_items_path_for_repo_path(&project_root);
+        let state_path = gwt_core::paths::gwt_workspace_work_events_intake_state_path_for_repo_path(
+            &project_root,
+        );
         thread::spawn(move || {
-            let summary = crate::work_events_ingest::ingest_project_work_events(&project_root);
+            let summary = crate::work_events_ingest::ingest_project_work_events_paths(
+                &project_root,
+                &work_items_path,
+                &state_path,
+            );
             proxy.send(UserEvent::WorkEventsIngested {
                 project_root,
                 changed: summary.changed(),
@@ -5788,6 +5874,10 @@ impl AppRuntime {
                 workspaces,
                 cleanup_candidate,
             );
+            // SPEC-2359 W16-2 (FR-389): group Works sharing a canonical
+            // branch into one Workspace row before the ledger attach, so the
+            // attach / identity-collapse / cap run once per Workspace.
+            assign_and_merge_workspace_groups(&mut view.active_works, &tab.project_root);
             // SPEC-2359 Phase W-16 (FR-402): attach the machine-local session
             // ledger to each Workspace (branch) row so sessions surface even
             // when works.json never recorded an agent for the branch.
@@ -5854,6 +5944,7 @@ impl AppRuntime {
             closed_at: None,
             session_agent_total: 0,
             merged_into_base: false,
+            workspace_key: None,
             updated_at: now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         }];
         Some(gwt::ActiveWorkProjectionView {

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -3700,6 +3700,9 @@ pub struct AppRuntime {
     /// events): cache hit clones instead of re-parsing per projection event.
     pub(crate) work_items_cache:
         std::cell::RefCell<gwt_core::workspace_projection::WorkspaceWorkItemsCache>,
+    /// SPEC-2359 W-16 (FR-387): last work-events ingest per project — the
+    /// 30s throttle for tab-change / post-launch triggers.
+    pub(crate) last_work_events_ingest: std::cell::RefCell<HashMap<PathBuf, std::time::Instant>>,
     pub(crate) window_pty_statuses: HashMap<String, WindowProcessStatus>,
     pub(crate) window_hook_states: HashMap<String, WindowProcessStatus>,
     pub(crate) hook_forward_target: Option<HookForwardTarget>,
@@ -3815,6 +3818,7 @@ impl AppRuntime {
             work_items_cache: std::cell::RefCell::new(
                 gwt_core::workspace_projection::WorkspaceWorkItemsCache::new(),
             ),
+            last_work_events_ingest: std::cell::RefCell::new(HashMap::new()),
             window_pty_statuses: HashMap::new(),
             window_hook_states: HashMap::new(),
             hook_forward_target: None,
@@ -3852,6 +3856,60 @@ impl AppRuntime {
     /// branches for merge-into-base off the UI thread (one `git cherry` per
     /// branch). Sends [`UserEvent::WorkMergeStatus`] when anything merged is
     /// found; silent otherwise so stub-proxy tests stay quiet.
+    /// SPEC-2359 W-16 (FR-387): note an ingest attempt for `project_root`;
+    /// returns false while the 30s throttle window is still open. Bootstrap
+    /// and project-open callers pass `force` to bypass the window.
+    pub(crate) fn note_work_events_ingest_attempt(&self, project_root: &Path, force: bool) -> bool {
+        let now = std::time::Instant::now();
+        let mut last = self.last_work_events_ingest.borrow_mut();
+        if !force {
+            if let Some(previous) = last.get(project_root) {
+                if now.duration_since(*previous) < Duration::from_secs(30) {
+                    return false;
+                }
+            }
+        }
+        last.insert(project_root.to_path_buf(), now);
+        true
+    }
+
+    /// SPEC-2359 W-16 (FR-387): run the cross-machine work events ingest on a
+    /// background thread, then hand control back to the event loop via
+    /// [`UserEvent::WorkEventsIngested`] so the worktree reconcile runs in
+    /// intake → reconcile order (plan decision 9).
+    pub(crate) fn spawn_work_events_ingest(&self, project_root: PathBuf, force: bool) {
+        if !self.note_work_events_ingest_attempt(&project_root, force) {
+            return;
+        }
+        let proxy = self.proxy.clone();
+        thread::spawn(move || {
+            let summary = crate::work_events_ingest::ingest_project_work_events(&project_root);
+            proxy.send(UserEvent::WorkEventsIngested {
+                project_root,
+                changed: summary.changed(),
+            });
+        });
+    }
+
+    /// Event-loop continuation of [`Self::spawn_work_events_ingest`]:
+    /// reconcile worktrees after the intake, kick the merge scan, and
+    /// rebroadcast the projection when the intake applied anything.
+    pub(crate) fn handle_work_events_ingested(
+        &mut self,
+        project_root: PathBuf,
+        changed: bool,
+    ) -> Vec<OutboundEvent> {
+        self.reconcile_workspace_worktrees(&project_root);
+        self.spawn_work_merge_status_scan(project_root);
+        if changed {
+            self.active_work_projection_broadcast_for_active_tab()
+                .into_iter()
+                .collect()
+        } else {
+            Vec::new()
+        }
+    }
+
     pub(crate) fn spawn_work_merge_status_scan(&self, project_root: PathBuf) {
         let proxy = self.proxy.clone();
         thread::spawn(move || {
@@ -3961,33 +4019,22 @@ impl AppRuntime {
             let _ = gwt_core::workspace_projection_migration::migrate_workspace_projection_for_repo(
                 &tab.project_root,
             );
-            // SPEC-2359 US-37: One-shot rebuild of work_items.json from the
-            // event log. Recovers legacy installations whose work_items.json
-            // shows status=active/idle for items that already have a Done
-            // event in work_events.jsonl (caused by the old apply_event
-            // semantics that regressed Done on subsequent update events).
-            // Idempotent via `work_items.migration.json` marker.
-            let _ = gwt_core::workspace_projection::rebuild_work_items_from_events_for_repo(
-                &tab.project_root,
-            );
             // SPEC-2359 Phase W-16 (FR-393): decompose legacy mega-items
             // (pre-W-12 records keyed to one projection UUID fusing dozens of
             // branches) into canonical branch-keyed items so each branch row
             // shows its real title / sessions. Idempotent; must run before
-            // the worktree reconcile so decomposed branches are not
+            // the intake/reconcile chain so decomposed branches are not
             // redundantly backfilled.
             let _ = gwt_core::workspace_projection::decompose_legacy_multi_branch_work_items(
                 &tab.project_root,
             );
-            // SPEC-2359 Phase W-15 (FR-379/FR-382): reconcile locally existing
-            // worktrees with the Work records so every real worktree surfaces
-            // on the Workspace list (union of existing worktrees and unclosed
-            // records). Runs after the rebuild above so already-recorded
-            // branches are not redundantly backfilled.
-            self.reconcile_workspace_worktrees(&tab.project_root);
-            // SPEC-2359 W-15 (FR-386): kick the background merge scan that
-            // feeds the "safe to delete" badge.
-            self.spawn_work_merge_status_scan(tab.project_root.clone());
+            // SPEC-2359 W-16 (FR-387): cross-machine work events intake.
+            // Supersedes the one-shot `rebuild_work_items_from_events_for_repo`
+            // migration gate — the intake is a permanently-installed idempotent
+            // consumer over the same (and more) sources. Runs on a background
+            // thread; its completion event then runs the worktree reconcile
+            // (intake → reconcile order) and the merge scan.
+            self.spawn_work_events_ingest(tab.project_root.clone(), true);
             // SPEC-2359 Phase W-11 (US-58 / FR-346): one-shot, version-guarded
             // clear of legacy prompt-derived title_summary / current_focus so
             // existing broken titles ("あなたの目的は何ですか" etc.) heal via the
@@ -5950,17 +5997,17 @@ impl AppRuntime {
                 if let Some(active_tab_id) = self.active_tab_id.clone() {
                     events.extend(self.restore_open_project_windows(&active_tab_id));
                 }
-                // SPEC-2359 Phase W-15 (FR-379): reconcile the opened
-                // project's worktrees before the first Workspace broadcast so
-                // backfilled rows are part of the initial list.
+                // SPEC-2359 W-16 (FR-387): run the cross-machine intake for
+                // the opened project; its completion event reconciles the
+                // worktrees (intake → reconcile order) and kicks the merge
+                // scan, then rebroadcasts the projection.
                 if let Some(project_root) = self
                     .active_tab_id
                     .as_ref()
                     .and_then(|id| self.tabs.iter().find(|tab| &tab.id == id))
                     .map(|tab| tab.project_root.clone())
                 {
-                    self.reconcile_workspace_worktrees(&project_root);
-                    self.spawn_work_merge_status_scan(project_root);
+                    self.spawn_work_events_ingest(project_root, true);
                 }
                 if let Some(event) = self.active_work_projection_broadcast_on_tab_change() {
                     events.push(event);
@@ -6169,6 +6216,16 @@ impl AppRuntime {
         }
         let wizard_closed = self.set_active_tab(tab_id.to_string());
         let _ = self.persist();
+        // SPEC-2359 W-16 (FR-387): tab changes piggyback the cross-machine
+        // intake, throttled to once per 30s per project.
+        if let Some(project_root) = self
+            .tabs
+            .iter()
+            .find(|tab| tab.id == tab_id)
+            .map(|tab| tab.project_root.clone())
+        {
+            self.spawn_work_events_ingest(project_root, false);
+        }
         let mut events = vec![self.workspace_state_broadcast()];
         if let Some(event) = self.active_work_projection_broadcast_on_tab_change() {
             events.push(event);
@@ -8419,6 +8476,10 @@ impl AppRuntime {
                         launch_feedback_context.clone(),
                     );
                 };
+                // SPEC-2359 W-16 (FR-387): a launch fetches origin refs, so
+                // piggyback the cross-machine intake (30s throttle keeps
+                // launch bursts cheap).
+                self.spawn_work_events_ingest(tab.project_root.clone(), false);
                 let Some(window) = tab.workspace.window(&address.raw_id) else {
                     return self.launch_error_events(
                         window_id,

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -2410,6 +2410,7 @@ fn active_work_items_from_projection(
                 session_agent_total: 0,
                 merged_into_base: false,
                 workspace_key: None,
+                remote_only: false,
                 updated_at: row_updated_at,
             }
         })
@@ -2495,6 +2496,7 @@ fn append_paused_work_items(
             session_agent_total: 0,
             merged_into_base: false,
             workspace_key: None,
+            remote_only: false,
             // FR-403: paused/backfill rows carry the record's last update.
             updated_at: work.updated_at.clone(),
         });
@@ -3223,6 +3225,35 @@ fn merged_branch_fallback(agents: &[gwt::ActiveWorkAgentView]) -> Option<String>
     agents.iter().find_map(|agent| agent.branch.clone())
 }
 
+/// SPEC-2359 W16-3 (FR-390): flag rows whose branch exists only as a fetched
+/// remote ref — no recorded worktree path and no local worktree for the
+/// branch. Display-only marking (FR-381/FR-390: rendering generates no
+/// events); the existing Launch path materializes a worktree on demand.
+fn mark_remote_only_active_works(
+    active_works: &mut [gwt::ActiveWorkItemView],
+    local_branches: Option<&std::collections::HashSet<String>>,
+) {
+    for work in active_works.iter_mut() {
+        let has_worktree = work
+            .worktree_path
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|path| !path.is_empty());
+        if has_worktree {
+            work.remote_only = false;
+            continue;
+        }
+        let branch_local = work
+            .branch
+            .as_deref()
+            .map(crate::runtime_support::normalize_branch_name)
+            .filter(|branch| !branch.is_empty())
+            .map(|branch| local_branches.is_some_and(|set| set.contains(&branch)));
+        // Branchless rows are never "remote": there is nothing to fetch.
+        work.remote_only = matches!(branch_local, Some(false));
+    }
+}
+
 /// SPEC-2359 W-15 (FR-386): flag rows whose branch is merged into a base on
 /// origin (background scan cache) or whose recorded PR state is merged — the
 /// "safe to delete" signal. Display-only; no automatic close (US-61).
@@ -3776,6 +3807,12 @@ pub struct AppRuntime {
     /// SPEC-2359 W-16 (FR-387): last work-events ingest per project — the
     /// 30s throttle for tab-change / post-launch triggers.
     pub(crate) last_work_events_ingest: std::cell::RefCell<HashMap<PathBuf, std::time::Instant>>,
+    /// SPEC-2359 W16-3 (FR-390): normalized branch names that currently have
+    /// a LOCAL worktree, per project — refreshed by the worktree reconcile.
+    /// The view marks `remote_only` by cache lookup alone (no git spawn on
+    /// the projection build path).
+    pub(crate) local_worktree_branches:
+        std::cell::RefCell<HashMap<PathBuf, std::collections::HashSet<String>>>,
     pub(crate) window_pty_statuses: HashMap<String, WindowProcessStatus>,
     pub(crate) window_hook_states: HashMap<String, WindowProcessStatus>,
     pub(crate) hook_forward_target: Option<HookForwardTarget>,
@@ -3892,6 +3929,7 @@ impl AppRuntime {
                 gwt_core::workspace_projection::WorkspaceWorkItemsCache::new(),
             ),
             last_work_events_ingest: std::cell::RefCell::new(HashMap::new()),
+            local_worktree_branches: std::cell::RefCell::new(HashMap::new()),
             window_pty_statuses: HashMap::new(),
             window_hook_states: HashMap::new(),
             hook_forward_target: None,
@@ -4062,6 +4100,18 @@ impl AppRuntime {
                 return;
             }
         };
+        // SPEC-2359 W16-3 (FR-390): refresh the local-worktree branch set the
+        // remote_only view marking reads (cache lookup only — no git spawn at
+        // view time).
+        let local_branches: std::collections::HashSet<String> = entries
+            .iter()
+            .filter_map(|entry| entry.branch.as_deref())
+            .map(crate::runtime_support::normalize_branch_name)
+            .filter(|branch| !branch.is_empty())
+            .collect();
+        self.local_worktree_branches
+            .borrow_mut()
+            .insert(project_root.to_path_buf(), local_branches);
         let sources = gwt::worktree_inventory::worktree_reconcile_sources(&entries);
         if sources.is_empty() {
             return;
@@ -5893,6 +5943,12 @@ impl AppRuntime {
                 &mut view.active_works,
                 self.work_merged_branches.get(&tab.project_root),
             );
+            // SPEC-2359 W16-3 (FR-390): "Remote" rows — branch known only
+            // from fetched refs, no local worktree (cache lookup only).
+            mark_remote_only_active_works(
+                &mut view.active_works,
+                self.local_worktree_branches.borrow().get(&tab.project_root),
+            );
             return Some(view);
         }
 
@@ -5945,6 +6001,7 @@ impl AppRuntime {
             session_agent_total: 0,
             merged_into_base: false,
             workspace_key: None,
+            remote_only: false,
             updated_at: now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         }];
         Some(gwt::ActiveWorkProjectionView {

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -2411,6 +2411,7 @@ fn active_work_items_from_projection(
                 merged_into_base: false,
                 workspace_key: None,
                 remote_only: false,
+                done_equivalent: false,
                 updated_at: row_updated_at,
             }
         })
@@ -2497,6 +2498,7 @@ fn append_paused_work_items(
             merged_into_base: false,
             workspace_key: None,
             remote_only: false,
+            done_equivalent: false,
             // FR-403: paused/backfill rows carry the record's last update.
             updated_at: work.updated_at.clone(),
         });
@@ -3259,20 +3261,45 @@ fn mark_remote_only_active_works(
 /// "safe to delete" signal. Display-only; no automatic close (US-61).
 fn mark_merged_active_works(
     active_works: &mut [gwt::ActiveWorkItemView],
-    merged_branches: Option<&std::collections::HashSet<String>>,
+    merged_branches: Option<&HashMap<String, chrono::DateTime<chrono::Utc>>>,
 ) {
     for work in active_works.iter_mut() {
-        let by_cache = work
+        let merge_reference = work
             .branch
             .as_deref()
             .map(crate::runtime_support::normalize_branch_name)
-            .map(|branch| merged_branches.is_some_and(|set| set.contains(&branch)))
-            .unwrap_or(false);
+            .and_then(|branch| merged_branches.and_then(|map| map.get(&branch)))
+            .copied();
         let by_pr = work
             .pr_state
             .as_deref()
             .is_some_and(|state| state.eq_ignore_ascii_case("merged"));
-        work.merged_into_base = by_cache || by_pr;
+        work.merged_into_base = merge_reference.is_some() || by_pr;
+
+        // SPEC-2359 W16-4 (FR-391): merged ∧ stale → derived Done-equivalent.
+        // Membership rides the scan verdict ONLY (pr_state stays badge-only);
+        // explicit terminal closes keep their own lifecycle; no event is ever
+        // recorded from this classification (US-61).
+        let terminal = matches!(work.lifecycle_state.as_str(), "done" | "discarded");
+        let last_activity = work
+            .agents
+            .iter()
+            .map(|agent| agent.updated_at.as_str())
+            .chain(std::iter::once(work.updated_at.as_str()))
+            .filter_map(|stamp| {
+                chrono::DateTime::parse_from_rfc3339(stamp)
+                    .ok()
+                    .map(|value| value.with_timezone(&chrono::Utc))
+            })
+            .max();
+        work.done_equivalent = !terminal
+            && last_activity.is_some_and(|last| {
+                gwt_core::workspace_projection::derive_merged_done_equivalent(
+                    merge_reference.is_some(),
+                    last,
+                    merge_reference,
+                )
+            });
     }
 }
 
@@ -3793,7 +3820,11 @@ pub struct AppRuntime {
     /// SPEC-2359 W-15 (FR-386): per-project set of branches (canonical names)
     /// fully merged into a base on origin, filled by the background merge
     /// scan. Runtime-only; never persisted.
-    pub(crate) work_merged_branches: HashMap<PathBuf, std::collections::HashSet<String>>,
+    /// SPEC-2359 W-15/W16-4 (FR-386/FR-391): merged branches per project →
+    /// merge reference time (branch tip committer time proxy). Drives the
+    /// "safe to delete" badge and the derived Done-equivalent classification.
+    pub(crate) work_merged_branches:
+        HashMap<PathBuf, HashMap<String, chrono::DateTime<chrono::Utc>>>,
     /// Incremental loader for the machine-local session ledger; keeps
     /// projection rebuilds from re-parsing thousands of unchanged TOMLs
     /// (window-close latency fix, 2026-06-11). RefCell: the runtime lives on
@@ -3954,7 +3985,7 @@ impl AppRuntime {
     pub(crate) fn apply_work_merge_status(
         &mut self,
         project_root: &Path,
-        merged_branches: std::collections::HashSet<String>,
+        merged_branches: HashMap<String, chrono::DateTime<chrono::Utc>>,
     ) -> Vec<OutboundEvent> {
         self.work_merged_branches
             .insert(project_root.to_path_buf(), merged_branches);
@@ -4064,21 +4095,39 @@ impl AppRuntime {
             if branches.is_empty() {
                 return;
             }
-            let mut merged = std::collections::HashSet::new();
+            let mut merged: Vec<String> = Vec::new();
             for branch in branches {
                 if matches!(
                     gwt_git::branch::merged_base_target(&project_root, &branch),
                     Ok(Some(_))
                 ) {
-                    merged.insert(branch);
+                    merged.push(branch);
                 }
             }
             if merged.is_empty() {
                 return;
             }
+            // SPEC-2359 W16-4 (FR-391): one extra spawn resolves every tip
+            // committer time — the merge-reference-time proxy for the derived
+            // Done classification (plan decision 8).
+            let tip_times =
+                gwt_git::refs::branch_tip_committer_times(&project_root).unwrap_or_default();
+            let merged_branches: HashMap<String, chrono::DateTime<chrono::Utc>> = merged
+                .into_iter()
+                .map(|branch| {
+                    let unix = tip_times
+                        .get(&branch)
+                        .or_else(|| tip_times.get(&format!("origin/{branch}")))
+                        .copied();
+                    let reference = unix
+                        .and_then(|seconds| chrono::DateTime::from_timestamp(seconds, 0))
+                        .unwrap_or_else(chrono::Utc::now);
+                    (branch, reference)
+                })
+                .collect();
             proxy.send(UserEvent::WorkMergeStatus {
                 project_root,
-                merged_branches: merged,
+                merged_branches,
             });
         });
     }
@@ -6002,6 +6051,7 @@ impl AppRuntime {
             merged_into_base: false,
             workspace_key: None,
             remote_only: false,
+            done_equivalent: false,
             updated_at: now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
         }];
         Some(gwt::ActiveWorkProjectionView {

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -14100,6 +14100,7 @@ fn attach_registry_sessions_caps_total_agents_on_the_wire() {
         merged_into_base: false,
         workspace_key: None,
         remote_only: false,
+        done_equivalent: false,
         updated_at: String::new(),
     }];
 
@@ -14214,6 +14215,7 @@ fn attach_registry_sessions_keeps_latest_entry_per_agent_identity() {
         merged_into_base: false,
         workspace_key: None,
         remote_only: false,
+        done_equivalent: false,
         updated_at: String::new(),
     }];
 
@@ -14296,6 +14298,7 @@ fn attach_registry_sessions_drops_ghost_agents_without_identity_or_sessions() {
         merged_into_base: false,
         workspace_key: None,
         remote_only: false,
+        done_equivalent: false,
         updated_at: String::new(),
     }];
 
@@ -14416,6 +14419,7 @@ fn attach_registry_sessions_dedupes_agents_sharing_a_conversation() {
         merged_into_base: false,
         workspace_key: None,
         remote_only: false,
+        done_equivalent: false,
         updated_at: String::new(),
     }];
 
@@ -14511,6 +14515,7 @@ fn active_works_are_sorted_by_latest_update_descending() {
         merged_into_base: false,
         workspace_key: None,
         remote_only: false,
+        done_equivalent: false,
         updated_at: updated_at.to_string(),
     };
     let mut works = vec![
@@ -14581,6 +14586,7 @@ fn mark_merged_active_works_flags_cache_and_pr_state() {
         merged_into_base: false,
         workspace_key: None,
         remote_only: false,
+        done_equivalent: false,
         updated_at: String::new(),
     };
     let mut works = vec![
@@ -14588,8 +14594,10 @@ fn mark_merged_active_works_flags_cache_and_pr_state() {
         row(Some("work/open"), None),
         row(None, Some("MERGED")),
     ];
-    let merged: std::collections::HashSet<String> =
-        ["work/merged".to_string()].into_iter().collect();
+    let merged: HashMap<String, chrono::DateTime<chrono::Utc>> =
+        [("work/merged".to_string(), chrono::Utc::now())]
+            .into_iter()
+            .collect();
 
     super::mark_merged_active_works(&mut works, Some(&merged));
 
@@ -14640,8 +14648,10 @@ fn apply_work_merge_status_caches_and_flags_rows() {
 
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
-    let merged: std::collections::HashSet<String> =
-        ["work/merged".to_string()].into_iter().collect();
+    let merged: HashMap<String, chrono::DateTime<chrono::Utc>> =
+        [("work/merged".to_string(), chrono::Utc::now())]
+            .into_iter()
+            .collect();
     let _ = runtime.apply_work_merge_status(&repo, merged);
 
     let view = runtime
@@ -14977,6 +14987,7 @@ fn assign_and_merge_workspace_groups_unifies_same_branch_rows() {
             merged_into_base: false,
             workspace_key: None,
             remote_only: false,
+            done_equivalent: false,
             updated_at: updated_at.to_string(),
         }
     }
@@ -15060,6 +15071,7 @@ fn mark_remote_only_flags_fetched_branches_without_local_worktree() {
             merged_into_base: false,
             workspace_key: None,
             remote_only: false,
+            done_equivalent: false,
             updated_at: String::new(),
         }
     }
@@ -15079,4 +15091,86 @@ fn mark_remote_only_flags_fetched_branches_without_local_worktree() {
     assert!(!works[1].remote_only, "locally checked-out branch is not");
     assert!(!works[2].remote_only, "rows with a worktree are not");
     assert!(!works[3].remote_only, "branchless rows are not");
+}
+
+/// SPEC-2359 W16-4 (FR-391): merged ∧ stale rows classify as derived Done;
+/// activity after the merge reference clears it; explicit terminal closes
+/// and pr_state-only merges never enter the derived classification; and the
+/// marking writes nothing (US-61).
+#[test]
+fn mark_merged_classifies_done_equivalent_for_stale_merged_rows() {
+    fn row(
+        id: &str,
+        branch: Option<&str>,
+        pr_state: Option<&str>,
+        lifecycle: &str,
+        updated_at: &str,
+    ) -> gwt::ActiveWorkItemView {
+        gwt::ActiveWorkItemView {
+            id: id.to_string(),
+            title: id.to_string(),
+            status_category: "idle".to_string(),
+            status_text: "Paused".to_string(),
+            summary: None,
+            owner: None,
+            next_action: None,
+            active_agents: 0,
+            blocked_agents: 0,
+            branch: branch.map(str::to_string),
+            worktree_path: None,
+            pr_number: None,
+            pr_url: None,
+            pr_state: pr_state.map(str::to_string),
+            board_refs: Vec::new(),
+            agents: Vec::new(),
+            lifecycle_state: lifecycle.to_string(),
+            closed_at: None,
+            session_agent_total: 0,
+            merged_into_base: false,
+            workspace_key: None,
+            remote_only: false,
+            done_equivalent: false,
+            updated_at: updated_at.to_string(),
+        }
+    }
+
+    let merge_at = chrono::Utc::now();
+    let stale =
+        (merge_at - chrono::Duration::hours(2)).to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let fresh =
+        (merge_at + chrono::Duration::hours(2)).to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let merged: HashMap<String, chrono::DateTime<chrono::Utc>> =
+        [("work/merged".to_string(), merge_at)]
+            .into_iter()
+            .collect();
+
+    let mut works = vec![
+        row("w-stale", Some("work/merged"), None, "paused", &stale),
+        row("w-fresh", Some("work/merged"), None, "paused", &fresh),
+        row("w-closed", Some("work/merged"), None, "done", &stale),
+        row(
+            "w-pr-only",
+            Some("work/other"),
+            Some("MERGED"),
+            "paused",
+            &stale,
+        ),
+    ];
+
+    super::mark_merged_active_works(&mut works, Some(&merged));
+
+    assert!(works[0].done_equivalent, "merged ∧ stale → derived Done");
+    assert!(
+        !works[1].done_equivalent,
+        "updated after the merge → back to Active/Paused (FR-391)"
+    );
+    assert!(
+        !works[2].done_equivalent,
+        "explicit terminal close keeps its own lifecycle"
+    );
+    assert!(
+        !works[3].done_equivalent,
+        "pr_state stays badge-only — membership rides the scan verdict"
+    );
+    assert!(works[3].merged_into_base, "pr_state still drives the badge");
 }

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -1703,6 +1703,7 @@ fn sample_runtime_with_events(
             gwt_core::workspace_projection::WorkspaceWorkItemsCache::new(),
         ),
         last_work_events_ingest: std::cell::RefCell::new(HashMap::new()),
+        local_worktree_branches: std::cell::RefCell::new(HashMap::new()),
         window_pty_statuses: HashMap::new(),
         window_hook_states: HashMap::new(),
         hook_forward_target: None,
@@ -14098,6 +14099,7 @@ fn attach_registry_sessions_caps_total_agents_on_the_wire() {
         session_agent_total: 0,
         merged_into_base: false,
         workspace_key: None,
+        remote_only: false,
         updated_at: String::new(),
     }];
 
@@ -14211,6 +14213,7 @@ fn attach_registry_sessions_keeps_latest_entry_per_agent_identity() {
         session_agent_total: 0,
         merged_into_base: false,
         workspace_key: None,
+        remote_only: false,
         updated_at: String::new(),
     }];
 
@@ -14292,6 +14295,7 @@ fn attach_registry_sessions_drops_ghost_agents_without_identity_or_sessions() {
         session_agent_total: 0,
         merged_into_base: false,
         workspace_key: None,
+        remote_only: false,
         updated_at: String::new(),
     }];
 
@@ -14411,6 +14415,7 @@ fn attach_registry_sessions_dedupes_agents_sharing_a_conversation() {
         session_agent_total: 0,
         merged_into_base: false,
         workspace_key: None,
+        remote_only: false,
         updated_at: String::new(),
     }];
 
@@ -14505,6 +14510,7 @@ fn active_works_are_sorted_by_latest_update_descending() {
         session_agent_total: 0,
         merged_into_base: false,
         workspace_key: None,
+        remote_only: false,
         updated_at: updated_at.to_string(),
     };
     let mut works = vec![
@@ -14574,6 +14580,7 @@ fn mark_merged_active_works_flags_cache_and_pr_state() {
         session_agent_total: 0,
         merged_into_base: false,
         workspace_key: None,
+        remote_only: false,
         updated_at: String::new(),
     };
     let mut works = vec![
@@ -14969,6 +14976,7 @@ fn assign_and_merge_workspace_groups_unifies_same_branch_rows() {
             session_agent_total: 1,
             merged_into_base: false,
             workspace_key: None,
+            remote_only: false,
             updated_at: updated_at.to_string(),
         }
     }
@@ -15020,4 +15028,55 @@ fn assign_and_merge_workspace_groups_unifies_same_branch_rows() {
         legacy.workspace_key.as_deref(),
         Some("workspace-1748822400000")
     );
+}
+
+/// SPEC-2359 W16-3 (FR-390): a row whose branch is known only from fetched
+/// refs (no recorded worktree, not in the local-worktree set) is flagged
+/// `remote_only`; rows with a worktree or a locally checked-out branch and
+/// branchless rows are not.
+#[test]
+fn mark_remote_only_flags_fetched_branches_without_local_worktree() {
+    fn row(id: &str, branch: Option<&str>, worktree: Option<&str>) -> gwt::ActiveWorkItemView {
+        gwt::ActiveWorkItemView {
+            id: id.to_string(),
+            title: id.to_string(),
+            status_category: "idle".to_string(),
+            status_text: "Paused".to_string(),
+            summary: None,
+            owner: None,
+            next_action: None,
+            active_agents: 0,
+            blocked_agents: 0,
+            branch: branch.map(str::to_string),
+            worktree_path: worktree.map(str::to_string),
+            pr_number: None,
+            pr_url: None,
+            pr_state: None,
+            board_refs: Vec::new(),
+            agents: Vec::new(),
+            lifecycle_state: "paused".to_string(),
+            closed_at: None,
+            session_agent_total: 0,
+            merged_into_base: false,
+            workspace_key: None,
+            remote_only: false,
+            updated_at: String::new(),
+        }
+    }
+
+    let mut local = std::collections::HashSet::new();
+    local.insert("work/local".to_string());
+    let mut works = vec![
+        row("w-remote", Some("origin/work/fetched"), None),
+        row("w-local-branch", Some("work/local"), None),
+        row("w-with-worktree", Some("work/other"), Some("/tmp/x")),
+        row("w-branchless", None, None),
+    ];
+
+    super::mark_remote_only_active_works(&mut works, Some(&local));
+
+    assert!(works[0].remote_only, "fetched-only branch is Remote");
+    assert!(!works[1].remote_only, "locally checked-out branch is not");
+    assert!(!works[2].remote_only, "rows with a worktree are not");
+    assert!(!works[3].remote_only, "branchless rows are not");
 }

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -1702,6 +1702,7 @@ fn sample_runtime_with_events(
         work_items_cache: std::cell::RefCell::new(
             gwt_core::workspace_projection::WorkspaceWorkItemsCache::new(),
         ),
+        last_work_events_ingest: std::cell::RefCell::new(HashMap::new()),
         window_pty_statuses: HashMap::new(),
         window_hook_states: HashMap::new(),
         hook_forward_target: None,
@@ -14848,4 +14849,76 @@ fn stop_window_runtime_records_paused_work_off_the_event_loop() {
         thread::sleep(Duration::from_millis(50));
     }
     assert!(recorded, "Paused Work record must land in works.json");
+}
+
+/// SPEC-2359 W-16 (FR-387): the tab-change ingest trigger is throttled to
+/// once per 30s per project; bootstrap / project-open callers bypass it.
+#[test]
+fn work_events_ingest_attempt_is_throttled_per_project() {
+    let temp = tempdir().expect("tempdir");
+    let runtime = sample_runtime(temp.path(), Vec::new(), None);
+    let root = temp.path().join("repo");
+
+    assert!(runtime.note_work_events_ingest_attempt(&root, false));
+    assert!(
+        !runtime.note_work_events_ingest_attempt(&root, false),
+        "second attempt within 30s is throttled"
+    );
+    assert!(
+        runtime.note_work_events_ingest_attempt(&root, true),
+        "force bypasses the throttle"
+    );
+    let other = temp.path().join("other");
+    assert!(
+        runtime.note_work_events_ingest_attempt(&other, false),
+        "throttle is per project root"
+    );
+}
+
+/// SPEC-2359 W-16 (FR-387): the ingest completion handler runs the worktree
+/// reconcile AFTER the intake (intake → reconcile order) and rebroadcasts
+/// the projection only when the intake applied events.
+#[test]
+fn handle_work_events_ingested_broadcasts_only_on_change() {
+    let _env_lock = env_test_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let temp = tempdir().expect("tempdir");
+    let _home = ScopedEnvVar::set("HOME", temp.path());
+    let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+    let repo = temp.path().join("repo");
+    fs::create_dir_all(&repo).expect("repo dir");
+    let tab = sample_project_tab(
+        "tab-1",
+        "Repo",
+        repo.clone(),
+        ProjectKind::Git,
+        &[WindowPreset::Shell],
+    );
+    let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+
+    // Seed one Work record so the projection broadcast has content.
+    let mut seed = gwt_core::workspace_projection::WorkspaceWorkEvent::new(
+        gwt_core::workspace_projection::WorkspaceWorkEventKind::Start,
+        "work-session-ingest-seed",
+        chrono::Utc::now(),
+    );
+    seed.status_category = Some(gwt_core::workspace_projection::WorkspaceStatusCategory::Active);
+    seed.title = Some("seed".to_string());
+    gwt_core::workspace_projection::record_workspace_work_event(&repo, seed)
+        .expect("seed work record");
+
+    let unchanged = runtime.handle_work_events_ingested(repo.clone(), false);
+    assert!(
+        unchanged.is_empty(),
+        "no-op ingest must not rebroadcast the projection"
+    );
+
+    let changed = runtime.handle_work_events_ingested(repo, true);
+    assert!(
+        changed
+            .iter()
+            .any(|outbound| matches!(&outbound.event, BackendEvent::ActiveWorkProjection { .. })),
+        "changed ingest rebroadcasts the projection"
+    );
 }

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -4939,19 +4939,25 @@ fn app_runtime_active_work_projection_separates_sessions_on_same_branch() {
         .active_work_projection_for_tab("tab-1", &runtime.tabs[0])
         .expect("projection view");
 
-    assert_eq!(view.active_work_count, 2);
-    assert_eq!(view.active_works.len(), 2);
-    assert!(view.active_works.iter().all(|work| work.agents.len() == 1));
-    assert!(view.active_works.iter().any(|work| work
+    // SPEC-2359 W16-2 (FR-389 / SC-259) supersedes the original two-row
+    // contract here: storage still keys one Work per agent session (FR-348),
+    // but the VIEW groups same-branch Works into one Workspace row carrying
+    // both live agents.
+    assert_eq!(
+        view.active_works.len(),
+        1,
+        "same branch groups into one row"
+    );
+    let row = &view.active_works[0];
+    assert!(row
         .agents
         .iter()
-        .any(|agent| agent.session_id == "session-a")));
-    assert!(view.active_works.iter().any(|work| work
+        .any(|agent| agent.session_id == "session-a"));
+    assert!(row
         .agents
         .iter()
-        .any(|agent| agent.session_id == "session-b")));
-    // Same branch, different sessions → distinct Work ids.
-    assert_ne!(view.active_works[0].id, view.active_works[1].id);
+        .any(|agent| agent.session_id == "session-b"));
+    assert!(row.workspace_key.is_some());
 }
 
 /// SPEC-2359 Phase W-12 Slice 2 (FR-349): each `active_works` item carries a
@@ -14091,6 +14097,7 @@ fn attach_registry_sessions_caps_total_agents_on_the_wire() {
         closed_at: None,
         session_agent_total: 0,
         merged_into_base: false,
+        workspace_key: None,
         updated_at: String::new(),
     }];
 
@@ -14203,6 +14210,7 @@ fn attach_registry_sessions_keeps_latest_entry_per_agent_identity() {
         closed_at: None,
         session_agent_total: 0,
         merged_into_base: false,
+        workspace_key: None,
         updated_at: String::new(),
     }];
 
@@ -14283,6 +14291,7 @@ fn attach_registry_sessions_drops_ghost_agents_without_identity_or_sessions() {
         closed_at: None,
         session_agent_total: 0,
         merged_into_base: false,
+        workspace_key: None,
         updated_at: String::new(),
     }];
 
@@ -14401,6 +14410,7 @@ fn attach_registry_sessions_dedupes_agents_sharing_a_conversation() {
         closed_at: None,
         session_agent_total: 0,
         merged_into_base: false,
+        workspace_key: None,
         updated_at: String::new(),
     }];
 
@@ -14494,6 +14504,7 @@ fn active_works_are_sorted_by_latest_update_descending() {
         closed_at: None,
         session_agent_total: 0,
         merged_into_base: false,
+        workspace_key: None,
         updated_at: updated_at.to_string(),
     };
     let mut works = vec![
@@ -14562,6 +14573,7 @@ fn mark_merged_active_works_flags_cache_and_pr_state() {
         closed_at: None,
         session_agent_total: 0,
         merged_into_base: false,
+        workspace_key: None,
         updated_at: String::new(),
     };
     let mut works = vec![
@@ -14920,5 +14932,92 @@ fn handle_work_events_ingested_broadcasts_only_on_change() {
             .iter()
             .any(|outbound| matches!(&outbound.event, BackendEvent::ActiveWorkProjection { .. })),
         "changed ingest rebroadcasts the projection"
+    );
+}
+
+/// SPEC-2359 W16-2 (FR-389 / SC-259): two Works on the same canonical branch
+/// (any spelling) merge into ONE Workspace row — newest representative,
+/// agents concatenated, counts summed — while branchless legacy rows keep
+/// their own identity.
+#[test]
+fn assign_and_merge_workspace_groups_unifies_same_branch_rows() {
+    fn row(
+        id: &str,
+        branch: Option<&str>,
+        updated_at: &str,
+        agents: usize,
+    ) -> gwt::ActiveWorkItemView {
+        gwt::ActiveWorkItemView {
+            id: id.to_string(),
+            title: id.to_string(),
+            status_category: "idle".to_string(),
+            status_text: "Paused".to_string(),
+            summary: None,
+            owner: None,
+            next_action: None,
+            active_agents: agents,
+            blocked_agents: 0,
+            branch: branch.map(str::to_string),
+            worktree_path: None,
+            pr_number: None,
+            pr_url: None,
+            pr_state: None,
+            board_refs: Vec::new(),
+            agents: Vec::new(),
+            lifecycle_state: "paused".to_string(),
+            closed_at: None,
+            session_agent_total: 1,
+            merged_into_base: false,
+            workspace_key: None,
+            updated_at: updated_at.to_string(),
+        }
+    }
+
+    let temp = tempdir().expect("tempdir");
+    let root = temp.path().join("repo");
+    let mut works = vec![
+        row(
+            "work-session-aaaa",
+            Some("work/x"),
+            "2026-06-11T10:00:00Z",
+            1,
+        ),
+        row(
+            "work-session-bbbb",
+            Some("origin/work/x"),
+            "2026-06-12T10:00:00Z",
+            2,
+        ),
+        row("workspace-1748822400000", None, "2026-06-10T10:00:00Z", 0),
+    ];
+
+    super::assign_and_merge_workspace_groups(&mut works, &root);
+
+    assert_eq!(
+        works.len(),
+        2,
+        "same-branch rows merge; legacy row survives"
+    );
+    let group = works
+        .iter()
+        .find(|work| {
+            work.branch.as_deref() == Some("origin/work/x")
+                || work.branch.as_deref() == Some("work/x")
+        })
+        .expect("grouped row");
+    assert_eq!(
+        group.id, "work-session-bbbb",
+        "newest row is the representative"
+    );
+    assert_eq!(group.active_agents, 3, "agent counts sum");
+    assert_eq!(group.session_agent_total, 2, "session totals sum");
+    assert!(group.workspace_key.is_some());
+    let legacy = works
+        .iter()
+        .find(|work| work.id == "workspace-1748822400000")
+        .expect("legacy row");
+    assert_eq!(
+        legacy.workspace_key.as_deref(),
+        Some("workspace-1748822400000")
     );
 }

--- a/crates/gwt/src/cli/workspace.rs
+++ b/crates/gwt/src/cli/workspace.rs
@@ -442,7 +442,34 @@ pub(super) fn run<E: CliEnv>(
         } => {
             let existing =
                 load_or_synthesize_workspace_work_items(env.repo_path()).map_err(core_error)?;
-            if split_from.is_none()
+            let mut projection =
+                load_or_default_workspace_projection(env.repo_path()).map_err(core_error)?;
+            let Some(agent) = projection
+                .agents
+                .iter()
+                .find(|agent| agent.session_id == agent_session)
+            else {
+                return Err(string_error(format!(
+                    "agent session not found: {agent_session}"
+                )));
+            };
+            let agent_display_name = agent.display_name.clone();
+            // SPEC-2359 W16-2 (FR-389): mint the canonical (machine-
+            // independent, branch-keyed) Work id when the agent has a branch
+            // so every machine's records join the same Workspace.
+            let canonical_id = gwt_core::workspace_projection::canonical_work_id(
+                env.repo_path(),
+                agent.branch.as_deref(),
+                agent.worktree_path.as_deref(),
+            );
+            let canonical_joins_existing = canonical_id.as_deref().is_some_and(|id| {
+                existing
+                    .work_items
+                    .iter()
+                    .any(|item| item.is_incomplete() && item.id == id)
+            });
+            if !canonical_joins_existing
+                && split_from.is_none()
                 && boundary
                     .as_deref()
                     .map(str::trim)
@@ -464,19 +491,8 @@ pub(super) fn run<E: CliEnv>(
                     )));
                 }
             }
-            let mut projection =
-                load_or_default_workspace_projection(env.repo_path()).map_err(core_error)?;
-            let Some(agent) = projection
-                .agents
-                .iter()
-                .find(|agent| agent.session_id == agent_session)
-            else {
-                return Err(string_error(format!(
-                    "agent session not found: {agent_session}"
-                )));
-            };
-            let agent_display_name = agent.display_name.clone();
-            let workspace_id = format!("workspace-{}", Utc::now().timestamp_millis());
+            let workspace_id = canonical_id
+                .unwrap_or_else(|| format!("workspace-{}", Utc::now().timestamp_millis()));
             let owner = spec
                 .map(|number| format!("SPEC-{number}"))
                 .or_else(|| issue.map(|number| format!("Issue #{number}")));
@@ -758,6 +774,42 @@ pub(super) fn ensure_workspace_for_agent(
     }
 
     let existing = load_or_synthesize_workspace_work_items(repo_path).map_err(core_error)?;
+    // SPEC-2359 W16-2 (FR-389): when the canonical (branch-keyed) Work id
+    // already names an incomplete item, join it directly — the similarity
+    // guard never blocks same-branch convergence.
+    if let Some(canonical_id) = gwt_core::workspace_projection::canonical_work_id(
+        repo_path,
+        agent.branch.as_deref(),
+        agent.worktree_path.as_deref(),
+    ) {
+        if existing
+            .work_items
+            .iter()
+            .any(|item| item.is_incomplete() && item.id == canonical_id)
+        {
+            record_workspace_join_event(repo_path, &canonical_id, &input, owner.clone(), &agent)?;
+            assign_agent_to_workspace(
+                &mut projection,
+                &input.agent_session,
+                &canonical_id,
+                input.current_focus,
+                Some(input.title_summary),
+            )?;
+            if let Some(item) = existing
+                .work_items
+                .iter()
+                .find(|item| item.id == canonical_id)
+            {
+                apply_workspace_item_to_projection(&mut projection, item);
+            }
+            save_workspace_projection(repo_path, &projection).map_err(core_error)?;
+            publish_workspace_change(repo_path);
+            return Ok(WorkspaceEnsureResult {
+                workspace_id: canonical_id,
+                disposition: WorkspaceEnsureDisposition::Joined,
+            });
+        }
+    }
     let ensure_text = workspace_ensure_text(&input, owner.as_deref());
     if let Some(item) = best_workspace_candidate(&existing.work_items, &ensure_text) {
         let workspace_id = item.id.clone();
@@ -859,7 +911,14 @@ fn create_workspace_for_agent(
     owner: Option<String>,
     agent: &WorkspaceAgentSummary,
 ) -> Result<String, SpecOpsError> {
-    let workspace_id = format!("workspace-{}", Utc::now().timestamp_millis());
+    // SPEC-2359 W16-2 (FR-389): canonical, machine-independent Work id when
+    // the agent has a branch / worktree; millis fallback for branchless agents.
+    let workspace_id = gwt_core::workspace_projection::canonical_work_id(
+        repo_path,
+        agent.branch.as_deref(),
+        agent.worktree_path.as_deref(),
+    )
+    .unwrap_or_else(|| format!("workspace-{}", Utc::now().timestamp_millis()));
     let now = Utc::now();
     let mut event =
         WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Start, workspace_id.clone(), now);
@@ -1605,7 +1664,7 @@ mod tests {
         .expect("create workspace");
 
         assert_eq!(code, 0);
-        assert!(out.contains("workspace created: workspace-"));
+        assert!(out.contains("workspace created: work-"), "{out}");
         let saved = load_workspace_projection(&repo)
             .expect("load projection")
             .expect("projection");
@@ -1815,7 +1874,8 @@ mod tests {
         .expect("explicit split boundary should create a new Workspace");
 
         assert_eq!(code, 0);
-        assert!(out.contains("workspace created: workspace-"), "{out}");
+        // SPEC-2359 W16-2: branch-bearing agents mint the canonical work- id.
+        assert!(out.contains("workspace created: work-"), "{out}");
         let saved = load_workspace_projection(&repo)
             .expect("load projection")
             .expect("projection");
@@ -1834,6 +1894,95 @@ mod tests {
             .iter()
             .any(|item| item.id == "workspace-existing"));
         assert!(items.work_items.iter().any(|item| item.id == saved.id));
+    }
+
+    #[test]
+    fn workspace_ensure_joins_existing_canonical_branch_workspace_bypassing_similarity() {
+        let _guard = gwt_core::test_support::env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let home = tempfile::tempdir().expect("home");
+        let _home = ScopedHome::set(home.path());
+        let repo = tempfile::tempdir().expect("repo");
+
+        // Existing incomplete Work keyed by the canonical branch id.
+        let canonical_id = gwt_core::workspace_projection::canonical_work_id(
+            repo.path(),
+            Some("work/canonical"),
+            None,
+        )
+        .expect("canonical id");
+        let now = Utc::now();
+        let mut start =
+            WorkspaceWorkEvent::new(WorkspaceWorkEventKind::Start, canonical_id.clone(), now);
+        start.title = Some("totally different wording".to_string());
+        start.status_category = Some(WorkspaceStatusCategory::Active);
+        record_workspace_work_event(repo.path(), start).expect("seed canonical work");
+
+        // Live agent on the same branch with entirely dissimilar text.
+        let mut projection = load_or_default_workspace_projection(repo.path()).expect("projection");
+        let mut canonical_agent = unassigned_agent("session-canonical");
+        canonical_agent.branch = Some("work/canonical".to_string());
+        projection.agents.push(canonical_agent);
+        save_workspace_projection(repo.path(), &projection).expect("save projection");
+
+        let result = ensure_workspace_for_agent(
+            repo.path(),
+            WorkspaceEnsureInput {
+                agent_session: "session-canonical".to_string(),
+                title_summary: "no lexical overlap at all".to_string(),
+                current_focus: None,
+                spec: None,
+                issue: None,
+                topic: None,
+                boundary: None,
+            },
+        )
+        .expect("ensure");
+        assert_eq!(result.workspace_id, canonical_id);
+        assert!(matches!(
+            result.disposition,
+            WorkspaceEnsureDisposition::Joined
+        ));
+    }
+
+    #[test]
+    fn workspace_create_for_agent_mints_canonical_id_for_branch() {
+        let _guard = gwt_core::test_support::env_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let home = tempfile::tempdir().expect("home");
+        let _home = ScopedHome::set(home.path());
+        let repo = tempfile::tempdir().expect("repo");
+
+        let mut projection = load_or_default_workspace_projection(repo.path()).expect("projection");
+        let mut agent = unassigned_agent("session-mint");
+        agent.branch = Some("work/minted".to_string());
+        agent.worktree_path = None;
+        projection.agents.push(agent.clone());
+        let workspace_id = create_workspace_for_agent(
+            repo.path(),
+            &mut projection,
+            &WorkspaceEnsureInput {
+                agent_session: "session-mint".to_string(),
+                title_summary: "mint".to_string(),
+                current_focus: None,
+                spec: None,
+                issue: None,
+                topic: None,
+                boundary: None,
+            },
+            None,
+            &agent,
+        )
+        .expect("create");
+        let expected = gwt_core::workspace_projection::canonical_work_id(
+            repo.path(),
+            Some("work/minted"),
+            None,
+        )
+        .expect("canonical id");
+        assert_eq!(workspace_id, expected);
     }
 
     #[test]
@@ -1930,7 +2079,7 @@ mod tests {
         .expect("ensure workspace");
 
         assert_eq!(code, 0);
-        assert!(out.contains("workspace ensured: workspace-"));
+        assert!(out.contains("workspace ensured: work-"), "{out}");
         assert!(out.contains("(created)"));
         let saved = load_workspace_projection(&repo)
             .expect("load projection")

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -49,6 +49,7 @@ mod runtime_support;
 mod session_ledger_cache;
 mod update_front_door;
 mod usage_poller;
+mod work_events_ingest;
 mod workspace_session_registry;
 
 #[cfg(test)]
@@ -925,6 +926,14 @@ enum UserEvent {
     WorkMergeStatus {
         project_root: PathBuf,
         merged_branches: std::collections::HashSet<String>,
+    },
+    /// SPEC-2359 W-16 (FR-387): a background work-events ingest finished.
+    /// The handler runs the worktree reconcile AFTER the intake (so branches
+    /// already recorded elsewhere are not redundantly backfilled) and
+    /// rebroadcasts the Workspace projection when anything was applied.
+    WorkEventsIngested {
+        project_root: PathBuf,
+        changed: bool,
     },
     WorkspaceProjectionChanged {
         project_root: PathBuf,
@@ -2166,6 +2175,7 @@ mod tests {
             work_items_cache: std::cell::RefCell::new(
                 gwt_core::workspace_projection::WorkspaceWorkItemsCache::new(),
             ),
+            last_work_events_ingest: std::cell::RefCell::new(HashMap::new()),
             window_pty_statuses: HashMap::new(),
             window_hook_states: HashMap::new(),
             hook_forward_target: None,
@@ -6672,6 +6682,13 @@ fn main() -> std::io::Result<()> {
             }
             Event::UserEvent(UserEvent::BoardProjectionChanged { project_root }) => {
                 let events = app.handle_board_projection_changed_events(&project_root);
+                clients.dispatch(events);
+            }
+            Event::UserEvent(UserEvent::WorkEventsIngested {
+                project_root,
+                changed,
+            }) => {
+                let events = app.handle_work_events_ingested(project_root, changed);
                 clients.dispatch(events);
             }
             Event::UserEvent(UserEvent::WorkMergeStatus {

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -925,7 +925,7 @@ enum UserEvent {
     /// so rows can show the "safe to delete" badge.
     WorkMergeStatus {
         project_root: PathBuf,
-        merged_branches: std::collections::HashSet<String>,
+        merged_branches: std::collections::HashMap<String, chrono::DateTime<chrono::Utc>>,
     },
     /// SPEC-2359 W-16 (FR-387): a background work-events ingest finished.
     /// The handler runs the worktree reconcile AFTER the intake (so branches

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2176,6 +2176,7 @@ mod tests {
                 gwt_core::workspace_projection::WorkspaceWorkItemsCache::new(),
             ),
             last_work_events_ingest: std::cell::RefCell::new(HashMap::new()),
+            local_worktree_branches: std::cell::RefCell::new(HashMap::new()),
             window_pty_statuses: HashMap::new(),
             window_hook_states: HashMap::new(),
             hook_forward_target: None,

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -1123,6 +1123,11 @@ pub struct ActiveWorkItemView {
     /// Workspace row at view assembly. `None` on legacy payloads.
     #[serde(default)]
     pub workspace_key: Option<String>,
+    /// SPEC-2359 W16-3 (FR-390): the branch exists only as a fetched remote
+    /// ref — no local worktree. Display-only; launching materializes the
+    /// worktree through the existing Launch path. Default false (legacy).
+    #[serde(default)]
+    pub remote_only: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -2765,6 +2770,7 @@ mod tests {
                     session_agent_total: 0,
                     merged_into_base: false,
                     workspace_key: None,
+                    remote_only: false,
                     updated_at: "2026-01-01T00:00:00Z".to_string(),
                 }],
                 agents: vec![super::ActiveWorkAgentView {

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -1118,6 +1118,11 @@ pub struct ActiveWorkItemView {
     /// safe to delete. Display-only; no automatic close (US-61).
     #[serde(default)]
     pub merged_into_base: bool,
+    /// SPEC-2359 W16-2 (FR-389): Workspace grouping key — Works sharing a
+    /// canonical branch (any spelling) carry the same key and merge into one
+    /// Workspace row at view assembly. `None` on legacy payloads.
+    #[serde(default)]
+    pub workspace_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -2759,6 +2764,7 @@ mod tests {
                     closed_at: None,
                     session_agent_total: 0,
                     merged_into_base: false,
+                    workspace_key: None,
                     updated_at: "2026-01-01T00:00:00Z".to_string(),
                 }],
                 agents: vec![super::ActiveWorkAgentView {

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -1128,6 +1128,12 @@ pub struct ActiveWorkItemView {
     /// worktree through the existing Launch path. Default false (legacy).
     #[serde(default)]
     pub remote_only: bool,
+    /// SPEC-2359 W16-4 (FR-391): derived Done classification — the branch is
+    /// merged into a base AND the Workspace has no update after the merge
+    /// reference time. Display-only (US-61: never records a close); clears
+    /// automatically when the Workspace is updated after the merge.
+    #[serde(default)]
+    pub done_equivalent: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -2771,6 +2777,7 @@ mod tests {
                     merged_into_base: false,
                     workspace_key: None,
                     remote_only: false,
+                    done_equivalent: false,
                     updated_at: "2026-01-01T00:00:00Z".to_string(),
                 }],
                 agents: vec![super::ActiveWorkAgentView {

--- a/crates/gwt/src/work_events_ingest.rs
+++ b/crates/gwt/src/work_events_ingest.rs
@@ -1,0 +1,303 @@
+//! SPEC-2359 W-16 (FR-387/FR-388): project-level work events ingest
+//! orchestrator.
+//!
+//! Collects `.gwt/work/events.jsonl` content from every reachable source —
+//! local worktree filesystems (the base/main checkout included) and fetched
+//! `origin/*` refs (checkout-free blob reads) — and funnels each through the
+//! idempotent gwt-core intake into the home works projection. A fingerprint
+//! cache (`work-events-intake.json`) skips unchanged sources; correctness
+//! never depends on it (dedup is event-id based, SC-260).
+//!
+//! Spawn budget per run: 1 `git worktree list` (inventory) + 1
+//! `for-each-ref` + 1 `cat-file --batch-check` + one `cat-file blob` per
+//! not-yet-ingested events blob. Callers run this off the UI thread.
+
+use std::path::{Path, PathBuf};
+
+use gwt_core::work_events_intake::{
+    content_fingerprint, ingest_work_events_content, load_work_events_intake_state,
+    save_work_events_intake_state, WorkEventsIntakeReport,
+};
+
+/// Where one ingested chunk of content came from (cache key prefix).
+const SOURCE_WORKTREE: &str = "worktree:";
+const SOURCE_REF: &str = "ref:";
+
+/// Tree path of the persistent core inside a worktree / commit.
+const EVENTS_TREE_PATH: &str = ".gwt/work/events.jsonl";
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct WorkEventsIngestSummary {
+    /// Sources whose content was read and offered to the intake.
+    pub sources_ingested: usize,
+    /// Sources skipped because their fingerprint was already current.
+    pub sources_skipped: usize,
+    /// Events applied across all ingested sources.
+    pub events_applied: usize,
+}
+
+impl WorkEventsIngestSummary {
+    pub fn changed(&self) -> bool {
+        self.events_applied > 0
+    }
+
+    fn absorb(&mut self, report: &WorkEventsIntakeReport) {
+        self.sources_ingested += 1;
+        self.events_applied += report.applied;
+    }
+}
+
+/// Run the full ingest for a project, resolving the home-projection paths
+/// from the repository (the paths-injected variant carries the logic).
+pub fn ingest_project_work_events(project_root: &Path) -> WorkEventsIngestSummary {
+    let work_items_path =
+        gwt_core::paths::gwt_workspace_work_items_path_for_repo_path(project_root);
+    let state_path =
+        gwt_core::paths::gwt_workspace_work_events_intake_state_path_for_repo_path(project_root);
+    ingest_project_work_events_paths(project_root, &work_items_path, &state_path)
+}
+
+/// Paths-injected ingest (#3022): all writes go to `work_items_path` /
+/// `state_path`. Source-level failures are logged and skipped — a broken
+/// worktree or unreadable ref never aborts the sweep.
+pub fn ingest_project_work_events_paths(
+    project_root: &Path,
+    work_items_path: &Path,
+    state_path: &Path,
+) -> WorkEventsIngestSummary {
+    let mut summary = WorkEventsIngestSummary::default();
+    let mut state = load_work_events_intake_state(state_path);
+    let mut state_changed = false;
+
+    // 1) Local worktree filesystems (base/main checkout included): committed
+    //    or not, the working copy is the freshest view of each branch's log.
+    for events_path in worktree_events_files(project_root) {
+        let Ok(content) = std::fs::read_to_string(&events_path) else {
+            continue;
+        };
+        let key = format!("{SOURCE_WORKTREE}{}", events_path.display());
+        let fingerprint = content_fingerprint(&content);
+        if state.is_current(&key, &fingerprint) {
+            summary.sources_skipped += 1;
+            continue;
+        }
+        match ingest_work_events_content(work_items_path, &content) {
+            Ok(report) => {
+                summary.absorb(&report);
+                state.record(key, fingerprint);
+                state_changed = true;
+            }
+            Err(error) => {
+                tracing::warn!(%error, path = %events_path.display(), "work events ingest: worktree source failed");
+            }
+        }
+    }
+
+    // 2) Fetched origin/* refs — checkout-free blob reads. Close-kind
+    //    filtering inside the intake keeps foreign close state out (FR-384)
+    //    and lenient parsing guards against contaminated logs (#3023).
+    match gwt_git::refs::list_origin_refs_with_commit(project_root) {
+        Ok(refs) if !refs.is_empty() => {
+            let commits: Vec<String> = refs.iter().map(|(_, sha)| sha.clone()).collect();
+            match gwt_git::blob::events_blob_oids_batch(project_root, &commits, EVENTS_TREE_PATH) {
+                Ok(oids) => {
+                    for ((refname, _), oid) in refs.iter().zip(oids) {
+                        let Some(oid) = oid else { continue };
+                        let key = format!("{SOURCE_REF}{refname}");
+                        if state.is_current(&key, &oid) {
+                            summary.sources_skipped += 1;
+                            continue;
+                        }
+                        let content = match gwt_git::blob::read_blob(project_root, &oid) {
+                            Ok(content) => content,
+                            Err(error) => {
+                                tracing::warn!(%error, refname, "work events ingest: blob read failed");
+                                continue;
+                            }
+                        };
+                        match ingest_work_events_content(work_items_path, &content) {
+                            Ok(report) => {
+                                summary.absorb(&report);
+                                state.record(key, oid);
+                                state_changed = true;
+                            }
+                            Err(error) => {
+                                tracing::warn!(%error, refname, "work events ingest: ref source failed");
+                            }
+                        }
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "work events ingest: batch-check failed");
+                }
+            }
+        }
+        Ok(_) => {}
+        Err(error) => {
+            tracing::warn!(%error, "work events ingest: origin ref listing failed");
+        }
+    }
+
+    if state_changed {
+        if let Err(error) = save_work_events_intake_state(state_path, &state) {
+            tracing::warn!(%error, "work events ingest: state save failed");
+        }
+    }
+    summary
+}
+
+/// The events.jsonl file of every local worktree (main checkout included).
+fn worktree_events_files(project_root: &Path) -> Vec<PathBuf> {
+    match gwt::worktree_inventory::enumerate_worktrees(project_root, None) {
+        Ok(entries) => entries
+            .into_iter()
+            .map(|entry| entry.path.join(EVENTS_TREE_PATH))
+            .filter(|path| path.exists())
+            .collect(),
+        Err(error) => {
+            tracing::warn!(%error, "work events ingest: worktree enumeration failed");
+            Vec::new()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    fn run(cmd: &mut Command) {
+        let output = cmd.output().expect("git command should run");
+        assert!(
+            output.status.success(),
+            "git command failed: {}\nstderr: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_repo(path: &Path) {
+        run(Command::new("git")
+            .args(["init", "--initial-branch=main"])
+            .current_dir(path));
+        run(Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(path));
+        run(Command::new("git")
+            .args(["config", "user.name", "Test User"])
+            .current_dir(path));
+        run(Command::new("git")
+            .args(["commit", "--allow-empty", "-m", "init"])
+            .current_dir(path));
+    }
+
+    fn event_line(id: &str, work_id: &str, title: &str, updated_at: &str) -> String {
+        format!(
+            "{{\"id\":\"{id}\",\"work_item_id\":\"{work_id}\",\"kind\":\"start\",\"updated_at\":\"{updated_at}\",\"title\":\"{title}\",\"status_category\":\"active\"}}"
+        )
+    }
+
+    /// SC-258: events committed on another branch (visible only as a fetched
+    /// origin ref) restore the Work skeleton without any checkout; the local
+    /// working copy of the repo is also swept. Second run is fingerprint-
+    /// skipped end to end.
+    #[test]
+    fn ingest_restores_skeleton_from_worktree_fs_and_origin_ref() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo dir");
+        init_repo(&repo);
+
+        // Worktree fs source: uncommitted events.jsonl in the main checkout.
+        std::fs::create_dir_all(repo.join(".gwt/work")).expect("mk .gwt/work");
+        std::fs::write(
+            repo.join(".gwt/work/events.jsonl"),
+            format!(
+                "{}\n",
+                event_line(
+                    "evt-fs-1",
+                    "work-fs-aaaa1111",
+                    "fs work",
+                    "2026-06-01T10:00:00Z"
+                )
+            ),
+        )
+        .expect("write fs events");
+
+        // Origin ref source: events.jsonl committed on a side branch that is
+        // NOT checked out anywhere, forged as a remote tracking ref.
+        run(Command::new("git")
+            .args(["checkout", "-b", "work/remote-side"])
+            .current_dir(&repo));
+        std::fs::write(
+            repo.join(".gwt/work/events.jsonl"),
+            format!(
+                "{}\n",
+                event_line(
+                    "evt-ref-1",
+                    "work-ref-bbbb2222",
+                    "remote work",
+                    "2026-06-02T10:00:00Z"
+                )
+            ),
+        )
+        .expect("write ref events");
+        run(Command::new("git")
+            .args(["add", ".gwt/work/events.jsonl"])
+            .current_dir(&repo));
+        run(Command::new("git")
+            .args(["commit", "-m", "remote events"])
+            .current_dir(&repo));
+        run(Command::new("git")
+            .args(["update-ref", "refs/remotes/origin/work/remote-side", "HEAD"])
+            .current_dir(&repo));
+        run(Command::new("git")
+            .args(["checkout", "main"])
+            .current_dir(&repo));
+        // Restore the fs source clobbered by the branch dance.
+        std::fs::create_dir_all(repo.join(".gwt/work")).expect("mk .gwt/work");
+        std::fs::write(
+            repo.join(".gwt/work/events.jsonl"),
+            format!(
+                "{}\n",
+                event_line(
+                    "evt-fs-1",
+                    "work-fs-aaaa1111",
+                    "fs work",
+                    "2026-06-01T10:00:00Z"
+                )
+            ),
+        )
+        .expect("rewrite fs events");
+
+        let work_items_path = temp.path().join("state/works.json");
+        let state_path = temp.path().join("state/work-events-intake.json");
+
+        let first = ingest_project_work_events_paths(&repo, &work_items_path, &state_path);
+        assert!(
+            first.events_applied >= 2,
+            "fs + ref events applied: {first:?}"
+        );
+
+        let projection =
+            gwt_core::workspace_projection::load_workspace_work_items_from_path(&work_items_path)
+                .expect("load")
+                .expect("projection");
+        let ids: Vec<&str> = projection
+            .work_items
+            .iter()
+            .map(|item| item.id.as_str())
+            .collect();
+        assert!(ids.contains(&"work-fs-aaaa1111"), "fs skeleton restored");
+        assert!(
+            ids.contains(&"work-ref-bbbb2222"),
+            "origin ref skeleton restored"
+        );
+
+        // Second run: every source fingerprint is current — nothing re-reads.
+        let second = ingest_project_work_events_paths(&repo, &work_items_path, &state_path);
+        assert_eq!(second.events_applied, 0);
+        assert_eq!(second.sources_ingested, 0);
+        assert!(second.sources_skipped >= 2, "fingerprint skip: {second:?}");
+    }
+}

--- a/crates/gwt/src/work_events_ingest.rs
+++ b/crates/gwt/src/work_events_ingest.rs
@@ -47,16 +47,6 @@ impl WorkEventsIngestSummary {
     }
 }
 
-/// Run the full ingest for a project, resolving the home-projection paths
-/// from the repository (the paths-injected variant carries the logic).
-pub fn ingest_project_work_events(project_root: &Path) -> WorkEventsIngestSummary {
-    let work_items_path =
-        gwt_core::paths::gwt_workspace_work_items_path_for_repo_path(project_root);
-    let state_path =
-        gwt_core::paths::gwt_workspace_work_events_intake_state_path_for_repo_path(project_root);
-    ingest_project_work_events_paths(project_root, &work_items_path, &state_path)
-}
-
 /// Paths-injected ingest (#3022): all writes go to `work_items_path` /
 /// `state_path`. Source-level failures are logged and skipped — a broken
 /// worktree or unreadable ref never aborts the sweep.

--- a/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
+++ b/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
@@ -1027,6 +1027,76 @@ test("merged Workspace detail offers a Clean Up control for its branch", () => {
   assert.equal(cleanupCalls[0]?.branch, "work/merged");
 });
 
+// User verification 2026-06-12: completed (merged) local branches need a
+// BULK cleanup path — the list header offers "Clean Up Merged (N)" that opens
+// the cleanup flow with every merged row preselected.
+test("list header offers bulk Clean Up Merged for all merged Workspaces", () => {
+  const fixture = createFixture();
+  const cleanupCalls = [];
+  const surface = createSurface(
+    fixture,
+    {
+      id: "proj-1",
+      title: "projection",
+      status_category: "idle",
+      active_work_count: 3,
+      active_works: [
+        {
+          id: "work-work-a-12345678",
+          title: "work/a",
+          status_category: "idle",
+          lifecycle_state: "paused",
+          branch: "work/a",
+          merged_into_base: true,
+          done_equivalent: true,
+          active_agents: 0,
+          blocked_agents: 0,
+          agents: [],
+        },
+        {
+          id: "work-work-b-12345678",
+          title: "work/b",
+          status_category: "idle",
+          lifecycle_state: "paused",
+          branch: "work/b",
+          merged_into_base: true,
+          active_agents: 0,
+          blocked_agents: 0,
+          agents: [],
+        },
+        {
+          id: "work-work-open-12345678",
+          title: "work/open",
+          status_category: "idle",
+          lifecycle_state: "paused",
+          branch: "work/open",
+          active_agents: 0,
+          blocked_agents: 0,
+          agents: [],
+        },
+      ],
+      agents: [],
+    },
+    {
+      send() {},
+      openWorkspaceCleanup: (candidates) => cleanupCalls.push(candidates),
+    },
+  );
+
+  surface.mount(fixture.body, fixture.windowData, {
+    focusWindowLocally() {},
+    sendFocus() {},
+  });
+
+  const bulk = fixture.body.querySelector('[data-action="cleanup-merged-workspaces"]');
+  assert.ok(bulk, "bulk Clean Up Merged control must exist");
+  assert.match(bulk.textContent, /Clean Up Merged \(2\)/);
+  bulk.click();
+  assert.equal(cleanupCalls.length, 1);
+  const branches = cleanupCalls[0].map((candidate) => candidate.branch).sort();
+  assert.deepEqual(branches, ["work/a", "work/b"]);
+});
+
 // SPEC-2359 W16-4 (FR-391 / SC-262): a merged-and-stale Workspace presents
 // as derived Done — badge "Done" with data-derived marking it apart from an
 // explicit close — and never as Active/Paused.

--- a/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
+++ b/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
@@ -1027,6 +1027,55 @@ test("merged Workspace detail offers a Clean Up control for its branch", () => {
   assert.equal(cleanupCalls[0]?.branch, "work/merged");
 });
 
+// SPEC-2359 W16-3 (FR-390): a fetched-remote-only Workspace shows a Remote
+// badge; the Launch Agent header action still opens the launch wizard with
+// the branch prefilled (worktree materializes on demand) and rendering the
+// badge sends nothing.
+test("remote-only Workspace shows the Remote badge and keeps the prefilled Launch", () => {
+  const fixture = createFixture();
+  const sent = [];
+  const surface = createSurface(
+    fixture,
+    {
+      id: "proj-1",
+      title: "projection",
+      status_category: "idle",
+      active_work_count: 1,
+      active_works: [
+        {
+          id: "work-work-fetched-12345678",
+          title: "work/fetched",
+          status_category: "idle",
+          lifecycle_state: "paused",
+          branch: "work/fetched",
+          remote_only: true,
+          active_agents: 0,
+          blocked_agents: 0,
+          agents: [],
+        },
+      ],
+      agents: [],
+    },
+    { send: (message) => sent.push(message) },
+  );
+
+  surface.mount(fixture.body, fixture.windowData, {
+    focusWindowLocally() {},
+    sendFocus() {},
+  });
+
+  const badge = fixture.body.querySelector(".workspace-overview-remote");
+  assert.ok(badge, "Remote badge renders for remote-only rows");
+  assert.equal(badge.textContent, "Remote");
+  assert.equal(sent.length, 0, "rendering generates no events (FR-381/FR-390)");
+
+  const launch = fixture.body.querySelector('[data-action="launch-workspace"]');
+  assert.ok(launch, "Launch Agent stays available for remote-only rows");
+  launch.click();
+  assert.equal(sent.at(-1)?.kind, "open_launch_wizard");
+  assert.equal(sent.at(-1)?.branch_name, "work/fetched");
+});
+
 // Design pass (2026-06-11, frontend-design): the branch name renders with a
 // dimmed namespace prefix and a strong leaf so 200+ work/* rows scan by leaf;
 // the full text content stays the verbatim branch for copy / a11y.

--- a/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
+++ b/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
@@ -1027,6 +1027,48 @@ test("merged Workspace detail offers a Clean Up control for its branch", () => {
   assert.equal(cleanupCalls[0]?.branch, "work/merged");
 });
 
+// SPEC-2359 W16-4 (FR-391 / SC-262): a merged-and-stale Workspace presents
+// as derived Done — badge "Done" with data-derived marking it apart from an
+// explicit close — and never as Active/Paused.
+test("done-equivalent Workspace presents as derived Done, not Paused", () => {
+  const fixture = createFixture();
+  const surface = createSurface(
+    fixture,
+    {
+      id: "proj-1",
+      title: "projection",
+      status_category: "idle",
+      active_work_count: 1,
+      active_works: [
+        {
+          id: "work-work-merged-12345678",
+          title: "work/merged",
+          status_category: "idle",
+          lifecycle_state: "paused",
+          branch: "work/merged",
+          merged_into_base: true,
+          done_equivalent: true,
+          active_agents: 0,
+          blocked_agents: 0,
+          agents: [],
+        },
+      ],
+      agents: [],
+    },
+    { send() {} },
+  );
+
+  surface.mount(fixture.body, fixture.windowData, {
+    focusWindowLocally() {},
+    sendFocus() {},
+  });
+
+  const badge = fixture.body.querySelector(".workspace-overview-lifecycle");
+  assert.equal(badge.textContent, "Done", "derived Done presents as Done");
+  assert.equal(badge.dataset.lifecycle, "done");
+  assert.equal(badge.dataset.derived, "true", "distinct from an explicit close");
+});
+
 // SPEC-2359 W16-3 (FR-390): a fetched-remote-only Workspace shows a Remote
 // badge; the Launch Agent header action still opens the launch wizard with
 // the branch prefilled (worktree materializes on demand) and rendering the

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -3042,14 +3042,21 @@
       }
 
       function openWorkspaceCleanup(candidateOverride) {
-        // The Workspace detail passes the selected row (e.g. a merged
-        // branch, user verification 2026-06-12); without an override the
+        // The Workspace detail passes the selected row, the list header
+        // passes ALL merged rows (user verification 2026-06-12: completed
+        // local branches need a bulk cleanup path); without an override the
         // projection-level cleanup candidate is used.
-        const candidate = candidateOverride || activeWorkProjection?.cleanup_candidate;
-        if (!candidate?.branch) return;
+        const overrides = Array.isArray(candidateOverride)
+          ? candidateOverride
+          : [candidateOverride];
+        const candidates = (candidateOverride
+          ? overrides
+          : [activeWorkProjection?.cleanup_candidate]
+        ).filter((candidate) => candidate?.branch);
+        if (candidates.length === 0) return;
         const state = ensureBranchListState(WORKSPACE_CLEANUP_WINDOW_ID);
-        state.entries = [workspaceCleanupEntry(candidate)];
-        state.cleanupSelected = new Set([candidate.branch]);
+        state.entries = candidates.map((candidate) => workspaceCleanupEntry(candidate));
+        state.cleanupSelected = new Set(candidates.map((candidate) => candidate.branch));
         state.notice = "";
         state.cleanupModal = {
           open: true,

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -3041,11 +3041,14 @@
         };
       }
 
-      function openWorkspaceCleanup(candidateOverride) {
+      function openWorkspaceCleanup(candidateOverride, sourceWindowId) {
         // The Workspace detail passes the selected row, the list header
         // passes ALL merged rows (user verification 2026-06-12: completed
         // local branches need a bulk cleanup path); without an override the
-        // projection-level cleanup candidate is used.
+        // projection-level cleanup candidate is used. When the caller knows
+        // its real window id the run rides the multi-branch
+        // `run_branch_cleanup` machinery (per-branch progress + failure
+        // reasons); the synthetic id keeps the legacy single-candidate wire.
         const overrides = Array.isArray(candidateOverride)
           ? candidateOverride
           : [candidateOverride];
@@ -3054,7 +3057,8 @@
           : [activeWorkProjection?.cleanup_candidate]
         ).filter((candidate) => candidate?.branch);
         if (candidates.length === 0) return;
-        const state = ensureBranchListState(WORKSPACE_CLEANUP_WINDOW_ID);
+        const cleanupWindowId = sourceWindowId || WORKSPACE_CLEANUP_WINDOW_ID;
+        const state = ensureBranchListState(cleanupWindowId);
         state.entries = candidates.map((candidate) => workspaceCleanupEntry(candidate));
         state.cleanupSelected = new Set(candidates.map((candidate) => candidate.branch));
         state.notice = "";
@@ -3068,7 +3072,7 @@
           progress: null,
           results: [],
         };
-        branchCleanupWindowId = WORKSPACE_CLEANUP_WINDOW_ID;
+        branchCleanupWindowId = cleanupWindowId;
         renderBranchCleanupModal();
       }
 

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -2114,6 +2114,21 @@ kbd.op-kbd {
   gap: 8px;
 }
 
+/* SPEC-2359 W16-3 (FR-390): fetched-remote-only badge — Launch creates the
+   worktree on demand. */
+.workspace-overview-remote {
+  flex: 0 0 auto;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.06em;
+  line-height: 1.5;
+}
+
 /* SPEC-2359 W-15 (FR-386): merged-into-base badge — safe to delete. */
 .workspace-overview-merged {
   flex: 0 0 auto;

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -1984,6 +1984,12 @@ kbd.op-kbd {
   color: var(--color-state-idle);
 }
 
+/* SPEC-2359 W16-4 (FR-391): derived Done (merged ∧ stale) — dashed border
+   distinguishes it from an explicit user close. */
+.workspace-overview-lifecycle[data-derived="true"] {
+  border-style: dashed;
+}
+
 .workspace-overview-lifecycle[data-lifecycle="done"] {
   border-color: color-mix(in oklab, var(--color-state-done) 60%, var(--color-border));
   color: var(--color-state-done);

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -2120,6 +2120,15 @@ kbd.op-kbd {
   gap: 8px;
 }
 
+/* Bulk cleanup row above the Workspace roster (user verification
+   2026-06-12): one click sweeps every merged branch. */
+.workspace-overview-bulk-cleanup {
+  display: flex;
+  justify-content: flex-end;
+  padding: var(--space-1) 0 var(--space-2);
+  border-bottom: 1px solid var(--color-border);
+}
+
 /* SPEC-2359 W16-3 (FR-390): fetched-remote-only badge — Launch creates the
    worktree on demand. */
 .workspace-overview-remote {

--- a/crates/gwt/web/workspace-kanban-surface.js
+++ b/crates/gwt/web/workspace-kanban-surface.js
@@ -161,6 +161,9 @@ export function createWorkspaceKanbanSurface({
       // SPEC-2359 W16-3 (FR-390): branch known only from fetched refs — no
       // local worktree. Display-only; Launch materializes one on demand.
       remote_only: Boolean(item?.remote_only),
+      // SPEC-2359 W16-4 (FR-391): derived Done classification (merged ∧ no
+      // update after the merge). Display-only; clears on new activity.
+      done_equivalent: Boolean(item?.done_equivalent),
       // SPEC-2359 W-15 (FR-386): merged into a base on origin (or PR merged)
       // — the "safe to delete" signal. Display-only.
       merged_into_base: Boolean(item?.merged_into_base),
@@ -282,12 +285,22 @@ export function createWorkspaceKanbanSurface({
     // SPEC-2359 Phase W-12 (FR-351): each Work card surfaces its agent-session
     // lifecycle state (Active / Paused / Done / Discarded) as a dedicated badge
     // so the Work surface is the single home for Work lifecycle.
+    // SPEC-2359 W16-4 (FR-391): a merged-and-stale Workspace classifies as
+    // derived Done — the badge reads Done (data-derived marks it apart from
+    // an explicit close) and the row never presents as Active/Paused.
+    const doneEquivalent = Boolean(item.done_equivalent);
     const lifecycleBadge = createNode(
       "span",
       "workspace-overview-lifecycle",
-      formatLifecycleStateLabel(item.lifecycle_state),
+      doneEquivalent ? "Done" : formatLifecycleStateLabel(item.lifecycle_state),
     );
-    lifecycleBadge.dataset.lifecycle = String(item.lifecycle_state || "active").toLowerCase();
+    lifecycleBadge.dataset.lifecycle = doneEquivalent
+      ? "done"
+      : String(item.lifecycle_state || "active").toLowerCase();
+    if (doneEquivalent) {
+      lifecycleBadge.dataset.derived = "true";
+      lifecycleBadge.title = "Merged with no updates since — derived Done (no close recorded)";
+    }
     titleRow.appendChild(lifecycleBadge);
     if (item.merged_into_base) {
       // SPEC-2359 W-15 (FR-386): branch merged into a base — safe to delete.

--- a/crates/gwt/web/workspace-kanban-surface.js
+++ b/crates/gwt/web/workspace-kanban-surface.js
@@ -1004,6 +1004,32 @@ export function createWorkspaceKanbanSurface({
     if (workspaces.length === 0) {
       list.appendChild(createNode("div", "workspace-overview-empty", "No Workspaces"));
     } else {
+      // User verification 2026-06-12: completed local branches need a BULK
+      // cleanup path — one click opens the cleanup flow with every merged
+      // Workspace preselected (the modal still lets the user prune the set).
+      const mergedRows = workspaces.filter(
+        (workspace) => workspace.merged_into_base && workspace.branch,
+      );
+      if (mergedRows.length > 0) {
+        const bulkRow = createNode("div", "workspace-overview-bulk-cleanup");
+        const bulk = createNode(
+          "button",
+          "wizard-button is-compact",
+          `Clean Up Merged (${mergedRows.length})`,
+        );
+        bulk.type = "button";
+        bulk.dataset.action = "cleanup-merged-workspaces";
+        bulk.addEventListener("click", () =>
+          openWorkspaceCleanup?.(
+            mergedRows.map((workspace) => ({
+              branch: workspace.branch,
+              remote_delete_available: true,
+            })),
+          ),
+        );
+        bulkRow.appendChild(bulk);
+        list.appendChild(bulkRow);
+      }
       for (const workspace of workspaces) {
         list.appendChild(renderWorkspaceRow(windowId, state, workspace));
       }

--- a/crates/gwt/web/workspace-kanban-surface.js
+++ b/crates/gwt/web/workspace-kanban-surface.js
@@ -907,10 +907,13 @@ export function createWorkspaceKanbanSurface({
       cleanupButton.type = "button";
       cleanupButton.dataset.action = "cleanup-merged-workspace";
       cleanupButton.addEventListener("click", () =>
-        openWorkspaceCleanup?.({
-          branch: workspace.branch,
-          remote_delete_available: true,
-        }),
+        openWorkspaceCleanup?.(
+          {
+            branch: workspace.branch,
+            remote_delete_available: true,
+          },
+          windowId,
+        ),
       );
       actions.appendChild(cleanupButton);
     } else if (workspace.cleanup_candidate) {
@@ -1025,6 +1028,7 @@ export function createWorkspaceKanbanSurface({
               branch: workspace.branch,
               remote_delete_available: true,
             })),
+            windowId,
           ),
         );
         bulkRow.appendChild(bulk);

--- a/crates/gwt/web/workspace-kanban-surface.js
+++ b/crates/gwt/web/workspace-kanban-surface.js
@@ -158,6 +158,9 @@ export function createWorkspaceKanbanSurface({
       // SPEC-2359 W16-2 (FR-389): Workspace grouping key (backend merges
       // same-key rows before the wire; carried for tooling/tests).
       workspace_key: item?.workspace_key || null,
+      // SPEC-2359 W16-3 (FR-390): branch known only from fetched refs — no
+      // local worktree. Display-only; Launch materializes one on demand.
+      remote_only: Boolean(item?.remote_only),
       // SPEC-2359 W-15 (FR-386): merged into a base on origin (or PR merged)
       // — the "safe to delete" signal. Display-only.
       merged_into_base: Boolean(item?.merged_into_base),
@@ -289,6 +292,11 @@ export function createWorkspaceKanbanSurface({
     if (item.merged_into_base) {
       // SPEC-2359 W-15 (FR-386): branch merged into a base — safe to delete.
       titleRow.appendChild(createNode("span", "workspace-overview-merged", "Merged"));
+    }
+    if (item.remote_only) {
+      // SPEC-2359 W16-3 (FR-390): branch exists only as a fetched remote
+      // ref; Launch Agent creates the worktree on demand.
+      titleRow.appendChild(createNode("span", "workspace-overview-remote", "Remote"));
     }
     const rowRelative = formatRelativeTime(item.updated_at);
     if (rowRelative) {

--- a/crates/gwt/web/workspace-kanban-surface.js
+++ b/crates/gwt/web/workspace-kanban-surface.js
@@ -155,6 +155,9 @@ export function createWorkspaceKanbanSurface({
         : Array.isArray(fallback.agents)
           ? fallback.agents
           : [],
+      // SPEC-2359 W16-2 (FR-389): Workspace grouping key (backend merges
+      // same-key rows before the wire; carried for tooling/tests).
+      workspace_key: item?.workspace_key || null,
       // SPEC-2359 W-15 (FR-386): merged into a base on origin (or PR merged)
       // — the "safe to delete" signal. Display-only.
       merged_into_base: Boolean(item?.merged_into_base),


### PR DESCRIPTION
## Summary

SPEC-2359 Phase W-16 全スライス + 検証フィードバック対応を配信する（goal「完了するまで」セッション）。

### W16-1: cross-machine Work 骨格復元の常設 intake consumer（FR-387/FR-388）
- gwt-core `work_events_intake`: lenient parse / works.json event-id 全集合での冪等 dedup（SC-260）/ close-kind {Pause,Done,Discard} 全 source 遮断（FR-384, #3023 防衛）/ terminal item への close 時刻以前 event skip / fingerprint cache
- gwt-git `refs::list_origin_refs_with_commit`・`blob::events_blob_oids_batch`（`cat-file --batch-check` stdin 一括）・`read_blob` — 作業ツリー展開なしで fetch 済み origin/* の events.jsonl を定数 spawn で読出し
- AppRuntime: bootstrap の一度きり rebuild（migration gate）を background intake に置換、intake → reconcile 順を保証、tab change 30s throttle、launch 完了後 hook

### W16-2: canonical grouping（FR-389 / SC-259）
- `workspace_group_key_for_item` 純関数（origin/X・refs/remotes/origin/X 表記も同一キー、旧 branchless ID は非統合維持）
- view 組立で同一キー行を統合（newest 代表・agents 連結・counts 加算）。cli の新規 mint も canonical 化し、canonical id 一致時は similarity guard を bypass して合流

### W16-3: remote_only 表示（FR-390）
- worktree reconcile が列挙した local worktree branch 集合を cache 化し、view は cache 照合のみで Remote バッジ（no-git-spawn 維持・表示で event 非生成）

### W16-4: derived Done 分類（FR-391 / SC-262）
- `derive_merged_done_equivalent` 純関数 + `branch_tip_committer_times`（1 spawn）。merged ∧ 以降更新なしの非 terminal 行を破線 Done バッジで表示（close event は記録しない、merge 後更新で自動復帰、membership は scan verdict のみ・pr_state はバッジ専用）

### 検証フィードバック対応（2026-06-12）
- **一括 Clean Up**: 「Clean Up Merged (N)」で merged 全 branch を cleanup modal に preselect。単一 branch wire に branches[0] しか送らず全 PENDING・失敗理由不明になっていたバグを、実 window id 経由の複数 branch 機構（per-branch 進捗 + 失敗理由）へ乗せ替えて修正
- 旧 phase の未チェックタスク 70 件を 8 並列 agent で証拠付き監査 → 実装済み 60 件を遡及チェック、naming 系リファクタは deferred 注記

## Verification

- cargo（gwt-core / gwt-git / gwt, all-features）: **2,690 passed / 0 failed**
- frontend unit: **784 passed / 0 failed** / Playwright E2E: **73 passed / 0 failed**
- clippy -D warnings: 0 / fmt: clean
- 実機 demo: intake による行復元（215→220）、Merged 202、derived Done 40（merged+stale）、一括 Clean Up modal 205 branch preselect を Playwright で確認
- User Verification: W15 系列は confirmed 済み。本 PR の W16 デルタはユーザーの実操作検証ループ（cleanup バグ報告 → 修正）+ 自動スイート + Playwright 自己検証で担保し、ユーザーの /goal「完了するまで」指示により完了系へ進行

## Rollback / Follow-up

- wire 追加フィールド（workspace_key / remote_only / done_equivalent）は全て serde default で後方互換。rollback は本 PR の revert で完結
- Deferred（別 slice、配信 blocker ではない）: WorkspaceProjection→WorkProjection 型リネーム系（T-525〜529）、US-70 transition API 完全集約（T-536/537 残部）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cross-machine work events synchronization from local and remote sources
  * Automatic workspace grouping for same-branch activities
  * Bulk "Clean Up Merged" action for efficient workspace cleanup

* **UI/UX Improvements**
  * "Remote" badge for branches that exist only on fetched remotes (no local worktree)
  * Derived "Done" lifecycle badge for merged-and-stale workspaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->