### PR TITLE
fix(cli): error prefix should reflect invoked binary name (gwt/gwtd)

### DIFF
--- a/crates/gwt/src/cli/env/mod.rs
+++ b/crates/gwt/src/cli/env/mod.rs
@@ -170,9 +170,32 @@ impl<'a, C: IssueClient> IssueClient for ClientRef<'a, C> {
 // DefaultCliEnv: production runtime wiring
 // ---------------------------------------------------------------------------
 
+/// Derive the user-facing program name for CLI error prefixes from `args[0]`.
+///
+/// Returns the basename without extension (so a full path like
+/// `/Applications/GWT.app/Contents/MacOS/gwtd` and a Windows `gwtd.exe` both
+/// resolve to `gwtd`). Falls back to `"gwt"` when `args[0]` is missing or has
+/// no usable file stem.
+fn program_name(args: &[String]) -> &str {
+    args.first()
+        .map(String::as_str)
+        .and_then(|raw| {
+            std::path::Path::new(raw)
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+        })
+        .filter(|name| !name.is_empty())
+        .unwrap_or("gwt")
+}
+
 pub fn dispatch<E: CliEnv>(env: &mut E, args: &[String]) -> i32 {
     // args[0] is the program name. args[1] is the top-level verb we already
     // matched in `should_dispatch_cli`.
+    // Issue #3080: `gwt` and `gwtd` share this dispatcher, so the error prefix
+    // must reflect the actually-invoked binary (derived from args[0]'s
+    // basename) rather than a hardcoded "gwt"; otherwise `gwtd` errors read as
+    // `gwt ...` and mislead users into thinking the wrong binary was used.
+    let prog = program_name(args);
     let top_verb = args.get(1).map(String::as_str).unwrap_or("");
     let rest: Vec<String> = args.iter().skip(2).cloned().collect();
 
@@ -232,12 +255,12 @@ pub fn dispatch<E: CliEnv>(env: &mut E, args: &[String]) -> i32 {
         Ok(cmd) => match run(env, cmd) {
             Ok(code) => code,
             Err(e) => {
-                let _ = writeln!(env.stderr(), "gwt {top_verb}: {e}");
+                let _ = writeln!(env.stderr(), "{prog} {top_verb}: {e}");
                 1
             }
         },
         Err(e) => {
-            let _ = writeln!(env.stderr(), "gwt {top_verb}: {e}");
+            let _ = writeln!(env.stderr(), "{prog} {top_verb}: {e}");
             2
         }
     }

--- a/crates/gwt/src/cli/env/tests.rs
+++ b/crates/gwt/src/cli/env/tests.rs
@@ -563,3 +563,47 @@ fn dispatch_error_prefix_reflects_gwt_binary() {
         "gwt invocation must keep the `gwt` prefix, got: {stderr:?}"
     );
 }
+
+// Regression guard for the OTHER changed line: the run-error arm
+// (`dispatch()` exit code 1, reached when `run()` returns `Err`). The three
+// tests above only drive the parse-error arm (exit code 2), so without this a
+// future single-line revert of the run-error arm would silently reintroduce
+// #3080 for execution failures. `board post -f <unseeded path>` parses
+// successfully then fails reading the missing file before any session/board
+// access, so it reaches the run-error arm deterministically and offline.
+#[test]
+fn dispatch_run_error_prefix_reflects_gwtd_binary() {
+    let mut env = TestEnv::new(PathBuf::from("cache-root"));
+    let args = vec![
+        "gwtd".to_string(),
+        "board".to_string(),
+        "post".to_string(),
+        "--kind".to_string(),
+        "note".to_string(),
+        "-f".to_string(),
+        "/no/such/file".to_string(),
+    ];
+    let code = dispatch(&mut env, &args);
+    assert_eq!(code, 1, "run error must exit with code 1");
+    let stderr = String::from_utf8(env.stderr.clone()).expect("stderr is utf8");
+    assert!(
+        stderr.starts_with("gwtd board:"),
+        "run-error arm must also use the invoked binary prefix, got: {stderr:?}"
+    );
+}
+
+// Lock the `program_name` contract directly (it is module-private but reachable
+// via `use super::*`): the `.exe` stripping and the fallback-to-"gwt" branches
+// are not reachable through `dispatch()` with real binary names.
+#[test]
+fn program_name_strips_exe_extension() {
+    assert_eq!(program_name(&["gwtd.exe".to_string()]), "gwtd");
+    assert_eq!(program_name(&["gwt.exe".to_string()]), "gwt");
+}
+
+#[test]
+fn program_name_falls_back_to_gwt_for_unusable_args() {
+    assert_eq!(program_name(&[]), "gwt");
+    assert_eq!(program_name(&[String::new()]), "gwt");
+    assert_eq!(program_name(&["/".to_string()]), "gwt");
+}

--- a/crates/gwt/src/cli/env/tests.rs
+++ b/crates/gwt/src/cli/env/tests.rs
@@ -521,3 +521,45 @@ fn client_ref_forwards_issue_client_methods_to_the_underlying_fake_client() {
         );
     }
 }
