### PR TITLE
fix(skills): gwt-discussion の Board active-claim preflight を復元

### DIFF
--- a/.claude/skills/gwt-discussion/SKILL.md
+++ b/.claude/skills/gwt-discussion/SKILL.md
@@ -117,8 +117,9 @@ reason. To let Stop succeed, mark each proposal explicitly using the exit CLI:
   question line. It does not bypass incomplete evidence.
 
 When the `Action Bundle` is produced, call the matching exit command for each
-proposal before stopping. Claude Code's built-in `stop_hook_active` flag keeps
-the handler fail-safe: at most one forced continuation per Stop cycle.
+proposal before stopping. The runtime's `stop_hook_active` flag (built into
+Claude Code; shared with Codex via `codex_hooks`) keeps the handler fail-safe:
+at most one forced continuation per Stop cycle.
 
 ## Resume hooks
 
@@ -170,6 +171,23 @@ exception path. Keep the same one-question-at-a-time discipline.
 4. If an existing Issue number or URL is already the primary owner, capture it
    in the `Intake Memo`.
 5. If a clear owner exists, present it before going further.
+6. If the clear owner is an existing SPEC, run the Board active-claim preflight
+   before changing `.gwt/discussion.md` or any SPEC/plan artifacts:
+   - Read the current Board with `gwtd board show --json` when available, or
+     `gwtd board show` as the fallback.
+   - Look for active `claim` entries from another session that mention the same
+     owner (`#<N>` or `SPEC-<N>`) or the same phase/topic under discussion.
+   - If a matching claim exists, pause the discussion flow and present the
+     conflict: join that session with a Board handoff request, redesign a
+     disjoint work split, or continue only after the user explicitly accepts
+     duplicate risk.
+   - Intentional parallel discussion/planning is allowed only when ownership is
+     disjoint. Post a fresh Board `claim` with a `Boundary:` line naming the
+     topic, artifacts, or files owned by this session before continuing.
+   - Acceptance scenario: Given another session has an active Board claim for
+     `SPEC-2008 Phase 24`, when `gwt-discussion --deepen SPEC-2008` starts,
+     then the preflight reports the claim and requires user confirmation before
+     producing an Action Delta or changing SPEC artifacts.
 
 ### Phase 2: Investigation
 

--- a/.codex/skills/gwt-discussion/SKILL.md
+++ b/.codex/skills/gwt-discussion/SKILL.md
@@ -117,8 +117,9 @@ reason. To let Stop succeed, mark each proposal explicitly using the exit CLI:
   question line. It does not bypass incomplete evidence.
 
 When the `Action Bundle` is produced, call the matching exit command for each
-proposal before stopping. Claude Code's built-in `stop_hook_active` flag keeps
-the handler fail-safe: at most one forced continuation per Stop cycle.
+proposal before stopping. The runtime's `stop_hook_active` flag (built into
+Claude Code; shared with Codex via `codex_hooks`) keeps the handler fail-safe:
+at most one forced continuation per Stop cycle.
 
 ## Resume hooks
 
@@ -170,6 +171,23 @@ exception path. Keep the same one-question-at-a-time discipline.
 4. If an existing Issue number or URL is already the primary owner, capture it
    in the `Intake Memo`.
 5. If a clear owner exists, present it before going further.
+6. If the clear owner is an existing SPEC, run the Board active-claim preflight
+   before changing `.gwt/discussion.md` or any SPEC/plan artifacts:
+   - Read the current Board with `gwtd board show --json` when available, or
+     `gwtd board show` as the fallback.
+   - Look for active `claim` entries from another session that mention the same
+     owner (`#<N>` or `SPEC-<N>`) or the same phase/topic under discussion.
+   - If a matching claim exists, pause the discussion flow and present the
+     conflict: join that session with a Board handoff request, redesign a
+     disjoint work split, or continue only after the user explicitly accepts
+     duplicate risk.
+   - Intentional parallel discussion/planning is allowed only when ownership is
+     disjoint. Post a fresh Board `claim` with a `Boundary:` line naming the
+     topic, artifacts, or files owned by this session before continuing.
+   - Acceptance scenario: Given another session has an active Board claim for
+     `SPEC-2008 Phase 24`, when `gwt-discussion --deepen SPEC-2008` starts,
+     then the preflight reports the claim and requires user confirmation before
+     producing an Action Delta or changing SPEC artifacts.
 
 ### Phase 2: Investigation
 


### PR DESCRIPTION
## Summary

- PR #3053 の `.claude`→`.codex` byte 同期で、旧 `.codex` 版にのみ存在した gwt-discussion の **Board active-claim preflight**（Phase 1 step 6）を誤って削除していたため復元する（Codex review P2 指摘への対応）。

## Changes

- `.claude/skills/gwt-discussion/SKILL.md`: Phase 1 に step 6（既存 SPEC owner 検出時、`.gwt/discussion.md` / SPEC artifacts 変更前に他 session の active Board claim を確認する preflight）を復元。claim 確認は runtime 非依存の coordination ロジックのため、従来 `.codex` 専用だった本文を canonical 側へ取り込み
- `.claude/skills/gwt-discussion/SKILL.md`: `stop_hook_active` の文言を runtime 中立（Claude Code built-in / Codex は `codex_hooks` 経由）に修正
- `.codex/skills/gwt-discussion/SKILL.md`: byte 同一で同期

## Testing

- [x] `bunx --bun markdownlint-cli`（変更 2 ファイル）— 0 エラー
- [x] `diff -q .claude/skills/gwt-discussion/SKILL.md .codex/skills/gwt-discussion/SKILL.md` — byte 同一
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — 通過
- Rust コード変更なし（skill markdown のみ）のため cargo マトリクスは対象外

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — skill 文言の復元のみで、単独でマージ・配信可能
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- PR #3053（復元対象の削除が入った PR。該当 review thread には reply-and-resolve 済み）

## Checklist

- [x] Tests added/updated — N/A 相当: markdown のみのため lint / parity 検証で担保
- [x] Lint/format passed（markdownlint）
- [x] Documentation updated (if user-facing change) — 本変更自体が skill 文書の修正
- [ ] Migration/backfill plan included (if schema/data change) — N/A: スキーマ/データ変更なし
- [x] CHANGELOG impact considered — `fix`（patch）、breaking なし

## Notes

- 調査の副産物として、`.claude` と `.codex` の SKILL.md は他にも 4 skill（gwt-build-spec / gwt-fix-issue / gwt-manage-pr / gwt-plan-spec）で乖離しており、claim preflight が `.codex` 側にのみ存在することを確認した。materialization（`write_gwt_skill_dir_assets`）は `.claude` 資産を byte 同一で `.codex` へ書き出すため、これらの乖離は将来の再 materialize で消失するリスクがある。別 Issue として追跡する。
