### PR TITLE
fix(launch): gate continue start method by capability

### DIFF
--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -66,6 +66,23 @@ impl AgentId {
         matches!(self, Self::ClaudeCode | Self::Codex)
     }
 
+    /// Whether this agent can continue the latest session without an explicit
+    /// session id.
+    pub fn supports_continue_latest(&self) -> bool {
+        matches!(
+            self,
+            Self::ClaudeCode | Self::Codex | Self::OpenCode | Self::Hermes
+        )
+    }
+
+    /// Whether this agent can resume a specific saved session id.
+    pub fn supports_resume_session_id(&self) -> bool {
+        matches!(
+            self,
+            Self::ClaudeCode | Self::Codex | Self::OpenCode | Self::OpenClaw | Self::Hermes
+        )
+    }
+
     /// Whether this agent exposes a Fast mode launch setting that can be
     /// enabled before the agent starts.
     ///
@@ -467,6 +484,58 @@ mod tests {
             assert!(
                 !non_picker.supports_resume_picker(),
                 "{non_picker:?} should not advertise picker support"
+            );
+        }
+    }
+
+    #[test]
+    fn supports_continue_latest_only_for_agents_with_latest_session_args() {
+        for supported in [
+            AgentId::ClaudeCode,
+            AgentId::Codex,
+            AgentId::OpenCode,
+            AgentId::Hermes,
+        ] {
+            assert!(
+                supported.supports_continue_latest(),
+                "{supported:?} should support latest-session continue"
+            );
+        }
+        for unsupported in [
+            AgentId::Gemini,
+            AgentId::OpenClaw,
+            AgentId::Copilot,
+            AgentId::Custom("aider".into()),
+        ] {
+            assert!(
+                !unsupported.supports_continue_latest(),
+                "{unsupported:?} should not advertise latest-session continue"
+            );
+        }
+    }
+
+    #[test]
+    fn supports_resume_session_id_matches_agents_with_specific_resume_args() {
+        for supported in [
+            AgentId::ClaudeCode,
+            AgentId::Codex,
+            AgentId::OpenCode,
+            AgentId::OpenClaw,
+            AgentId::Hermes,
+        ] {
+            assert!(
+                supported.supports_resume_session_id(),
+                "{supported:?} should support explicit session resume"
+            );
+        }
+        for unsupported in [
+            AgentId::Gemini,
+            AgentId::Copilot,
+            AgentId::Custom("aider".into()),
+        ] {
+            assert!(
+                !unsupported.supports_resume_session_id(),
+                "{unsupported:?} should not advertise explicit session resume"
             );
         }
     }

--- a/crates/gwt/src/launch_wizard/state.rs
+++ b/crates/gwt/src/launch_wizard/state.rs
@@ -839,6 +839,10 @@ impl LaunchWizardState {
             self.error = Some("No saved session is available".to_string());
             return;
         };
+        if !self.quick_start_entry_supports_session_continuation(&entry) {
+            self.error = Some("Session continuation is unavailable for this agent".to_string());
+            return;
+        }
         self.selected_quick_start_index = Some(index);
         self.launch_path = LaunchWizardLaunchPath::QuickStart;
         self.start_method_selected = true;
@@ -1373,6 +1377,12 @@ impl LaunchWizardState {
         }
     }
 
