### PR TITLE
feat(workspace): Workspace 一覧要約に AI 磨きを追加 (SPEC-3075 FR-006)

### DIFF
--- a/crates/gwt-ai/src/lib.rs
+++ b/crates/gwt-ai/src/lib.rs
@@ -13,6 +13,7 @@ pub mod error;
 pub mod issue_classify;
 pub mod models_probe;
 pub mod session_converter;
+pub mod work_summary;
 
 pub use branch_suggest::{parse_suggestions, suggest_branch_name};
 pub use client::{AIClient, ChatMessage};
@@ -26,3 +27,4 @@ pub use session_converter::{
     convert_session, get_encoder, ClaudeEncoder, CodexEncoder, GeminiEncoder, OpenCodeEncoder,
     Role, SessionEncoder, SessionMessage,
 };
+pub use work_summary::{parse_work_summaries, summarize_work_purposes, WorkSummaryInput};

--- a/crates/gwt-ai/src/work_summary.rs
+++ b/crates/gwt-ai/src/work_summary.rs
@@ -1,0 +1,176 @@
+//! AI polish for Workspace rail summaries (SPEC-3075 FR-006).
+//!
+//! Given each Workspace's structured meta — owner plus raw signals (recent
+//! non-merge commit subjects, PR title) — the AI produces a concise, human
+//! "what work was running" purpose. This is the optional top-priority source of
+//! the rail summary: it cleans up merge/release commit noise and conventional
+//! commit prefixes that the non-AI fallback (PR title / commit subject) cannot.
+//!
+//! No session transcript is sent — only the structured meta. Callers gate this
+//! behind `AISettings.summary_enabled && AISettings.is_enabled()` and fall back
+//! to the non-AI chain when AI is disabled or errors.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use crate::{
+    client::{AIClient, ChatMessage},
+    error::AIError,
+};
+
+/// Structured meta for one Workspace, fed to the AI summary generator. Holds no
+/// session transcript — only the branch, its owner, and raw textual signals.
+#[derive(Debug, Clone)]
+pub struct WorkSummaryInput {
+    pub branch: String,
+    pub owner: Option<String>,
+    /// Recent non-merge commit subjects, a PR title, etc. — the raw material the
+    /// AI condenses into a single human purpose line.
+    pub signals: Vec<String>,
+}
+
+const SYSTEM_PROMPT: &str = "\
+You write concise one-line summaries of what work was happening on each git \
+branch (a developer's \"Workspace\"). For every branch you are given its owner \
+(a SPEC/Issue id, optional) and raw signals (recent commit subjects). Produce a \
+short, human-readable purpose describing what the work is about.\n\n\
+Rules:\n\
+- Write in the same language as the signals (Japanese stays Japanese).\n\
+- Strip conventional-commit prefixes (feat:, fix(scope):, chore:, etc.).\n\
+- Ignore merge and release noise (\"Merge pull request ...\", \"Merge branch ...\", \
+\"chore(release): vX.Y.Z\"); infer the real work from the other signals instead.\n\
+- One line, no trailing period, at most 80 characters.\n\
+- If the signals carry no real purpose, omit that branch from the output.\n\n\
+Respond with JSON only in this exact shape:\n\
+{\"summaries\": [{\"branch\": \"<branch>\", \"summary\": \"<one line>\"}]}";
+
+const MAX_SUMMARY_CHARS: usize = 80;
+
+#[derive(Debug, Deserialize)]
+struct SummaryItem {
+    branch: String,
+    summary: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SummariesResponse {
+    summaries: Vec<SummaryItem>,
+}
+
+/// Parse the AI JSON response into a `branch -> summary` map. Empty branches /
+/// summaries are skipped; over-long summaries are truncated on a char boundary.
+pub fn parse_work_summaries(response: &str) -> Result<HashMap<String, String>, AIError> {
+    let parsed: SummariesResponse = serde_json::from_str(response.trim())
+        .map_err(|error| AIError::ParseError(format!("work summaries JSON: {error}")))?;
+    let mut map = HashMap::new();
+    for item in parsed.summaries {
+        let branch = item.branch.trim();
+        let summary = item.summary.trim();
+        if branch.is_empty() || summary.is_empty() {
+            continue;
+        }
+        map.insert(
+            branch.to_string(),
+            truncate_chars(summary, MAX_SUMMARY_CHARS),
+        );
+    }
+    Ok(map)
+}
+
+fn truncate_chars(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        return text.to_string();
+    }
+    text.chars().take(max).collect::<String>()
+}
+
+/// Build the user payload (a compact JSON array of the structured meta).
+fn build_user_payload(inputs: &[WorkSummaryInput]) -> String {
+    let items: Vec<serde_json::Value> = inputs
+        .iter()
+        .map(|input| {
+            serde_json::json!({
+                "branch": input.branch,
+                "owner": input.owner,
+                "signals": input.signals,
+            })
+        })
+        .collect();
+    serde_json::json!({ "branches": items }).to_string()
+}
+
+/// Ask the AI client to summarize each Workspace's purpose in one batched call.
+/// Returns a `branch -> summary` map; branches the AI could not summarize are
+/// simply absent. Returns an empty map (no AI call) when `inputs` is empty.
+pub fn summarize_work_purposes(
+    client: &AIClient,
+    inputs: &[WorkSummaryInput],
+) -> Result<HashMap<String, String>, AIError> {
+    if inputs.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let messages = vec![
+        ChatMessage {
+            role: "system".into(),
+            content: SYSTEM_PROMPT.into(),
+        },
+        ChatMessage {
+            role: "user".into(),
+            content: build_user_payload(inputs),
+        },
+    ];
+    let response = client.create_response(messages)?;
+    parse_work_summaries(&response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_work_summaries_maps_branch_to_summary_and_skips_empty() {
+        let json = r#"{"summaries": [
+            {"branch": "work/20260601-0908", "summary": "tray の Copy URL のちらつきを修正"},
+            {"branch": "work/x", "summary": ""},
+            {"branch": "", "summary": "ignored"},
+            {"branch": "develop", "summary": "リリース準備"}
+        ]}"#;
+        let map = parse_work_summaries(json).unwrap();
+        assert_eq!(
+            map.get("work/20260601-0908").map(String::as_str),
+            Some("tray の Copy URL のちらつきを修正"),
+        );
+        assert_eq!(map.get("develop").map(String::as_str), Some("リリース準備"));
+        // Empty summary / empty branch are skipped.
+        assert!(!map.contains_key("work/x"));
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn parse_work_summaries_truncates_overlong_summary_on_char_boundary() {
+        let long = "あ".repeat(120);
+        let json = format!(r#"{{"summaries":[{{"branch":"b","summary":"{long}"}}]}}"#);
+        let map = parse_work_summaries(&json).unwrap();
+        let summary = map.get("b").unwrap();
+        assert_eq!(summary.chars().count(), MAX_SUMMARY_CHARS);
+    }
+
+    #[test]
+    fn parse_work_summaries_rejects_malformed_json() {
+        assert!(parse_work_summaries("not json").is_err());
+    }
+
+    #[test]
+    fn build_user_payload_includes_branch_owner_signals() {
+        let inputs = vec![WorkSummaryInput {
+            branch: "work/x".into(),
+            owner: Some("SPEC-3075".into()),
+            signals: vec!["feat(workspace): purpose-first rail".into()],
+        }];
+        let payload = build_user_payload(&inputs);
+        assert!(payload.contains("work/x"));
+        assert!(payload.contains("SPEC-3075"));
+        assert!(payload.contains("purpose-first rail"));
+    }
+}

--- a/crates/gwt-git/src/commit.rs
+++ b/crates/gwt-git/src/commit.rs
@@ -42,6 +42,43 @@ pub fn recent_commits(repo_path: &Path, count: usize) -> Result<Vec<CommitEntry>
     Ok(parse_log_output(&stdout))
 }
 
