### PR TITLE
fix: reveal reused surface tabs

### DIFF
--- a/crates/gwt/web/__tests__/surface-window-reopen.test.mjs
+++ b/crates/gwt/web/__tests__/surface-window-reopen.test.mjs
@@ -82,6 +82,20 @@ test("existing surface helper restores minimized windows and centers focus with 
   );
 });
 
+test("existing grouped surface tabs are activated before focus", () => {
+  const helperBody = extractFunctionBody(appSource, "openExistingSurfaceWindow");
+
+  assert.match(
+    helperBody,
+    /windowData\.tab_group_id[\s\S]*kind:\s*"activate_window_tab"[\s\S]*id:\s*windowData\.id/,
+    "inactive grouped surface tabs must be activated before focus",
+  );
+  assert.ok(
+    helperBody.indexOf('kind: "activate_window_tab"') < helperBody.indexOf('kind: "focus_window"'),
+    "tab activation must be sent before focus_window so the requested tab is revealed",
+  );
+});
+
 test("Add Window surface buttons use the same reopen path as rail and palette commands", () => {
   const modalLoop = appSource.match(
     /for\s*\(\s*const\s+button\s+of\s+modal\.querySelectorAll\("\[data-preset\]"\)\s*\)\s*\{([\s\S]*?)\n\s*\}\n\s*\n\s*\/\/ SPEC-2356 "Surface Deck"/,
@@ -96,6 +110,27 @@ test("Add Window surface buttons use the same reopen path as rail and palette co
     modalLoop[1],
     /kind:\s*"create_window"/,
     "Add Window buttons must not bypass the shared surface reopen helper",
+  );
+});
+
+test("work surface aliases are normalized before singleton lookup", () => {
+  const normalizeBody = extractFunctionBody(appSource, "normalizeSurfacePreset");
+  assert.match(
+    normalizeBody,
+    /preset\s*===\s*"branches"[\s\S]*preset\s*===\s*"workspace"[\s\S]*return\s+"work"/,
+    "branches and legacy workspace presets must normalize to work",
+  );
+
+  const focusBody = extractFunctionBody(appSource, "focusOrSpawnPreset");
+  assert.match(
+    focusBody,
+    /preset\s*=\s*normalizeSurfacePreset\(preset\)/,
+    "requested preset must be canonicalized before lookup",
+  );
+  assert.match(
+    focusBody,
+    /normalizeSurfacePreset\(w\.preset\)\s*===\s*preset/,
+    "existing legacy workspace windows must match canonical work requests",
   );
 });
 

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -5348,11 +5348,24 @@
         return !sessionPresets.has(preset);
       }
 
+      function normalizeSurfacePreset(preset) {
+        if (preset === "branches" || preset === "workspace") {
+          return "work";
+        }
+        return preset;
+      }
+
       function openExistingSurfaceWindow(windowData) {
         focusWindowLocally(windowData.id);
         if (windowData.minimized) {
           frontendUnits.socketTransport.send({
             kind: "restore_window",
+            id: windowData.id,
+          });
+        }
+        if (windowData.tab_group_id) {
+          frontendUnits.socketTransport.send({
+            kind: "activate_window_tab",
             id: windowData.id,
           });
         }
@@ -5364,10 +5377,10 @@
       }
 
       function focusOrSpawnPreset(preset) {
-        if (preset === "branches") preset = "work";
+        preset = normalizeSurfacePreset(preset);
         const allWindows = activeWorkspace().windows || [];
         const existing = isSingletonSurfacePreset(preset)
-          ? allWindows.find((w) => w.preset === preset)
+          ? allWindows.find((w) => normalizeSurfacePreset(w.preset) === preset)
           : null;
         if (existing) {
           openExistingSurfaceWindow(existing);


### PR DESCRIPTION
## Summary

- Reused surface windows now normalize legacy `workspace` and `branches` preset aliases to the canonical `work` preset before singleton lookup.
- Reused grouped surface windows now send `activate_window_tab` before `focus_window` so an inactive tab is revealed instead of remaining hidden.
- This addresses the actionable review feedback left on merged PR #3076.

## Changes

- `crates/gwt/web/app.js`: adds `normalizeSurfacePreset`, applies it to requested and existing presets, and activates grouped existing surfaces before focus.
- `crates/gwt/web/__tests__/surface-window-reopen.test.mjs`: adds regression coverage for legacy Work aliases and inactive grouped surface tab reuse.

## Testing

- [x] `node --test crates/gwt/web/__tests__/surface-window-reopen.test.mjs` - PASS, 6/6 tests.
- [x] `bash scripts/run-node-tests-with-linkedom.sh crates/gwt/web/__tests__/surface-window-reopen.test.mjs crates/gwt/web/__tests__/preset-modal-surface-deck.test.mjs crates/gwt/web/__tests__/operator-rail.test.mjs crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` - PASS, 195/195 tests.
- [x] `bash scripts/check-frontend-bundle.sh` - PASS.
- [x] `bash scripts/run-frontend-unit-tests.sh` - PASS, 803/803 tests.
- [x] `cargo test -p gwt embedded_web --all-features` - PASS, 104 embedded_web tests.
- [x] `cargo fmt -- --check` - PASS.
- [x] `git diff --check` - PASS.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` - PASS.
- [x] GitHub Actions - all required visible jobs pass; optional e5 e2e and draft-only auto-merge job are skipped as expected.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes. This follow-up can ship independently because it only tightens existing surface-window reuse behavior and preserves rollback to the #3076 behavior.
- Known blockers: None.
- Remaining acceptance: None.
- User Verification Result: confirmed on 2026-06-13 by user request to mark the PR ready.

## Closing Issues

- None

## Related Issues / Links

- #2008
- #3076

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo fmt`; no Rust logic changed)
- [x] Documentation updated (N/A: review follow-up for UI behavior; no README change required)
- [x] Migration/backfill plan included (N/A: no schema or data migration)
- [x] CHANGELOG impact considered (patch fix via `fix:` commit)

## Context

- PR #3076 was auto-merged before two automated review threads were resolved.
- This follow-up keeps the fix small and directly covers both review edge cases with regression tests.

## Risk / Impact

- **Affected areas**: WebView surface preset reuse, legacy Work alias handling, and tabbed surface window reveal behavior.
- **Rollback plan**: revert this PR to return to the #3076 behavior.

## Screenshots

- N/A - behavior-only follow-up verified by focused automated coverage and user confirmation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved surface window reopening behavior by activating the appropriate grouped tab before issuing focus requests.
  * Enhanced preset normalization to consistently handle "branches" and "workspace" aliases as the "work" preset for both new and existing windows.

* **Tests**
  * Added automated tests to validate surface window reopen functionality and preset normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->