### PR TITLE
revert(core): 用語裁定に基づき WorkspaceProjection / gwtd workspace を正へ復帰 (SPEC-2359)

### DIFF
--- a/crates/gwt-core/src/lib.rs
+++ b/crates/gwt-core/src/lib.rs
@@ -26,13 +26,7 @@ pub mod test_support;
 pub mod update;
 pub mod usage;
 pub mod work_events_intake;
-pub mod work_projection;
-/// SPEC-2359 US-66 (T-526): legacy adapter module — the canonical module is
-/// [`work_projection`]. Re-exports everything so staged migration never
-/// breaks call sites; new code must use the Work spelling.
-pub mod workspace_projection {
-    pub use crate::work_projection::*;
-}
+pub mod workspace_projection;
 pub mod workspace_projection_migration;
 pub mod worktree_hash;
 
@@ -40,18 +34,16 @@ pub use error::{GwtError, Result};
 
 #[cfg(test)]
 mod canonical_naming_tests {
-    //! SPEC-2359 US-66 (T-525): canonical names are Work-based; the legacy
-    //! `workspace_projection` module / `WorkProjection` type survive
-    //! only as adapter aliases.
+    //! SPEC-2359 US-66 (user decision 2026-06-12): `WorkspaceProjection` in
+    //! the `workspace_projection` module is the canonical current-state type
+    //! (the Workspace is the branch-level place). The per-launch record
+    //! family keeps its Work-era aliases until the terminology settles.
 
     #[test]
-    fn work_projection_is_canonical_and_legacy_names_are_aliases() {
-        // Canonical module + type.
-        let canonical = crate::work_projection::WorkProjection::default_for_project(
+    fn workspace_projection_is_canonical() {
+        let projection = crate::workspace_projection::WorkspaceProjection::default_for_project(
             std::path::Path::new("/tmp/repo"),
         );
-        // Legacy adapter spellings resolve to the SAME type.
-        let legacy: crate::work_projection::WorkProjection = canonical;
-        let _ = legacy;
+        let _ = projection;
     }
 }

--- a/crates/gwt-core/src/work_events_intake.rs
+++ b/crates/gwt-core/src/work_events_intake.rs
@@ -25,7 +25,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{GwtError, Result};
-use crate::work_projection::{
+use crate::workspace_projection::{
     load_workspace_work_items_from_path, save_workspace_work_items_projection_to_path, WorkEvent,
     WorkEventKind, WorkItemsProjection,
 };
@@ -55,7 +55,7 @@ fn is_close_kind(kind: WorkEventKind) -> bool {
 
 /// The moment a terminal item closed: `completed_at` when recorded, else its
 /// last update. Events at or before this instant must not re-apply.
-fn terminal_close_time(item: &crate::work_projection::WorkItem) -> Option<DateTime<Utc>> {
+fn terminal_close_time(item: &crate::workspace_projection::WorkItem) -> Option<DateTime<Utc>> {
     item.is_terminal()
         .then(|| item.completed_at.unwrap_or(item.updated_at))
 }
@@ -166,7 +166,7 @@ pub fn save_work_events_intake_state(path: &Path, state: &WorkEventsIntakeState)
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    crate::work_projection::write_atomic(path, &body)
+    crate::workspace_projection::write_atomic(path, &body)
 }
 
 /// Content sha256 used as the fingerprint for filesystem sources (git blob
@@ -181,7 +181,7 @@ pub fn content_fingerprint(content: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::work_projection::{WorkItemsProjection, WorkspaceStatusCategory};
+    use crate::workspace_projection::{WorkItemsProjection, WorkspaceStatusCategory};
     use chrono::TimeZone;
 
     fn event_json(id: &str, work_id: &str, kind: &str, updated_at: &str, extra: &str) -> String {
@@ -345,7 +345,7 @@ mod tests {
         let works = tmp.path().join("works.json");
         let closed_at = chrono::Utc.with_ymd_and_hms(2026, 6, 5, 12, 0, 0).unwrap();
         let mut projection = WorkItemsProjection::empty(closed_at);
-        let mut done = crate::work_projection::WorkEvent::new(
+        let mut done = crate::workspace_projection::WorkEvent::new(
             WorkEventKind::Done,
             "work-x-eeee5555",
             closed_at,

--- a/crates/gwt-core/src/workspace_projection.rs
+++ b/crates/gwt-core/src/workspace_projection.rs
@@ -2,9 +2,9 @@
 //! GUI, CLI, and hooks all read and update.
 //!
 //! SPEC-2359 Phase W-14 (US-70 / FR-378): every state transition of
-//! [`WorkProjection`] (status category changes, agent merge/assign/retain
+//! [`WorkspaceProjection`] (status category changes, agent merge/assign/retain
 //! rules, launch/start composition) is owned by the methods on
-//! [`WorkProjection`] in this module. Callers in UI/CLI layers must go
+//! [`WorkspaceProjection`] in this module. Callers in UI/CLI layers must go
 //! through these APIs; assigning transition fields (`status_category`,
 //! `status_text`, `next_action`, `agents`) directly from outside this module
 //! is not allowed in new code, so the transition rules stay single-source.
@@ -471,7 +471,7 @@ impl Default for WorkspaceRetentionConfig {
     }
 }
 
-/// Per-agent slice of a [`WorkProjection`]: session identity, runtime
+/// Per-agent slice of a [`WorkspaceProjection`]: session identity, runtime
 /// status, current focus, and Board linkage. Updated from agent session
 /// events and `gwtd workspace update`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -514,7 +514,7 @@ impl WorkspaceAgentSummary {
 /// Board stays the coordination/history log while this projection tracks the
 /// present.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct WorkProjection {
+pub struct WorkspaceProjection {
     pub id: String,
     pub project_root: PathBuf,
     pub title: String,
@@ -576,7 +576,7 @@ pub struct WorkProjection {
     pub progress_pct: Option<u8>,
 }
 
-impl WorkProjection {
+impl WorkspaceProjection {
     pub fn default_for_project(project_root: impl Into<PathBuf>) -> Self {
         let now = Utc::now();
         Self {
@@ -1142,7 +1142,7 @@ impl WorkProjection {
     }
 }
 
-/// Partial update applied to a [`WorkProjection`] (e.g. from
+/// Partial update applied to a [`WorkspaceProjection`] (e.g. from
 /// `gwtd workspace update`); `None` fields keep their current values.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkspaceProjectionUpdate {
@@ -1158,7 +1158,7 @@ pub struct WorkspaceProjectionUpdate {
 }
 
 /// SPEC-2359 Phase W-14 (US-70 / FR-375): parameters for
-/// [`WorkProjection::apply_launch`].
+/// [`WorkspaceProjection::apply_launch`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkspaceLaunchUpdate {
     /// Canonical work id; `None` keeps the current projection id.
@@ -1179,7 +1179,7 @@ pub struct WorkspaceLaunchUpdate {
 }
 
 /// SPEC-2359 Phase W-14 (US-70 / FR-375): parameters for
-/// [`WorkProjection::start_work`].
+/// [`WorkspaceProjection::start_work`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkspaceStartUpdate {
     pub workspace_id: String,
@@ -1652,7 +1652,7 @@ fn ensure_work_events_gitattributes(repo_path: &Path) -> Result<()> {
 fn migrate_legacy_workspace_projection(
     repo_path: &Path,
     canonical_path: &Path,
-) -> Result<Option<WorkProjection>> {
+) -> Result<Option<WorkspaceProjection>> {
     if canonical_path.exists() {
         return load_workspace_projection_from_path(canonical_path);
     }
@@ -1686,7 +1686,7 @@ fn migrate_legacy_workspace_work_items(
     Ok(Some(projection))
 }
 
-pub fn load_workspace_projection(repo_path: &Path) -> Result<Option<WorkProjection>> {
+pub fn load_workspace_projection(repo_path: &Path) -> Result<Option<WorkspaceProjection>> {
     let path = gwt_workspace_projection_path_for_repo_path(repo_path);
     if let Some(projection) = load_workspace_projection_from_path(&path)? {
         return Ok(Some(projection));
@@ -1738,12 +1738,12 @@ pub fn resolve_workspace_id_for_mention(
         .and_then(|agent| agent.workspace_id.clone())
 }
 
-pub fn load_or_default_workspace_projection(repo_path: &Path) -> Result<WorkProjection> {
+pub fn load_or_default_workspace_projection(repo_path: &Path) -> Result<WorkspaceProjection> {
     Ok(load_workspace_projection(repo_path)?
-        .unwrap_or_else(|| WorkProjection::default_for_project(repo_path)))
+        .unwrap_or_else(|| WorkspaceProjection::default_for_project(repo_path)))
 }
 
-pub fn save_workspace_projection(repo_path: &Path, projection: &WorkProjection) -> Result<()> {
+pub fn save_workspace_projection(repo_path: &Path, projection: &WorkspaceProjection) -> Result<()> {
     save_workspace_projection_to_path(
         &gwt_workspace_projection_path_for_repo_path(repo_path),
         projection,
@@ -1784,10 +1784,10 @@ pub fn mark_workspace_agent_stopped(
     mark_workspace_agent_stopped_at(&current_path, repo_path, session_id, window_id, Utc::now())
 }
 
-pub fn load_workspace_projection_from_path(path: &Path) -> Result<Option<WorkProjection>> {
+pub fn load_workspace_projection_from_path(path: &Path) -> Result<Option<WorkspaceProjection>> {
     match fs::read(path) {
         Ok(bytes) => {
-            let mut projection: WorkProjection = serde_json::from_slice(&bytes)
+            let mut projection: WorkspaceProjection = serde_json::from_slice(&bytes)
                 .map_err(|error| GwtError::Other(format!("workspace projection json: {error}")))?;
             migrate_workspace_to_work_terminology(&mut projection);
             Ok(Some(projection))
@@ -1797,7 +1797,7 @@ pub fn load_workspace_projection_from_path(path: &Path) -> Result<Option<WorkPro
     }
 }
 
-fn migrate_workspace_to_work_terminology(projection: &mut WorkProjection) {
+fn migrate_workspace_to_work_terminology(projection: &mut WorkspaceProjection) {
     if projection.title == "Workspace" {
         projection.title = "Work".to_string();
     } else if projection.title.starts_with("Workspace ") {
@@ -2705,7 +2705,7 @@ fn work_item_is_eligible_for_auto_done(item: &WorkItem) -> bool {
     })
 }
 
-fn workspace_projection_is_eligible_for_auto_done(projection: &WorkProjection) -> bool {
+fn workspace_projection_is_eligible_for_auto_done(projection: &WorkspaceProjection) -> bool {
     let Some(details) = projection.git_details.as_ref() else {
         return false;
     };
@@ -2768,12 +2768,15 @@ pub fn emit_workspace_done_event_for_branch(
 pub fn load_or_default_workspace_projection_from_path(
     path: &Path,
     project_root: &Path,
-) -> Result<WorkProjection> {
+) -> Result<WorkspaceProjection> {
     Ok(load_workspace_projection_from_path(path)?
-        .unwrap_or_else(|| WorkProjection::default_for_project(project_root)))
+        .unwrap_or_else(|| WorkspaceProjection::default_for_project(project_root)))
 }
 
-pub fn save_workspace_projection_to_path(path: &Path, projection: &WorkProjection) -> Result<()> {
+pub fn save_workspace_projection_to_path(
+    path: &Path,
+    projection: &WorkspaceProjection,
+) -> Result<()> {
     let bytes = serde_json::to_vec_pretty(projection)
         .map_err(|error| GwtError::Other(format!("workspace projection json: {error}")))?;
     write_atomic(path, &bytes)
@@ -2920,7 +2923,7 @@ fn synthesize_workspace_work_items_from_legacy_paths(
 }
 
 fn synthesize_workspace_work_item_from_legacy(
-    projection: Option<&WorkProjection>,
+    projection: Option<&WorkspaceProjection>,
     journal_entries: &[WorkspaceJournalEntry],
     _project_root: &Path,
 ) -> Option<WorkItem> {
@@ -2952,7 +2955,7 @@ fn synthesize_workspace_work_item_from_legacy(
         })
         .unwrap_or_else(|| "Work history".to_string());
     let status_category = projection
-        .map(WorkProjection::effective_status_category)
+        .map(WorkspaceProjection::effective_status_category)
         .or_else(|| last_entry.and_then(|entry| entry.status_category))
         .unwrap_or(WorkspaceStatusCategory::Unknown);
     let summary = projection
@@ -3062,7 +3065,7 @@ fn synthesize_workspace_work_item_from_legacy(
 }
 
 fn workspace_work_event_from_journal_entry(
-    projection: &WorkProjection,
+    projection: &WorkspaceProjection,
     entry: &WorkspaceJournalEntry,
 ) -> WorkEvent {
     let mut event = WorkEvent::new(
@@ -3103,7 +3106,7 @@ fn workspace_work_event_from_journal_entry(
 }
 
 pub fn workspace_work_event_from_board_entry(
-    projection: &WorkProjection,
+    projection: &WorkspaceProjection,
     entry: &BoardEntry,
 ) -> WorkEvent {
     let mut event = WorkEvent::new(
@@ -3205,7 +3208,7 @@ fn workspace_work_event_kind_from_status(
 }
 
 fn workspace_execution_container_from_projection(
-    projection: &WorkProjection,
+    projection: &WorkspaceProjection,
 ) -> Option<WorkspaceExecutionContainerRef> {
     projection
         .git_details
@@ -3284,7 +3287,7 @@ pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
 /// `git_details.pr_state`, which are populated by the existing GitHub Issue
 /// cache via `gh` API (the caller keeps that cache fresh).
 pub fn workspace_projection_stale_reason(
-    projection: &WorkProjection,
+    projection: &WorkspaceProjection,
     config: &WorkspaceRetentionConfig,
     now: DateTime<Utc>,
 ) -> Option<StaleReason> {
@@ -3396,7 +3399,7 @@ pub fn classify_workspace_projections<F>(
     is_active_session: F,
 ) -> Vec<ClassifiedProjection>
 where
-    F: Fn(&WorkProjection) -> bool,
+    F: Fn(&WorkspaceProjection) -> bool,
 {
     let mut results = Vec::new();
 
@@ -3510,11 +3513,6 @@ pub fn apply_prune_plan(plan: &[ClassifiedProjection], dry_run: bool) -> Result<
     }
     Ok(summary)
 }
-
-/// SPEC-2359 US-66 (T-526): legacy adapter alias — the canonical name is
-/// [`WorkProjection`]. Kept so staged migration never breaks call sites;
-/// new code must use the Work spelling.
-pub type WorkspaceProjection = WorkProjection;
 
 /// SPEC-2359 US-66 (T-529): legacy adapter aliases for the renamed Work
 /// entity family. In-repo call sites are fully migrated; these exist only
@@ -3645,7 +3643,7 @@ mod tests {
 
     #[test]
     fn effective_status_prioritizes_blocked_agents_over_active_projection() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.status_category = WorkspaceStatusCategory::Active;
         projection.status_text = "Still describing the current task".to_string();
         projection.agents.push(WorkspaceAgentSummary {
@@ -3685,7 +3683,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let current_path = temp.path().join("current.json");
 
-        let mut projection = WorkProjection::default_for_project(temp.path());
+        let mut projection = WorkspaceProjection::default_for_project(temp.path());
         projection.agents.push(WorkspaceAgentSummary {
             session_id: "sess-legacy".to_string(),
             window_id: None,
@@ -3755,7 +3753,7 @@ mod tests {
 
     #[test]
     fn effective_status_uses_active_agent_before_idle_projection() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.status_category = WorkspaceStatusCategory::Idle;
         projection.agents.push(WorkspaceAgentSummary {
             session_id: "sess-1".to_string(),
@@ -3784,7 +3782,7 @@ mod tests {
     #[test]
     fn cleanup_candidate_requires_done_or_merged_start_work_workspace_branch() {
         let created_at = Utc.with_ymd_and_hms(2026, 5, 7, 2, 0, 0).unwrap();
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.status_category = WorkspaceStatusCategory::Done;
         projection.git_details = Some(GitDetails {
             branch: Some("work/20260507-0200".to_string()),
@@ -3825,7 +3823,7 @@ mod tests {
     #[test]
     fn cleanup_candidate_preserves_non_workspace_or_active_branches() {
         let created_at = Utc.with_ymd_and_hms(2026, 5, 7, 2, 0, 0).unwrap();
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.status_category = WorkspaceStatusCategory::Done;
         projection.git_details = Some(GitDetails {
             branch: Some("feature/manual".to_string()),
@@ -3858,7 +3856,7 @@ mod tests {
 
     #[test]
     fn board_milestone_records_ref_id_and_copies_current_text() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         let mut entry = BoardEntry::new(
             crate::coordination::AuthorKind::Agent,
             "codex",
@@ -3885,7 +3883,7 @@ mod tests {
 
     #[test]
     fn board_milestone_updates_next_and_blocked_state_without_replay() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         let mut next = BoardEntry::new(
             crate::coordination::AuthorKind::Agent,
             "codex",
@@ -3929,7 +3927,7 @@ mod tests {
 
     #[test]
     fn board_milestone_restores_blocked_agent_to_active_on_progress() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.agents.push(WorkspaceAgentSummary {
             session_id: "sess-1".to_string(),
             window_id: None,
@@ -3991,7 +3989,7 @@ mod tests {
 
     #[test]
     fn board_milestone_keeps_title_summary_separate_from_current_focus() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.agents.push(WorkspaceAgentSummary {
             session_id: "sess-1".to_string(),
             window_id: None,
@@ -4045,7 +4043,7 @@ mod tests {
 
     #[test]
     fn board_milestone_next_keeps_blocked_agent_blocked() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.agents.push(WorkspaceAgentSummary {
             session_id: "sess-1".to_string(),
             window_id: None,
@@ -4108,7 +4106,7 @@ mod tests {
 
     #[test]
     fn board_milestone_records_agent_coordination_kind_and_scope() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.agents.push(WorkspaceAgentSummary {
             session_id: "sess-1".to_string(),
             window_id: None,
@@ -4296,7 +4294,7 @@ mod tests {
         let first_at = Utc.with_ymd_and_hms(2026, 5, 11, 2, 0, 0).unwrap();
         let second_at = Utc.with_ymd_and_hms(2026, 5, 11, 2, 5, 0).unwrap();
 
-        let mut projection = WorkProjection::default_for_project(&project_root);
+        let mut projection = WorkspaceProjection::default_for_project(&project_root);
         projection.id = "workspace-current".to_string();
         projection.title = "Workspace WorkItem history".to_string();
         projection.status_category = WorkspaceStatusCategory::Active;
@@ -4374,7 +4372,7 @@ mod tests {
     #[test]
     fn workspace_update_persists_agent_title_summary_separately_from_focus() {
         let updated_at = Utc.with_ymd_and_hms(2026, 5, 7, 2, 30, 0).unwrap();
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.agents.push(WorkspaceAgentSummary {
             session_id: "session-1".to_string(),
             window_id: Some("tab-1::agent-1".to_string()),
@@ -4437,7 +4435,7 @@ mod tests {
         // (Phase U-3) so `apply_update` is the only point where this CLI
         // path can guarantee the agent is registered.
         let updated_at = Utc.with_ymd_and_hms(2026, 5, 15, 12, 0, 0).unwrap();
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         assert!(projection.agents.is_empty());
 
         let journal = projection.apply_update(
@@ -4478,7 +4476,7 @@ mod tests {
         // registered it with richer state). Only title_summary /
         // current_focus from the update should change.
         let updated_at = Utc.with_ymd_and_hms(2026, 5, 15, 12, 0, 0).unwrap();
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.agents.push(WorkspaceAgentSummary {
             session_id: "session-launched".to_string(),
             window_id: Some("tab-1::agent-1".to_string()),
@@ -4536,7 +4534,7 @@ mod tests {
         // entries from the pre-existing-agent path so downstream consumers
         // (UI, broadcasts) cannot tell them apart.
         let updated_at = Utc.with_ymd_and_hms(2026, 5, 15, 12, 0, 0).unwrap();
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
 
         let journal = projection.apply_update(
             WorkspaceProjectionUpdate {
@@ -4589,7 +4587,7 @@ mod tests {
 
     #[test]
     fn unassigned_agent_is_not_effective_active_workspace_status() {
-        let mut projection = WorkProjection::default_for_project("/tmp/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/tmp/repo");
         projection.register_unassigned_agent(WorkspaceAgentSummary {
             session_id: "session-unassigned".to_string(),
             window_id: Some("tab-1:agent-1".to_string()),
@@ -4619,7 +4617,7 @@ mod tests {
     #[test]
     fn stopped_agent_is_removed_from_current_projection_without_losing_summary() {
         let now = Utc::now();
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.status_category = WorkspaceStatusCategory::Active;
         projection.status_text = "Codex is running".to_string();
         projection.next_action = Some("Review output".to_string());
@@ -4749,7 +4747,7 @@ mod tests {
     fn resolve_workspace_id_for_session_returns_assigned_workspace_id() {
         let _guard = lock_test_env();
         let dir = tempfile::tempdir().unwrap();
-        let mut projection = WorkProjection::default_for_project(dir.path());
+        let mut projection = WorkspaceProjection::default_for_project(dir.path());
         projection
             .agents
             .push(assigned_agent("sess-A", "codex", "ws-1"));
@@ -4765,7 +4763,7 @@ mod tests {
     fn resolve_workspace_id_for_session_returns_none_for_unassigned_agent() {
         let _guard = lock_test_env();
         let dir = tempfile::tempdir().unwrap();
-        let mut projection = WorkProjection::default_for_project(dir.path());
+        let mut projection = WorkspaceProjection::default_for_project(dir.path());
         projection.agents.push(unassigned_agent("sess-B", "codex"));
         save_workspace_projection(dir.path(), &projection).unwrap();
 
@@ -4776,7 +4774,7 @@ mod tests {
     fn resolve_workspace_id_for_session_returns_none_when_session_missing() {
         let _guard = lock_test_env();
         let dir = tempfile::tempdir().unwrap();
-        let projection = WorkProjection::default_for_project(dir.path());
+        let projection = WorkspaceProjection::default_for_project(dir.path());
         save_workspace_projection(dir.path(), &projection).unwrap();
 
         assert_eq!(
@@ -4789,7 +4787,7 @@ mod tests {
     fn resolve_workspace_id_for_mention_session_matches_session_id() {
         let _guard = lock_test_env();
         let dir = tempfile::tempdir().unwrap();
-        let mut projection = WorkProjection::default_for_project(dir.path());
+        let mut projection = WorkspaceProjection::default_for_project(dir.path());
         projection
             .agents
             .push(assigned_agent("sess-C", "codex", "ws-2"));
@@ -4805,7 +4803,7 @@ mod tests {
     fn resolve_workspace_id_for_mention_agent_matches_display_or_agent_id() {
         let _guard = lock_test_env();
         let dir = tempfile::tempdir().unwrap();
-        let mut projection = WorkProjection::default_for_project(dir.path());
+        let mut projection = WorkspaceProjection::default_for_project(dir.path());
         projection
             .agents
             .push(assigned_agent("sess-D", "codex", "ws-3"));
@@ -4826,7 +4824,7 @@ mod tests {
     fn resolve_workspace_id_for_mention_returns_none_for_unassigned_target() {
         let _guard = lock_test_env();
         let dir = tempfile::tempdir().unwrap();
-        let mut projection = WorkProjection::default_for_project(dir.path());
+        let mut projection = WorkspaceProjection::default_for_project(dir.path());
         projection.agents.push(unassigned_agent("sess-E", "codex"));
         save_workspace_projection(dir.path(), &projection).unwrap();
 
@@ -4844,7 +4842,7 @@ mod tests {
     fn resolve_workspace_id_for_mention_user_or_branch_kind_returns_none() {
         let _guard = lock_test_env();
         let dir = tempfile::tempdir().unwrap();
-        let mut projection = WorkProjection::default_for_project(dir.path());
+        let mut projection = WorkspaceProjection::default_for_project(dir.path());
         projection
             .agents
             .push(assigned_agent("sess-F", "codex", "ws-4"));
@@ -5092,7 +5090,7 @@ mod tests {
         let project_root = temp.path().join("repo");
         std::fs::create_dir_all(&project_root).expect("create repo");
 
-        let mut projection = WorkProjection::default_for_project(&project_root);
+        let mut projection = WorkspaceProjection::default_for_project(&project_root);
         projection.id = "wi-cleanup-target".to_string();
         projection.git_details = Some(GitDetails {
             branch: Some("work/auto-done-branch".to_string()),
@@ -5148,7 +5146,7 @@ mod tests {
         let project_root = temp.path().join("repo");
         std::fs::create_dir_all(&project_root).expect("create repo");
 
-        let mut projection = WorkProjection::default_for_project(&project_root);
+        let mut projection = WorkspaceProjection::default_for_project(&project_root);
         projection.id = "wi-different-branch".to_string();
         projection.git_details = Some(GitDetails {
             branch: Some("work/current-branch".to_string()),
@@ -5227,7 +5225,7 @@ mod tests {
         let project_root = temp.path().join("repo");
         std::fs::create_dir_all(&project_root).expect("create repo");
 
-        let mut projection = WorkProjection::default_for_project(&project_root);
+        let mut projection = WorkspaceProjection::default_for_project(&project_root);
         projection.id = "wi-current-merged".to_string();
         projection.git_details = Some(GitDetails {
             branch: Some("work/20260513-0100".to_string()),
@@ -5280,7 +5278,7 @@ mod tests {
         let project_root = temp.path().join("repo");
         std::fs::create_dir_all(&project_root).expect("create repo");
 
-        let mut projection = WorkProjection::default_for_project(&project_root);
+        let mut projection = WorkspaceProjection::default_for_project(&project_root);
         projection.id = "wi-manual-branch".to_string();
         projection.git_details = Some(GitDetails {
             branch: Some("work/20260513-0200".to_string()),
@@ -5308,8 +5306,8 @@ mod tests {
         );
     }
 
-    fn make_stale_projection(updated_at: DateTime<Utc>) -> WorkProjection {
-        let mut projection = WorkProjection::default_for_project("/repo");
+    fn make_stale_projection(updated_at: DateTime<Utc>) -> WorkspaceProjection {
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.updated_at = updated_at;
         projection
     }
@@ -5436,7 +5434,7 @@ mod tests {
         assert_eq!(StaleReason::Compound.as_str(), "compound");
     }
 
-    fn write_projection_at(workspace_dir: &Path, projection: &WorkProjection) {
+    fn write_projection_at(workspace_dir: &Path, projection: &WorkspaceProjection) {
         std::fs::create_dir_all(workspace_dir).expect("create workspace dir");
         let current = workspace_dir.join("current.json");
         save_workspace_projection_to_path(&current, projection).expect("save projection");
@@ -5447,8 +5445,8 @@ mod tests {
         project_root: &Path,
         updated_at: DateTime<Utc>,
         lifecycle: WorkspaceLifecycleStage,
-    ) -> WorkProjection {
-        let mut projection = WorkProjection::default_for_project(project_root);
+    ) -> WorkspaceProjection {
+        let mut projection = WorkspaceProjection::default_for_project(project_root);
         projection.id = id.to_string();
         projection.updated_at = updated_at;
         projection.lifecycle_stage = lifecycle;
@@ -6712,7 +6710,7 @@ mod tests {
 
     #[test]
     fn upsert_agent_summary_preserves_blocked_status_and_merges_fields() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         let mut blocked = us70_agent(
             "sess-1",
             WorkspaceStatusCategory::Blocked,
@@ -6747,7 +6745,7 @@ mod tests {
 
     #[test]
     fn upsert_agent_summary_inserts_new_sessions_and_never_rewinds_updated_at() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         let mut first = us70_agent(
             "sess-1",
             WorkspaceStatusCategory::Active,
@@ -6773,7 +6771,7 @@ mod tests {
 
     #[test]
     fn retain_live_agents_transitions_to_idle_when_no_assigned_agent_remains() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.status_category = WorkspaceStatusCategory::Active;
         projection.status_text = "Codex is running".to_string();
         projection.next_action = Some("Keep going".to_string());
@@ -6795,7 +6793,7 @@ mod tests {
 
     #[test]
     fn retain_live_agents_keeps_active_state_while_assigned_agent_lives() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         let before = projection.updated_at;
         projection.status_category = WorkspaceStatusCategory::Active;
         projection.status_text = "Codex is running".to_string();
@@ -6818,7 +6816,7 @@ mod tests {
 
     #[test]
     fn assign_agent_marks_assigned_active_and_merges_identity() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.agents.push(us70_agent(
             "sess-1",
             WorkspaceStatusCategory::Idle,
@@ -6852,7 +6850,7 @@ mod tests {
 
     #[test]
     fn apply_launch_composes_active_projection_with_defaults() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.git_details = Some(GitDetails {
             branch: Some("work/old".to_string()),
             worktree_path: None,
@@ -6913,7 +6911,7 @@ mod tests {
 
     #[test]
     fn apply_launch_reports_multiple_active_agents() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         let mut resident = us70_agent(
             "sess-0",
             WorkspaceStatusCategory::Active,
@@ -6958,7 +6956,7 @@ mod tests {
 
     #[test]
     fn start_work_applies_active_identity_with_defaults() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         let now = Utc.timestamp_opt(7_000, 0).unwrap();
         projection.start_work(
             WorkspaceStartUpdate {
@@ -6987,7 +6985,7 @@ mod tests {
 
     #[test]
     fn apply_work_item_copies_status_fields() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         let now = Utc.timestamp_opt(8_000, 0).unwrap();
         let item = WorkItem {
             id: "item-1".to_string(),
@@ -7020,7 +7018,7 @@ mod tests {
 
     #[test]
     fn reset_idle_identity_clears_identity_and_transitions_to_idle() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.status_category = WorkspaceStatusCategory::Active;
         projection.status_text = "Codex is running".to_string();
         projection.summary = Some("summary".to_string());
@@ -7050,7 +7048,7 @@ mod tests {
 
     #[test]
     fn clear_git_details_to_idle_clears_details_and_transitions() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.status_category = WorkspaceStatusCategory::Active;
         projection.status_text = "Codex is running".to_string();
         projection.next_action = Some("next".to_string());
@@ -7078,7 +7076,7 @@ mod tests {
 
     #[test]
     fn has_current_agents_requires_assigned_active_or_blocked() {
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         assert!(!projection.has_current_agents());
 
         projection.agents.push(us70_agent(

--- a/crates/gwt-core/src/workspace_projection_migration.rs
+++ b/crates/gwt-core/src/workspace_projection_migration.rs
@@ -24,8 +24,8 @@ use serde::{Deserialize, Serialize};
 use crate::error::{GwtError, Result};
 use crate::paths::gwt_workspace_projection_path_for_repo_path;
 #[cfg(test)]
-use crate::work_projection::WorkProjection;
-use crate::work_projection::{
+use crate::workspace_projection::WorkspaceProjection;
+use crate::workspace_projection::{
     load_workspace_projection_from_path, save_workspace_projection_to_path,
     workspace_projection_default_created_at, WorkspaceLifecycleStage, WorkspaceStatusCategory,
 };
@@ -141,7 +141,7 @@ pub fn migrate_workspace_projection_path(
 /// root path, resolves the canonical Workspace projection JSON path via
 /// [`gwt_workspace_projection_path_for_repo_path`], and runs the Phase U-6
 /// migration. Mirrors the signature of
-/// `work_projection::retroactive_auto_done_scan` (peer SPEC-2359 US-37)
+/// `workspace_projection::retroactive_auto_done_scan` (peer SPEC-2359 US-37)
 /// so the two scans can be called from `AppRuntime::bootstrap` side by
 /// side.
 pub fn migrate_workspace_projection_for_repo(
@@ -233,7 +233,7 @@ mod tests {
             migrate_workspace_projection_path(&projection_path).expect("migrate legacy projection");
 
         assert_eq!(outcome, WorkspaceProjectionMigrationOutcome::Applied);
-        let migrated: WorkProjection =
+        let migrated: WorkspaceProjection =
             serde_json::from_slice(&fs::read(&projection_path).expect("read migrated"))
                 .expect("parse migrated");
         assert_eq!(
@@ -314,7 +314,7 @@ mod tests {
         let workspace_dir = temp.path().join("workspace");
         fs::create_dir_all(&workspace_dir).expect("workspace dir");
         let projection_path = workspace_dir.join("current.json");
-        let fresh = WorkProjection {
+        let fresh = WorkspaceProjection {
             id: "fresh-1".to_string(),
             project_root: PathBuf::from("/repo"),
             title: "Fresh workspace".to_string(),

--- a/crates/gwt-core/tests/workspace_projection.rs
+++ b/crates/gwt-core/tests/workspace_projection.rs
@@ -7,10 +7,10 @@ use gwt_core::{
         gwt_workspace_projection_path_for_repo_path,
     },
     repo_hash::compute_repo_hash,
-    work_projection::{
+    workspace_projection::{
         load_or_default_workspace_projection_from_path, load_workspace_projection_from_path,
-        save_workspace_projection_to_path, GitDetails, WorkProjection,
-        WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary, WorkspaceStatusCategory,
+        save_workspace_projection_to_path, GitDetails, WorkspaceAgentAffiliationStatus,
+        WorkspaceAgentSummary, WorkspaceProjection, WorkspaceStatusCategory,
     },
 };
 
@@ -21,8 +21,8 @@ fn env_lock() -> std::sync::MutexGuard<'static, ()> {
         .expect("env lock")
 }
 
-fn projection(project_root: &Path) -> WorkProjection {
-    WorkProjection {
+fn projection(project_root: &Path) -> WorkspaceProjection {
+    WorkspaceProjection {
         id: "work-1".to_string(),
         project_root: project_root.to_path_buf(),
         title: "Start payment cleanup".to_string(),
@@ -63,7 +63,7 @@ fn projection(project_root: &Path) -> WorkProjection {
         updated_at: Utc.with_ymd_and_hms(2026, 5, 4, 12, 1, 0).unwrap(),
         created_at: Utc.with_ymd_and_hms(2026, 5, 4, 11, 30, 0).unwrap(),
         creator: Some("codex".to_string()),
-        lifecycle_stage: gwt_core::work_projection::WorkspaceLifecycleStage::Active,
+        lifecycle_stage: gwt_core::workspace_projection::WorkspaceLifecycleStage::Active,
         blocked_reason: None,
         linked_issues: Vec::new(),
         linked_prs: Vec::new(),
@@ -78,7 +78,7 @@ fn projection(project_root: &Path) -> WorkProjection {
 /// signals route to Active; Unknown stays in Planning.
 #[test]
 fn recompute_lifecycle_stage_follows_documented_precedence_rules() {
-    use gwt_core::work_projection::{
+    use gwt_core::workspace_projection::{
         recompute_lifecycle_stage, WorkspaceLifecycleStage, WorkspacePrLink,
     };
 
@@ -154,7 +154,7 @@ fn recompute_lifecycle_stage_follows_documented_precedence_rules() {
 fn record_board_milestone_backfills_summary_when_missing_for_status_entry() {
     use gwt_core::coordination::{AuthorKind, BoardEntry, BoardEntryKind};
 
-    let mut projection = WorkProjection::default_for_project("/repo");
+    let mut projection = WorkspaceProjection::default_for_project("/repo");
     projection.agents.push(WorkspaceAgentSummary {
         session_id: "session-1".to_string(),
         window_id: None,
@@ -201,7 +201,7 @@ fn record_board_milestone_backfills_summary_when_missing_for_status_entry() {
 fn record_board_milestone_sets_blocked_reason_separately_from_status_text() {
     use gwt_core::coordination::{AuthorKind, BoardEntry, BoardEntryKind};
 
-    let mut projection = WorkProjection::default_for_project("/repo");
+    let mut projection = WorkspaceProjection::default_for_project("/repo");
     projection.agents.push(WorkspaceAgentSummary {
         session_id: "session-1".to_string(),
         window_id: None,
@@ -252,7 +252,7 @@ fn record_board_milestone_sets_blocked_reason_separately_from_status_text() {
 fn record_board_milestone_preserves_existing_summary_on_status_entry() {
     use gwt_core::coordination::{AuthorKind, BoardEntry, BoardEntryKind};
 
-    let mut projection = WorkProjection::default_for_project("/repo");
+    let mut projection = WorkspaceProjection::default_for_project("/repo");
     projection.agents.push(WorkspaceAgentSummary {
         session_id: "session-1".to_string(),
         window_id: None,
@@ -314,7 +314,7 @@ fn workspace_projection_legacy_json_deserializes_with_serde_defaults() {
         "updated_at": "2026-04-01T12:00:00Z"
     });
 
-    let projection: WorkProjection =
+    let projection: WorkspaceProjection =
         serde_json::from_value(legacy_json).expect("legacy projection deserializes");
 
     assert_eq!(projection.id, "legacy-1");
@@ -322,13 +322,13 @@ fn workspace_projection_legacy_json_deserializes_with_serde_defaults() {
     // New fields populate via serde defaults so legacy data does not panic.
     assert_eq!(
         projection.created_at,
-        gwt_core::work_projection::workspace_projection_default_created_at(),
+        gwt_core::workspace_projection::workspace_projection_default_created_at(),
         "legacy data lacks created_at; default is UNIX_EPOCH sentinel for migration"
     );
     assert_eq!(projection.creator, None);
     assert_eq!(
         projection.lifecycle_stage,
-        gwt_core::work_projection::WorkspaceLifecycleStage::Planning,
+        gwt_core::workspace_projection::WorkspaceLifecycleStage::Planning,
         "legacy data defaults to Planning until migration recomputes"
     );
     assert_eq!(projection.blocked_reason, None);
@@ -343,9 +343,11 @@ fn workspace_projection_legacy_json_deserializes_with_serde_defaults() {
 /// and CLI updates all persist losslessly.
 #[test]
 fn workspace_projection_serde_round_trip_preserves_new_fields() {
-    use gwt_core::work_projection::{WorkspaceIssueLink, WorkspaceLifecycleStage, WorkspacePrLink};
+    use gwt_core::workspace_projection::{
+        WorkspaceIssueLink, WorkspaceLifecycleStage, WorkspacePrLink,
+    };
 
-    let original = WorkProjection {
+    let original = WorkspaceProjection {
         id: "round-trip-1".to_string(),
         project_root: PathBuf::from("/repo"),
         title: "Schema round-trip".to_string(),
@@ -378,7 +380,7 @@ fn workspace_projection_serde_round_trip_preserves_new_fields() {
     };
 
     let json = serde_json::to_string(&original).expect("serialize");
-    let restored: WorkProjection = serde_json::from_str(&json).expect("deserialize");
+    let restored: WorkspaceProjection = serde_json::from_str(&json).expect("deserialize");
 
     assert_eq!(restored, original);
 }
@@ -416,7 +418,7 @@ fn workspace_projection_repo_path_migrates_legacy_workspace_current_json() {
         "test precondition: canonical project-state file should not exist"
     );
 
-    let loaded = gwt_core::work_projection::load_workspace_projection(repo.path())
+    let loaded = gwt_core::workspace_projection::load_workspace_projection(repo.path())
         .expect("migrate")
         .expect("migrated projection");
 

--- a/crates/gwt/src/agent_project_state.rs
+++ b/crates/gwt/src/agent_project_state.rs
@@ -5,7 +5,7 @@ use gwt_agent::Session;
 use gwt_core::{
     error::Result,
     paths::normalize_windows_child_process_path,
-    work_projection::{
+    workspace_projection::{
         load_workspace_projection, save_workspace_projection, WorkspaceAgentSummary,
     },
 };
@@ -223,7 +223,7 @@ mod tests {
             window_id: Some("project::agent-1".to_string()),
             agent_id: "codex".to_string(),
             display_name: "Codex".to_string(),
-            status_category: gwt_core::work_projection::WorkspaceStatusCategory::Active,
+            status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
             current_focus: current_focus.map(str::to_string),
             title_summary: title_summary.map(str::to_string),
             worktree_path: Some(PathBuf::from("/tmp/worktree")),
@@ -232,7 +232,7 @@ mod tests {
             last_board_entry_kind: None,
             coordination_scope: None,
             affiliation_status:
-                gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
             workspace_id: None,
             updated_at,
         }

--- a/crates/gwt/src/app_runtime/board.rs
+++ b/crates/gwt/src/app_runtime/board.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 use gwt_agent::{AgentId, AgentLaunchBuilder, LaunchConfig, SessionMode};
 use gwt_core::{
     coordination::{self, BoardEntryKind, BoardMention},
-    work_projection,
+    workspace_projection,
 };
 
 use gwt::board_audience::{gui_default_board_scope, post_audience_for_gui};
@@ -367,7 +367,7 @@ impl AppRuntime {
     ) -> Vec<OutboundEvent> {
         let _ = tab_id;
         let mut projection =
-            match work_projection::load_or_default_workspace_projection(project_root) {
+            match workspace_projection::load_or_default_workspace_projection(project_root) {
                 Ok(projection) => projection,
                 Err(error) => {
                     tracing::warn!(
@@ -379,7 +379,9 @@ impl AppRuntime {
                 }
             };
         projection.record_board_milestone(entry);
-        if let Err(error) = work_projection::save_workspace_projection(project_root, &projection) {
+        if let Err(error) =
+            workspace_projection::save_workspace_projection(project_root, &projection)
+        {
             tracing::warn!(
                 error = %error,
                 project_root = %project_root.display(),
@@ -389,9 +391,9 @@ impl AppRuntime {
         }
         if board_entry_origin_can_record_workspace_work_event(&projection, entry) {
             let work_event =
-                work_projection::workspace_work_event_from_board_entry(&projection, entry);
+                workspace_projection::workspace_work_event_from_board_entry(&projection, entry);
             if let Err(error) =
-                work_projection::record_workspace_work_event(project_root, work_event)
+                workspace_projection::record_workspace_work_event(project_root, work_event)
             {
                 tracing::warn!(
                     error = %error,
@@ -406,7 +408,7 @@ impl AppRuntime {
 }
 
 fn board_entry_origin_can_record_workspace_work_event(
-    projection: &work_projection::WorkProjection,
+    projection: &workspace_projection::WorkspaceProjection,
     entry: &coordination::BoardEntry,
 ) -> bool {
     let Some(session_id) = entry.origin_session_id.as_deref() else {

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1925,7 +1925,7 @@ pub fn build_frontend_sync_events(
 ) -> Vec<OutboundEvent> {
     let mut events = vec![OutboundEvent::reply(
         client_id,
-        BackendEvent::WorkState { workspace },
+        BackendEvent::WorkspaceState { workspace },
     )];
 
     for (id, status, detail) in terminal_statuses {
@@ -1970,9 +1970,9 @@ pub fn build_frontend_sync_events(
 }
 
 fn workspace_status_category_wire(
-    category: gwt_core::work_projection::WorkspaceStatusCategory,
+    category: gwt_core::workspace_projection::WorkspaceStatusCategory,
 ) -> &'static str {
-    use gwt_core::work_projection::WorkspaceStatusCategory;
+    use gwt_core::workspace_projection::WorkspaceStatusCategory;
 
     match category {
         WorkspaceStatusCategory::Active => "active",
@@ -1986,9 +1986,9 @@ fn workspace_status_category_wire(
 /// SPEC-2359 Phase W-12 (FR-349): map the agent-session Work lifecycle state
 /// to its snake_case wire string for [`gwt::ActiveWorkItemView::lifecycle_state`].
 fn work_active_lifecycle_state_wire(
-    state: gwt_core::work_projection::WorkActiveLifecycleState,
+    state: gwt_core::workspace_projection::WorkActiveLifecycleState,
 ) -> &'static str {
-    use gwt_core::work_projection::WorkActiveLifecycleState;
+    use gwt_core::workspace_projection::WorkActiveLifecycleState;
 
     match state {
         WorkActiveLifecycleState::Active => "active",
@@ -2003,7 +2003,7 @@ const WORKSPACE_CLEANUP_EVENT_ID: &str = "__workspace_cleanup__";
 
 #[cfg(test)]
 fn active_work_projection_from_saved(
-    projection: gwt_core::work_projection::WorkProjection,
+    projection: gwt_core::workspace_projection::WorkspaceProjection,
 ) -> gwt::ActiveWorkProjectionView {
     let cleanup_candidate = projection
         .cleanup_candidate(false)
@@ -2017,7 +2017,7 @@ fn active_work_projection_from_saved(
 }
 
 fn active_work_projection_from_saved_with_journal(
-    projection: gwt_core::work_projection::WorkProjection,
+    projection: gwt_core::workspace_projection::WorkspaceProjection,
     journal_entries: Vec<gwt::WorkspaceJournalEntryView>,
     works: Vec<gwt::WorkspaceHistoryView>,
     cleanup_candidate: Option<gwt::ActiveWorkCleanupCandidateView>,
@@ -2143,9 +2143,9 @@ fn empty_active_work_projection_view(
 
 fn workspace_agent_summary_work_id(
     project_root: &Path,
-    agent: &gwt_core::work_projection::WorkspaceAgentSummary,
+    agent: &gwt_core::workspace_projection::WorkspaceAgentSummary,
 ) -> Option<String> {
-    gwt_core::work_projection::canonical_work_id(
+    gwt_core::workspace_projection::canonical_work_id(
         project_root,
         agent.branch.as_deref(),
         agent.worktree_path.as_deref(),
@@ -2168,7 +2168,7 @@ fn active_work_agent_work_id(
         return Some(format!("work-session-{session_id}"));
     }
     let worktree_path = agent.worktree_path.as_deref().map(Path::new);
-    gwt_core::work_projection::canonical_work_id(
+    gwt_core::workspace_projection::canonical_work_id(
         project_root,
         agent.branch.as_deref(),
         worktree_path,
@@ -2185,14 +2185,14 @@ fn active_work_agent_work_id(
 }
 
 fn projection_matches_active_work(
-    projection: &gwt_core::work_projection::WorkProjection,
+    projection: &gwt_core::workspace_projection::WorkspaceProjection,
     work_id: &str,
 ) -> bool {
     projection
         .git_details
         .as_ref()
         .and_then(|details| {
-            gwt_core::work_projection::canonical_work_id(
+            gwt_core::workspace_projection::canonical_work_id(
                 &projection.project_root,
                 details.branch.as_deref(),
                 details.worktree_path.as_deref(),
@@ -2210,7 +2210,7 @@ fn projection_matches_active_work(
 /// title / status_text / summary / PR selection driven by `is_current_projection`
 /// keeps choosing the live projection values.
 fn agent_matches_projection_git_details(
-    projection: &gwt_core::work_projection::WorkProjection,
+    projection: &gwt_core::workspace_projection::WorkspaceProjection,
     agent: &gwt::ActiveWorkAgentView,
 ) -> bool {
     let Some(details) = projection.git_details.as_ref() else {
@@ -2253,7 +2253,7 @@ fn find_active_work_history<'a>(
 }
 
 fn active_work_items_from_projection(
-    projection: &gwt_core::work_projection::WorkProjection,
+    projection: &gwt_core::workspace_projection::WorkspaceProjection,
     agents: &[gwt::ActiveWorkAgentView],
     works: &[gwt::WorkspaceHistoryView],
 ) -> Vec<gwt::ActiveWorkItemView> {
@@ -2405,8 +2405,8 @@ fn active_work_items_from_projection(
                 // assigned agents, so the owning agent session is Running and
                 // not user-closed → Active.
                 lifecycle_state: work_active_lifecycle_state_wire(
-                    gwt_core::work_projection::recompute_work_active_lifecycle(
-                        gwt_core::work_projection::WorkAgentRuntime::Running,
+                    gwt_core::workspace_projection::recompute_work_active_lifecycle(
+                        gwt_core::workspace_projection::WorkAgentRuntime::Running,
                         None,
                     ),
                 )
@@ -2492,8 +2492,8 @@ fn append_paused_work_items(
             // No live agent session owns this Work and it is not user-closed →
             // WorkAgentRuntime::None resolves to Paused (FR-350).
             lifecycle_state: work_active_lifecycle_state_wire(
-                gwt_core::work_projection::recompute_work_active_lifecycle(
-                    gwt_core::work_projection::WorkAgentRuntime::None,
+                gwt_core::workspace_projection::recompute_work_active_lifecycle(
+                    gwt_core::workspace_projection::WorkAgentRuntime::None,
                     None,
                 ),
             )
@@ -2554,7 +2554,7 @@ fn active_work_already_present(
 }
 
 fn active_work_cleanup_candidate_view_from_candidate(
-    candidate: gwt_core::work_projection::WorkspaceCleanupCandidate,
+    candidate: gwt_core::workspace_projection::WorkspaceCleanupCandidate,
 ) -> gwt::ActiveWorkCleanupCandidateView {
     gwt::ActiveWorkCleanupCandidateView {
         branch: candidate.branch,
@@ -2569,7 +2569,7 @@ fn active_work_cleanup_candidate_view_from_candidate(
 }
 
 fn workspace_journal_entry_view_from_entry(
-    entry: &gwt_core::work_projection::WorkspaceJournalEntry,
+    entry: &gwt_core::workspace_projection::WorkspaceJournalEntry,
 ) -> gwt::WorkspaceJournalEntryView {
     gwt::WorkspaceJournalEntryView {
         id: entry.id.clone(),
@@ -2603,7 +2603,7 @@ fn work_session_index(
 }
 
 pub(crate) fn workspace_work_item_view_from_item(
-    item: &gwt_core::work_projection::WorkItem,
+    item: &gwt_core::workspace_projection::WorkItem,
     session_index: &std::collections::HashMap<&str, &gwt_agent::Session>,
 ) -> gwt::WorkspaceHistoryView {
     gwt::WorkspaceHistoryView {
@@ -2650,7 +2650,7 @@ pub(crate) fn workspace_work_item_view_from_item(
 }
 
 fn workspace_work_agent_view_from_ref(
-    agent: &gwt_core::work_projection::WorkAgentRef,
+    agent: &gwt_core::workspace_projection::WorkAgentRef,
     session_index: &std::collections::HashMap<&str, &gwt_agent::Session>,
 ) -> gwt::WorkspaceHistoryAgentView {
     // A Work's `session_id` is the gwt session id (the launch). It keys into the
@@ -2730,7 +2730,7 @@ fn workspace_work_agent_view_from_ref(
 }
 
 fn workspace_execution_container_view_from_ref(
-    container: &gwt_core::work_projection::WorkspaceExecutionContainerRef,
+    container: &gwt_core::workspace_projection::WorkspaceExecutionContainerRef,
 ) -> gwt::WorkspaceExecutionContainerView {
     gwt::WorkspaceExecutionContainerView {
         branch: container.branch.clone(),
@@ -2745,7 +2745,7 @@ fn workspace_execution_container_view_from_ref(
 }
 
 fn workspace_work_event_view_from_event(
-    event: &gwt_core::work_projection::WorkEvent,
+    event: &gwt_core::workspace_projection::WorkEvent,
 ) -> gwt::WorkspaceHistoryEventView {
     gwt::WorkspaceHistoryEventView {
         id: event.id.clone(),
@@ -2769,8 +2769,10 @@ fn workspace_work_event_view_from_event(
     }
 }
 
-fn workspace_work_event_kind_wire(kind: gwt_core::work_projection::WorkEventKind) -> &'static str {
-    use gwt_core::work_projection::WorkEventKind;
+fn workspace_work_event_kind_wire(
+    kind: gwt_core::workspace_projection::WorkEventKind,
+) -> &'static str {
+    use gwt_core::workspace_projection::WorkEventKind;
 
     match kind {
         WorkEventKind::Start => "start",
@@ -2797,7 +2799,7 @@ fn non_empty_workspace_text(value: Option<&str>) -> Option<String> {
 }
 
 fn workspace_resume_context_from_projection(
-    projection: &gwt_core::work_projection::WorkProjection,
+    projection: &gwt_core::workspace_projection::WorkspaceProjection,
 ) -> WorkspaceResumeContext {
     WorkspaceResumeContext {
         title: non_empty_workspace_text(Some(&projection.title)),
@@ -2808,7 +2810,7 @@ fn workspace_resume_context_from_projection(
 }
 
 fn workspace_resume_context_from_journal(
-    entry: &gwt_core::work_projection::WorkspaceJournalEntry,
+    entry: &gwt_core::workspace_projection::WorkspaceJournalEntry,
 ) -> WorkspaceResumeContext {
     WorkspaceResumeContext {
         title: non_empty_workspace_text(entry.title.as_deref())
@@ -2970,11 +2972,11 @@ fn active_work_agent_priority_rank(agent: &gwt::ActiveWorkAgentView) -> u8 {
 }
 
 fn active_work_agent_view_from_summary(
-    agent: &gwt_core::work_projection::WorkspaceAgentSummary,
+    agent: &gwt_core::workspace_projection::WorkspaceAgentSummary,
 ) -> gwt::ActiveWorkAgentView {
     let affiliation_status = match agent.affiliation_status {
-        gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Unassigned => "unassigned",
-        gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Assigned => "assigned",
+        gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned => "unassigned",
+        gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned => "assigned",
     };
     gwt::ActiveWorkAgentView {
         session_id: agent.session_id.clone(),
@@ -3040,7 +3042,7 @@ fn attach_registry_sessions_to_active_works(
             );
         work.session_agent_total = (work.agents.len() + extra_total) as u32;
         for session in additions {
-            let agent_ref = gwt_core::work_projection::WorkAgentRef {
+            let agent_ref = gwt_core::workspace_projection::WorkAgentRef {
                 session_id: session.id.clone(),
                 agent_id: Some(session.agent_id.command().to_string()),
                 display_name: Some(session.display_name.clone()),
@@ -3177,8 +3179,10 @@ fn assign_and_merge_workspace_groups(
             .map(str::trim)
             .filter(|value| !value.is_empty());
         let worktree = work.worktree_path.as_deref().map(std::path::Path::new);
-        let key = gwt_core::work_projection::canonical_work_id(project_root, branch, None)
-            .or_else(|| gwt_core::work_projection::canonical_work_id(project_root, None, worktree))
+        let key = gwt_core::workspace_projection::canonical_work_id(project_root, branch, None)
+            .or_else(|| {
+                gwt_core::workspace_projection::canonical_work_id(project_root, None, worktree)
+            })
             .unwrap_or_else(|| work.id.clone());
         work.workspace_key = Some(key);
     }
@@ -3295,7 +3299,7 @@ fn mark_merged_active_works(
             .max();
         work.done_equivalent = !terminal
             && last_activity.is_some_and(|last| {
-                gwt_core::work_projection::derive_merged_done_equivalent(
+                gwt_core::workspace_projection::derive_merged_done_equivalent(
                     merge_reference.is_some(),
                     last,
                     merge_reference,
@@ -3343,10 +3347,10 @@ fn active_agent_session_matches_work(
 fn unassigned_agent_summary_from_session(
     session: &ActiveAgentSession,
     updated_at: chrono::DateTime<chrono::Utc>,
-) -> gwt_core::work_projection::WorkspaceAgentSummary {
+) -> gwt_core::workspace_projection::WorkspaceAgentSummary {
     let mut summary = active_agent_summary_from_session(session, updated_at);
     summary.affiliation_status =
-        gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Unassigned;
+        gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned;
     summary.workspace_id = None;
     summary
 }
@@ -3401,12 +3405,12 @@ fn save_unassigned_workspace_launch_projection(
 ) -> Result<(), String> {
     let now = chrono::Utc::now();
     let mut projection =
-        gwt_core::work_projection::load_or_default_workspace_projection(project_root)
+        gwt_core::workspace_projection::load_or_default_workspace_projection(project_root)
             .map_err(|error| error.to_string())?;
     projection.project_root = project_root.to_path_buf();
     projection.register_unassigned_agent(unassigned_agent_summary_from_session(session, now));
     projection.updated_at = now;
-    gwt_core::work_projection::save_workspace_projection(project_root, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(project_root, &projection)
         .map_err(|error| error.to_string())
 }
 
@@ -3834,7 +3838,7 @@ pub struct AppRuntime {
         std::cell::RefCell<crate::session_ledger_cache::SessionLedgerCache>,
     /// Same root fix for the home works.json (megabytes of Work items +
     /// events): cache hit clones instead of re-parsing per projection event.
-    pub(crate) work_items_cache: std::cell::RefCell<gwt_core::work_projection::WorkItemsCache>,
+    pub(crate) work_items_cache: std::cell::RefCell<gwt_core::workspace_projection::WorkItemsCache>,
     /// SPEC-2359 W-16 (FR-387): last work-events ingest per project — the
     /// 30s throttle for tab-change / post-launch triggers.
     pub(crate) last_work_events_ingest: std::cell::RefCell<HashMap<PathBuf, std::time::Instant>>,
@@ -3957,7 +3961,7 @@ impl AppRuntime {
                 crate::session_ledger_cache::SessionLedgerCache::new(),
             ),
             work_items_cache: std::cell::RefCell::new(
-                gwt_core::work_projection::WorkItemsCache::new(),
+                gwt_core::workspace_projection::WorkItemsCache::new(),
             ),
             last_work_events_ingest: std::cell::RefCell::new(HashMap::new()),
             local_worktree_branches: std::cell::RefCell::new(HashMap::new()),
@@ -4069,7 +4073,9 @@ impl AppRuntime {
         let proxy = self.proxy.clone();
         thread::spawn(move || {
             let Ok(projection) =
-                gwt_core::work_projection::load_or_synthesize_workspace_work_items(&project_root)
+                gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(
+                    &project_root,
+                )
             else {
                 return;
             };
@@ -4163,7 +4169,7 @@ impl AppRuntime {
         if sources.is_empty() {
             return;
         }
-        match gwt_core::work_projection::reconcile_worktree_work_items(
+        match gwt_core::workspace_projection::reconcile_worktree_work_items(
             project_root,
             &sources,
             chrono::Utc::now(),
@@ -4189,7 +4195,8 @@ impl AppRuntime {
         // files are missing or unreadable.
         let now = chrono::Utc::now();
         for tab in &self.tabs {
-            let _ = gwt_core::work_projection::retroactive_auto_done_scan(&tab.project_root, now);
+            let _ =
+                gwt_core::workspace_projection::retroactive_auto_done_scan(&tab.project_root, now);
             // SPEC-2359 US-39 / FR-142..145: backfill Phase U-6 schema
             // additions (`summary`, `created_at`, `creator`,
             // `lifecycle_stage`) on legacy `workspace.json` files. Runs
@@ -4207,7 +4214,7 @@ impl AppRuntime {
             // shows its real title / sessions. Idempotent; must run before
             // the intake/reconcile chain so decomposed branches are not
             // redundantly backfilled.
-            let _ = gwt_core::work_projection::decompose_legacy_multi_branch_work_items(
+            let _ = gwt_core::workspace_projection::decompose_legacy_multi_branch_work_items(
                 &tab.project_root,
             );
             // SPEC-2359 W-16 (FR-387): cross-machine work events intake.
@@ -4223,8 +4230,9 @@ impl AppRuntime {
             // display fallback and agent re-authoring. Idempotent via
             // `agent_identity.migration.json`; never re-clears agent-authored
             // values written after the marker.
-            let _ =
-                gwt_core::work_projection::reset_legacy_agent_identity_for_repo(&tab.project_root);
+            let _ = gwt_core::workspace_projection::reset_legacy_agent_identity_for_repo(
+                &tab.project_root,
+            );
         }
 
         self.queue_startup_auto_resume_sessions();
@@ -4324,7 +4332,7 @@ impl AppRuntime {
                 continue;
             }
             let workspace_resume_context =
-                gwt_core::work_projection::load_workspace_projection(&session.worktree_path)
+                gwt_core::workspace_projection::load_workspace_projection(&session.worktree_path)
                     .ok()
                     .flatten()
                     .map(|projection| workspace_resume_context_from_projection(&projection));
@@ -4469,10 +4477,12 @@ impl AppRuntime {
                     continue;
                 }
                 let workspace_resume_context =
-                    gwt_core::work_projection::load_workspace_projection(&session.worktree_path)
-                        .ok()
-                        .flatten()
-                        .map(|projection| workspace_resume_context_from_projection(&projection));
+                    gwt_core::workspace_projection::load_workspace_projection(
+                        &session.worktree_path,
+                    )
+                    .ok()
+                    .flatten()
+                    .map(|projection| workspace_resume_context_from_projection(&projection));
                 let fallback_geometry = window.geometry.clone();
                 let mut spawned = self.spawn_restored_agent_session(
                     tab_id,
@@ -5278,7 +5288,7 @@ impl AppRuntime {
         ids: Vec<String>,
     ) -> Vec<OutboundEvent> {
         use gwt_core::paths::gwt_projects_dir;
-        use gwt_core::work_projection::{
+        use gwt_core::workspace_projection::{
             apply_prune_plan, classify_workspace_projections, WorkspaceRetentionConfig,
         };
 
@@ -5287,12 +5297,13 @@ impl AppRuntime {
         let config = WorkspaceRetentionConfig::default();
         let live_session_ids: std::collections::HashSet<String> =
             self.active_agent_sessions.keys().cloned().collect();
-        let is_active_session = |projection: &gwt_core::work_projection::WorkProjection| {
-            projection
-                .agents
-                .iter()
-                .any(|agent| live_session_ids.contains(&agent.session_id))
-        };
+        let is_active_session =
+            |projection: &gwt_core::workspace_projection::WorkspaceProjection| {
+                projection
+                    .agents
+                    .iter()
+                    .any(|agent| live_session_ids.contains(&agent.session_id))
+            };
         let plan = classify_workspace_projections(&scan_root, &config, now, is_active_session);
         let filtered: Vec<_> = if ids.is_empty() {
             plan
@@ -5899,7 +5910,7 @@ impl AppRuntime {
             .filter(|session| session.tab_id == tab_id)
             .collect::<Vec<_>>();
         let saved_projection =
-            gwt_core::work_projection::load_workspace_projection(&tab.project_root)
+            gwt_core::workspace_projection::load_workspace_projection(&tab.project_root)
                 .ok()
                 .flatten();
         // SPEC-2359 Phase W-15 (FR-379/FR-382): the Workspace list is the
@@ -5915,7 +5926,7 @@ impl AppRuntime {
                 .ok()
                 .filter(|works| !works.work_items.is_empty())
                 .map(|_| {
-                    gwt_core::work_projection::WorkProjection::default_for_project(
+                    gwt_core::workspace_projection::WorkspaceProjection::default_for_project(
                         &tab.project_root,
                     )
                 })
@@ -5935,14 +5946,15 @@ impl AppRuntime {
             if had_saved_agents && !projection.has_current_agents() {
                 projection.reset_idle_identity(&tab.title, updated_at);
             }
-            let journal_entries = gwt_core::work_projection::load_recent_workspace_journal_entries(
-                &tab.project_root,
-                WORKSPACE_OVERVIEW_JOURNAL_LIMIT,
-            )
-            .unwrap_or_default()
-            .iter()
-            .map(workspace_journal_entry_view_from_entry)
-            .collect::<Vec<_>>();
+            let journal_entries =
+                gwt_core::workspace_projection::load_recent_workspace_journal_entries(
+                    &tab.project_root,
+                    WORKSPACE_OVERVIEW_JOURNAL_LIMIT,
+                )
+                .unwrap_or_default()
+                .iter()
+                .map(workspace_journal_entry_view_from_entry)
+                .collect::<Vec<_>>();
             let agent_sessions = self
                 .session_ledger_cache
                 .borrow_mut()
@@ -5952,7 +5964,7 @@ impl AppRuntime {
                 .work_items_cache
                 .borrow_mut()
                 .load_or_synthesize(&tab.project_root)
-                .unwrap_or_else(|_| gwt_core::work_projection::WorkItemsProjection {
+                .unwrap_or_else(|_| gwt_core::workspace_projection::WorkItemsProjection {
                     updated_at,
                     work_items: Vec::new(),
                 })
@@ -6033,8 +6045,8 @@ impl AppRuntime {
             // SPEC-2359 Phase W-12 (FR-349): synthesized from live sessions, so
             // the owning agent is Running and not user-closed → Active.
             lifecycle_state: work_active_lifecycle_state_wire(
-                gwt_core::work_projection::recompute_work_active_lifecycle(
-                    gwt_core::work_projection::WorkAgentRuntime::Running,
+                gwt_core::workspace_projection::recompute_work_active_lifecycle(
+                    gwt_core::workspace_projection::WorkAgentRuntime::Running,
                     None,
                 ),
             )
@@ -7817,7 +7829,7 @@ impl AppRuntime {
         project_root: &Path,
     ) -> Vec<OutboundEvent> {
         let Ok(Some(projection)) =
-            gwt_core::work_projection::load_workspace_projection(project_root)
+            gwt_core::workspace_projection::load_workspace_projection(project_root)
         else {
             return Vec::new();
         };
@@ -7836,7 +7848,7 @@ impl AppRuntime {
     pub(crate) fn sync_agent_window_titles_from_workspace_projection(
         &mut self,
         project_root: &Path,
-        projection: &gwt_core::work_projection::WorkProjection,
+        projection: &gwt_core::workspace_projection::WorkspaceProjection,
     ) -> bool {
         // SPEC-2359 Phase W-11 (US-58 / FR-344): resolve the effective window
         // title with the display fallback chain — the agent-authored
@@ -7920,7 +7932,7 @@ impl AppRuntime {
     /// `active_agent_sessions` is sufficient to identify the target.
     fn resolve_title_sync_window_id(
         &self,
-        agent: &gwt_core::work_projection::WorkspaceAgentSummary,
+        agent: &gwt_core::workspace_projection::WorkspaceAgentSummary,
         project_root: &Path,
     ) -> Option<String> {
         if let Some((window_id, _session)) = self
@@ -9615,8 +9627,8 @@ impl AppRuntime {
             return Vec::new();
         }
         let close_kind = match close_kind.trim().to_ascii_lowercase().as_str() {
-            "done" => gwt_core::work_projection::WorkCloseKind::Done,
-            "discarded" => gwt_core::work_projection::WorkCloseKind::Discarded,
+            "done" => gwt_core::workspace_projection::WorkCloseKind::Done,
+            "discarded" => gwt_core::workspace_projection::WorkCloseKind::Discarded,
             other => {
                 tracing::warn!(
                     work_id = %work_id,
@@ -9649,10 +9661,11 @@ impl AppRuntime {
         // Work can have its worktree removed without a live session.
         let worktree_path = self.resolve_work_worktree_path(&project_root, work_id);
 
-        let decision = gwt_core::work_projection::decide_work_close(has_live_agent, worktree_path);
+        let decision =
+            gwt_core::workspace_projection::decide_work_close(has_live_agent, worktree_path);
 
         match decision {
-            gwt_core::work_projection::WorkCloseDecision::BlockedLiveAgent => {
+            gwt_core::workspace_projection::WorkCloseDecision::BlockedLiveAgent => {
                 // FR-352: never clean up a Work while its agent session is live.
                 tracing::warn!(
                     work_id = %work_id,
@@ -9661,10 +9674,12 @@ impl AppRuntime {
                 );
                 return Vec::new();
             }
-            gwt_core::work_projection::WorkCloseDecision::CleanupWorktree { worktree_path } => {
+            gwt_core::workspace_projection::WorkCloseDecision::CleanupWorktree {
+                worktree_path,
+            } => {
                 self.remove_work_worktree_only(&project_root, &worktree_path);
             }
-            gwt_core::work_projection::WorkCloseDecision::RecordOnly => {
+            gwt_core::workspace_projection::WorkCloseDecision::RecordOnly => {
                 // No resolvable worktree path: record the close without any
                 // filesystem side effect.
             }
@@ -9674,15 +9689,15 @@ impl AppRuntime {
         // already-closed Work, so a duplicate close emits no new event.
         let now = chrono::Utc::now();
         let recorded = match close_kind {
-            gwt_core::work_projection::WorkCloseKind::Done => {
-                gwt_core::work_projection::emit_workspace_done_event_if_absent(
+            gwt_core::workspace_projection::WorkCloseKind::Done => {
+                gwt_core::workspace_projection::emit_workspace_done_event_if_absent(
                     &project_root,
                     work_id,
                     now,
                 )
             }
-            gwt_core::work_projection::WorkCloseKind::Discarded => {
-                gwt_core::work_projection::emit_workspace_discard_event_if_absent(
+            gwt_core::workspace_projection::WorkCloseKind::Discarded => {
+                gwt_core::workspace_projection::emit_workspace_discard_event_if_absent(
                     &project_root,
                     work_id,
                     now,
@@ -9763,7 +9778,7 @@ impl AppRuntime {
             // before clearing the agent from the live projection so the Work is
             // retained on the Work surface until the user explicitly closes it.
             self.persist_paused_work_for_stopped_session(&project_root, &session);
-            if let Err(error) = gwt_core::work_projection::mark_workspace_agent_stopped(
+            if let Err(error) = gwt_core::workspace_projection::mark_workspace_agent_stopped(
                 &project_root,
                 &session.session_id,
                 Some(&session.window_id),
@@ -9802,7 +9817,7 @@ impl AppRuntime {
             return;
         }
         let work_id = format!("work-session-{session_id}");
-        let projection = gwt_core::work_projection::load_workspace_projection(project_root)
+        let projection = gwt_core::workspace_projection::load_workspace_projection(project_root)
             .ok()
             .flatten();
         let agent_summary = projection.as_ref().and_then(|projection| {
@@ -9857,7 +9872,7 @@ impl AppRuntime {
             .as_ref()
             .and_then(|projection| projection.git_details.clone());
         let execution_container = (branch.is_some() || worktree_path.is_some()).then(|| {
-            gwt_core::work_projection::WorkspaceExecutionContainerRef {
+            gwt_core::workspace_projection::WorkspaceExecutionContainerRef {
                 branch,
                 worktree_path,
                 pr_number: git_details.as_ref().and_then(|details| details.pr_number),
@@ -9881,7 +9896,7 @@ impl AppRuntime {
         let session_id = session_id.to_string();
         let log_session_id = session.session_id.clone();
         let record = thread::spawn(move || {
-            if let Err(error) = gwt_core::work_projection::record_workspace_work_paused_event(
+            if let Err(error) = gwt_core::workspace_projection::record_workspace_work_paused_event(
                 &project_root,
                 &work_id,
                 title.as_deref(),
@@ -10279,7 +10294,7 @@ impl AppRuntime {
     }
 
     pub(crate) fn workspace_state_broadcast(&self) -> OutboundEvent {
-        OutboundEvent::broadcast(BackendEvent::WorkState {
+        OutboundEvent::broadcast(BackendEvent::WorkspaceState {
             workspace: self.app_state_view(),
         })
     }

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -550,7 +550,7 @@ fn workspace_work_agent_view_attaches_session_history() {
     let sessions = vec![session];
     let index = super::work_session_index(&sessions);
 
-    let agent_ref = gwt_core::work_projection::WorkAgentRef {
+    let agent_ref = gwt_core::workspace_projection::WorkAgentRef {
         session_id: "work-1".to_string(),
         agent_id: Some("codex".to_string()),
         display_name: Some("Codex".to_string()),
@@ -603,13 +603,13 @@ fn save_assigned_workspace_projection_for_test(
 fn workspace_agent_summary_for_test(
     session_id: &str,
     workspace_id: Option<&str>,
-) -> gwt_core::work_projection::WorkspaceAgentSummary {
-    gwt_core::work_projection::WorkspaceAgentSummary {
+) -> gwt_core::workspace_projection::WorkspaceAgentSummary {
+    gwt_core::workspace_projection::WorkspaceAgentSummary {
         session_id: session_id.to_string(),
         window_id: None,
         agent_id: "codex".to_string(),
         display_name: "Codex".to_string(),
-        status_category: gwt_core::work_projection::WorkspaceStatusCategory::Active,
+        status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
         current_focus: Some("Board audience follow-up".to_string()),
         title_summary: Some("Board audience follow-up".to_string()),
         worktree_path: None,
@@ -617,7 +617,8 @@ fn workspace_agent_summary_for_test(
         last_board_entry_id: None,
         last_board_entry_kind: None,
         coordination_scope: None,
-        affiliation_status: gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Assigned,
+        affiliation_status:
+            gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
         workspace_id: workspace_id.map(str::to_string),
         updated_at: chrono::Utc::now(),
     }
@@ -1698,7 +1699,9 @@ fn sample_runtime_with_events(
         session_ledger_cache: std::cell::RefCell::new(
             crate::session_ledger_cache::SessionLedgerCache::new(),
         ),
-        work_items_cache: std::cell::RefCell::new(gwt_core::work_projection::WorkItemsCache::new()),
+        work_items_cache: std::cell::RefCell::new(
+            gwt_core::workspace_projection::WorkItemsCache::new(),
+        ),
         last_work_events_ingest: std::cell::RefCell::new(HashMap::new()),
         local_worktree_branches: std::cell::RefCell::new(HashMap::new()),
         window_pty_statuses: HashMap::new(),
@@ -2030,11 +2033,11 @@ fn append_workspace_resume_journal(
     summary: &str,
 ) {
     let path = gwt_core::paths::gwt_workspace_journal_path_for_repo_path(repo);
-    let entry = gwt_core::work_projection::WorkspaceJournalEntry {
+    let entry = gwt_core::workspace_projection::WorkspaceJournalEntry {
         id: journal_id.to_string(),
         project_root,
         title: Some("Suspended review".to_string()),
-        status_category: Some(gwt_core::work_projection::WorkspaceStatusCategory::Idle),
+        status_category: Some(gwt_core::workspace_projection::WorkspaceStatusCategory::Idle),
         status_text: Some("Suspended".to_string()),
         owner: Some(owner.to_string()),
         next_action: Some("Resume the review".to_string()),
@@ -2044,7 +2047,7 @@ fn append_workspace_resume_journal(
         agent_title_summary: Some("Suspended review".to_string()),
         updated_at: chrono::Utc::now(),
     };
-    gwt_core::work_projection::append_workspace_journal_entry_to_path(&path, &entry)
+    gwt_core::workspace_projection::append_workspace_journal_entry_to_path(&path, &entry)
         .expect("append journal");
 }
 
@@ -2147,7 +2150,7 @@ fn app_runtime_frontend_ready_replies_only_to_requesting_client_and_starts_with_
         events.first(),
         Some(event)
             if matches!(&event.target, DispatchTarget::Client(client_id) if client_id == "client-1")
-                && matches!(event.event, BackendEvent::WorkState { .. })
+                && matches!(event.event, BackendEvent::WorkspaceState { .. })
     ));
     assert!(events.iter().all(|event| matches!(
         &event.target,
@@ -2778,7 +2781,7 @@ fn app_runtime_frontend_ready_replays_active_work_projection_separately_from_wor
 
     assert!(matches!(
         events.first().map(|event| &event.event),
-        Some(BackendEvent::WorkState { .. })
+        Some(BackendEvent::WorkspaceState { .. })
     ));
     let projection = events.iter().find_map(|event| match &event.event {
         BackendEvent::ActiveWorkProjection { projection } => Some(projection),
@@ -2835,7 +2838,10 @@ fn app_runtime_select_project_tab_broadcasts_workspace_before_clearing_wizard() 
 
     assert_eq!(events.len(), 3);
     assert!(matches!(events[0].target, DispatchTarget::Broadcast));
-    assert!(matches!(events[0].event, BackendEvent::WorkState { .. }));
+    assert!(matches!(
+        events[0].event,
+        BackendEvent::WorkspaceState { .. }
+    ));
     assert!(matches!(events[1].target, DispatchTarget::Broadcast));
     assert!(matches!(
         events[1].event,
@@ -2961,7 +2967,7 @@ fn app_runtime_runtime_status_uses_lightweight_events_for_non_structural_status(
     assert!(
         !events
             .iter()
-            .any(|event| matches!(event.event, BackendEvent::WorkState { .. })),
+            .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
         "non-structural runtime status changes must not force a full workspace_state"
     );
     assert!(matches!(events[0].target, DispatchTarget::Broadcast));
@@ -4310,7 +4316,7 @@ fn app_runtime_launch_wizard_submit_emits_agent_window_launching_status() {
     let workspace = events
         .iter()
         .find_map(|event| match &event.event {
-            BackendEvent::WorkState { workspace } => Some(workspace),
+            BackendEvent::WorkspaceState { workspace } => Some(workspace),
             _ => None,
         })
         .expect("workspace state after wizard submit");
@@ -4461,12 +4467,12 @@ fn app_runtime_start_work_launch_completion_registers_unassigned_agent() {
         )),
     );
 
-    let projection = gwt_core::work_projection::load_workspace_projection(&repo)
+    let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
         .expect("load projection")
         .expect("projection");
     assert_eq!(
         projection.status_category,
-        gwt_core::work_projection::WorkspaceStatusCategory::Unknown,
+        gwt_core::workspace_projection::WorkspaceStatusCategory::Unknown,
         "Start Work must not make an unassigned Agent an active Workspace"
     );
     assert!(projection.git_details.is_none());
@@ -4474,7 +4480,7 @@ fn app_runtime_start_work_launch_completion_registers_unassigned_agent() {
     assert_eq!(projection.agents[0].session_id, "session-1");
     assert_eq!(
         projection.agents[0].affiliation_status,
-        gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Unassigned
+        gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned
     );
     assert_eq!(
         projection.agents[0].branch.as_deref(),
@@ -4485,7 +4491,7 @@ fn app_runtime_start_work_launch_completion_registers_unassigned_agent() {
         Some(worktree.as_path())
     );
     let work_items =
-        gwt_core::work_projection::load_workspace_work_items(&repo).expect("load work items");
+        gwt_core::workspace_projection::load_workspace_work_items(&repo).expect("load work items");
     assert!(
         work_items.is_none(),
         "Start Work launch must not create Workspace history before explicit assignment"
@@ -4547,14 +4553,14 @@ fn app_runtime_non_work_launch_registers_unassigned_agent() {
         )),
     );
 
-    let projection = gwt_core::work_projection::load_workspace_projection(&repo)
+    let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
         .expect("load projection")
         .expect("projection");
     assert_eq!(projection.agents.len(), 1);
     assert_eq!(projection.agents[0].session_id, "session-develop");
     assert_eq!(
         projection.agents[0].affiliation_status,
-        gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Unassigned
+        gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned
     );
     assert_eq!(projection.agents[0].branch.as_deref(), Some("develop"));
 }
@@ -4625,7 +4631,7 @@ fn app_runtime_workspace_resume_launch_completion_carries_context_to_projection(
         )),
     );
 
-    let projection = gwt_core::work_projection::load_workspace_projection(&repo)
+    let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
         .expect("load projection")
         .expect("projection");
     let details = projection.git_details.expect("git details");
@@ -4641,12 +4647,12 @@ fn app_runtime_workspace_resume_launch_completion_carries_context_to_projection(
     assert!(details.created_by_start_work);
     assert_eq!(projection.agents.len(), 1);
     assert_eq!(projection.agents[0].session_id, "session-1");
-    let work_items = gwt_core::work_projection::load_workspace_work_items(&repo)
+    let work_items = gwt_core::workspace_projection::load_workspace_work_items(&repo)
         .expect("load work items")
         .expect("work items");
     assert_eq!(
         work_items.work_items[0].events[0].kind,
-        gwt_core::work_projection::WorkEventKind::Resume
+        gwt_core::workspace_projection::WorkEventKind::Resume
     );
 }
 
@@ -4742,7 +4748,7 @@ fn app_runtime_start_work_launch_completion_registers_multiple_unassigned_agents
         )),
     );
 
-    let projection = gwt_core::work_projection::load_workspace_projection(&repo)
+    let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
         .expect("load projection")
         .expect("projection");
     let session_ids = projection
@@ -4757,7 +4763,7 @@ fn app_runtime_start_work_launch_completion_registers_multiple_unassigned_agents
     assert!(projection
         .agents
         .iter()
-        .all(gwt_core::work_projection::WorkspaceAgentSummary::is_unassigned));
+        .all(gwt_core::workspace_projection::WorkspaceAgentSummary::is_unassigned));
     assert!(second_events.iter().any(|event| matches!(
         event,
         OutboundEvent {
@@ -4780,7 +4786,8 @@ fn app_runtime_active_work_projection_groups_live_assigned_agents_by_work_id() {
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     projection.agents.push({
         let mut agent = workspace_agent_summary_for_test("session-a", Some("work-a"));
         agent.window_id = Some("tab-1::agent-a".to_string());
@@ -4795,7 +4802,7 @@ fn app_runtime_active_work_projection_groups_live_assigned_agents_by_work_id() {
         agent.title_summary = Some("UI polish".to_string());
         agent
     });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -4851,14 +4858,15 @@ fn app_runtime_active_work_projection_groups_same_session_windows_in_one_work_ro
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     for window_id in ["tab-1::agent-a", "tab-1::agent-b"] {
         let mut agent = workspace_agent_summary_for_test("session-shared", Some("work-shared"));
         agent.window_id = Some(window_id.to_string());
         agent.branch = Some("work/shared".to_string());
         projection.agents.push(agent);
     }
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -4900,7 +4908,8 @@ fn app_runtime_active_work_projection_separates_sessions_on_same_branch() {
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     for (session_id, window_id) in [
         ("session-a", "tab-1::agent-a"),
         ("session-b", "tab-1::agent-b"),
@@ -4910,7 +4919,7 @@ fn app_runtime_active_work_projection_separates_sessions_on_same_branch() {
         agent.branch = Some("work/shared".to_string());
         projection.agents.push(agent);
     }
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -4967,14 +4976,15 @@ fn app_runtime_active_work_projection_sets_lifecycle_state_active() {
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     projection.agents.push({
         let mut agent = workspace_agent_summary_for_test("session-a", Some("work-a"));
         agent.window_id = Some("tab-1::agent-a".to_string());
         agent.branch = Some("work/a".to_string());
         agent
     });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -5041,9 +5051,10 @@ fn app_runtime_active_work_projection_uses_agent_session_id_over_branch_and_work
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
     let branch_derived_work_id =
-        gwt_core::work_projection::canonical_work_id(&repo, Some("work/test"), None)
+        gwt_core::workspace_projection::canonical_work_id(&repo, Some("work/test"), None)
             .expect("canonical work id");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     projection.agents.push({
         let mut agent = workspace_agent_summary_for_test("session-a", Some("legacy-work-id"));
         agent.window_id = Some("tab-1::agent-a".to_string());
@@ -5051,7 +5062,7 @@ fn app_runtime_active_work_projection_uses_agent_session_id_over_branch_and_work
         agent.title_summary = Some("Parser cleanup".to_string());
         agent
     });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -5087,7 +5098,8 @@ fn app_runtime_active_work_projection_retains_stopped_agent_work_as_paused() {
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     projection.agents.push({
         let mut agent = workspace_agent_summary_for_test("session-paused", Some("work-paused"));
         agent.window_id = Some("tab-1::agent-paused".to_string());
@@ -5095,7 +5107,7 @@ fn app_runtime_active_work_projection_retains_stopped_agent_work_as_paused() {
         agent.title_summary = Some("Paused persistence".to_string());
         agent
     });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -5152,14 +5164,15 @@ fn app_runtime_close_work_done_removes_paused_work_from_active_surface() {
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     projection.agents.push({
         let mut agent = workspace_agent_summary_for_test("session-done", Some("work-done"));
         agent.window_id = Some("tab-1::agent-done".to_string());
         agent.branch = Some("work/done".to_string());
         agent
     });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -5199,7 +5212,7 @@ fn app_runtime_close_work_done_removes_paused_work_from_active_surface() {
     );
 
     // The retained work history records the Done terminal close.
-    let works = gwt_core::work_projection::load_or_synthesize_workspace_work_items(&repo)
+    let works = gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(&repo)
         .expect("load work items");
     let item = works
         .work_items
@@ -5208,7 +5221,7 @@ fn app_runtime_close_work_done_removes_paused_work_from_active_surface() {
         .expect("work item exists");
     assert_eq!(
         item.status_category,
-        gwt_core::work_projection::WorkspaceStatusCategory::Done
+        gwt_core::workspace_projection::WorkspaceStatusCategory::Done
     );
     assert!(!item.discarded);
     assert!(item.is_terminal());
@@ -5227,14 +5240,15 @@ fn app_runtime_close_work_discarded_marks_terminal_and_removes_from_surface() {
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     projection.agents.push({
         let mut agent = workspace_agent_summary_for_test("session-discard", Some("work-discard"));
         agent.window_id = Some("tab-1::agent-discard".to_string());
         agent.branch = Some("work/discard".to_string());
         agent
     });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -5263,7 +5277,7 @@ fn app_runtime_close_work_discarded_marks_terminal_and_removes_from_surface() {
         "Discarded Work must not appear in active_works"
     );
 
-    let works = gwt_core::work_projection::load_or_synthesize_workspace_work_items(&repo)
+    let works = gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(&repo)
         .expect("load work items");
     let item = works
         .work_items
@@ -5273,7 +5287,7 @@ fn app_runtime_close_work_discarded_marks_terminal_and_removes_from_surface() {
     assert!(item.discarded, "Discard close must mark the Work discarded");
     assert_ne!(
         item.status_category,
-        gwt_core::work_projection::WorkspaceStatusCategory::Done,
+        gwt_core::workspace_projection::WorkspaceStatusCategory::Done,
         "Discard is distinct from Done"
     );
     assert!(item.is_terminal());
@@ -5296,14 +5310,15 @@ fn app_runtime_close_work_blocks_when_owning_agent_is_live() {
     // A real worktree directory so we can assert it is NOT removed.
     let worktree_path = repo.join("work/live");
     fs::create_dir_all(&worktree_path).expect("create worktree dir");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     projection.agents.push({
         let mut agent = workspace_agent_summary_for_test("session-live", Some("work-live"));
         agent.window_id = Some("tab-1::agent-live".to_string());
         agent.branch = Some("work/live".to_string());
         agent
     });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -5337,7 +5352,7 @@ fn app_runtime_close_work_blocks_when_owning_agent_is_live() {
         .find(|work| work.id == "work-session-session-live")
         .expect("live Work still present");
     assert_eq!(work.lifecycle_state, "active");
-    let works = gwt_core::work_projection::load_or_synthesize_workspace_work_items(&repo)
+    let works = gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(&repo)
         .expect("load work items");
     assert!(
         works
@@ -5397,26 +5412,29 @@ fn app_runtime_close_work_removes_worktree_only_and_retains_branch() {
 
     // A saved (empty) Workspace projection so the close broadcast can build
     // the active-work projection view for the tab.
-    let projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    let projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
 
     // Persist a Paused Work whose execution container points at the worktree.
     let now = chrono::Utc::now();
-    gwt_core::work_projection::record_workspace_work_paused_event(
+    gwt_core::workspace_projection::record_workspace_work_paused_event(
         &repo,
         "work-session-session-cleanup",
         Some("Cleanup work"),
         None,
         None,
         &[],
-        Some(gwt_core::work_projection::WorkspaceExecutionContainerRef {
-            branch: Some("work/cleanup".to_string()),
-            worktree_path: Some(worktree_path.clone()),
-            pr_number: None,
-            pr_url: None,
-            pr_state: None,
-        }),
+        Some(
+            gwt_core::workspace_projection::WorkspaceExecutionContainerRef {
+                branch: Some("work/cleanup".to_string()),
+                worktree_path: Some(worktree_path.clone()),
+                pr_number: None,
+                pr_url: None,
+                pr_state: None,
+            },
+        ),
         Some("session-cleanup"),
         now,
     )
@@ -5453,14 +5471,15 @@ fn app_runtime_active_work_projection_resumed_paused_work_is_single_active_row()
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     projection.agents.push({
         let mut agent = workspace_agent_summary_for_test("session-resume", Some("work-resume"));
         agent.window_id = Some("tab-1::agent-resume".to_string());
         agent.branch = Some("work/resume".to_string());
         agent
     });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -5514,14 +5533,15 @@ fn app_runtime_active_work_projection_merges_live_and_paused_work_rows() {
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     for (session_id, branch) in [("session-live", "work/live"), ("session-stop", "work/stop")] {
         let mut agent = workspace_agent_summary_for_test(session_id, Some(session_id));
         agent.window_id = Some(format!("tab-1::agent-{session_id}"));
         agent.branch = Some(branch.to_string());
         projection.agents.push(agent);
     }
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -5565,14 +5585,15 @@ fn app_runtime_active_work_projection_resolves_branch_known_unassigned_agents_as
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     projection.register_unassigned_agent({
         let mut agent = workspace_agent_summary_for_test("session-unassigned", None);
         agent.window_id = Some("tab-1::agent-unassigned".to_string());
         agent.branch = Some("work/unassigned-but-known".to_string());
         agent
     });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -5621,7 +5642,7 @@ fn app_runtime_open_active_work_launch_wizard_focuses_existing_agent_for_branch(
         event,
         OutboundEvent {
             target: DispatchTarget::Broadcast,
-            event: BackendEvent::WorkState { .. },
+            event: BackendEvent::WorkspaceState { .. },
         }
     )));
 }
@@ -5664,13 +5685,14 @@ fn app_runtime_active_work_projection_promotes_branch_known_unassigned_agents_to
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     projection.register_unassigned_agent({
         let mut agent = workspace_agent_summary_for_test("session-unassigned", None);
         agent.window_id = Some("tab-1::agent-unassigned".to_string());
         agent
     });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -5759,7 +5781,10 @@ fn app_runtime_runtime_status_stopped_auto_closes_active_agent_window() {
     // the surface must update without a saved current.json or live agents —
     // so the projection broadcast accompanies the WorkspaceState event.
     assert_eq!(events.len(), 2);
-    assert!(matches!(events[0].event, BackendEvent::WorkState { .. }));
+    assert!(matches!(
+        events[0].event,
+        BackendEvent::WorkspaceState { .. }
+    ));
     assert!(matches!(
         events[1].event,
         BackendEvent::ActiveWorkProjection { .. }
@@ -5779,17 +5804,18 @@ fn app_runtime_active_work_projection_filters_stale_saved_agents_when_no_agent_i
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
-    projection.status_category = gwt_core::work_projection::WorkspaceStatusCategory::Active;
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+    projection.status_category = gwt_core::workspace_projection::WorkspaceStatusCategory::Active;
     projection.status_text = "Old agent is running".to_string();
     projection
         .agents
-        .push(gwt_core::work_projection::WorkspaceAgentSummary {
+        .push(gwt_core::workspace_projection::WorkspaceAgentSummary {
             session_id: "stale-session".to_string(),
             window_id: Some("tab-1::agent-1".to_string()),
             agent_id: "codex".to_string(),
             display_name: "Codex".to_string(),
-            status_category: gwt_core::work_projection::WorkspaceStatusCategory::Active,
+            status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
             current_focus: Some("Old focus".to_string()),
             title_summary: None,
             worktree_path: None,
@@ -5798,11 +5824,11 @@ fn app_runtime_active_work_projection_filters_stale_saved_agents_when_no_agent_i
             last_board_entry_kind: None,
             coordination_scope: None,
             affiliation_status:
-                gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
             workspace_id: None,
             updated_at: chrono::Utc::now(),
         });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save stale projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -5828,15 +5854,16 @@ fn app_runtime_active_work_projection_resets_stale_current_identity_when_no_agen
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     projection.title = "PR-2525".to_string();
-    projection.status_category = gwt_core::work_projection::WorkspaceStatusCategory::Active;
+    projection.status_category = gwt_core::workspace_projection::WorkspaceStatusCategory::Active;
     projection.status_text = "Old PR is active".to_string();
     projection.summary = Some("Old PR summary".to_string());
     projection.owner = Some("PR-2525".to_string());
     projection.next_action = Some("Review old PR".to_string());
     projection.board_refs = vec!["board-old".to_string()];
-    projection.git_details = Some(gwt_core::work_projection::GitDetails {
+    projection.git_details = Some(gwt_core::workspace_projection::GitDetails {
         branch: Some("work/old".to_string()),
         worktree_path: Some(repo.join("work-old")),
         base_branch: Some("origin/develop".to_string()),
@@ -5849,12 +5876,12 @@ fn app_runtime_active_work_projection_resets_stale_current_identity_when_no_agen
     });
     projection
         .agents
-        .push(gwt_core::work_projection::WorkspaceAgentSummary {
+        .push(gwt_core::workspace_projection::WorkspaceAgentSummary {
             session_id: "stale-session".to_string(),
             window_id: Some("tab-1::agent-1".to_string()),
             agent_id: "codex".to_string(),
             display_name: "Codex".to_string(),
-            status_category: gwt_core::work_projection::WorkspaceStatusCategory::Active,
+            status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
             current_focus: Some("Old focus".to_string()),
             title_summary: Some("Old title".to_string()),
             worktree_path: None,
@@ -5863,11 +5890,11 @@ fn app_runtime_active_work_projection_resets_stale_current_identity_when_no_agen
             last_board_entry_kind: None,
             coordination_scope: None,
             affiliation_status:
-                gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
             workspace_id: None,
             updated_at: chrono::Utc::now(),
         });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save stale projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -5899,17 +5926,18 @@ fn app_runtime_active_work_projection_filters_stale_agent_when_window_id_is_reus
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
     let window_id = "tab-1::agent-1";
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
-    projection.status_category = gwt_core::work_projection::WorkspaceStatusCategory::Active;
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+    projection.status_category = gwt_core::workspace_projection::WorkspaceStatusCategory::Active;
     projection.status_text = "Old agent is running".to_string();
     projection
         .agents
-        .push(gwt_core::work_projection::WorkspaceAgentSummary {
+        .push(gwt_core::workspace_projection::WorkspaceAgentSummary {
             session_id: "stale-session".to_string(),
             window_id: Some(window_id.to_string()),
             agent_id: "codex".to_string(),
             display_name: "Old Codex".to_string(),
-            status_category: gwt_core::work_projection::WorkspaceStatusCategory::Active,
+            status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
             current_focus: Some("Old focus".to_string()),
             title_summary: Some("Old title".to_string()),
             worktree_path: None,
@@ -5918,11 +5946,11 @@ fn app_runtime_active_work_projection_filters_stale_agent_when_window_id_is_reus
             last_board_entry_kind: None,
             coordination_scope: None,
             affiliation_status:
-                gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
             workspace_id: None,
             updated_at: chrono::Utc::now(),
         });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save stale projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -5966,11 +5994,11 @@ fn app_runtime_active_work_projection_includes_recent_workspace_journal_entries(
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    gwt_core::work_projection::update_workspace_projection_with_journal(
+    gwt_core::workspace_projection::update_workspace_projection_with_journal(
         &repo,
-        gwt_core::work_projection::WorkspaceProjectionUpdate {
+        gwt_core::workspace_projection::WorkspaceProjectionUpdate {
             title: Some("Work".to_string()),
-            status_category: Some(gwt_core::work_projection::WorkspaceStatusCategory::Idle),
+            status_category: Some(gwt_core::workspace_projection::WorkspaceStatusCategory::Idle),
             status_text: Some("Ready for review".to_string()),
             owner: Some("SPEC-2359".to_string()),
             next_action: Some("Review summary".to_string()),
@@ -6015,9 +6043,9 @@ fn app_runtime_resume_workspace_journal_reuses_existing_branch_as_execution_cont
     init_git_clone_with_origin(&repo);
     let branch = "work/20260507-0001";
     run_git(&repo, &["branch", branch]);
-    gwt_core::work_projection::save_workspace_projection(
+    gwt_core::workspace_projection::save_workspace_projection(
         &repo,
-        &gwt_core::work_projection::WorkProjection::default_for_project(&repo),
+        &gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo),
     )
     .expect("save projection");
     append_workspace_resume_journal(
@@ -6084,10 +6112,11 @@ fn write_resumable_session_for_test(
 fn projection_with_assigned_agent(
     repo: &Path,
     session_id: &str,
-) -> gwt_core::work_projection::WorkProjection {
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(repo);
+) -> gwt_core::workspace_projection::WorkspaceProjection {
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(repo);
     projection.title = "Work with Resume candidate".to_string();
-    projection.status_category = gwt_core::work_projection::WorkspaceStatusCategory::Active;
+    projection.status_category = gwt_core::workspace_projection::WorkspaceStatusCategory::Active;
     projection
         .agents
         .push(workspace_agent_summary_for_test(session_id, None));
@@ -6106,7 +6135,7 @@ fn app_runtime_list_resumable_agents_returns_assigned_with_session_toml() {
     fs::create_dir_all(&repo).expect("create repo");
     let session_id = "session-resumable-1";
     let projection = projection_with_assigned_agent(&repo, session_id);
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let sessions_dir = temp.path().join("sessions");
     write_resumable_session_for_test(
@@ -6165,8 +6194,8 @@ fn app_runtime_list_resumable_agents_includes_unassigned_agents_with_session_tom
     let session_id = "session-unassigned-1";
     let mut projection = projection_with_assigned_agent(&repo, session_id);
     projection.agents[0].affiliation_status =
-        gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Unassigned;
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+        gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned;
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let sessions_dir = temp.path().join("sessions");
     write_resumable_session_for_test(
@@ -6211,7 +6240,7 @@ fn app_runtime_list_resumable_agents_includes_live_session_as_running() {
     fs::create_dir_all(&repo).expect("create repo");
     let session_id = "session-live-1";
     let projection = projection_with_assigned_agent(&repo, session_id);
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let sessions_dir = temp.path().join("sessions");
     write_resumable_session_for_test(
@@ -7652,9 +7681,9 @@ fn app_runtime_resume_workspace_journal_populates_quick_start_entries_from_prior
     init_git_clone_with_origin(&repo);
     let branch = "work/20260518-resume-qs";
     run_git(&repo, &["branch", branch]);
-    gwt_core::work_projection::save_workspace_projection(
+    gwt_core::workspace_projection::save_workspace_projection(
         &repo,
-        &gwt_core::work_projection::WorkProjection::default_for_project(&repo),
+        &gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo),
     )
     .expect("save projection");
     append_workspace_resume_journal(
@@ -7714,9 +7743,9 @@ fn app_runtime_resume_workspace_journal_falls_back_to_new_work_branch_when_branc
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     init_git_clone_with_origin(&repo);
-    gwt_core::work_projection::save_workspace_projection(
+    gwt_core::workspace_projection::save_workspace_projection(
         &repo,
-        &gwt_core::work_projection::WorkProjection::default_for_project(&repo),
+        &gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo),
     )
     .expect("save projection");
     append_workspace_resume_journal(
@@ -7766,13 +7795,14 @@ fn app_runtime_resume_workspace_current_ignores_idle_stale_git_details() {
     init_git_clone_with_origin(&repo);
     let stale_branch = "work/20260507-stale";
     run_git(&repo, &["branch", stale_branch]);
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     projection.title = "Stale Workspace".to_string();
-    projection.status_category = gwt_core::work_projection::WorkspaceStatusCategory::Idle;
+    projection.status_category = gwt_core::workspace_projection::WorkspaceStatusCategory::Idle;
     projection.status_text = "No active work".to_string();
     projection.summary = Some("Old work should not be resumed".to_string());
     projection.owner = Some("Issue #2359".to_string());
-    projection.git_details = Some(gwt_core::work_projection::GitDetails {
+    projection.git_details = Some(gwt_core::workspace_projection::GitDetails {
         branch: Some(stale_branch.to_string()),
         worktree_path: Some(temp.path().join("work/20260507-stale")),
         base_branch: Some("origin/develop".to_string()),
@@ -7783,7 +7813,7 @@ fn app_runtime_resume_workspace_current_ignores_idle_stale_git_details() {
         created_by_start_work: true,
         created_at: chrono::Utc::now(),
     });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -7822,9 +7852,9 @@ fn app_runtime_resume_workspace_journal_derives_feature_branch_under_work_named_
     init_git_clone_with_origin(&repo);
     let branch = "feature/resume-existing";
     run_git(&repo, &["branch", branch]);
-    gwt_core::work_projection::save_workspace_projection(
+    gwt_core::workspace_projection::save_workspace_projection(
         &repo,
-        &gwt_core::work_projection::WorkProjection::default_for_project(&repo),
+        &gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo),
     )
     .expect("save projection");
     append_workspace_resume_journal(
@@ -7877,9 +7907,10 @@ fn app_runtime_active_work_projection_exposes_done_workspace_cleanup_candidate()
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
-    projection.status_category = gwt_core::work_projection::WorkspaceStatusCategory::Done;
-    projection.git_details = Some(gwt_core::work_projection::GitDetails {
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+    projection.status_category = gwt_core::workspace_projection::WorkspaceStatusCategory::Done;
+    projection.git_details = Some(gwt_core::workspace_projection::GitDetails {
         branch: Some("work/20260507-0200".to_string()),
         worktree_path: Some(repo.join("work/20260507-0200")),
         base_branch: Some("origin/main".to_string()),
@@ -7890,7 +7921,7 @@ fn app_runtime_active_work_projection_exposes_done_workspace_cleanup_candidate()
         created_by_start_work: true,
         created_at: chrono::Utc::now(),
     });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -7921,9 +7952,10 @@ fn app_runtime_active_work_projection_does_not_spawn_git_for_cleanup_candidate()
     let _git_log = ScopedEnvVar::set("GWT_FAKE_GIT_LOG", &git_log);
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
-    projection.status_category = gwt_core::work_projection::WorkspaceStatusCategory::Done;
-    projection.git_details = Some(gwt_core::work_projection::GitDetails {
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+    projection.status_category = gwt_core::workspace_projection::WorkspaceStatusCategory::Done;
+    projection.git_details = Some(gwt_core::workspace_projection::GitDetails {
         branch: Some("work/20260507-0200".to_string()),
         worktree_path: Some(repo.join("work/20260507-0200")),
         base_branch: Some("origin/main".to_string()),
@@ -7934,7 +7966,7 @@ fn app_runtime_active_work_projection_does_not_spawn_git_for_cleanup_candidate()
         created_by_start_work: true,
         created_at: chrono::Utc::now(),
     });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -7962,8 +7994,9 @@ fn workspace_cleanup_failure_does_not_emit_done_work_item() {
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
     let branch = "work/missing";
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
-    projection.git_details = Some(gwt_core::work_projection::GitDetails {
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+    projection.git_details = Some(gwt_core::workspace_projection::GitDetails {
         branch: Some(branch.to_string()),
         worktree_path: Some(repo.join("work/missing")),
         base_branch: Some("origin/develop".to_string()),
@@ -7975,14 +8008,15 @@ fn workspace_cleanup_failure_does_not_emit_done_work_item() {
         created_at: chrono::Utc::now(),
     });
     let work_item_id = projection.id.clone();
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
-    let start = gwt_core::work_projection::WorkEvent::new(
-        gwt_core::work_projection::WorkEventKind::Start,
+    let start = gwt_core::workspace_projection::WorkEvent::new(
+        gwt_core::workspace_projection::WorkEventKind::Start,
         &work_item_id,
         chrono::Utc::now(),
     );
-    gwt_core::work_projection::record_workspace_work_event(&repo, start).expect("record start");
+    gwt_core::workspace_projection::record_workspace_work_event(&repo, start)
+        .expect("record start");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let (runtime, events) = sample_runtime_with_events(temp.path(), vec![tab], Some("tab-1"));
 
@@ -8002,7 +8036,7 @@ fn workspace_cleanup_failure_does_not_emit_done_work_item() {
             )
         })
     });
-    let work_items = gwt_core::work_projection::load_workspace_work_items(&repo)
+    let work_items = gwt_core::workspace_projection::load_workspace_work_items(&repo)
         .expect("load work items")
         .expect("work items");
     let item = work_items
@@ -8015,7 +8049,7 @@ fn workspace_cleanup_failure_does_not_emit_done_work_item() {
         !item
             .events
             .iter()
-            .any(|event| event.kind == gwt_core::work_projection::WorkEventKind::Done),
+            .any(|event| event.kind == gwt_core::workspace_projection::WorkEventKind::Done),
         "failed cleanup must not mark the Workspace work item done"
     );
 }
@@ -8030,10 +8064,11 @@ fn app_runtime_active_work_projection_exposes_saved_pr_metadata_without_live_age
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     projection.title = "Active Work PR display".to_string();
     projection.status_text = "No active work".to_string();
-    projection.git_details = Some(gwt_core::work_projection::GitDetails {
+    projection.git_details = Some(gwt_core::workspace_projection::GitDetails {
         branch: Some("work/20260507-0808".to_string()),
         worktree_path: Some(repo.join("work/20260507-0808")),
         base_branch: Some("origin/develop".to_string()),
@@ -8044,7 +8079,7 @@ fn app_runtime_active_work_projection_exposes_saved_pr_metadata_without_live_age
         created_by_start_work: true,
         created_at: chrono::Utc::now(),
     });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -8083,9 +8118,10 @@ fn app_runtime_active_work_projection_hides_cleanup_candidate_for_live_agent_bra
         WindowPreset::Codex,
         WindowProcessStatus::Running,
     );
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
-    projection.status_category = gwt_core::work_projection::WorkspaceStatusCategory::Done;
-    projection.git_details = Some(gwt_core::work_projection::GitDetails {
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+    projection.status_category = gwt_core::workspace_projection::WorkspaceStatusCategory::Done;
+    projection.git_details = Some(gwt_core::workspace_projection::GitDetails {
         branch: Some("work/20260507-0200".to_string()),
         worktree_path: Some(repo.join("work/20260507-0200")),
         base_branch: Some("origin/main".to_string()),
@@ -8096,7 +8132,7 @@ fn app_runtime_active_work_projection_hides_cleanup_candidate_for_live_agent_bra
         created_by_start_work: true,
         created_at: chrono::Utc::now(),
     });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
     let window_id = combined_window_id("tab-1", "codex-1");
@@ -8164,13 +8200,13 @@ fn app_runtime_stopped_agent_cleans_saved_projection_and_broadcasts_active_work_
         Some("Process exited".to_string()),
     );
 
-    let projection = gwt_core::work_projection::load_workspace_projection(&repo)
+    let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
         .expect("load projection")
         .expect("projection");
     assert!(projection.agents.is_empty());
     assert_eq!(
         projection.status_category,
-        gwt_core::work_projection::WorkspaceStatusCategory::Idle
+        gwt_core::workspace_projection::WorkspaceStatusCategory::Idle
     );
     assert!(events.iter().any(|event| matches!(
         event,
@@ -8289,7 +8325,10 @@ fn app_runtime_runtime_hook_stopped_auto_closes_active_agent_window() {
     // the surface must update without a saved current.json or live agents —
     // so the projection broadcast accompanies the WorkspaceState event.
     assert_eq!(events.len(), 2);
-    assert!(matches!(events[0].event, BackendEvent::WorkState { .. }));
+    assert!(matches!(
+        events[0].event,
+        BackendEvent::WorkspaceState { .. }
+    ));
     assert!(matches!(
         events[1].event,
         BackendEvent::ActiveWorkProjection { .. }
@@ -8319,7 +8358,10 @@ fn app_runtime_workspace_projection_surface_helper_groups_state_and_active_work_
     runtime.push_workspace_and_active_work_projection_broadcasts(&mut events);
 
     assert_eq!(events.len(), 2);
-    assert!(matches!(events[0].event, BackendEvent::WorkState { .. }));
+    assert!(matches!(
+        events[0].event,
+        BackendEvent::WorkspaceState { .. }
+    ));
     assert!(matches!(
         events[1].event,
         BackendEvent::ActiveWorkProjection { .. }
@@ -8531,7 +8573,7 @@ fn app_runtime_stopped_runtime_state_after_prior_state_still_auto_closes() {
 
     assert!(matches!(
         events.first().map(|event| &event.event),
-        Some(BackendEvent::WorkState { .. })
+        Some(BackendEvent::WorkspaceState { .. })
     ));
     assert!(!runtime.active_agent_sessions.contains_key(&window_id));
     assert!(!runtime.window_lookup.contains_key(&window_id));
@@ -8921,16 +8963,17 @@ fn app_runtime_load_board_defaults_to_current_workspace_audience() {
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     projection.id = "workspace-current".to_string();
     projection
         .agents
-        .push(gwt_core::work_projection::WorkspaceAgentSummary {
+        .push(gwt_core::workspace_projection::WorkspaceAgentSummary {
             session_id: "session-current".to_string(),
             window_id: None,
             agent_id: "codex".to_string(),
             display_name: "Codex".to_string(),
-            status_category: gwt_core::work_projection::WorkspaceStatusCategory::Active,
+            status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
             current_focus: Some("Board audience".to_string()),
             title_summary: Some("Board audience".to_string()),
             worktree_path: Some(repo.clone()),
@@ -8939,11 +8982,11 @@ fn app_runtime_load_board_defaults_to_current_workspace_audience() {
             last_board_entry_kind: None,
             coordination_scope: None,
             affiliation_status:
-                gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
             workspace_id: Some("workspace-current".to_string()),
             updated_at: chrono::Utc::now(),
         });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     post_entry(
         &repo,
@@ -9130,7 +9173,7 @@ fn app_runtime_open_board_origin_agent_focuses_live_origin_session_window() {
     assert!(events.iter().any(|event| matches!(
         event,
         OutboundEvent {
-            event: BackendEvent::WorkState { .. },
+            event: BackendEvent::WorkspaceState { .. },
             ..
         }
     )));
@@ -10487,7 +10530,7 @@ fn app_runtime_post_board_entry_updates_workspace_projection_current_state() {
         },
     );
 
-    let projection = gwt_core::work_projection::load_workspace_projection(&repo)
+    let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
         .expect("load projection")
         .expect("projection");
     let board_entry_id = projection
@@ -10502,7 +10545,7 @@ fn app_runtime_post_board_entry_updates_workspace_projection_current_state() {
     );
     assert_eq!(projection.owner.as_deref(), Some("SPEC-2359"));
     assert_eq!(projection.board_refs.len(), 1);
-    let work_items = gwt_core::work_projection::load_workspace_work_items(&repo)
+    let work_items = gwt_core::workspace_projection::load_workspace_work_items(&repo)
         .expect("load work items")
         .expect("work items");
     assert_eq!(
@@ -10511,7 +10554,7 @@ fn app_runtime_post_board_entry_updates_workspace_projection_current_state() {
     );
     assert_eq!(
         work_items.work_items[0].events[0].kind,
-        gwt_core::work_projection::WorkEventKind::Update
+        gwt_core::workspace_projection::WorkEventKind::Update
     );
     let projected_event = events
         .iter()
@@ -10546,15 +10589,16 @@ fn app_runtime_board_milestone_from_unassigned_origin_does_not_create_workspace_
         WindowProcessStatus::Ready,
     );
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     projection
         .agents
-        .push(gwt_core::work_projection::WorkspaceAgentSummary {
+        .push(gwt_core::workspace_projection::WorkspaceAgentSummary {
             session_id: "session-unassigned".to_string(),
             window_id: None,
             agent_id: "codex".to_string(),
             display_name: "Codex".to_string(),
-            status_category: gwt_core::work_projection::WorkspaceStatusCategory::Active,
+            status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
             current_focus: Some("Investigate Workspace materialization".to_string()),
             title_summary: Some("Work materialization".to_string()),
             worktree_path: None,
@@ -10563,11 +10607,11 @@ fn app_runtime_board_milestone_from_unassigned_origin_does_not_create_workspace_
             last_board_entry_kind: None,
             coordination_scope: None,
             affiliation_status:
-                gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Unassigned,
+                gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned,
             workspace_id: None,
             updated_at: chrono::Utc::now(),
         });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let entry = BoardEntry::new(
         AuthorKind::Agent,
@@ -10584,7 +10628,7 @@ fn app_runtime_board_milestone_from_unassigned_origin_does_not_create_workspace_
 
     runtime.record_workspace_board_milestone_event("tab-1", &repo, &entry);
 
-    let saved = gwt_core::work_projection::load_workspace_projection(&repo)
+    let saved = gwt_core::workspace_projection::load_workspace_projection(&repo)
         .expect("load projection")
         .expect("projection");
     let agent = saved
@@ -10594,10 +10638,10 @@ fn app_runtime_board_milestone_from_unassigned_origin_does_not_create_workspace_
         .expect("agent");
     assert_eq!(
         agent.affiliation_status,
-        gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Unassigned
+        gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned
     );
     assert!(
-        gwt_core::work_projection::load_workspace_work_items(&repo)
+        gwt_core::workspace_projection::load_workspace_work_items(&repo)
             .expect("load workspace history")
             .is_none(),
         "Unassigned origin Board entries must not append to unrelated Workspace history"
@@ -10679,11 +10723,11 @@ fn app_runtime_active_work_projection_preserves_blocked_agent_board_state() {
 
 #[test]
 fn app_runtime_active_work_projection_prioritizes_handoff_agents() {
-    use gwt_core::work_projection::{
-        WorkProjection, WorkspaceAgentSummary, WorkspaceStatusCategory,
+    use gwt_core::workspace_projection::{
+        WorkspaceAgentSummary, WorkspaceProjection, WorkspaceStatusCategory,
     };
 
-    let mut projection = WorkProjection::default_for_project("/repo");
+    let mut projection = WorkspaceProjection::default_for_project("/repo");
     let now = chrono::Utc::now();
     projection.agents.push(WorkspaceAgentSummary {
         session_id: "session-active".to_string(),
@@ -10698,7 +10742,8 @@ fn app_runtime_active_work_projection_prioritizes_handoff_agents() {
         last_board_entry_id: None,
         last_board_entry_kind: None,
         coordination_scope: None,
-        affiliation_status: gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Assigned,
+        affiliation_status:
+            gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
         workspace_id: None,
         updated_at: now,
     });
@@ -10715,7 +10760,8 @@ fn app_runtime_active_work_projection_prioritizes_handoff_agents() {
         last_board_entry_id: Some("board-handoff".to_string()),
         last_board_entry_kind: Some(BoardEntryKind::Handoff),
         coordination_scope: Some("SPEC-2359 / workspace-ux".to_string()),
-        affiliation_status: gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Assigned,
+        affiliation_status:
+            gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
         workspace_id: None,
         updated_at: now,
     });
@@ -10959,7 +11005,7 @@ fn app_runtime_agent_window_initial_state_broadcast_includes_agent_id() {
     let workspace = events
         .iter()
         .find_map(|event| match &event.event {
-            BackendEvent::WorkState { workspace } => Some(workspace),
+            BackendEvent::WorkspaceState { workspace } => Some(workspace),
             _ => None,
         })
         .expect("initial WorkspaceState broadcast");
@@ -11039,9 +11085,10 @@ fn app_runtime_agent_window_initial_title_falls_back_to_projection_owner() {
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
     init_repo(&repo);
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     projection.owner = Some("SPEC-2008".to_string());
-    projection.git_details = Some(gwt_core::work_projection::GitDetails {
+    projection.git_details = Some(gwt_core::workspace_projection::GitDetails {
         branch: Some("work/20260506-1257".to_string()),
         worktree_path: Some(repo.join("work/20260506-1257")),
         base_branch: Some("origin/develop".to_string()),
@@ -11052,7 +11099,7 @@ fn app_runtime_agent_window_initial_title_falls_back_to_projection_owner() {
         created_by_start_work: true,
         created_at: chrono::Utc::now(),
     });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -11087,9 +11134,10 @@ fn app_runtime_agent_window_initial_title_ignores_projection_owner_for_other_bra
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
     init_repo(&repo);
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     projection.owner = Some("PR-2525".to_string());
-    projection.git_details = Some(gwt_core::work_projection::GitDetails {
+    projection.git_details = Some(gwt_core::workspace_projection::GitDetails {
         branch: Some("work/old".to_string()),
         worktree_path: Some(repo.join("work-old")),
         base_branch: Some("origin/develop".to_string()),
@@ -11100,7 +11148,7 @@ fn app_runtime_agent_window_initial_title_ignores_projection_owner_for_other_bra
         created_by_start_work: true,
         created_at: chrono::Utc::now(),
     });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
@@ -11314,7 +11362,7 @@ fn app_runtime_board_milestone_broadcasts_workspace_state_for_title_sync() {
     assert!(
             events
                 .iter()
-                .any(|event| matches!(event.event, BackendEvent::WorkState { .. })),
+                .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
             "expected WorkspaceState broadcast from Board path so pane heading refreshes on reconnect: {events:?}"
         );
     assert!(
@@ -11369,10 +11417,10 @@ fn frontend_sync_events_preserves_window_dynamic_title_for_reconnect_rehydrate()
 
     let workspace_event = events
         .iter()
-        .find(|event| matches!(event.event, BackendEvent::WorkState { .. }))
+        .find(|event| matches!(event.event, BackendEvent::WorkspaceState { .. }))
         .expect("WorkspaceState reply for FrontendReady");
     let workspace = match &workspace_event.event {
-        BackendEvent::WorkState { workspace } => workspace,
+        BackendEvent::WorkspaceState { workspace } => workspace,
         _ => unreachable!(),
     };
     let projected_window = workspace
@@ -11471,7 +11519,7 @@ fn app_runtime_board_milestone_skips_workspace_state_on_identical_resync() {
     assert!(
         first
             .iter()
-            .any(|event| matches!(event.event, BackendEvent::WorkState { .. })),
+            .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
         "first Board post should broadcast WorkspaceState: {first:?}"
     );
 
@@ -11479,7 +11527,7 @@ fn app_runtime_board_milestone_skips_workspace_state_on_identical_resync() {
     assert!(
             !second
                 .iter()
-                .any(|event| matches!(event.event, BackendEvent::WorkState { .. })),
+                .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
             "second Board post with identical title_summary must not duplicate WorkspaceState: {second:?}"
         );
     assert!(
@@ -11699,16 +11747,17 @@ fn app_runtime_workspace_projection_change_updates_agent_window_title_summary() 
         },
     );
 
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
-    projection.status_category = gwt_core::work_projection::WorkspaceStatusCategory::Active;
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+    projection.status_category = gwt_core::workspace_projection::WorkspaceStatusCategory::Active;
     projection
         .agents
-        .push(gwt_core::work_projection::WorkspaceAgentSummary {
+        .push(gwt_core::workspace_projection::WorkspaceAgentSummary {
             session_id: "session-1".to_string(),
             window_id: Some(window_id),
             agent_id: "codex".to_string(),
             display_name: "Codex".to_string(),
-            status_category: gwt_core::work_projection::WorkspaceStatusCategory::Active,
+            status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
             current_focus: Some(
                 "Implement mandatory Agent title summary updates for Workspace".to_string(),
             ),
@@ -11719,11 +11768,11 @@ fn app_runtime_workspace_projection_change_updates_agent_window_title_summary() 
             last_board_entry_kind: None,
             coordination_scope: None,
             affiliation_status:
-                gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
             workspace_id: None,
             updated_at: chrono::Utc::now(),
         });
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
 
     let events = runtime.handle_workspace_projection_changed_events(&repo);
@@ -11791,17 +11840,18 @@ fn apply_title_sync_sample_projection(
     window_id: &str,
     title_summary: Option<&str>,
     current_focus: Option<&str>,
-) -> gwt_core::work_projection::WorkProjection {
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(repo);
-    projection.status_category = gwt_core::work_projection::WorkspaceStatusCategory::Active;
+) -> gwt_core::workspace_projection::WorkspaceProjection {
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(repo);
+    projection.status_category = gwt_core::workspace_projection::WorkspaceStatusCategory::Active;
     projection
         .agents
-        .push(gwt_core::work_projection::WorkspaceAgentSummary {
+        .push(gwt_core::workspace_projection::WorkspaceAgentSummary {
             session_id: "session-1".to_string(),
             window_id: Some(window_id.to_string()),
             agent_id: "codex".to_string(),
             display_name: "Codex".to_string(),
-            status_category: gwt_core::work_projection::WorkspaceStatusCategory::Active,
+            status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
             current_focus: current_focus.map(str::to_string),
             title_summary: title_summary.map(str::to_string),
             worktree_path: Some(repo.to_path_buf()),
@@ -11810,7 +11860,7 @@ fn apply_title_sync_sample_projection(
             last_board_entry_kind: None,
             coordination_scope: None,
             affiliation_status:
-                gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
             workspace_id: None,
             updated_at: chrono::Utc::now(),
         });
@@ -11872,7 +11922,7 @@ fn apply_workspace_projection_title_sync_emits_active_work_projection_for_active
         Some("Phase U-1 broadcast assertion"),
         None,
     );
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
 
     let events = runtime.apply_workspace_projection_title_sync(&repo, &projection);
@@ -11936,7 +11986,7 @@ fn apply_workspace_projection_title_sync_emits_workspace_state_when_dynamic_titl
         Some("Phase U-2 WorkspaceState assertion"),
         None,
     );
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
 
     let events = runtime.apply_workspace_projection_title_sync(&repo, &projection);
@@ -11949,7 +11999,7 @@ fn apply_workspace_projection_title_sync_emits_workspace_state_when_dynamic_titl
     assert!(
         events
             .iter()
-            .any(|event| matches!(event.event, BackendEvent::WorkState { .. })),
+            .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
         "expected WorkspaceState broadcast when dynamic_title changed: {events:?}"
     );
 }
@@ -11974,7 +12024,7 @@ fn apply_workspace_projection_title_sync_skips_workspace_state_when_nothing_chan
     let mut projection =
         apply_title_sync_sample_projection(&repo, "tab-1::agent-1", Some("No-op"), None);
     projection.agents[0].window_id = None;
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
 
     let events = runtime.apply_workspace_projection_title_sync(&repo, &projection);
@@ -11982,7 +12032,7 @@ fn apply_workspace_projection_title_sync_skips_workspace_state_when_nothing_chan
     assert!(
         !events
             .iter()
-            .any(|event| matches!(event.event, BackendEvent::WorkState { .. })),
+            .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
         "WorkspaceState must be skipped when in-memory dynamic_title did not change: {events:?}"
     );
 }
@@ -12005,7 +12055,7 @@ fn apply_workspace_projection_title_sync_skips_workspace_state_when_same_title_r
         Some("Stable title"),
         Some("Stable focus"),
     );
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
 
     // First sync: dynamic_title transitions from None → "Stable title".
@@ -12013,7 +12063,7 @@ fn apply_workspace_projection_title_sync_skips_workspace_state_when_same_title_r
     assert!(
         first
             .iter()
-            .any(|event| matches!(event.event, BackendEvent::WorkState { .. })),
+            .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
         "first sync should broadcast WorkspaceState: {first:?}"
     );
 
@@ -12024,7 +12074,7 @@ fn apply_workspace_projection_title_sync_skips_workspace_state_when_same_title_r
     assert!(
         !second
             .iter()
-            .any(|event| matches!(event.event, BackendEvent::WorkState { .. })),
+            .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
         "second sync with identical title must not broadcast WorkspaceState: {second:?}"
     );
     // ActiveWorkProjection still fires (it's idempotent on the
@@ -12055,7 +12105,7 @@ fn handle_workspace_projection_changed_events_broadcasts_workspace_state_for_pan
         Some("Pane heading via WorkspaceState"),
         Some("triggered by gwtd workspace update --title-summary"),
     );
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
 
     let events = runtime.handle_workspace_projection_changed_events(&repo);
@@ -12067,7 +12117,7 @@ fn handle_workspace_projection_changed_events_broadcasts_workspace_state_for_pan
     assert!(
         events
             .iter()
-            .any(|event| matches!(event.event, BackendEvent::WorkState { .. })),
+            .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
         "handle_workspace_projection_changed_events must broadcast WorkspaceState: {events:?}"
     );
     assert!(
@@ -12103,7 +12153,7 @@ fn handle_workspace_projection_changed_events_syncs_title_from_canonical_project
         Some("Agent worktree differs from Project State root"),
     );
     projection.agents[0].worktree_path = Some(worktree);
-    gwt_core::work_projection::save_workspace_projection(&project_root, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&project_root, &projection)
         .expect("save projection");
 
     let events = runtime.handle_workspace_projection_changed_events(&project_root);
@@ -12111,7 +12161,7 @@ fn handle_workspace_projection_changed_events_syncs_title_from_canonical_project
     assert!(
         events
             .iter()
-            .any(|event| matches!(event.event, BackendEvent::WorkState { .. })),
+            .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
         "canonical Project State root updates must broadcast WorkspaceState: {events:?}"
     );
     let tab = runtime.tab("tab-1").expect("tab");
@@ -12450,7 +12500,7 @@ fn app_runtime_runtime_hook_state_does_not_update_agent_window_dynamic_title() {
     assert!(
         !events
             .iter()
-            .any(|event| matches!(event.event, BackendEvent::WorkState { .. })),
+            .any(|event| matches!(event.event, BackendEvent::WorkspaceState { .. })),
         "non-structural runtime hook state changes must not force a full workspace_state"
     );
     assert!(events
@@ -12480,7 +12530,8 @@ fn app_runtime_gui_board_scope_uses_active_workspace_id_not_first_agent_workspac
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     projection.id = "workspace-active".to_string();
     projection.agents.push(workspace_agent_summary_for_test(
         "session-other",
@@ -12489,7 +12540,7 @@ fn app_runtime_gui_board_scope_uses_active_workspace_id_not_first_agent_workspac
     projection
         .agents
         .push(workspace_agent_summary_for_test("session-active", None));
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
 
     let scope =
@@ -12514,12 +12565,13 @@ fn app_runtime_board_projection_change_preserves_all_view_for_live_updates() {
     let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
     let repo = temp.path().join("repo");
     fs::create_dir_all(&repo).expect("create repo");
-    let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+    let mut projection =
+        gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
     projection.id = "workspace-a".to_string();
     projection
         .agents
         .push(workspace_agent_summary_for_test("session-a", None));
-    gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
         .expect("save projection");
     post_entry(
         &repo,
@@ -12954,7 +13006,7 @@ fn clone_project_done_opens_workspace_home_and_broadcasts_done() {
         event,
         OutboundEvent {
             target: DispatchTarget::Broadcast,
-            event: BackendEvent::WorkState { .. },
+            event: BackendEvent::WorkspaceState { .. },
         }
     )));
 }
@@ -13628,12 +13680,12 @@ fn workspace_view_for_tab_omits_work_item_history_from_workspace_state() {
 
     use chrono::TimeZone as _;
     let completed_at = chrono::Utc.with_ymd_and_hms(2026, 5, 14, 10, 0, 0).unwrap();
-    let work_item = gwt_core::work_projection::WorkItem {
+    let work_item = gwt_core::workspace_projection::WorkItem {
         id: "work-item-done".to_string(),
         title: "Test Done Item".to_string(),
         intent: None,
         summary: None,
-        status_category: gwt_core::work_projection::WorkspaceStatusCategory::Done,
+        status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Done,
         owner: None,
         created_at: completed_at,
         updated_at: completed_at,
@@ -13645,14 +13697,14 @@ fn workspace_view_for_tab_omits_work_item_history_from_workspace_state() {
         events: Vec::new(),
         discarded: false,
     };
-    let projection = gwt_core::work_projection::WorkItemsProjection {
+    let projection = gwt_core::workspace_projection::WorkItemsProjection {
         updated_at: completed_at,
         work_items: vec![work_item],
     };
     let work_items_path = gwt_core::paths::gwt_workspace_work_items_path_for_repo_path(&repo);
     fs::create_dir_all(work_items_path.parent().expect("parent dir"))
         .expect("create workspace dir");
-    gwt_core::work_projection::save_workspace_work_items_projection_to_path(
+    gwt_core::workspace_projection::save_workspace_work_items_projection_to_path(
         &work_items_path,
         &projection,
     )
@@ -13781,7 +13833,9 @@ fn os_url_open_command_keeps_oauth_query_intact_and_avoids_cmd() {
 #[test]
 fn workspace_work_event_kind_wire_maps_backfill() {
     assert_eq!(
-        super::workspace_work_event_kind_wire(gwt_core::work_projection::WorkEventKind::Backfill),
+        super::workspace_work_event_kind_wire(
+            gwt_core::workspace_projection::WorkEventKind::Backfill
+        ),
         "backfill"
     );
 }
@@ -13837,7 +13891,7 @@ fn app_runtime_reconcile_workspace_worktrees_backfills_existing_worktree() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    // SPEC-2359 Phase W-15 (FR-382): deliberately NO saved WorkProjection
+    // SPEC-2359 Phase W-15 (FR-382): deliberately NO saved WorkspaceProjection
     // (current.json) and NO live agent session — a fresh home must still
     // surface backfilled records (the list must not depend on live agents or
     // on a previously launched project).
@@ -13848,16 +13902,17 @@ fn app_runtime_reconcile_workspace_worktrees_backfills_existing_worktree() {
 
     let work_items_path = gwt_core::paths::gwt_workspace_work_items_path_for_repo_path(&repo);
     let projection =
-        gwt_core::work_projection::load_workspace_work_items_from_path(&work_items_path)
+        gwt_core::workspace_projection::load_workspace_work_items_from_path(&work_items_path)
             .expect("load works")
             .expect("works projection exists");
-    let expected_main = gwt_core::work_projection::canonical_work_id(
+    let expected_main = gwt_core::workspace_projection::canonical_work_id(
         &repo,
         repo_head_branch(&repo).as_deref(),
         None,
     );
-    let expected_foo = gwt_core::work_projection::canonical_work_id(&repo, Some("work/foo"), None)
-        .expect("canonical id");
+    let expected_foo =
+        gwt_core::workspace_projection::canonical_work_id(&repo, Some("work/foo"), None)
+            .expect("canonical id");
     assert!(
         projection
             .work_items
@@ -13976,7 +14031,7 @@ fn app_runtime_active_work_projection_attaches_registry_sessions() {
         .active_work_projection_for_tab("tab-1", &runtime.tabs[0])
         .expect("projection view");
     let expected_id =
-        gwt_core::work_projection::canonical_work_id(&repo, Some("work/foo"), None).unwrap();
+        gwt_core::workspace_projection::canonical_work_id(&repo, Some("work/foo"), None).unwrap();
     let row = view
         .active_works
         .iter()
@@ -14279,7 +14334,7 @@ fn agent_view_borrows_identity_from_ledger_when_record_has_none() {
     let mut index = std::collections::HashMap::new();
     index.insert("gwt-session-anon", &session);
 
-    let agent_ref = gwt_core::work_projection::WorkAgentRef {
+    let agent_ref = gwt_core::workspace_projection::WorkAgentRef {
         session_id: "gwt-session-anon".to_string(),
         agent_id: None,
         display_name: None,
@@ -14412,7 +14467,7 @@ fn agent_view_synthesizes_latest_conversation_when_history_is_empty() {
     let mut index = std::collections::HashMap::new();
     index.insert(session.id.as_str(), &session);
 
-    let agent_ref = gwt_core::work_projection::WorkAgentRef {
+    let agent_ref = gwt_core::workspace_projection::WorkAgentRef {
         session_id: "gwt-session-1".to_string(),
         agent_id: Some("claude".to_string()),
         display_name: Some("Claude Code".to_string()),
@@ -14570,21 +14625,22 @@ fn apply_work_merge_status_caches_and_flags_rows() {
     fs::create_dir_all(&repo).expect("create repo");
     init_repo(&repo);
     let now = chrono::Utc::now();
-    gwt_core::work_projection::record_workspace_work_event(&repo, {
-        let mut event = gwt_core::work_projection::WorkEvent::new(
-            gwt_core::work_projection::WorkEventKind::Update,
+    gwt_core::workspace_projection::record_workspace_work_event(&repo, {
+        let mut event = gwt_core::workspace_projection::WorkEvent::new(
+            gwt_core::workspace_projection::WorkEventKind::Update,
             "work-merged-row",
             now,
         );
         event.title = Some("merged work".to_string());
-        event.execution_container =
-            Some(gwt_core::work_projection::WorkspaceExecutionContainerRef {
+        event.execution_container = Some(
+            gwt_core::workspace_projection::WorkspaceExecutionContainerRef {
                 branch: Some("work/merged".to_string()),
                 worktree_path: None,
                 pr_number: None,
                 pr_url: None,
                 pr_state: None,
-            });
+            },
+        );
         event
     })
     .expect("record work");
@@ -14803,14 +14859,15 @@ fn stop_window_runtime_records_paused_work_off_the_event_loop() {
     let deadline = Instant::now() + Duration::from_secs(5);
     let mut recorded = false;
     while Instant::now() < deadline {
-        let works = gwt_core::work_projection::load_or_synthesize_workspace_work_items(&repo)
-            .unwrap_or_else(|_| gwt_core::work_projection::WorkItemsProjection {
+        let works = gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(&repo)
+            .unwrap_or_else(|_| gwt_core::workspace_projection::WorkItemsProjection {
                 updated_at: chrono::Utc::now(),
                 work_items: Vec::new(),
             });
         recorded = works.work_items.iter().any(|item| {
             item.id == "work-session-session-paused-offloop"
-                && item.status_category == gwt_core::work_projection::WorkspaceStatusCategory::Idle
+                && item.status_category
+                    == gwt_core::workspace_projection::WorkspaceStatusCategory::Idle
         });
         if recorded {
             break;
@@ -14867,14 +14924,15 @@ fn handle_work_events_ingested_broadcasts_only_on_change() {
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
 
     // Seed one Work record so the projection broadcast has content.
-    let mut seed = gwt_core::work_projection::WorkEvent::new(
-        gwt_core::work_projection::WorkEventKind::Start,
+    let mut seed = gwt_core::workspace_projection::WorkEvent::new(
+        gwt_core::workspace_projection::WorkEventKind::Start,
         "work-session-ingest-seed",
         chrono::Utc::now(),
     );
-    seed.status_category = Some(gwt_core::work_projection::WorkspaceStatusCategory::Active);
+    seed.status_category = Some(gwt_core::workspace_projection::WorkspaceStatusCategory::Active);
     seed.title = Some("seed".to_string());
-    gwt_core::work_projection::record_workspace_work_event(&repo, seed).expect("seed work record");
+    gwt_core::workspace_projection::record_workspace_work_event(&repo, seed)
+        .expect("seed work record");
 
     let unchanged = runtime.handle_work_events_ingested(repo.clone(), false);
     assert!(

--- a/crates/gwt/src/app_runtime/title_sync.rs
+++ b/crates/gwt/src/app_runtime/title_sync.rs
@@ -1,4 +1,4 @@
-//! Canonical orchestration for syncing `WorkProjection` title surfaces
+//! Canonical orchestration for syncing `WorkspaceProjection` title surfaces
 //! (per-agent `title_summary` / `current_focus`) into in-memory window state
 //! and emitting the consequent broadcasts in one batch.
 //!
@@ -8,7 +8,7 @@
 //! (1) update `current.json` + `journal.jsonl`,
 //! (2) sync `tab.workspace.windows[<id>].dynamic_title` in memory,
 //! (3) broadcast `BackendEvent::ActiveWorkProjection`, and
-//! (4) broadcast `BackendEvent::WorkState` so the pane heading
+//! (4) broadcast `BackendEvent::WorkspaceState` so the pane heading
 //! `windowData.dynamic_title` consumed by `windowDisplayTitle` on the
 //! frontend refreshes. `gwtd workspace update --title-summary` ran (1)
 //! and (3) but never (4), so the pane heading kept the `agent_id`
@@ -26,7 +26,7 @@
 
 use std::path::Path;
 
-use gwt_core::work_projection::WorkProjection;
+use gwt_core::workspace_projection::WorkspaceProjection;
 
 use super::{AppRuntime, OutboundEvent};
 
@@ -41,7 +41,7 @@ impl AppRuntime {
     ///
     /// Return value:
     /// - The `OutboundEvent`s that callers should dispatch. Phase U-2
-    ///   (SPEC-2359 US-26) makes this emit `BackendEvent::WorkState`
+    ///   (SPEC-2359 US-26) makes this emit `BackendEvent::WorkspaceState`
     ///   when an in-memory `dynamic_title` actually changed, so the
     ///   frontend's pane heading (`windowDisplayTitle` →
     ///   `windowData.dynamic_title`) updates immediately without waiting
@@ -53,7 +53,7 @@ impl AppRuntime {
     pub(crate) fn apply_workspace_projection_title_sync(
         &mut self,
         project_root: &Path,
-        projection: &WorkProjection,
+        projection: &WorkspaceProjection,
     ) -> Vec<OutboundEvent> {
         let dynamic_title_changed =
             self.sync_agent_window_titles_from_workspace_projection(project_root, projection);

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -380,7 +380,7 @@ impl AppRuntime {
         let (branch_candidate, context) = match source {
             gwt::WorkspaceResumeSource::Current => {
                 let projection =
-                    gwt_core::work_projection::load_workspace_projection(&project_root)
+                    gwt_core::workspace_projection::load_workspace_projection(&project_root)
                         .ok()
                         .flatten()
                         .map(|projection| {
@@ -410,10 +410,12 @@ impl AppRuntime {
                 let Some(journal_id) = journal_id else {
                     return error_event("Work journal id is required");
                 };
-                let Ok(entries) = gwt_core::work_projection::load_recent_workspace_journal_entries(
-                    &project_root,
-                    WORKSPACE_OVERVIEW_JOURNAL_LIMIT,
-                ) else {
+                let Ok(entries) =
+                    gwt_core::workspace_projection::load_recent_workspace_journal_entries(
+                        &project_root,
+                        WORKSPACE_OVERVIEW_JOURNAL_LIMIT,
+                    )
+                else {
                     return error_event("Work journal could not be loaded");
                 };
                 let Some(entry) = entries.into_iter().find(|entry| entry.id == journal_id) else {
@@ -675,7 +677,7 @@ impl AppRuntime {
         // instead of falling back to the agent's default display name.
         let project_root = tab.project_root.clone();
         let workspace_resume_context =
-            gwt_core::work_projection::load_workspace_projection(&project_root)
+            gwt_core::workspace_projection::load_workspace_projection(&project_root)
                 .ok()
                 .flatten()
                 .map(|projection| workspace_resume_context_from_projection(&projection));
@@ -826,7 +828,7 @@ impl AppRuntime {
             ));
         }
         let workspace_resume_context =
-            gwt_core::work_projection::load_workspace_projection(&session.worktree_path)
+            gwt_core::workspace_projection::load_workspace_projection(&session.worktree_path)
                 .ok()
                 .flatten()
                 .map(|projection| workspace_resume_context_from_projection(&projection));
@@ -867,7 +869,7 @@ impl AppRuntime {
 
         let project_root = tab.project_root.clone();
         let Ok(Some(projection)) =
-            gwt_core::work_projection::load_workspace_projection(&project_root)
+            gwt_core::workspace_projection::load_workspace_projection(&project_root)
         else {
             return Vec::new();
         };
@@ -876,7 +878,7 @@ impl AppRuntime {
 
         let work_item_session_ids: Option<std::collections::HashSet<String>> = workspace_id
             .and_then(|wid| {
-                gwt_core::work_projection::load_workspace_work_items(&project_root)
+                gwt_core::workspace_projection::load_workspace_work_items(&project_root)
                     .ok()
                     .flatten()
                     .and_then(|items| {

--- a/crates/gwt/src/app_runtime/workspace.rs
+++ b/crates/gwt/src/app_runtime/workspace.rs
@@ -4,7 +4,7 @@
 //!
 //! Owns the free-function cluster that:
 //! - projects [`ActiveAgentSession`]s into the persisted
-//!   `WorkProjection` ([`active_agent_summary_from_session`],
+//!   `WorkspaceProjection` ([`active_agent_summary_from_session`],
 //!   [`merge_active_sessions_into_projection`],
 //!   [`retain_live_workspace_agents`],
 //!   [`workspace_projection_for_current_resume`])
@@ -39,13 +39,13 @@ use super::{
 pub(super) fn active_agent_summary_from_session(
     session: &ActiveAgentSession,
     updated_at: chrono::DateTime<chrono::Utc>,
-) -> gwt_core::work_projection::WorkspaceAgentSummary {
-    gwt_core::work_projection::WorkspaceAgentSummary {
+) -> gwt_core::workspace_projection::WorkspaceAgentSummary {
+    gwt_core::workspace_projection::WorkspaceAgentSummary {
         session_id: session.session_id.clone(),
         window_id: Some(session.window_id.clone()),
         agent_id: session.agent_id.clone(),
         display_name: session.display_name.clone(),
-        status_category: gwt_core::work_projection::WorkspaceStatusCategory::Active,
+        status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
         current_focus: None,
         title_summary: None,
         worktree_path: Some(session.worktree_path.clone()),
@@ -53,7 +53,8 @@ pub(super) fn active_agent_summary_from_session(
         last_board_entry_id: None,
         last_board_entry_kind: None,
         coordination_scope: None,
-        affiliation_status: gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Assigned,
+        affiliation_status:
+            gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
         workspace_id: None,
         updated_at,
     }
@@ -67,7 +68,7 @@ pub(super) fn workspace_projection_owner_title(
     if branch_name.is_empty() {
         return None;
     }
-    let projection = gwt_core::work_projection::load_workspace_projection(project_root)
+    let projection = gwt_core::workspace_projection::load_workspace_projection(project_root)
         .ok()
         .flatten()?;
     let projection_branch = projection.git_details.as_ref()?.branch.as_deref()?.trim();
@@ -79,7 +80,7 @@ pub(super) fn workspace_projection_owner_title(
 }
 
 pub(super) fn merge_active_sessions_into_projection<'a>(
-    projection: &mut gwt_core::work_projection::WorkProjection,
+    projection: &mut gwt_core::workspace_projection::WorkspaceProjection,
     sessions: impl IntoIterator<Item = &'a ActiveAgentSession>,
     updated_at: chrono::DateTime<chrono::Utc>,
 ) {
@@ -105,7 +106,7 @@ pub(super) fn merge_active_sessions_into_projection<'a>(
             summary.coordination_scope = existing.coordination_scope.clone();
         } else {
             summary.affiliation_status =
-                gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Unassigned;
+                gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Unassigned;
             summary.workspace_id = None;
         }
         projection.upsert_agent_summary(summary);
@@ -113,7 +114,7 @@ pub(super) fn merge_active_sessions_into_projection<'a>(
 }
 
 pub(super) fn retain_live_workspace_agents(
-    projection: &mut gwt_core::work_projection::WorkProjection,
+    projection: &mut gwt_core::workspace_projection::WorkspaceProjection,
     sessions: &[&ActiveAgentSession],
     updated_at: chrono::DateTime<chrono::Utc>,
 ) {
@@ -124,11 +125,11 @@ pub(super) fn retain_live_workspace_agents(
 }
 
 pub(super) fn workspace_projection_for_current_resume(
-    mut projection: gwt_core::work_projection::WorkProjection,
+    mut projection: gwt_core::workspace_projection::WorkspaceProjection,
     sessions: &[&ActiveAgentSession],
     tab_title: &str,
     updated_at: chrono::DateTime<chrono::Utc>,
-) -> gwt_core::work_projection::WorkProjection {
+) -> gwt_core::workspace_projection::WorkspaceProjection {
     merge_active_sessions_into_projection(&mut projection, sessions.iter().copied(), updated_at);
     retain_live_workspace_agents(&mut projection, sessions, updated_at);
     if !projection.has_current_agents() {
@@ -138,7 +139,7 @@ pub(super) fn workspace_projection_for_current_resume(
 }
 
 pub(super) fn workspace_cleanup_candidate_for_projection(
-    projection: &gwt_core::work_projection::WorkProjection,
+    projection: &gwt_core::workspace_projection::WorkspaceProjection,
     sessions: &[&ActiveAgentSession],
 ) -> Option<gwt::ActiveWorkCleanupCandidateView> {
     let branch = projection.git_details.as_ref()?.branch.as_deref()?;
@@ -157,10 +158,10 @@ pub(super) fn save_workspace_launch_projection(
 ) -> Result<(), String> {
     let now = chrono::Utc::now();
     let mut projection =
-        gwt_core::work_projection::load_or_default_workspace_projection(project_root)
+        gwt_core::workspace_projection::load_or_default_workspace_projection(project_root)
             .map_err(|error| error.to_string())?;
     projection.project_root = project_root.to_path_buf();
-    let work_id = gwt_core::work_projection::canonical_work_id(
+    let work_id = gwt_core::workspace_projection::canonical_work_id(
         project_root,
         Some(session.branch_name.as_str()),
         Some(session.worktree_path.as_path()),
@@ -170,7 +171,7 @@ pub(super) fn save_workspace_launch_projection(
         .or_else(|| linked_issue_number.map(|issue_number| format!("Issue #{issue_number}")));
     let agent = active_agent_summary_from_session(session, now);
     projection.apply_launch(
-        gwt_core::work_projection::WorkspaceLaunchUpdate {
+        gwt_core::workspace_projection::WorkspaceLaunchUpdate {
             work_id,
             title: workspace_resume_context
                 .and_then(|context| non_empty_workspace_text(context.title.as_deref())),
@@ -188,27 +189,27 @@ pub(super) fn save_workspace_launch_projection(
         now,
     );
 
-    gwt_core::work_projection::save_workspace_projection(project_root, &projection)
+    gwt_core::workspace_projection::save_workspace_projection(project_root, &projection)
         .map_err(|error| error.to_string())?;
     let work_event_kind = if workspace_resume_context.is_some() {
-        gwt_core::work_projection::WorkEventKind::Resume
+        gwt_core::workspace_projection::WorkEventKind::Resume
     } else {
-        gwt_core::work_projection::WorkEventKind::Start
+        gwt_core::workspace_projection::WorkEventKind::Start
     };
     let work_event =
         workspace_work_event_from_launch_projection(&projection, session, work_event_kind, now);
-    gwt_core::work_projection::record_workspace_work_event(project_root, work_event)
+    gwt_core::workspace_projection::record_workspace_work_event(project_root, work_event)
         .map_err(|error| error.to_string())
 }
 
 fn workspace_work_event_from_launch_projection(
-    projection: &gwt_core::work_projection::WorkProjection,
+    projection: &gwt_core::workspace_projection::WorkspaceProjection,
     session: &ActiveAgentSession,
-    kind: gwt_core::work_projection::WorkEventKind,
+    kind: gwt_core::workspace_projection::WorkEventKind,
     updated_at: chrono::DateTime<chrono::Utc>,
-) -> gwt_core::work_projection::WorkEvent {
+) -> gwt_core::workspace_projection::WorkEvent {
     let mut event =
-        gwt_core::work_projection::WorkEvent::new(kind, projection.id.clone(), updated_at);
+        gwt_core::workspace_projection::WorkEvent::new(kind, projection.id.clone(), updated_at);
     event.title = Some(projection.title.clone());
     event.intent = projection
         .summary
@@ -222,7 +223,7 @@ fn workspace_work_event_from_launch_projection(
     event.agent_id = Some(session.agent_id.to_string());
     event.display_name = Some(session.display_name.clone());
     event.execution_container = projection.git_details.as_ref().map(|details| {
-        gwt_core::work_projection::WorkspaceExecutionContainerRef {
+        gwt_core::workspace_projection::WorkspaceExecutionContainerRef {
             branch: details.branch.clone(),
             worktree_path: details.worktree_path.clone(),
             pr_number: details.pr_number,
@@ -285,11 +286,12 @@ pub(super) fn spawn_workspace_cleanup_async(
                     }) {
                         // SPEC-2359 US-37 / FR-118: emit Done only after the
                         // matching workspace cleanup actually succeeded.
-                        let _ = gwt_core::work_projection::emit_workspace_done_event_for_branch(
-                            &project_root,
-                            &branch,
-                            chrono::Utc::now(),
-                        );
+                        let _ =
+                            gwt_core::workspace_projection::emit_workspace_done_event_for_branch(
+                                &project_root,
+                                &branch,
+                                chrono::Utc::now(),
+                            );
                         if let Some(event) =
                             clear_workspace_cleanup_git_details_event(&project_root)
                         {
@@ -311,12 +313,12 @@ pub(super) fn spawn_workspace_cleanup_async(
 }
 
 fn clear_workspace_cleanup_git_details_event(project_root: &Path) -> Option<OutboundEvent> {
-    let mut projection = gwt_core::work_projection::load_workspace_projection(project_root)
+    let mut projection = gwt_core::workspace_projection::load_workspace_projection(project_root)
         .ok()
         .flatten()?;
     projection.clear_git_details_to_idle(chrono::Utc::now());
     if let Err(error) =
-        gwt_core::work_projection::save_workspace_projection(project_root, &projection)
+        gwt_core::workspace_projection::save_workspace_projection(project_root, &projection)
     {
         tracing::warn!(
             project_root = %project_root.display(),
@@ -325,7 +327,7 @@ fn clear_workspace_cleanup_git_details_event(project_root: &Path) -> Option<Outb
         );
         return None;
     }
-    let journal_entries = gwt_core::work_projection::load_recent_workspace_journal_entries(
+    let journal_entries = gwt_core::workspace_projection::load_recent_workspace_journal_entries(
         project_root,
         WORKSPACE_OVERVIEW_JOURNAL_LIMIT,
     )
@@ -339,8 +341,8 @@ fn clear_workspace_cleanup_git_details_event(project_root: &Path) -> Option<Outb
         .load(&gwt_core::paths::gwt_sessions_dir());
     let session_index = work_session_index(&agent_sessions);
     let workspaces =
-        gwt_core::work_projection::load_or_synthesize_workspace_work_items(project_root)
-            .unwrap_or_else(|_| gwt_core::work_projection::WorkItemsProjection {
+        gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(project_root)
+            .unwrap_or_else(|_| gwt_core::workspace_projection::WorkItemsProjection {
                 updated_at: projection.updated_at,
                 work_items: Vec::new(),
             })

--- a/crates/gwt/src/board_audience.rs
+++ b/crates/gwt/src/board_audience.rs
@@ -4,7 +4,7 @@ use gwt_core::{
     coordination::{
         normalize_board_audience, BoardAudienceScope, BoardMention, BoardMentionTargetKind,
     },
-    work_projection::{load_workspace_projection, WorkProjection, WorkspaceAgentSummary},
+    workspace_projection::{load_workspace_projection, WorkspaceAgentSummary, WorkspaceProjection},
 };
 
 fn non_empty_string(value: &str) -> Option<String> {
@@ -13,7 +13,7 @@ fn non_empty_string(value: &str) -> Option<String> {
 }
 
 fn workspace_id_for_agent(
-    projection: &WorkProjection,
+    projection: &WorkspaceProjection,
     agent: &WorkspaceAgentSummary,
 ) -> Option<String> {
     if !agent.is_assigned() {
@@ -26,11 +26,11 @@ fn workspace_id_for_agent(
         .or_else(|| non_empty_string(&projection.id))
 }
 
-fn active_workspace_id(projection: &WorkProjection) -> Option<String> {
+fn active_workspace_id(projection: &WorkspaceProjection) -> Option<String> {
     non_empty_string(&projection.id)
 }
 
-fn gui_workspace_id(projection: &WorkProjection) -> Option<String> {
+fn gui_workspace_id(projection: &WorkspaceProjection) -> Option<String> {
     projection.assigned_agents().next()?;
     active_workspace_id(projection).or_else(|| {
         projection
@@ -49,7 +49,7 @@ fn push_unique(values: &mut Vec<String>, value: impl Into<String>) {
 
 fn push_workspace_for_session(
     values: &mut Vec<String>,
-    projection: &WorkProjection,
+    projection: &WorkspaceProjection,
     session_id: &str,
 ) -> bool {
     let Some(agent) = projection
@@ -65,7 +65,11 @@ fn push_workspace_for_session(
     true
 }
 
-fn push_workspace_for_agent(values: &mut Vec<String>, projection: &WorkProjection, target: &str) {
+fn push_workspace_for_agent(
+    values: &mut Vec<String>,
+    projection: &WorkspaceProjection,
+    target: &str,
+) {
     let target = target.trim();
     if target.is_empty() {
         return;
@@ -176,7 +180,7 @@ pub fn post_audience_for_gui(
 
 fn collect_mention_audience(
     audience: &mut Vec<String>,
-    projection: Option<&WorkProjection>,
+    projection: Option<&WorkspaceProjection>,
     mentions: &[BoardMention],
 ) {
     for mention in mentions {
@@ -201,7 +205,7 @@ fn collect_mention_audience(
 mod tests {
     use super::*;
     use chrono::Utc;
-    use gwt_core::work_projection::{
+    use gwt_core::workspace_projection::{
         save_workspace_projection, WorkspaceAgentAffiliationStatus, WorkspaceStatusCategory,
     };
     use std::path::PathBuf;
@@ -231,8 +235,8 @@ mod tests {
         }
     }
 
-    fn projection_with(id: &str, agents: Vec<WorkspaceAgentSummary>) -> WorkProjection {
-        let mut projection = WorkProjection::default_for_project(PathBuf::from("/tmp/p"));
+    fn projection_with(id: &str, agents: Vec<WorkspaceAgentSummary>) -> WorkspaceProjection {
+        let mut projection = WorkspaceProjection::default_for_project(PathBuf::from("/tmp/p"));
         projection.id = id.to_string();
         projection.agents = agents;
         projection

--- a/crates/gwt/src/board_remote/mapping.rs
+++ b/crates/gwt/src/board_remote/mapping.rs
@@ -9,7 +9,7 @@ use std::hash::{Hash, Hasher};
 use chrono::{DateTime, TimeZone, Utc};
 use gwt_core::board_remote_roots::GENERAL_THREAD_KEY;
 use gwt_core::coordination::{AuthorKind, BoardEntry, BoardEntryKind, BoardMentionTargetKind};
-use gwt_core::work_projection::{WorkItem, WorkspaceStatusCategory};
+use gwt_core::workspace_projection::{WorkItem, WorkspaceStatusCategory};
 
 /// Parse a Slack message timestamp (`"1700000000.123456"`) into UTC.
 pub fn slack_ts_to_datetime(ts: &str) -> Option<DateTime<Utc>> {

--- a/crates/gwt/src/board_remote/slack.rs
+++ b/crates/gwt/src/board_remote/slack.rs
@@ -294,7 +294,7 @@ impl SlackProvider {
     ) -> Result<String> {
         let key = mapping::thread_key_for_entry(entry);
         let item =
-            gwt_core::work_projection::load_or_synthesize_workspace_work_items(worktree_root)
+            gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(worktree_root)
                 .ok()
                 .and_then(|proj| proj.work_items.into_iter().find(|work| work.id == key));
         let (card_title, card_body) =

--- a/crates/gwt/src/board_remote/teams.rs
+++ b/crates/gwt/src/board_remote/teams.rs
@@ -196,7 +196,7 @@ impl TeamsProvider {
     ) -> Result<String> {
         let key = mapping::thread_key_for_entry(entry);
         let item =
-            gwt_core::work_projection::load_or_synthesize_workspace_work_items(worktree_root)
+            gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(worktree_root)
                 .ok()
                 .and_then(|proj| proj.work_items.into_iter().find(|work| work.id == key));
         let (card_title, card_body) =

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -210,7 +210,7 @@ pub enum WorkspaceCommand {
     },
     /// SPEC-2359 US-41: `gwtd workspace projection-list [--stale] [--all]` —
     /// list saved Workspace projections under `~/.gwt/projects/*/workspace/`
-    /// classified by [`gwt_core::work_projection::workspace_projection_stale_reason`].
+    /// classified by [`gwt_core::workspace_projection::workspace_projection_stale_reason`].
     ProjectionList { stale: bool, all: bool },
     /// SPEC-2359 US-41: `gwtd workspace projection-prune [--dry-run] [--id <id>]...` —
     /// archive / delete stale Workspace projections (FR-153, FR-154).

--- a/crates/gwt/src/cli/board.rs
+++ b/crates/gwt/src/cli/board.rs
@@ -482,9 +482,9 @@ mod tests {
     use gwt_agent::{AgentId, Session, GWT_SESSION_ID_ENV};
     use gwt_core::{
         coordination::BoardEntryKind,
-        work_projection::{
-            save_workspace_projection, WorkProjection, WorkspaceAgentAffiliationStatus,
-            WorkspaceAgentSummary, WorkspaceStatusCategory,
+        workspace_projection::{
+            save_workspace_projection, WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary,
+            WorkspaceProjection, WorkspaceStatusCategory,
         },
     };
 
@@ -522,7 +522,7 @@ mod tests {
     }
 
     fn save_projection(repo: &std::path::Path, agents: Vec<WorkspaceAgentSummary>) {
-        let mut projection = WorkProjection::default_for_project(repo);
+        let mut projection = WorkspaceProjection::default_for_project(repo);
         projection.id = "workspace-current".to_string();
         projection.agents = agents;
         save_workspace_projection(repo, &projection).expect("save workspace projection");
@@ -1308,7 +1308,7 @@ mod tests {
             entry.audience.is_empty(),
             "Unassigned Board posts should not auto-materialize a Workspace or audience: {entry:?}"
         );
-        let projection = gwt_core::work_projection::load_workspace_projection(&repo)
+        let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
             .expect("load projection")
             .expect("projection");
         let agent = projection
@@ -1321,9 +1321,11 @@ mod tests {
             WorkspaceAgentAffiliationStatus::Unassigned
         );
         assert!(agent.workspace_id.is_none());
-        assert!(gwt_core::work_projection::load_workspace_work_items(&repo)
-            .expect("load workspace history")
-            .is_none());
+        assert!(
+            gwt_core::workspace_projection::load_workspace_work_items(&repo)
+                .expect("load workspace history")
+                .is_none()
+        );
     }
 
     #[test]
@@ -1372,7 +1374,7 @@ mod tests {
 
         let snapshot = load_snapshot(&repo).unwrap();
         assert!(snapshot.board.entries[0].audience.is_empty());
-        let projection = gwt_core::work_projection::load_workspace_projection(&repo)
+        let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
             .expect("load projection")
             .expect("projection");
         let agent = projection
@@ -1384,9 +1386,11 @@ mod tests {
             agent.affiliation_status,
             WorkspaceAgentAffiliationStatus::Unassigned
         );
-        assert!(gwt_core::work_projection::load_workspace_work_items(&repo)
-            .expect("load workspace history")
-            .is_none());
+        assert!(
+            gwt_core::workspace_projection::load_workspace_work_items(&repo)
+                .expect("load workspace history")
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/gwt/src/cli/env/mod.rs
+++ b/crates/gwt/src/cli/env/mod.rs
@@ -191,9 +191,6 @@ pub fn dispatch<E: CliEnv>(env: &mut E, args: &[String]) -> i32 {
         "build" => super::parse_build_args(&rest),
         "register" => super::register::parse_args(&rest),
         "daemon" => super::parse_daemon_args(&rest),
-        // SPEC-2359 US-66 (T-527): `work` is the canonical verb; `workspace`
-        // stays as the legacy adapter alias.
-        "work" => super::parse_workspace_args(&rest),
         "workspace" => super::parse_workspace_args(&rest),
         "pane" => parse_pane_args(&rest),
         "open" => super::open::parse_args(&rest),

--- a/crates/gwt/src/cli/env/tests.rs
+++ b/crates/gwt/src/cli/env/tests.rs
@@ -521,31 +521,3 @@ fn client_ref_forwards_issue_client_methods_to_the_underlying_fake_client() {
         );
     }
 }
-
-/// SPEC-2359 US-66 (T-527): `work` is the canonical CLI verb and routes to
-/// the same command family as the legacy `workspace` alias.
-#[test]
-fn work_verb_routes_like_workspace_alias() {
-    let mut env_work = TestEnv::new(std::path::PathBuf::from("cache-root"));
-    let work_code = super::dispatch(
-        &mut env_work,
-        &[
-            "gwtd".to_string(),
-            "work".to_string(),
-            "bogus-subcommand".to_string(),
-        ],
-    );
-    let mut env_workspace = TestEnv::new(std::path::PathBuf::from("cache-root"));
-    let workspace_code = super::dispatch(
-        &mut env_workspace,
-        &[
-            "gwtd".to_string(),
-            "workspace".to_string(),
-            "bogus-subcommand".to_string(),
-        ],
-    );
-    assert_eq!(
-        work_code, workspace_code,
-        "work and workspace verbs share one parser"
-    );
-}

--- a/crates/gwt/src/cli/hook/board_reminder/mod.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/mod.rs
@@ -33,7 +33,7 @@ use gwt_agent::{Session, GWT_SESSION_ID_ENV};
 use gwt_core::coordination::{
     load_reminders_state, write_reminders_state, BoardEntryKind, RemindersState,
 };
-use gwt_core::work_projection::WorkProjection;
+use gwt_core::workspace_projection::WorkspaceProjection;
 
 /// SPEC-2359 Phase U-9 (FR-178): minimum number of consecutive
 /// UserPromptSubmit turns with an unchanged `title_summary` before the
@@ -145,7 +145,8 @@ fn agent_title_summary_missing(session: &Session) -> Result<bool, HookError> {
         session,
         &session.worktree_path,
     );
-    let projection = gwt_core::work_projection::load_workspace_projection(&project_state_root)?;
+    let projection =
+        gwt_core::workspace_projection::load_workspace_projection(&project_state_root)?;
     Ok(title_summary_missing_in_projection(
         projection.as_ref(),
         &session.id,
@@ -163,7 +164,7 @@ fn agent_title_summary_missing(session: &Session) -> Result<bool, HookError> {
 /// unregistered session is treated as "not missing" so the reminder only
 /// fires once the agent is actually present in the projection.
 fn title_summary_missing_in_projection(
-    projection: Option<&gwt_core::work_projection::WorkProjection>,
+    projection: Option<&gwt_core::workspace_projection::WorkspaceProjection>,
     session_id: &str,
 ) -> bool {
     let Some(projection) = projection else {
@@ -219,7 +220,7 @@ fn append_title_summary_required_context(
 /// owned by the empty-trigger reminder path and never triggers stale.
 fn compute_title_summary_stale_state(
     event: IntentBoundaryEvent,
-    projection: Option<&WorkProjection>,
+    projection: Option<&WorkspaceProjection>,
     session_id: &str,
     current_state: &RemindersState,
 ) -> (bool, RemindersState) {
@@ -431,7 +432,7 @@ pub fn compute_plan(
         &session.worktree_path,
     );
     let projection_for_stale =
-        gwt_core::work_projection::load_workspace_projection(&project_state_root)?;
+        gwt_core::workspace_projection::load_workspace_projection(&project_state_root)?;
     let (stale, updated_state) = compute_title_summary_stale_state(
         intent_event,
         projection_for_stale.as_ref(),
@@ -471,9 +472,9 @@ mod tests {
     use gwt_agent::AgentId;
     use gwt_core::{
         coordination::{post_entry, AuthorKind, BoardEntry, BoardEntryKind},
-        work_projection::{
-            save_workspace_projection, WorkProjection, WorkspaceAgentAffiliationStatus,
-            WorkspaceAgentSummary, WorkspaceStatusCategory,
+        workspace_projection::{
+            save_workspace_projection, WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary,
+            WorkspaceProjection, WorkspaceStatusCategory,
         },
     };
 
@@ -510,7 +511,7 @@ mod tests {
     }
 
     fn save_projection(repo: &Path, agents: Vec<WorkspaceAgentSummary>) {
-        let mut projection = WorkProjection::default_for_project(repo);
+        let mut projection = WorkspaceProjection::default_for_project(repo);
         projection.id = "workspace-current".to_string();
         projection.agents = agents;
         save_workspace_projection(repo, &projection).expect("save workspace projection");
@@ -892,15 +893,16 @@ mod tests {
             "sessions without a Workspace projection are Unassigned and must not require a title update"
         );
 
-        let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
         projection
             .agents
-            .push(gwt_core::work_projection::WorkspaceAgentSummary {
+            .push(gwt_core::workspace_projection::WorkspaceAgentSummary {
                 session_id: session.id.clone(),
                 window_id: None,
                 agent_id: "codex".to_string(),
                 display_name: "Codex".to_string(),
-                status_category: gwt_core::work_projection::WorkspaceStatusCategory::Active,
+                status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
                 current_focus: Some("Implement title-summary guard".to_string()),
                 title_summary: Some("Title summary guard".to_string()),
                 worktree_path: Some(repo.clone()),
@@ -909,11 +911,11 @@ mod tests {
                 last_board_entry_kind: None,
                 coordination_scope: None,
                 affiliation_status:
-                    gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                    gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
                 workspace_id: None,
                 updated_at: Utc::now(),
             });
-        gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
             .expect("save projection");
 
         assert!(
@@ -932,15 +934,15 @@ mod tests {
         session.project_state_root = Some(project_root.clone());
 
         let mut projection =
-            gwt_core::work_projection::WorkProjection::default_for_project(&project_root);
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&project_root);
         projection
             .agents
-            .push(gwt_core::work_projection::WorkspaceAgentSummary {
+            .push(gwt_core::workspace_projection::WorkspaceAgentSummary {
                 session_id: session.id.clone(),
                 window_id: Some("project::agent-1".to_string()),
                 agent_id: "codex".to_string(),
                 display_name: "Codex".to_string(),
-                status_category: gwt_core::work_projection::WorkspaceStatusCategory::Active,
+                status_category: gwt_core::workspace_projection::WorkspaceStatusCategory::Active,
                 current_focus: Some("Implement canonical title guard".to_string()),
                 title_summary: Some("Canonical title guard".to_string()),
                 worktree_path: Some(worktree.clone()),
@@ -949,11 +951,11 @@ mod tests {
                 last_board_entry_kind: None,
                 coordination_scope: None,
                 affiliation_status:
-                    gwt_core::work_projection::WorkspaceAgentAffiliationStatus::Assigned,
+                    gwt_core::workspace_projection::WorkspaceAgentAffiliationStatus::Assigned,
                 workspace_id: None,
                 updated_at: Utc::now(),
             });
-        gwt_core::work_projection::save_workspace_projection(&project_root, &projection)
+        gwt_core::workspace_projection::save_workspace_projection(&project_root, &projection)
             .expect("save projection");
 
         assert!(
@@ -970,8 +972,8 @@ mod tests {
     /// Pure-logic test (no global store / env) to stay deterministic.
     #[test]
     fn title_summary_missing_in_projection_covers_affiliation_and_presence() {
-        use gwt_core::work_projection::{
-            WorkProjection, WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary,
+        use gwt_core::workspace_projection::{
+            WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary, WorkspaceProjection,
             WorkspaceStatusCategory,
         };
 
@@ -992,7 +994,7 @@ mod tests {
             workspace_id: None,
             updated_at: Utc::now(),
         };
-        let mut projection = WorkProjection::default_for_project("/repo");
+        let mut projection = WorkspaceProjection::default_for_project("/repo");
         projection.agents.push(agent.clone());
 
         // Unassigned + empty title -> missing (the fix).
@@ -1018,7 +1020,7 @@ mod tests {
         // No projection / unknown session -> not missing.
         assert!(!title_summary_missing_in_projection(None, "sess-1"));
         agent.title_summary = None;
-        let mut other = WorkProjection::default_for_project("/repo");
+        let mut other = WorkspaceProjection::default_for_project("/repo");
         other.agents.push(agent);
         assert!(!title_summary_missing_in_projection(
             Some(&other),
@@ -1464,8 +1466,8 @@ mod tests {
         session_id: &str,
         title_summary: Option<&str>,
         current_focus: Option<&str>,
-    ) -> WorkProjection {
-        let mut projection = WorkProjection::default_for_project(repo);
+    ) -> WorkspaceProjection {
+        let mut projection = WorkspaceProjection::default_for_project(repo);
         let mut agent = workspace_agent(
             session_id,
             Some("ws-stale"),

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -17,7 +17,7 @@ use gwt_agent::{
 };
 use gwt_core::{
     paths::{gwt_cache_dir, gwt_sessions_dir},
-    work_projection::load_workspace_projection,
+    workspace_projection::load_workspace_projection,
 };
 use gwt_github::{body::SpecBody, sections::SectionName, Cache, IssueNumber};
 use serde::Deserialize;

--- a/crates/gwt/src/cli/hook/workspace_identity.rs
+++ b/crates/gwt/src/cli/hook/workspace_identity.rs
@@ -2,9 +2,10 @@ use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use gwt_agent::{Session, GWT_SESSION_ID_ENV};
-use gwt_core::work_projection::{
-    load_or_default_workspace_projection, save_workspace_projection, WorkProjection,
-    WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary, WorkspaceStatusCategory,
+use gwt_core::workspace_projection::{
+    load_or_default_workspace_projection, save_workspace_projection,
+    WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary, WorkspaceProjection,
+    WorkspaceStatusCategory,
 };
 
 use super::HookError;
@@ -83,7 +84,7 @@ fn coordination_assets_need_refresh(worktree: &Path) -> bool {
 /// the same `session_id` is present. Returns `true` when a new record
 /// was inserted. Existing records are preserved as-is.
 pub(crate) fn register_session_in_projection(
-    projection: &mut WorkProjection,
+    projection: &mut WorkspaceProjection,
     session: &Session,
     now: DateTime<Utc>,
 ) -> bool {
@@ -175,16 +176,16 @@ fn current_session_from_env() -> Result<Option<Session>, HookError> {
 mod tests {
     use chrono::Utc;
     use gwt_agent::{AgentId, Session};
-    use gwt_core::work_projection::{
-        load_workspace_projection, save_workspace_projection, WorkProjection,
-        WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary, WorkspaceStatusCategory,
+    use gwt_core::workspace_projection::{
+        load_workspace_projection, save_workspace_projection, WorkspaceAgentAffiliationStatus,
+        WorkspaceAgentSummary, WorkspaceProjection, WorkspaceStatusCategory,
     };
 
     use super::*;
 
-    fn projection_for(repo: &std::path::Path) -> WorkProjection {
+    fn projection_for(repo: &std::path::Path) -> WorkspaceProjection {
         let now = Utc::now();
-        WorkProjection {
+        WorkspaceProjection {
             id: "ws-test".to_string(),
             project_root: repo.to_path_buf(),
             title: String::new(),

--- a/crates/gwt/src/cli/pr/mod.rs
+++ b/crates/gwt/src/cli/pr/mod.rs
@@ -179,7 +179,7 @@ pub(super) fn run<E: CliEnv>(
 
 fn sync_workspace_pr_metadata<E: CliEnv>(env: &E, pr: &PrStatus, requested_head: Option<&str>) {
     let Ok(Some(mut projection)) =
-        gwt_core::work_projection::load_workspace_projection(env.repo_path())
+        gwt_core::workspace_projection::load_workspace_projection(env.repo_path())
     else {
         return;
     };
@@ -199,13 +199,13 @@ fn sync_workspace_pr_metadata<E: CliEnv>(env: &E, pr: &PrStatus, requested_head:
     details.pr_url = (!pr.url.trim().is_empty()).then_some(pr.url.clone());
     details.pr_created_at = pr.created_at;
     projection.updated_at = chrono::Utc::now();
-    let _ = gwt_core::work_projection::save_workspace_projection(env.repo_path(), &projection);
+    let _ = gwt_core::workspace_projection::save_workspace_projection(env.repo_path(), &projection);
 
     // SPEC-2359 US-37 / FR-117: auto-emit Done for the linked Workspace WorkItem
     // when the PR transitions to merged. The helper is idempotent per work_item_id,
     // so repeated polling does not duplicate Done events.
     if pr.state.to_string().eq_ignore_ascii_case("merged") {
-        let _ = gwt_core::work_projection::emit_workspace_done_event_if_absent(
+        let _ = gwt_core::workspace_projection::emit_workspace_done_event_if_absent(
             env.repo_path(),
             &projection.id,
             chrono::Utc::now(),
@@ -525,8 +525,9 @@ mod tests {
             merge_state_status: "UNKNOWN".to_string(),
             review_status: "REVIEW_REQUIRED".to_string(),
         }));
-        let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
-        projection.git_details = Some(gwt_core::work_projection::GitDetails {
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+        projection.git_details = Some(gwt_core::workspace_projection::GitDetails {
             branch: Some("work/20260507-0808".to_string()),
             worktree_path: Some(repo.join("work/20260507-0808")),
             base_branch: Some("origin/develop".to_string()),
@@ -537,7 +538,7 @@ mod tests {
             created_by_start_work: true,
             created_at: chrono::Utc::now(),
         });
-        gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
             .expect("save projection");
 
         let mut out = String::new();
@@ -545,7 +546,7 @@ mod tests {
 
         assert_eq!(code, 0);
         assert!(out.contains("#2538 [OPEN] Active Work title"));
-        let projection = gwt_core::work_projection::load_workspace_projection(&repo)
+        let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
             .expect("load projection")
             .expect("projection");
         let details = projection.git_details.expect("git details");
@@ -587,8 +588,9 @@ mod tests {
             merge_state_status: "UNKNOWN".to_string(),
             review_status: "REVIEW_REQUIRED".to_string(),
         });
-        let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
-        projection.git_details = Some(gwt_core::work_projection::GitDetails {
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
+        projection.git_details = Some(gwt_core::workspace_projection::GitDetails {
             branch: Some("work/20260507-0808".to_string()),
             worktree_path: Some(repo.join("work/20260507-0808")),
             base_branch: Some("origin/develop".to_string()),
@@ -599,7 +601,7 @@ mod tests {
             created_by_start_work: true,
             created_at: chrono::Utc::now(),
         });
-        gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
             .expect("save projection");
 
         let mut out = String::new();
@@ -619,7 +621,7 @@ mod tests {
 
         assert_eq!(code, 0);
         assert!(out.contains("#2540 [OPEN] Other branch PR"));
-        let projection = gwt_core::work_projection::load_workspace_projection(&repo)
+        let projection = gwt_core::workspace_projection::load_workspace_projection(&repo)
             .expect("load projection")
             .expect("projection");
         let details = projection.git_details.expect("git details");
@@ -904,9 +906,10 @@ mod tests {
             review_status: "APPROVED".to_string(),
         }));
 
-        let mut projection = gwt_core::work_projection::WorkProjection::default_for_project(&repo);
+        let mut projection =
+            gwt_core::workspace_projection::WorkspaceProjection::default_for_project(&repo);
         projection.id = "wi-pr-merge-auto-done".to_string();
-        projection.git_details = Some(gwt_core::work_projection::GitDetails {
+        projection.git_details = Some(gwt_core::workspace_projection::GitDetails {
             branch: Some("work/20260513-0500".to_string()),
             worktree_path: Some(repo.join("work/20260513-0500")),
             base_branch: Some("origin/develop".to_string()),
@@ -917,24 +920,25 @@ mod tests {
             created_by_start_work: true,
             created_at: chrono::Utc::now(),
         });
-        gwt_core::work_projection::save_workspace_projection(&repo, &projection)
+        gwt_core::workspace_projection::save_workspace_projection(&repo, &projection)
             .expect("save projection");
 
-        let mut start = gwt_core::work_projection::WorkEvent::new(
-            gwt_core::work_projection::WorkEventKind::Start,
+        let mut start = gwt_core::workspace_projection::WorkEvent::new(
+            gwt_core::workspace_projection::WorkEventKind::Start,
             "wi-pr-merge-auto-done",
             chrono::Utc.with_ymd_and_hms(2026, 5, 13, 1, 0, 0).unwrap(),
         );
         start.title = Some("Auto-done PR work".to_string());
-        start.status_category = Some(gwt_core::work_projection::WorkspaceStatusCategory::Active);
-        gwt_core::work_projection::record_workspace_work_event(&repo, start)
+        start.status_category =
+            Some(gwt_core::workspace_projection::WorkspaceStatusCategory::Active);
+        gwt_core::workspace_projection::record_workspace_work_event(&repo, start)
             .expect("seed start event");
 
         let mut out = String::new();
         let code = run(&mut env, PrCommand::Current, &mut out).expect("run pr current");
         assert_eq!(code, 0);
 
-        let projection_after = gwt_core::work_projection::load_workspace_projection(&repo)
+        let projection_after = gwt_core::workspace_projection::load_workspace_projection(&repo)
             .expect("load projection")
             .expect("projection");
         assert_eq!(
@@ -947,7 +951,7 @@ mod tests {
             Some("MERGED")
         );
 
-        let work_items = gwt_core::work_projection::load_workspace_work_items(&repo)
+        let work_items = gwt_core::workspace_projection::load_workspace_work_items(&repo)
             .expect("load work items")
             .expect("work items");
         let item = work_items
@@ -957,7 +961,7 @@ mod tests {
             .expect("work item");
         assert_eq!(
             item.status_category,
-            gwt_core::work_projection::WorkspaceStatusCategory::Done,
+            gwt_core::workspace_projection::WorkspaceStatusCategory::Done,
             "PR merge must auto-emit Done for the linked Workspace WorkItem",
         );
     }

--- a/crates/gwt/src/cli/workspace.rs
+++ b/crates/gwt/src/cli/workspace.rs
@@ -2,12 +2,12 @@ use std::path::Path;
 
 use chrono::{DateTime, Utc};
 use gwt_core::paths::gwt_projects_dir;
-use gwt_core::work_projection::{
+use gwt_core::workspace_projection::{
     apply_prune_plan, classify_workspace_projections, load_or_default_workspace_projection,
     load_or_synthesize_workspace_work_items, record_workspace_work_event,
     save_workspace_projection, update_workspace_projection_with_journal, ClassifiedProjection,
-    PruneAction, PruneSkipReason, WorkEvent, WorkEventKind, WorkItem, WorkProjection,
-    WorkspaceAgentSummary, WorkspaceExecutionContainerRef, WorkspaceProjectionUpdate,
+    PruneAction, PruneSkipReason, WorkEvent, WorkEventKind, WorkItem, WorkspaceAgentSummary,
+    WorkspaceExecutionContainerRef, WorkspaceProjection, WorkspaceProjectionUpdate,
     WorkspaceRetentionConfig, WorkspaceStartUpdate, WorkspaceStatusCategory,
 };
 use gwt_github::{ApiError, SpecOpsError};
@@ -457,7 +457,7 @@ pub(super) fn run<E: CliEnv>(
             // SPEC-2359 W16-2 (FR-389): mint the canonical (machine-
             // independent, branch-keyed) Work id when the agent has a branch
             // so every machine's records join the same Workspace.
-            let canonical_id = gwt_core::work_projection::canonical_work_id(
+            let canonical_id = gwt_core::workspace_projection::canonical_work_id(
                 env.repo_path(),
                 agent.branch.as_deref(),
                 agent.worktree_path.as_deref(),
@@ -547,7 +547,8 @@ pub(super) fn run<E: CliEnv>(
             // retroactive migration.
             projection.created_at = now;
             projection.creator = Some(agent_display_name);
-            projection.lifecycle_stage = gwt_core::work_projection::WorkspaceLifecycleStage::Active;
+            projection.lifecycle_stage =
+                gwt_core::workspace_projection::WorkspaceLifecycleStage::Active;
             assign_agent_to_workspace(
                 &mut projection,
                 &agent_session,
@@ -630,7 +631,7 @@ fn run_projection_list_with_scan_root<F>(
     out: &mut String,
 ) -> Result<i32, SpecOpsError>
 where
-    F: Fn(&WorkProjection) -> bool,
+    F: Fn(&WorkspaceProjection) -> bool,
 {
     let plan = classify_workspace_projections(scan_root, config, now, is_active_session);
     let filtered = filter_projection_list(&plan, stale, all);
@@ -671,7 +672,7 @@ fn run_projection_prune_with_scan_root<F>(
     out: &mut String,
 ) -> Result<i32, SpecOpsError>
 where
-    F: Fn(&WorkProjection) -> bool,
+    F: Fn(&WorkspaceProjection) -> bool,
 {
     let plan = classify_workspace_projections(scan_root, config, now, is_active_session);
     let filtered: Vec<ClassifiedProjection> = if ids.is_empty() {
@@ -775,7 +776,7 @@ pub(super) fn ensure_workspace_for_agent(
     // SPEC-2359 W16-2 (FR-389): when the canonical (branch-keyed) Work id
     // already names an incomplete item, join it directly — the similarity
     // guard never blocks same-branch convergence.
-    if let Some(canonical_id) = gwt_core::work_projection::canonical_work_id(
+    if let Some(canonical_id) = gwt_core::workspace_projection::canonical_work_id(
         repo_path,
         agent.branch.as_deref(),
         agent.worktree_path.as_deref(),
@@ -903,14 +904,14 @@ fn record_workspace_join_event(
 
 fn create_workspace_for_agent(
     repo_path: &std::path::Path,
-    projection: &mut WorkProjection,
+    projection: &mut WorkspaceProjection,
     input: &WorkspaceEnsureInput,
     owner: Option<String>,
     agent: &WorkspaceAgentSummary,
 ) -> Result<String, SpecOpsError> {
     // SPEC-2359 W16-2 (FR-389): canonical, machine-independent Work id when
     // the agent has a branch / worktree; millis fallback for branchless agents.
-    let workspace_id = gwt_core::work_projection::canonical_work_id(
+    let workspace_id = gwt_core::workspace_projection::canonical_work_id(
         repo_path,
         agent.branch.as_deref(),
         agent.worktree_path.as_deref(),
@@ -1026,12 +1027,12 @@ fn workspace_item_by_id(
         .find(|item| item.id == workspace_id))
 }
 
-fn apply_workspace_item_to_projection(projection: &mut WorkProjection, item: &WorkItem) {
+fn apply_workspace_item_to_projection(projection: &mut WorkspaceProjection, item: &WorkItem) {
     projection.apply_work_item(item, Utc::now());
 }
 
 fn assign_agent_to_workspace(
-    projection: &mut WorkProjection,
+    projection: &mut WorkspaceProjection,
     agent_session: &str,
     workspace_id: &str,
     current_focus: Option<String>,
@@ -1124,10 +1125,10 @@ fn string_error(error: String) -> SpecOpsError {
 mod tests {
     use super::*;
     use crate::cli::env::TestEnv;
-    use gwt_core::work_projection::{
+    use gwt_core::workspace_projection::{
         load_workspace_projection, load_workspace_work_items, record_workspace_work_event,
-        save_workspace_projection, WorkProjection, WorkspaceAgentAffiliationStatus,
-        WorkspaceAgentSummary,
+        save_workspace_projection, WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary,
+        WorkspaceProjection,
     };
     use std::ffi::OsString;
 
@@ -1456,7 +1457,7 @@ mod tests {
         std::fs::create_dir_all(&worktree).expect("worktree");
         write_session_with_project_state_root("session-1", &worktree, &project_root);
 
-        let mut canonical = WorkProjection::default_for_project(&project_root);
+        let mut canonical = WorkspaceProjection::default_for_project(&project_root);
         canonical.agents.push(assigned_agent_with_window(
             "session-1",
             "project::agent-1",
@@ -1519,7 +1520,7 @@ mod tests {
         std::fs::create_dir_all(&worktree).expect("worktree");
         write_session_with_project_state_root("session-1", &worktree, &project_root);
 
-        let mut canonical = WorkProjection::default_for_project(&project_root);
+        let mut canonical = WorkspaceProjection::default_for_project(&project_root);
         canonical.agents.push(assigned_agent_with_window(
             "session-1",
             "project::agent-1",
@@ -1527,7 +1528,7 @@ mod tests {
         ));
         save_workspace_projection(&project_root, &canonical).expect("save canonical projection");
 
-        let mut split = WorkProjection::default_for_project(&worktree);
+        let mut split = WorkspaceProjection::default_for_project(&worktree);
         let mut split_agent =
             assigned_agent_with_window("session-1", "project::agent-1", &worktree);
         split_agent.title_summary = Some("Split root title".to_string());
@@ -1583,7 +1584,7 @@ mod tests {
         let repo = temp.path().join("repo");
         std::fs::create_dir_all(&repo).expect("repo");
         let mut env = TestEnv::new(repo.clone());
-        let mut projection = WorkProjection::default_for_project(&repo);
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
         projection.agents.push(unassigned_agent("session-1"));
         save_workspace_projection(&repo, &projection).expect("save projection");
         let mut event = WorkEvent::new(WorkEventKind::Start, "workspace-existing", Utc::now());
@@ -1632,7 +1633,7 @@ mod tests {
         let repo = temp.path().join("repo");
         std::fs::create_dir_all(&repo).expect("repo");
         let mut env = TestEnv::new(repo.clone());
-        let mut projection = WorkProjection::default_for_project(&repo);
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
         projection.agents.push(unassigned_agent("session-1"));
         save_workspace_projection(&repo, &projection).expect("save projection");
 
@@ -1691,7 +1692,7 @@ mod tests {
         let repo = temp.path().join("repo");
         std::fs::create_dir_all(&repo).expect("repo");
         let mut env = TestEnv::new(repo.clone());
-        let mut projection = WorkProjection::default_for_project(&repo);
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
         projection.agents.push(unassigned_agent("session-1"));
         save_workspace_projection(&repo, &projection).expect("save projection");
 
@@ -1722,12 +1723,12 @@ mod tests {
         );
         assert_eq!(
             saved.lifecycle_stage,
-            gwt_core::work_projection::WorkspaceLifecycleStage::Active,
+            gwt_core::workspace_projection::WorkspaceLifecycleStage::Active,
             "lifecycle_stage must initialize to Active on workspace create"
         );
         assert_ne!(
             saved.created_at,
-            gwt_core::work_projection::workspace_projection_default_created_at(),
+            gwt_core::workspace_projection::workspace_projection_default_created_at(),
             "created_at must be a real timestamp, not the migration sentinel"
         );
         assert!(
@@ -1754,7 +1755,7 @@ mod tests {
         let repo = temp.path().join("repo");
         std::fs::create_dir_all(&repo).expect("repo");
         let mut env = TestEnv::new(repo.clone());
-        let mut projection = WorkProjection::default_for_project(&repo);
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
         projection.agents.push(unassigned_agent("session-1"));
         save_workspace_projection(&repo, &projection).expect("save projection");
         let mut event = WorkEvent::new(WorkEventKind::Start, "workspace-existing", Utc::now());
@@ -1788,7 +1789,7 @@ mod tests {
         let repo = temp.path().join("repo");
         std::fs::create_dir_all(&repo).expect("repo");
         let mut env = TestEnv::new(repo.clone());
-        let mut projection = WorkProjection::default_for_project(&repo);
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
         projection.agents.push(unassigned_agent("session-1"));
         save_workspace_projection(&repo, &projection).expect("save projection");
         let mut event = WorkEvent::new(WorkEventKind::Start, "workspace-existing", Utc::now());
@@ -1825,7 +1826,7 @@ mod tests {
         let repo = temp.path().join("repo");
         std::fs::create_dir_all(&repo).expect("repo");
         let mut env = TestEnv::new(repo.clone());
-        let mut projection = WorkProjection::default_for_project(&repo);
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
         projection.agents.push(unassigned_agent("session-1"));
         save_workspace_projection(&repo, &projection).expect("save projection");
         let mut event = WorkEvent::new(WorkEventKind::Start, "workspace-existing", Utc::now());
@@ -1883,9 +1884,12 @@ mod tests {
         let repo = tempfile::tempdir().expect("repo");
 
         // Existing incomplete Work keyed by the canonical branch id.
-        let canonical_id =
-            gwt_core::work_projection::canonical_work_id(repo.path(), Some("work/canonical"), None)
-                .expect("canonical id");
+        let canonical_id = gwt_core::workspace_projection::canonical_work_id(
+            repo.path(),
+            Some("work/canonical"),
+            None,
+        )
+        .expect("canonical id");
         let now = Utc::now();
         let mut start = WorkEvent::new(WorkEventKind::Start, canonical_id.clone(), now);
         start.title = Some("totally different wording".to_string());
@@ -1949,9 +1953,12 @@ mod tests {
             &agent,
         )
         .expect("create");
-        let expected =
-            gwt_core::work_projection::canonical_work_id(repo.path(), Some("work/minted"), None)
-                .expect("canonical id");
+        let expected = gwt_core::workspace_projection::canonical_work_id(
+            repo.path(),
+            Some("work/minted"),
+            None,
+        )
+        .expect("canonical id");
         assert_eq!(workspace_id, expected);
     }
 
@@ -1964,7 +1971,7 @@ mod tests {
         let repo = temp.path().join("repo");
         std::fs::create_dir_all(&repo).expect("repo");
         let mut env = TestEnv::new(repo.clone());
-        let mut projection = WorkProjection::default_for_project(&repo);
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
         projection.agents.push(unassigned_agent("session-1"));
         save_workspace_projection(&repo, &projection).expect("save projection");
         let mut event = WorkEvent::new(WorkEventKind::Start, "workspace-existing", Utc::now());
@@ -2024,7 +2031,7 @@ mod tests {
         let repo = temp.path().join("repo");
         std::fs::create_dir_all(&repo).expect("repo");
         let mut env = TestEnv::new(repo.clone());
-        let mut projection = WorkProjection::default_for_project(&repo);
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
         projection.agents.push(unassigned_agent("session-1"));
         save_workspace_projection(&repo, &projection).expect("save projection");
 
@@ -2077,7 +2084,7 @@ mod tests {
         let mut agent = unassigned_agent("session-1");
         agent.affiliation_status = WorkspaceAgentAffiliationStatus::Assigned;
         agent.workspace_id = Some("workspace-existing".to_string());
-        let mut projection = WorkProjection::default_for_project(&repo);
+        let mut projection = WorkspaceProjection::default_for_project(&repo);
         projection.id = "workspace-existing".to_string();
         projection.agents.push(agent);
         save_workspace_projection(&repo, &projection).expect("save projection");
@@ -2190,7 +2197,9 @@ mod tests {
         assert!(matches!(err, CliParseError::UnknownSubcommand(_)));
     }
 
-    use gwt_core::work_projection::{save_workspace_projection_to_path, WorkspaceLifecycleStage};
+    use gwt_core::workspace_projection::{
+        save_workspace_projection_to_path, WorkspaceLifecycleStage,
+    };
 
     fn seed_stale_workspace(
         scan_root: &std::path::Path,
@@ -2202,7 +2211,7 @@ mod tests {
         let project_dir = scan_root.join(hash);
         let workspace_dir = project_dir.join("workspace");
         std::fs::create_dir_all(&workspace_dir).expect("create workspace dir");
-        let mut projection = WorkProjection::default_for_project(&project_dir);
+        let mut projection = WorkspaceProjection::default_for_project(&project_dir);
         projection.id = id.to_string();
         projection.updated_at = updated_at;
         projection.lifecycle_stage = lifecycle;
@@ -2305,7 +2314,7 @@ mod tests {
         // dry-run should not mutate lifecycle_stage
         let projection_path = tmp.path().join("stale-hash/workspace/current.json");
         let loaded =
-            gwt_core::work_projection::load_workspace_projection_from_path(&projection_path)
+            gwt_core::workspace_projection::load_workspace_projection_from_path(&projection_path)
                 .expect("load")
                 .expect("present");
         assert_eq!(loaded.lifecycle_stage, WorkspaceLifecycleStage::Active);
@@ -2339,7 +2348,7 @@ mod tests {
 
         let projection_path = tmp.path().join("stale-hash/workspace/current.json");
         let loaded =
-            gwt_core::work_projection::load_workspace_projection_from_path(&projection_path)
+            gwt_core::workspace_projection::load_workspace_projection_from_path(&projection_path)
                 .expect("load")
                 .expect("present");
         assert_eq!(loaded.lifecycle_stage, WorkspaceLifecycleStage::Archived);
@@ -2377,7 +2386,7 @@ mod tests {
         .expect("prune by id");
         assert!(out.contains("APPLIED: archive=1"));
 
-        let keep = gwt_core::work_projection::load_workspace_projection_from_path(
+        let keep = gwt_core::workspace_projection::load_workspace_projection_from_path(
             &tmp.path().join("keep-hash/workspace/current.json"),
         )
         .expect("load keep")
@@ -2387,7 +2396,7 @@ mod tests {
             WorkspaceLifecycleStage::Active,
             "id filter must leave non-matching workspaces untouched",
         );
-        let take = gwt_core::work_projection::load_workspace_projection_from_path(
+        let take = gwt_core::workspace_projection::load_workspace_projection_from_path(
             &tmp.path().join("take-hash/workspace/current.json"),
         )
         .expect("load take")

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -671,7 +671,7 @@ fn spawn_workspace_projection_watcher(
                             project_root = %project_root.display(),
                             "workspace projection watcher detected current.json change"
                         );
-                        let _ = proxy.send_event(UserEvent::WorkProjectionChanged {
+                        let _ = proxy.send_event(UserEvent::WorkspaceProjectionChanged {
                             project_root: project_root.clone(),
                         });
                     }
@@ -824,7 +824,7 @@ fn daemon_broadcast_user_event(
         });
     }
     if channel == "workspace" {
-        return Some(UserEvent::WorkProjectionChanged {
+        return Some(UserEvent::WorkspaceProjectionChanged {
             project_root: project_root.to_path_buf(),
         });
     }
@@ -935,7 +935,7 @@ enum UserEvent {
         project_root: PathBuf,
         changed: bool,
     },
-    WorkProjectionChanged {
+    WorkspaceProjectionChanged {
         project_root: PathBuf,
     },
     RuntimeHook(gwt::RuntimeHookEvent),
@@ -1901,7 +1901,7 @@ mod tests {
         }));
         assert!(matches!(
             &events[0].event,
-            gwt::BackendEvent::WorkState { .. }
+            gwt::BackendEvent::WorkspaceState { .. }
         ));
         assert!(events.iter().any(|event| matches!(
             &event.event,
@@ -2246,7 +2246,7 @@ mod tests {
                 crate::session_ledger_cache::SessionLedgerCache::new(),
             ),
             work_items_cache: std::cell::RefCell::new(
-                gwt_core::work_projection::WorkItemsCache::new(),
+                gwt_core::workspace_projection::WorkItemsCache::new(),
             ),
             last_work_events_ingest: std::cell::RefCell::new(HashMap::new()),
             local_worktree_branches: std::cell::RefCell::new(HashMap::new()),
@@ -2475,7 +2475,7 @@ mod tests {
             events.first(),
             Some(event)
                 if matches!(&event.target, DispatchTarget::Client(client_id) if client_id == "client-1")
-                    && matches!(event.event, BackendEvent::WorkState { .. })
+                    && matches!(event.event, BackendEvent::WorkspaceState { .. })
         ));
         assert!(events.iter().any(|event| {
             matches!(
@@ -6772,7 +6772,7 @@ fn main() -> std::io::Result<()> {
                 let events = app.apply_work_merge_status(&project_root, merged_branches);
                 clients.dispatch(events);
             }
-            Event::UserEvent(UserEvent::WorkProjectionChanged { project_root }) => {
+            Event::UserEvent(UserEvent::WorkspaceProjectionChanged { project_root }) => {
                 let events = app.handle_workspace_projection_changed_events(&project_root);
                 clients.dispatch(events);
             }

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -741,7 +741,7 @@ pub enum FrontendEvent {
     /// SPEC-2359 US-41: classify Workspace projections under `~/.gwt/projects/`
     /// and either preview (`dry_run = true`) or apply (`dry_run = false`) the
     /// archive→delete transitions. `ids` limits the action to specific
-    /// `WorkProjection::id` values; an empty list means "every classified
+    /// `WorkspaceProjection::id` values; an empty list means "every classified
     /// entry". Backend replies with [`BackendEvent::WorkspaceProjectionPruneResult`].
     WorkspaceProjectionPrune {
         #[serde(default)]
@@ -1181,7 +1181,7 @@ pub enum BackendEvent {
     /// `kind` stays `workspace_state` as the legacy adapter spelling so no
     /// frontend/client breaks.
     #[serde(rename = "workspace_state")]
-    WorkState {
+    WorkspaceState {
         workspace: AppStateView,
     },
     ActiveWorkProjection {
@@ -2246,7 +2246,7 @@ pub fn backend_event_policy(kind: &str) -> Option<BackendEventPolicy> {
 impl BackendEvent {
     pub fn event_kind(&self) -> &'static str {
         match self {
-            BackendEvent::WorkState { .. } => "workspace_state",
+            BackendEvent::WorkspaceState { .. } => "workspace_state",
             BackendEvent::ActiveWorkProjection { .. } => "active_work_projection",
             BackendEvent::WindowList { .. } => "window_list",
             BackendEvent::ProviderUsage { .. } => "provider_usage",

--- a/crates/gwt/src/web_protocol_enums.rs
+++ b/crates/gwt/src/web_protocol_enums.rs
@@ -20,7 +20,7 @@
 use serde::Serialize;
 
 use crate::persistence::WindowState;
-use gwt_core::work_projection::{
+use gwt_core::workspace_projection::{
     WorkActiveLifecycleState, WorkspaceLifecycleStage, WorkspaceStatusCategory,
 };
 

--- a/crates/gwt/src/work_events_ingest.rs
+++ b/crates/gwt/src/work_events_ingest.rs
@@ -270,7 +270,7 @@ mod tests {
         );
 
         let projection =
-            gwt_core::work_projection::load_workspace_work_items_from_path(&work_items_path)
+            gwt_core::workspace_projection::load_workspace_work_items_from_path(&work_items_path)
                 .expect("load")
                 .expect("projection");
         let ids: Vec<&str> = projection

--- a/crates/gwt/src/worktree_inventory.rs
+++ b/crates/gwt/src/worktree_inventory.rs
@@ -189,18 +189,20 @@ fn label_for(info: &WorktreeInfo, kind: WorktreeEntryKind) -> String {
 /// backfill target). Prunable worktrees never reach here because
 /// `enumerate_worktrees` already skips them. Branchless (detached) entries are
 /// passed through; the FR-381 guard in
-/// `gwt_core::work_projection::worktree_sources_needing_backfill` skips
+/// `gwt_core::workspace_projection::worktree_sources_needing_backfill` skips
 /// them so the policy lives in one place.
 pub fn worktree_reconcile_sources(
     entries: &[WorktreeEntry],
-) -> Vec<gwt_core::work_projection::WorktreeReconcileSource> {
+) -> Vec<gwt_core::workspace_projection::WorktreeReconcileSource> {
     entries
         .iter()
         .filter(|entry| entry.kind == WorktreeEntryKind::Workspace)
-        .map(|entry| gwt_core::work_projection::WorktreeReconcileSource {
-            branch: entry.branch.clone(),
-            worktree_path: entry.path.clone(),
-        })
+        .map(
+            |entry| gwt_core::workspace_projection::WorktreeReconcileSource {
+                branch: entry.branch.clone(),
+                worktree_path: entry.path.clone(),
+            },
+        )
         .collect()
 }
 

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -14,9 +14,9 @@ use gwt_core::{
     },
     paths::gwt_sessions_dir,
     repo_hash::compute_repo_hash,
-    work_projection::{
+    workspace_projection::{
         record_workspace_work_event, save_workspace_projection, WorkEvent, WorkEventKind,
-        WorkProjection, WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary,
+        WorkspaceAgentAffiliationStatus, WorkspaceAgentSummary, WorkspaceProjection,
         WorkspaceStatusCategory,
     },
 };
@@ -163,7 +163,7 @@ fn save_session(repo_path: &Path, branch: &str, linked_issue_number: Option<u64>
 }
 
 fn seed_workspace_agent_title(repo_path: &Path, session_id: &str) {
-    let mut projection = WorkProjection::default_for_project(repo_path);
+    let mut projection = WorkspaceProjection::default_for_project(repo_path);
     projection.agents.push(workspace_agent(
         session_id,
         "Testing workflow policy",
@@ -223,7 +223,7 @@ fn seed_workspace_agents(
     other_session_id: &str,
     other_title: &str,
 ) {
-    let mut projection = WorkProjection::default_for_project(repo_path);
+    let mut projection = WorkspaceProjection::default_for_project(repo_path);
     projection.title = "Workspace semantic coordination".to_string();
     projection.status_category = WorkspaceStatusCategory::Active;
     projection.summary = Some("Coordinate same-work detection across agents".to_string());
@@ -241,7 +241,7 @@ fn seed_workspace_agents(
 }
 
 fn seed_workspace_current_agent(repo_path: &Path, session_id: &str, title: &str, focus: &str) {
-    let mut projection = WorkProjection::default_for_project(repo_path);
+    let mut projection = WorkspaceProjection::default_for_project(repo_path);
     projection
         .agents
         .push(workspace_agent(session_id, focus, title));
@@ -691,7 +691,7 @@ fn active_board_claim_does_not_hard_block_mutation() {
         let repo_path = init_repo(home);
         let session_id = save_session(&repo_path, "work/current", None);
         std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
-        let mut projection = WorkProjection::default_for_project(&repo_path);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
         projection.agents.push(workspace_agent(
             &session_id,
             "Implement Workspace semantic coordination gate",
@@ -737,7 +737,7 @@ fn unassigned_agent_does_not_inherit_projection_title_for_duplicate_gate() {
         let repo_path = init_repo(home);
         let session_id = save_session(&repo_path, "work/unassigned", None);
         std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
-        let mut projection = WorkProjection::default_for_project(&repo_path);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
         projection.title = "Workspace affiliation fix".to_string();
         projection.summary = Some("Stale project-level workspace title".to_string());
         projection.status_category = WorkspaceStatusCategory::Active;
@@ -790,7 +790,7 @@ fn does_not_block_when_active_board_claim_is_audienced_to_other_workspace() {
         let repo_path = init_repo(home);
         let session_id = save_session(&repo_path, "work/current", None);
         std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
-        let mut projection = WorkProjection::default_for_project(&repo_path);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
         projection.agents.push(workspace_agent(
             &session_id,
             "Implement Workspace audience scoped gate",
@@ -842,7 +842,7 @@ fn unassigned_agent_without_title_summary_is_not_title_blocked() {
         let repo_path = init_repo(home);
         let session_id = save_session(&repo_path, "work/unassigned", None);
         std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
-        let mut projection = WorkProjection::default_for_project(&repo_path);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
         projection
             .agents
             .push(unassigned_workspace_agent(&session_id));
@@ -873,7 +873,7 @@ fn actionable_unassigned_agent_can_mutate_without_forced_workspace_affiliation()
         let repo_path = init_repo(home);
         let session_id = save_session(&repo_path, "work/unassigned", None);
         std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
-        let mut projection = WorkProjection::default_for_project(&repo_path);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
         let mut agent = unassigned_workspace_agent(&session_id);
         agent.title_summary = Some("Workspace materialization".to_string());
         agent.current_focus = Some("Ensure actionable intent enters a Workspace".to_string());
@@ -905,7 +905,7 @@ fn actionable_unassigned_agent_can_run_workspace_ensure_command() {
         let repo_path = init_repo(home);
         let session_id = save_session(&repo_path, "work/unassigned", None);
         std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
-        let mut projection = WorkProjection::default_for_project(&repo_path);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
         let mut agent = unassigned_workspace_agent(&session_id);
         agent.title_summary = Some("Workspace materialization".to_string());
         agent.current_focus = Some("Ensure actionable intent enters a Workspace".to_string());
@@ -935,7 +935,7 @@ fn assigned_agent_without_title_summary_remains_title_blocked() {
         let repo_path = init_repo(home);
         let session_id = save_session(&repo_path, "work/assigned", None);
         std::env::set_var(GWT_SESSION_ID_ENV, &session_id);
-        let mut projection = WorkProjection::default_for_project(&repo_path);
+        let mut projection = WorkspaceProjection::default_for_project(&repo_path);
         let mut agent = workspace_agent(&session_id, "Implement assigned work", "");
         agent.title_summary = None;
         projection.agents.push(agent);
@@ -983,7 +983,7 @@ fn incomplete_work_item_history_does_not_hard_block_mutation() {
         let event = event(
             "Edit",
             json!({
-                "file_path": "crates/gwt-core/src/work_projection.rs",
+                "file_path": "crates/gwt-core/src/workspace_projection.rs",
                 "old_string": "old",
                 "new_string": "new"
             }),
@@ -1025,7 +1025,7 @@ fn completed_work_item_history_does_not_block_new_related_work() {
 
         let event = event(
             "Write",
-            json!({ "file_path": "crates/gwt-core/src/work_projection.rs", "content": "x" }),
+            json!({ "file_path": "crates/gwt-core/src/workspace_projection.rs", "content": "x" }),
         );
 
         let decision = workflow_policy::evaluate_with_context(

--- a/crates/gwt/tests/workspace_identity_session_start_test.rs
+++ b/crates/gwt/tests/workspace_identity_session_start_test.rs
@@ -1,7 +1,7 @@
 //! SPEC-2359: SessionStart hook must register the running agent session
 //! into `projection.agents[]` so that `gwtd workspace update --title-summary`
 //! reaches the matching agent record instead of being silently dropped at
-//! the `apply_update` matcher in `gwt_core::work_projection`.
+//! the `apply_update` matcher in `gwt_core::workspace_projection`.
 
 use std::{
     path::{Path, PathBuf},
@@ -12,7 +12,7 @@ use gwt::cli::hook::event_dispatcher;
 use gwt_agent::{session::GWT_SESSION_ID_ENV, AgentId, Session};
 use gwt_core::{
     paths::gwt_sessions_dir,
-    work_projection::{
+    workspace_projection::{
         load_workspace_projection, update_workspace_projection_with_journal,
         WorkspaceProjectionUpdate,
     },


### PR DESCRIPTION
## Summary

ユーザー裁定によるドメイン用語の最終整理。**Workspace = branch（作業場）/ Work = エージェントの 1 回の起動 / Session = 会話** を正とし、US-66 の canonical Work 化で行き過ぎた 2 点を戻す。UI / wire 影響なし。

### 変更
- `work_projection.rs` → **`workspace_projection.rs`** に復帰（work_projection shim は削除）。current.json の型は **`WorkspaceProjection`**（場の現在状態）
- protocol Rust 名を `BackendEvent::WorkspaceState` / `UserEvent::WorkspaceProjectionChanged` へ復帰（wire は元から `workspace_state` のまま不変）
- CLI: **`gwtd workspace` が正**。昨日追加した `gwtd work` verb は削除（Work の語を CLI 表面から撤去）
- launch 単位の記録型 `WorkItem` / `WorkEvent` 族は「Work = エージェントの起動」の正当な命名として維持（`WorkspaceWork*` 互換 alias 併存）

## Verification

- cargo（3 crate, all-features）: **2,698 passed / 0 failed** / clippy: 0 / fmt: clean
- frontend unit: **784 passed / 0 failed**
- User Verification Result: **n/a**（内部命名のみ、UI/wire/CLI 挙動互換 — `gwtd work` は昨日追加・未リリースのため削除も非破壊）

## Rollback / Follow-up

- revert で完結。follow-up なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