+/// SPEC-3075 FR-006: the recent NON-merge commit subjects of a single branch,
+/// newest first (up to `count`). This is the AI summary input for branches
+/// whose tip is a merge/release commit (no informative purpose): the real work
+/// is in the underlying feature commits, so `--no-merges` skips the noise. The
+/// branch may be a local or `origin/<branch>` short ref. Empty when the branch
+/// is unknown or has only merge commits.
+pub fn branch_recent_subjects(repo_path: &Path, branch: &str, count: usize) -> Result<Vec<String>> {
+    let branch = branch.trim();
+    if branch.is_empty() {
+        return Ok(Vec::new());
+    }
+    let max_count = format!("--max-count={count}");
+    let output = gwt_core::process::run_git_logged(
+        &[
+            "log",
+            "--no-merges",
+            &max_count,
+            "--format=%s",
+            branch,
+            "--",
+        ],
+        Some(repo_path),
+    )
+    .map_err(|e| GwtError::Git(format!("log {branch}: {e}")))?;
+    if !output.status.success() {
+        // Unknown branch / empty history is not an error for this best-effort
+        // signal — return nothing so the caller falls back to other sources.
+        return Ok(Vec::new());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
 /// Parse tab-separated git log output.
 pub fn parse_log_output(output: &str) -> Vec<CommitEntry> {
     output
@@ -64,6 +101,35 @@ pub fn parse_log_output(output: &str) -> Vec<CommitEntry> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn branch_recent_subjects_returns_non_merge_subjects_newest_first() {
+        use std::process::Command;
+        let dir = tempfile::TempDir::new().unwrap();
+        let repo = dir.path();
+        let git = |args: &[&str]| {
+            let ok = Command::new("git")
+                .args(args)
+                .current_dir(repo)
+                .output()
+                .unwrap()
+                .status
+                .success();
+            assert!(ok, "git {args:?}");
+        };
+        git(&["init", "--initial-branch=main"]);
+        git(&["config", "user.email", "t@example.com"]);
+        git(&["config", "user.name", "T"]);
+        git(&["commit", "--allow-empty", "-m", "feat: first work"]);
+        git(&["commit", "--allow-empty", "-m", "fix: second work"]);
+
+        let subjects = branch_recent_subjects(repo, "main", 5).unwrap();
+        assert_eq!(subjects, vec!["fix: second work", "feat: first work"]);
+        // Unknown branch is best-effort empty, not an error.
+        assert!(branch_recent_subjects(repo, "no/such-branch", 5)
+            .unwrap()
+            .is_empty());
+    }
 
     #[test]
     fn parse_log_output_valid() {

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -371,6 +371,89 @@ pub struct ProjectOpenTarget {
     pub(crate) needs_migration: bool,
 }
 
+/// SPEC-3075 FR-006: at most this many Workspaces get an AI-polished summary per
+/// scan, bounding both the git calls and the AI prompt size for large repos.
+const AI_SUMMARY_BRANCH_CAP: usize = 40;
+
+/// SPEC-3075 FR-006: a tip commit subject that carries no real purpose — merge
+/// commits and release-version bumps. These are the cases the AI polish targets
+/// (it reads the underlying feature commits instead).
+fn is_summary_noise(subject: &str) -> bool {
+    let s = subject.trim();
+    s.is_empty()
+        || s.starts_with("Merge pull request")
+        || s.starts_with("Merge branch")
+        || s.starts_with("Merge remote-tracking")
+        || s.starts_with("Merge tag")
+        || s.starts_with("merge:")
+        || s.starts_with("chore: merge")
+        || s.starts_with("chore(release):")
+        || s.starts_with("chore(deps):")
+}
+
+/// SPEC-3075 FR-006: build the AI-summary inputs for a project. For every
+/// non-terminal Workspace whose branch tip is merge/release noise, gather the
+/// recent non-merge commit subjects (the real work) plus the owner. Only the
+/// noisy Workspaces are included (PR titles / clean commit subjects need no
+/// polish), and the count is capped. Pure structured meta — no transcript.
+fn build_ai_summary_inputs(project_root: &Path, cap: usize) -> Vec<gwt_ai::WorkSummaryInput> {
+    let Ok(projection) =
+        gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(project_root)
+    else {
+        return Vec::new();
+    };
+    let tip_subjects = gwt_git::refs::branch_tip_subjects(project_root).unwrap_or_default();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut inputs = Vec::new();
+    for item in &projection.work_items {
+        if item.is_terminal() || inputs.len() >= cap {
+            continue;
+        }
+        let Some(branch) = item
+            .execution_containers
+            .iter()
+            .find_map(|container| container.branch.as_deref())
+            .map(crate::runtime_support::normalize_branch_name)
+            .filter(|branch| !branch.is_empty())
+        else {
+            continue;
+        };
+        if !seen.insert(branch.clone()) {
+            continue;
+        }
+        let tip = tip_subjects
+            .get(&branch)
+            .or_else(|| tip_subjects.get(&format!("origin/{branch}")))
+            .map(String::as_str)
+            .unwrap_or("");
+        // Only polish the noisy ones — a clean tip subject is already a usable
+        // summary, and a missing branch has nothing to read.
+        if !is_summary_noise(tip) {
+            continue;
+        }
+        let mut signals =
+            gwt_git::commit::branch_recent_subjects(project_root, &branch, 5).unwrap_or_default();
+        if signals.is_empty() {
+            signals = gwt_git::commit::branch_recent_subjects(
+                project_root,
+                &format!("origin/{branch}"),
+                5,
+            )
+            .unwrap_or_default();
+        }
+        signals.retain(|subject| !is_summary_noise(subject));
+        if signals.is_empty() {
+            continue;
+        }
+        inputs.push(gwt_ai::WorkSummaryInput {
+            branch,
+            owner: item.owner.clone(),
+            signals,
+        });
+    }
+    inputs
+}
+
 pub struct AppRuntime {
     pub(crate) tabs: Vec<ProjectTabRuntime>,
     pub(crate) active_tab_id: Option<String>,
@@ -418,6 +501,13 @@ pub struct AppRuntime {
     /// list` call). The PR title is the human-written purpose, so it is the
     /// top-priority Workspace rail summary. Empty when offline / `gh` absent.
     pub(crate) work_pr_titles: HashMap<PathBuf, HashMap<String, String>>,
+    /// SPEC-3075 FR-006: per-project `branch -> AI-polished summary`, generated
+    /// off the hot path by [`AppRuntime::spawn_work_ai_summaries_scan`] only when
+    /// AI is enabled (`summary_enabled` + valid endpoint/model). The AI cleans
+    /// merge/release commit noise into a human purpose; it fills the gap above
+    /// the raw commit subject but below PR title / agent title-summary. Empty
+    /// when AI is disabled — the non-AI chain then stands unchanged.
+    pub(crate) work_ai_summaries: HashMap<PathBuf, HashMap<String, String>>,
     /// Incremental loader for the machine-local session ledger; keeps
     /// projection rebuilds from re-parsing thousands of unchanged TOMLs
     /// (window-close latency fix, 2026-06-11). RefCell: the runtime lives on
@@ -556,6 +646,7 @@ impl AppRuntime {
             work_merged_branches: HashMap::new(),
             work_tip_subjects: HashMap::new(),
             work_pr_titles: HashMap::new(),
+            work_ai_summaries: HashMap::new(),
             session_ledger_cache: std::cell::RefCell::new(
                 crate::session_ledger_cache::SessionLedgerCache::new(),
             ),
@@ -677,7 +768,8 @@ impl AppRuntime {
         self.reconcile_workspace_worktrees(&project_root);
         self.spawn_work_merge_status_scan(project_root.clone());
         self.spawn_work_tip_subjects_scan(project_root.clone());
-        self.spawn_work_pr_titles_scan(project_root);
+        self.spawn_work_pr_titles_scan(project_root.clone());
+        self.spawn_work_ai_summaries_scan(project_root);
         if changed {
             self.active_work_projection_broadcast_for_active_tab()
                 .into_iter()
@@ -821,6 +913,58 @@ impl AppRuntime {
             proxy.send(UserEvent::WorkPrTitles {
                 project_root,
                 pr_titles,
+            });
+        });
+    }
+
+    /// SPEC-3075 FR-006: cache the AI-polished `branch -> summary` map and
+    /// rebroadcast so the Workspace rail re-renders with the cleaned summaries.
+    pub(crate) fn apply_work_ai_summaries(
+        &mut self,
+        project_root: &Path,
+        ai_summaries: HashMap<String, String>,
+    ) -> Vec<OutboundEvent> {
+        self.work_ai_summaries
+            .insert(project_root.to_path_buf(), ai_summaries);
+        self.active_work_projection_broadcast_for_active_tab()
+            .into_iter()
+            .collect()
+    }
+
+    /// SPEC-3075 FR-006: optional AI polish for the rail summary. Runs off the UI
+    /// thread and ONLY when AI is enabled (`summary_enabled` + valid
+    /// endpoint/model). For the Workspaces whose best non-AI summary would be
+    /// merge/release commit noise, it feeds the structured meta (owner + recent
+    /// non-merge commit subjects — never the session transcript) to the AI and
+    /// caches a cleaned one-line purpose. Sends [`UserEvent::WorkAiSummaries`]
+    /// when anything was produced; silent (no event) when AI is disabled, the
+    /// AI call fails, or nothing needed polishing — the non-AI chain then
+    /// stands unchanged (fallback always).
+    pub(crate) fn spawn_work_ai_summaries_scan(&self, project_root: PathBuf) {
+        let ai = gwt_config::Settings::load().unwrap_or_default().ai;
+        if !ai.summary_enabled || !ai.is_enabled() {
+            return;
+        }
+        let proxy = self.proxy.clone();
+        thread::spawn(move || {
+            let inputs = build_ai_summary_inputs(&project_root, AI_SUMMARY_BRANCH_CAP);
+            if inputs.is_empty() {
+                return;
+            }
+            let Ok(client) =
+                gwt_ai::AIClient::new(&ai.endpoint, ai.api_key.as_deref().unwrap_or(""), &ai.model)
+            else {
+                return;
+            };
+            let Ok(ai_summaries) = gwt_ai::summarize_work_purposes(&client, &inputs) else {
+                return;
+            };
+            if ai_summaries.is_empty() {
+                return;
+            }
+            proxy.send(UserEvent::WorkAiSummaries {
+                project_root,
+                ai_summaries,
             });
         });
     }

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -1839,6 +1839,7 @@ fn sample_runtime_with_events(
         work_merged_branches: HashMap::new(),
         work_tip_subjects: HashMap::new(),
         work_pr_titles: HashMap::new(),
+        work_ai_summaries: HashMap::new(),
         session_ledger_cache: std::cell::RefCell::new(
             crate::session_ledger_cache::SessionLedgerCache::new(),
         ),
@@ -15497,7 +15498,7 @@ fn derive_work_summary_is_none_when_no_declared_purpose() {
 }
 
 #[test]
-fn apply_work_summary_external_sources_prefers_pr_title_then_commit_subject() {
+fn apply_work_summary_external_sources_prefers_pr_then_ai_then_commit_subject() {
     use std::collections::HashMap;
     let mut tip_subjects: HashMap<String, String> = HashMap::new();
     tip_subjects.insert(
@@ -15507,6 +15508,17 @@ fn apply_work_summary_external_sources_prefers_pr_title_then_commit_subject() {
     tip_subjects.insert(
         "work/20260610-0907".to_string(),
         "work/20260610-0907".to_string(), // subject == branch -> not a purpose
+    );
+    // SPEC-3075 FR-006: an AI-polished summary wins over the raw commit subject
+    // for a gap row (no PR, no title-summary).
+    tip_subjects.insert(
+        "work/20260609-1130".to_string(),
+        "Merge pull request #42 from x".to_string(), // noisy raw subject
+    );
+    let mut ai_summaries: HashMap<String, String> = HashMap::new();
+    ai_summaries.insert(
+        "work/20260609-1130".to_string(),
+        "tray の Copy URL のちらつきを修正".to_string(),
     );
     let mut pr_titles: HashMap<String, String> = HashMap::new();
     // A PR title overrides even a declared title-summary already in work_summary.
@@ -15546,8 +15558,14 @@ fn apply_work_summary_external_sources_prefers_pr_title_then_commit_subject() {
         base("work/20260614-0444", None), // no PR, gap -> filled by commit subject
         base("work/20260612-1405", Some("Keep my purpose")), // PR title overrides title-summary
         base("work/20260610-0907", None), // no PR, subject == branch -> stays None
+        base("work/20260609-1130", None), // no PR, AI summary beats noisy commit subject
     ];
-    super::apply_work_summary_external_sources(&mut works, Some(&pr_titles), Some(&tip_subjects));
+    super::apply_work_summary_external_sources(
+        &mut works,
+        Some(&pr_titles),
+        Some(&ai_summaries),
+        Some(&tip_subjects),
+    );
     assert_eq!(
         works[0].work_summary.as_deref(),
         Some("feat(workspace): purpose-first rail"),
@@ -15558,6 +15576,30 @@ fn apply_work_summary_external_sources_prefers_pr_title_then_commit_subject() {
         "PR title overrides the declared title-summary",
     );
     assert_eq!(works[2].work_summary, None);
+    assert_eq!(
+        works[3].work_summary.as_deref(),
+        Some("tray の Copy URL のちらつきを修正"),
+        "AI-polished summary wins over the raw commit subject",
+    );
+}
+
+#[test]
+fn is_summary_noise_flags_merge_and_release_commits() {
+    assert!(super::is_summary_noise(""));
+    assert!(super::is_summary_noise(
+        "Merge pull request #3078 from akiojin/work/x"
+    ));
+    assert!(super::is_summary_noise("Merge branch 'develop'"));
+    assert!(super::is_summary_noise(
+        "Merge remote-tracking branch 'origin/develop'"
+    ));
+    assert!(super::is_summary_noise("chore(release): v9.58.0"));
+    assert!(super::is_summary_noise("chore: merge origin/develop"));
+    // Real work is not noise.
+    assert!(!super::is_summary_noise(
+        "feat(workspace): purpose-first rail"
+    ));
+    assert!(!super::is_summary_noise("fix: reveal reused surface tabs"));
 }
 
 #[test]

--- a/crates/gwt/src/app_runtime/workspace_views.rs
+++ b/crates/gwt/src/app_runtime/workspace_views.rs
@@ -436,17 +436,25 @@ fn journal_title_summary_by_session(
 ///
 /// First the PR title — the human-written purpose — which OVERRIDES the
 /// agent-declared `title-summary` already in `work_summary` (the user's chosen
-/// precedence). Then, for rows still missing a summary, the branch tip commit
-/// subject — the historical fallback for the ~96% of Workspaces that predate
-/// `title-summary` (for a conventional-commit repo `feat(...): ...` is
-/// readable). Both maps come from background scan caches (one `gh pr list` and
-/// one `for-each-ref` spawn), mirroring [`mark_merged_active_works`]; no git or
-/// network runs on this view-build path.
+/// precedence). Then, for rows still missing a summary, the AI-polished summary
+/// (FR-006, present only when AI is enabled — it cleans merge/release commit
+/// noise), and finally the raw branch tip commit subject — the historical
+/// fallback for the ~96% of Workspaces that predate `title-summary`. All maps
+/// come from background scan caches, mirroring [`mark_merged_active_works`]; no
+/// git, network, or AI call runs on this view-build path.
 pub(super) fn apply_work_summary_external_sources(
     active_works: &mut [gwt::ActiveWorkItemView],
     pr_titles: Option<&std::collections::HashMap<String, String>>,
+    ai_summaries: Option<&std::collections::HashMap<String, String>>,
     tip_subjects: Option<&std::collections::HashMap<String, String>>,
 ) {
+    let lookup = |map: Option<&std::collections::HashMap<String, String>>, branch: &str| {
+        map.and_then(|map| {
+            map.get(branch)
+                .or_else(|| map.get(&format!("origin/{branch}")))
+        })
+        .and_then(|value| purpose_candidate(Some(value.as_str()), Some(branch)))
+    };
     for work in active_works.iter_mut() {
         let Some(branch) = work
             .branch
@@ -457,23 +465,18 @@ pub(super) fn apply_work_summary_external_sources(
             continue;
         };
         // 1. PR title — top priority, overrides any declared title-summary.
-        if let Some(title) = pr_titles
-            .and_then(|map| map.get(&branch))
-            .and_then(|title| purpose_candidate(Some(title.as_str()), Some(branch.as_str())))
-        {
+        if let Some(title) = lookup(pr_titles, &branch) {
             work.work_summary = Some(title);
             continue;
         }
-        // 2. tip commit subject — only fills a row with no declared purpose.
+        // 2/3. AI summary then raw commit subject — only fill a row with no
+        // declared purpose. The AI-polished summary cleans the noise the raw
+        // commit subject would otherwise show, so it wins over it.
         if work.work_summary.is_some() {
             continue;
         }
-        if let Some(summary) = tip_subjects
-            .and_then(|map| {
-                map.get(&branch)
-                    .or_else(|| map.get(&format!("origin/{branch}")))
-            })
-            .and_then(|subject| purpose_candidate(Some(subject.as_str()), Some(branch.as_str())))
+        if let Some(summary) =
+            lookup(ai_summaries, &branch).or_else(|| lookup(tip_subjects, &branch))
         {
             work.work_summary = Some(summary);
         }
@@ -1946,12 +1949,14 @@ impl AppRuntime {
                 &mut view.active_works,
                 self.work_merged_branches.get(&tab.project_root),
             );
-            // SPEC-3075: fill the rail summary — PR title (top priority) then the
-            // branch tip commit subject for Works with no recorded purpose (both
-            // from background scan caches).
+            // SPEC-3075: fill the rail summary — PR title (top), then the
+            // AI-polished summary (FR-006), then the raw branch tip commit
+            // subject for Works with no recorded purpose (all from background
+            // scan caches).
             apply_work_summary_external_sources(
                 &mut view.active_works,
                 self.work_pr_titles.get(&tab.project_root),
+                self.work_ai_summaries.get(&tab.project_root),
                 self.work_tip_subjects.get(&tab.project_root),
             );
             // SPEC-2359 W16-3 (FR-390): "Remote" rows — branch known only

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -942,6 +942,13 @@ enum UserEvent {
         project_root: PathBuf,
         pr_titles: std::collections::HashMap<String, String>,
     },
+    /// SPEC-3075 FR-006: result of the background AI summary polish. The runtime
+    /// caches the `branch -> AI summary` map and rebroadcasts the Workspace
+    /// projection so noisy commit-subject rows show a clean human purpose.
+    WorkAiSummaries {
+        project_root: PathBuf,
+        ai_summaries: std::collections::HashMap<String, String>,
+    },
     /// SPEC-2359 W-16 (FR-387): a background work-events ingest finished.
     /// The handler runs the worktree reconcile AFTER the intake (so branches
     /// already recorded elsewhere are not redundantly backfilled) and
@@ -2259,6 +2266,7 @@ mod tests {
             work_merged_branches: HashMap::new(),
             work_tip_subjects: HashMap::new(),
             work_pr_titles: HashMap::new(),
+            work_ai_summaries: HashMap::new(),
             session_ledger_cache: std::cell::RefCell::new(
                 crate::session_ledger_cache::SessionLedgerCache::new(),
             ),
@@ -6809,6 +6817,13 @@ fn main() -> std::io::Result<()> {
                 pr_titles,
             }) => {
                 let events = app.apply_work_pr_titles(&project_root, pr_titles);
+                clients.dispatch(events);
+            }
+            Event::UserEvent(UserEvent::WorkAiSummaries {
+                project_root,
+                ai_summaries,
+            }) => {
+                let events = app.apply_work_ai_summaries(&project_root, ai_summaries);
                 clients.dispatch(events);
             }
             Event::UserEvent(UserEvent::WorkspaceProjectionChanged { project_root }) => {


### PR DESCRIPTION
## 概要 (Refs #3075 — FR-006)

SPEC-3075 の follow-up。Workspace 一覧（rail）の主ラベルに出る **merge/release commit のノイズ**（`Merge pull request #...`, `chore(release): vX.Y.Z` 等）を、**AI 有効時のみ**人間可読の purpose に磨いて解消します。AI 無効が既定のため、既存挙動（commit subject）には回帰しません。

## 設計

要約ソースの優先順に **AI 磨き**を追加:
**PR title → title-summary → AI 磨き → raw commit subject → branch**

- AI 磨きは raw commit subject を**置換**（ノイズを掃除）。PR title / title-summary は上書きしない。
- 生成対象は **noisy/gap branch のみ**（tip が merge/release ノイズ）。`AI_SUMMARY_BRANCH_CAP=40` で上限。
- 入力は**構造化メタのみ**（owner + 直近 non-merge commit subjects）。**session transcript は送信しない**。
- `summary_enabled` & `is_enabled()`（endpoint+model 必須）の二重ガード。無効/AI エラー/生成ゼロ時は何もしない（フォールバック常時）。
- 1 バッチ AI 呼び出し（noisy branch をまとめて）。background thread（hot path / UI を塞がない）。

## 主な変更
- `crates/gwt-ai/src/work_summary.rs`（新規）: `summarize_work_purposes` / `parse_work_summaries` / `WorkSummaryInput`。system prompt は「conventional prefix 除去・merge/release ノイズ無視・signals の言語を維持・1行 ≤80 字」。
- `crates/gwt-git/src/commit.rs`: `branch_recent_subjects`（per-branch `--no-merges` commit subjects、best-effort）。
- `crates/gwt/src/app_runtime/mod.rs`: `work_ai_summaries` cache + `spawn_work_ai_summaries_scan`（AI ゲート + `build_ai_summary_inputs` + `is_summary_noise`）+ `apply_work_ai_summaries`。`handle_work_events_ingested` から起動。
- `crates/gwt/src/app_runtime/workspace_views.rs`: `apply_work_summary_external_sources` に ai_summaries を追加（PR と raw subject の間）。
- `crates/gwt/src/main.rs`: `UserEvent::WorkAiSummaries` + handler。

## 検証
- `cargo test`（gwt / gwt-ai / gwt-git / gwt-core / gwt-skills, all-features）: 全 green。新規単体: `parse_work_summaries` / `build_user_payload` / `summarize` 入力空 / `branch_recent_subjects`（`--no-merges`） / `is_summary_noise`（merge/release 判定） / `apply_work_summary_external_sources`（PR→AI→commit の優先順）。
- `cargo clippy --all-targets --all-features -- -D warnings`: clean / `cargo fmt`: clean。
- **AI 無効が既定**のため、AI を設定していないユーザーの表示は SPEC-3075（PR #3082）で User confirmed の挙動と同一（commit subject）。AI 有効時のみ磨きが活性化。

## PR Readiness
- State: Ready
- 単独で配信可能な releaseable slice（AI ゲートで既存挙動に影響なし、AI 有効時のみ追加価値）。
- 既知 blocker: なし。
- User Verification Result: **n/a**（AI 無効の既定表示は #3082 で confirmed 済みと同一。AI 磨きは AI provider 設定が前提で、ロジックは単体テストで担保）。

## Closing Issues
None（SPEC-3075 は他の追跡項目が無くなれば close）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace rail summaries are now AI-polished, providing cleaned one-line purpose descriptions for branches automatically generated by AI based on recent commit history.
  * Added intelligent filtering to exclude merge and release commit noise from summary generation, focusing on meaningful work descriptions.
  * AI-generated summaries now intelligently fill in workspace rail summaries when PR titles are unavailable, improving overall workspace visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->