+
+// Issue #3080: the CLI error prefix must reflect the invoked binary name
+// (`gwt` vs `gwtd`), not a hardcoded `"gwt"`. `gwt` and `gwtd` share this
+// `dispatch()`, so a hardcoded prefix makes `gwtd` errors read as `gwt ...`,
+// which misleads users into thinking the wrong binary was used.
+
+fn dispatch_stderr(program: &str) -> String {
+    let mut env = TestEnv::new(PathBuf::from("cache-root"));
+    let args = vec![program.to_string(), "board".to_string(), "list".to_string()];
+    // `board list` fails at parse time (board only has `show`/`post`), so the
+    // error path runs without needing a repo or board backend.
+    let code = dispatch(&mut env, &args);
+    assert_eq!(code, 2, "parse error must exit with code 2");
+    String::from_utf8(env.stderr.clone()).expect("stderr is utf8")
+}
+
+#[test]
+fn dispatch_error_prefix_reflects_gwtd_binary() {
+    let stderr = dispatch_stderr("gwtd");
+    assert!(
+        stderr.starts_with("gwtd board: unknown subcommand: list"),
+        "gwtd invocation must use a `gwtd` prefix, got: {stderr:?}"
+    );
+}
+
+#[test]
+fn dispatch_error_prefix_uses_basename_of_full_path() {
+    let stderr = dispatch_stderr("/Applications/GWT.app/Contents/MacOS/gwtd");
+    assert!(
+        stderr.starts_with("gwtd board:"),
+        "full-path invocation must derive `gwtd` from the basename, got: {stderr:?}"
+    );
+}
+
+#[test]
+fn dispatch_error_prefix_reflects_gwt_binary() {
+    let stderr = dispatch_stderr("gwt");
+    assert!(
+        stderr.starts_with("gwt board:"),
+        "gwt invocation must keep the `gwt` prefix, got: {stderr:?}"
+    );
+}


### PR DESCRIPTION
## 概要

`gwtd` で CLI のサブコマンド/実行エラーが出たとき、stderr の接頭辞が常に `gwt ...:` と表示される問題を修正する。`gwt`（GUI）と `gwtd`（CLI/daemon）は同じ `dispatch()` を共有しており、接頭辞が `"gwt"` 固定でハードコードされていたため、`gwtd` 実行時でも `gwt board: ...` と表示され、「誤って `gwt` を使ったのでは」というユーザーの誤読を招いていた。

きっかけは「`gwtd` ではなく `gwt` を使って失敗している」という相談。調査の結論は **前提が誤読**で、実際に呼ばれたバイナリは `gwtd` で正しく、真因は2つ:

1. 失敗コマンド `gwtd board list` の `list` は存在しないサブコマンド（`board` は `show`/`post` のみ）。正しくは `gwtd board show [--json]`。
2. エラー中の `"gwt"` は `dispatch()`（`cli/env/mod.rs`）のハードコード由来で、バイナリ選択ミスではない。← 本 PR が修正。

## 変更内容（外科的・dispatch の2箇所のみ）

- `program_name(args)` ヘルパーを追加。`args[0]` の basename を `std::path::Path::file_stem()` で導出（`.exe` 除去、取得不能時は `"gwt"` フォールバック）。
- `dispatch()` の error-print 2箇所（run-error arm: exit 1 / parse-error arm: exit 2）を `"gwt {top_verb}: {e}"` → `"{prog} {top_verb}: {e}"` に変更。

他の `"gwt "` ハードコード箇所（`runtime_support.rs`, `cli/open.rs`）は対象外（前者は GUI バイナリ専用経路で `gwtd` には `bin/gwtd.rs` に正しい複製があり、後者は success 経路のみで dispatch error 経路に乗らないため、ユーザー向けの不整合にはならない）。

## テスト

`crates/gwt/src/cli/env/tests.rs` に6件追加:

- `dispatch_error_prefix_reflects_gwtd_binary` / `..._uses_basename_of_full_path` / `..._reflects_gwt_binary`（parse-error arm, exit 2）
- `dispatch_run_error_prefix_reflects_gwtd_binary`（**run-error arm, exit 1** の回帰ガード。`board post -f <未シードパス>` で決定的・offline に駆動）
- `program_name_strips_exe_extension` / `program_name_falls_back_to_gwt_for_unusable_args`

> 補足: 当初 parse-error arm のみテストしていたが、PR 前の敵対的レビューで run-error arm（独立した別行）が未カバーと判明。将来 run-error arm だけ revert されると #3080 を黙って再発させるため、専用テストを追加した。

## 検証（gwt-verify --mode pre-pr）

- `cargo test -p gwt --lib cli::env::` : PASS（12）
- `cargo test -p gwt --lib cli::board::` : PASS（33）
- `cargo clippy -p gwt --all-targets --all-features -- -D warnings` : PASS（exit 0）
- `cargo fmt --all -- --check` : PASS（exit 0）
- commitlint（各コミット）: PASS
- 手動: `gwtd board list` → `gwtd board: unknown subcommand: list` / `gwt board list` → `gwt board: ...`（回帰維持）/ `gwtd pr bogus` → `gwtd pr: ...`
- **Overall: PASS** / **User Verification Result: n/a**（GUI/WebView 影響なしの CLI 文言変更のため視覚検証不要）

### Known limitation
`cargo test -p gwt`（lib 全体）はこの環境で本変更と無関係なテストが 0% CPU で停止する既存問題があり full スイートは未完走。変更面はモジュール単位（env 12 + board 33）+ clippy + fmt で網羅検証済み。

## チェックリスト
- [x] 全テスト通過（変更面）・lint / 型チェック成功
- [x] 未実装・TODO なし
- [x] コミット＆プッシュ済み
- [x] User Verification Result 確定（n/a）

## 関連
- Closes #3080
- 関連 SPEC: #1942（gwt CLI — デュアルモードバイナリ・サブコマンド規約, FR-109）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CLI error messages now correctly display the name of the program that was invoked, replacing generic defaults with the actual binary name for improved clarity and debugging.

* **Tests**
  * Added regression tests verifying CLI error messages properly identify the invoked program name, including handling of full paths and different binary names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->