+    pub(super) fn agent_option_by_id(&self, agent_id: &str) -> Option<&AgentOption> {
+        self.detected_agents
+            .iter()
+            .find(|agent| agent.id == agent_id)
+    }
+
     pub(super) fn effective_agent_id(&self) -> &str {
         self.selected_agent()
             .map(|agent| agent.id.as_str())
@@ -1415,6 +1425,43 @@ impl LaunchWizardState {
             return custom.supports_resume_picker;
         }
         agent_id_from_key(self.effective_agent_id()).supports_resume_picker()
+    }
+
+    pub(super) fn agent_supports_continue_latest(&self, agent_id: &str) -> bool {
+        if let Some(custom) = self
+            .agent_option_by_id(agent_id)
+            .and_then(|agent| agent.custom_agent.as_ref())
+        {
+            return custom
+                .mode_args
+                .as_ref()
+                .is_some_and(|args| !args.continue_mode.is_empty());
+        }
+        agent_id_from_key(agent_id).supports_continue_latest()
+    }
+
+    pub(super) fn agent_supports_resume_session_id(&self, agent_id: &str) -> bool {
+        if let Some(custom) = self
+            .agent_option_by_id(agent_id)
+            .and_then(|agent| agent.custom_agent.as_ref())
+        {
+            return custom
+                .mode_args
+                .as_ref()
+                .is_some_and(|args| !args.resume.is_empty());
+        }
+        agent_id_from_key(agent_id).supports_resume_session_id()
+    }
+
+    pub(super) fn quick_start_entry_supports_session_continuation(
+        &self,
+        entry: &QuickStartEntry,
+    ) -> bool {
+        if entry.resume_session_id.is_some() {
+            self.agent_supports_resume_session_id(&entry.agent_id)
+        } else {
+            self.agent_supports_continue_latest(&entry.agent_id)
+        }
     }
 
     pub(super) fn agent_has_models(&self) -> bool {
@@ -2659,6 +2706,104 @@ mod tests {
                     assert_eq!(config.agent_id, gwt_agent::AgentId::Codex);
                     assert_eq!(config.session_mode, gwt_agent::SessionMode::Continue);
                     assert!(config.resume_session_id.is_none());
+                }
+                other => panic!("expected agent launch request, got {other:?}"),
+            },
+            other => panic!("expected launch completion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn continue_last_session_is_unavailable_when_agent_cannot_continue_latest() {
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/current"), "feature/current"),
+            vec![AgentOption {
+                id: "gemini".to_string(),
+                name: "Gemini CLI".to_string(),
+                available: true,
+                installed_version: Some("1.0.0".to_string()),
+                versions: vec!["1.0.0".to_string()],
+                custom_agent: None,
+            }],
+            vec![quick_start_entry(
+                "session-1",
+                "gemini",
+                None,
+                None,
+                gwt_agent::LaunchRuntimeTarget::Host,
+                None,
+            )],
+        );
+
+        let view = state.view();
+        let continue_method = view
+            .start_methods
+            .iter()
+            .find(|method| method.kind == "continue_last_session")
+            .expect("continue start method");
+        assert!(!continue_method.enabled);
+        assert_eq!(continue_method.group, "unavailable");
+        assert!(!continue_method.recommended);
+        assert_eq!(
+            continue_method.disabled_reason.as_deref(),
+            Some("Not supported by agent")
+        );
+        assert!(view.start_methods.iter().any(|method| {
+            method.kind == "start_with_last_settings" && method.enabled && method.recommended
+        }));
+
+        state.apply(LaunchWizardAction::UseStartMethod {
+            method: LaunchWizardStartMethodKind::ContinueLastSession,
+        });
+
+        assert!(state.completion.is_none());
+        assert_eq!(
+            state.view().error.as_deref(),
+            Some("Session continuation is unavailable for this agent")
+        );
+    }
+
+    #[test]
+    fn continue_last_session_allows_exact_resume_for_non_picker_agent() {
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/current"), "feature/current"),
+            vec![AgentOption {
+                id: "openclaw".to_string(),
+                name: "OpenClaw".to_string(),
+                available: true,
+                installed_version: Some("1.0.0".to_string()),
+                versions: vec!["1.0.0".to_string()],
+                custom_agent: None,
+            }],
+            vec![quick_start_entry(
+                "session-1",
+                "openclaw",
+                Some("resume-1"),
+                None,
+                gwt_agent::LaunchRuntimeTarget::Host,
+                None,
+            )],
+        );
+
+        let continue_method = state
+            .view()
+            .start_methods
+            .into_iter()
+            .find(|method| method.kind == "continue_last_session")
+            .expect("continue start method");
+        assert!(continue_method.enabled);
+        assert!(continue_method.recommended);
+
+        state.apply(LaunchWizardAction::UseStartMethod {
+            method: LaunchWizardStartMethodKind::ContinueLastSession,
+        });
+
+        match state.completion.as_ref() {
+            Some(LaunchWizardCompletion::Launch(config)) => match config.as_ref() {
+                LaunchWizardLaunchRequest::Agent(config) => {
+                    assert_eq!(config.agent_id, gwt_agent::AgentId::OpenClaw);
+                    assert_eq!(config.session_mode, gwt_agent::SessionMode::Resume);
+                    assert_eq!(config.resume_session_id.as_deref(), Some("resume-1"));
                 }
                 other => panic!("expected agent launch request, got {other:?}"),
             },

--- a/crates/gwt/src/launch_wizard/view_model.rs
+++ b/crates/gwt/src/launch_wizard/view_model.rs
@@ -126,9 +126,12 @@ impl LaunchWizardState {
         let has_previous_settings = self.has_previous_start_settings();
         let latest_session = self.latest_quick_start_entry().map(|(_, entry)| entry);
         let latest_live = self.latest_running_session().map(|(_, session)| session);
+        let latest_session_can_continue = latest_session
+            .map(|entry| self.quick_start_entry_supports_session_continuation(entry))
+            .unwrap_or(false);
         let recommended_method = if latest_live.is_some() {
             LaunchWizardStartMethodKind::FocusRunningSession
-        } else if latest_session.is_some() {
+        } else if latest_session_can_continue {
             LaunchWizardStartMethodKind::ContinueLastSession
         } else if has_previous_settings {
             LaunchWizardStartMethodKind::StartWithLastSettings
@@ -185,13 +188,15 @@ impl LaunchWizardState {
                 badge: "Session".to_string(),
                 group: start_method_group(
                     LaunchWizardStartMethodKind::ContinueLastSession,
-                    latest_session.is_some(),
+                    latest_session_can_continue,
                     recommended_method,
                 ),
                 recommended: recommended_method == LaunchWizardStartMethodKind::ContinueLastSession,
                 summary: latest_session
                     .map(|entry| {
-                        if entry.resume_session_id.is_some() {
+                        if !self.quick_start_entry_supports_session_continuation(entry) {
+                            "Resume recent session"
+                        } else if entry.resume_session_id.is_some() {
                             "Resume conversation history"
                         } else {
                             "Continue latest agent session"
@@ -202,10 +207,14 @@ impl LaunchWizardState {
                 detail: latest_session
                     .and_then(|entry| entry.resume_session_id.as_deref())
                     .map(|resume_id| format!("Resume ID · {resume_id}")),
-                enabled: latest_session.is_some(),
-                disabled_reason: latest_session
-                    .is_none()
-                    .then(|| "No saved session".to_string()),
+                enabled: latest_session_can_continue,
+                disabled_reason: if latest_session.is_some() && !latest_session_can_continue {
+                    Some("Not supported by agent".to_string())
+                } else if latest_session.is_none() {
+                    Some("No saved session".to_string())
+                } else {
+                    None
+                },
             },
         ];
         if self.current_agent_supports_resume_picker() {


### PR DESCRIPTION
## Summary

- Gate `Continue last session` by agent capability so agents that cannot continue a latest session no longer launch an empty normal session.
- Preserve explicit resume-id behavior for agents that can resume a specific saved session, even when they do not support an interactive picker.
- Add backend guards so stale or older frontend actions cannot bypass the Start method availability state.

## Changes

- `crates/gwt-agent/src/types.rs`: adds built-in capability metadata for latest-session continue and explicit resume-id support, with regression coverage for supported and unsupported agents.
- `crates/gwt/src/launch_wizard/state.rs`: gates `ContinueLastSession` handling through agent/custom-agent capability checks and returns a clear unavailable error for unsupported entries.
- `crates/gwt/src/launch_wizard/view_model.rs`: updates Start method recommendation, enabled state, group, summary, and disabled reason based on whether the latest quick-start entry can actually continue.

## Testing

- [x] `cargo test -p gwt-agent supports_ -- --nocapture` - passed.
- [x] `cargo test -p gwt --lib continue_last_session -- --nocapture` - passed.
- [x] `cargo test -p gwt --all-features launch_wizard -- --nocapture` - passed.
- [x] `bash scripts/run-node-tests-with-linkedom.sh crates/gwt/web/__tests__/operator-chrome-structure.test.mjs` - passed.
- [x] `bash scripts/run-frontend-unit-tests.sh` - passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` - passed.
- [x] `cargo fmt -- --check` - passed.
- [x] `git diff --check` - passed.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - passed.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` - passed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` - passed.
- [x] Fresh GUI verification: `target/debug/gwt.exe --no-tray --no-open` served `http://127.0.0.1:59334/` with HTTP 200 from an isolated `USERPROFILE`; user confirmed the visible Start method disabled/recommended state on 2026-06-14.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes, this is a focused follow-up that prevents unsupported session continuation while preserving existing supported resume paths.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- #2014
- #3078
- Review thread: `PRRT_kwDOPLof2M6JWQGP`

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (SPEC #2014 tasks/evidence updated; README unchanged because this adjusts an existing Launch Agent behavior)
- [x] Migration/backfill plan included (N/A: no schema or persisted-data migration)
- [x] CHANGELOG impact considered (patch-level fix; no breaking change)

## Context

- PR #3078 moved session-oriented launch choices into Start methods, but review identified that metadata-only latest sessions from agents such as Gemini could still make `Continue last session` selectable even though their launch builders do not support latest-session continuation.

## Risk / Impact

- **Affected areas**: Launch Agent Start methods, quick-start session continuation, custom agent mode argument handling.
- **Rollback plan**: revert commit `8a28fbabe` to restore the prior Start method capability behavior.

## Screenshots

| Before | After |
|--------|-------|
| `Continue last session` could be selected for a metadata-only latest session from an agent that cannot continue latest sessions. | Fresh GUI verification confirmed the same case now shows the action as unavailable with `Not supported by agent`. |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced "Continue last session" feature to verify agent compatibility before enabling
  * Added support for agents to resume sessions via saved session IDs

* **Improvements**
  * "Continue last session" option now only appears for agents that support it
  * Clearer messaging when session continuation is unavailable for selected agent

<!-- end of auto-generated comment: release notes by coderabbit.ai -->