### PR TITLE
fix(agent): limit resume recovery to live hook errors

### DIFF
--- a/.gwt/work/discussions.md
+++ b/.gwt/work/discussions.md
@@ -12,7 +12,7 @@ Related Works:
 Promoted To: SPEC #2359 US-79B / T-651〜T-655
 
 Summary:
-セッション復元時に Codex pane が `CODEX Codex Error` や blank terminal になり、復元できないように見える場合がある。添付画像では複数の resumed Codex pane が Error 表示になっている一方、対応する session TOML / runtime sidecar / OS process では `codex resume <agent_session_id>` が生存している。現時点では「resume プロセスが起動できない」よりも、「live agent session があるのに stale な PTY Error/Stopped state が hook Running state より優先され、GUI 表示だけ Error 固定になる」可能性が高い。
+セッション復元時に Codex pane が `CODEX Codex Error` や blank terminal になり、復元できないように見える場合がある。添付画像では複数の resumed Codex pane が Error 表示になっている一方、対応する session TOML / runtime sidecar / OS process では `codex resume <agent_session_id>` が生存している。現時点では「resume プロセスが起動できない」よりも、「live agent session があるのに stale な PTY Error state が hook Running state より優先され、GUI 表示だけ Error 固定になる」可能性が高い。
 
 Evidence:
 - 添付画像では `work/20260617-0255` と `work/20260617-0425` 系の Codex pane が Error/blank 表示。
@@ -20,11 +20,11 @@ Evidence:
 - `ps` では `/Users/akiojin/.bun/bin/codex --no-alt-screen resume <agent_session_id>` が該当セッションで生存。
 - 対象 worktree / branch は存在しており、SPEC #2359 US-79 の「missing worktree/branch」ケースとは現在のスクリーンショット上では一致しない。
 - `gwtd pane.list` は pane websocket timeout になり、UI/pane 更新系の詰まりも併発している可能性がある。
-- `crates/gwt/src/window_state.rs` の `compose_window_state_with_active_session` は PTY state が `Stopped` / `Error` の場合、Agent hook state を見ずに PTY state を返す。
+- `crates/gwt/src/window_state.rs` の `compose_window_state_with_active_session` は PTY state が `Error` の場合、Agent hook state を見ずに PTY state を返す。
 - `crates/gwt/src/app_runtime/runtime_events.rs` は PTY status `Error` / `Stopped` で active agent session tracking と runtime tracking を落とすため、その後の hook event が live session を GUI 上で復旧しにくい。
 
 Approaches:
-- Approach 1: Agent window に active session または matching runtime hook がある場合、PTY terminal state より hook state を優先する。実際の process exit と stale UI state の境界を test で固定できるが、auto-close / stopped 表示の既存期待を見直す必要がある。
+- Approach 1: Agent window に active session と matching live runtime hook がある場合、PTY Error より hook state を優先する。実際の process exit と stale UI state の境界を test で固定できるが、auto-close / stopped 表示の既存期待を壊さないよう Stopped は対象外にする必要がある。
 - Approach 2: hook Running/Waiting/Idle を受けたタイミングで同じ window の PTY terminal state を clear する。局所的だが、status composition の意図が分散する。
 - Approach 3: pane websocket timeout / render blank の retry と status refresh を追加する。表示更新の堅牢性は上がるが、Error 固定の根本原因を直接直さない。
 

--- a/crates/gwt/src/app_runtime/runtime_events.rs
+++ b/crates/gwt/src/app_runtime/runtime_events.rs
@@ -245,6 +245,10 @@ impl AppRuntime {
             && self
                 .window_preset(window_id)
                 .is_some_and(gwt::window_state::uses_agent_hook_state)
+            && self
+                .window_hook_states
+                .get(window_id)
+                .is_some_and(|state| gwt::window_state::is_live_agent_hook_state(*state))
     }
 
     fn should_broadcast_runtime_hook_event_to_frontend(event: &gwt::RuntimeHookEvent) -> bool {

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -6216,6 +6216,11 @@ fn app_runtime_runtime_hook_running_recovers_active_agent_after_pty_error() {
         window_id.clone(),
         sample_active_agent_session("tab-1", &window_id),
     );
+    let _ = runtime.handle_runtime_hook_event(runtime_hook_state_for_event(
+        "Running",
+        "PreToolUse",
+        "session-1",
+    ));
 
     let error_events = runtime.handle_runtime_status(
         window_id.clone(),
@@ -6255,6 +6260,43 @@ fn app_runtime_runtime_hook_running_recovers_active_agent_after_pty_error() {
         event.event,
         BackendEvent::WindowState {
             state: WindowProcessStatus::Running,
+            ..
+        }
+    )));
+}
+
+#[test]
+fn app_runtime_runtime_status_error_without_live_hook_stops_active_agent() {
+    let _env_lock = env_test_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let temp = tempdir().expect("tempdir");
+    let _home = ScopedEnvVar::set("HOME", temp.path());
+    let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+    let tab = sample_project_tab_with_window(
+        "tab-1",
+        "codex-1",
+        WindowPreset::Codex,
+        WindowProcessStatus::Running,
+    );
+    let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+    let window_id = combined_window_id("tab-1", "codex-1");
+    runtime.active_agent_sessions.insert(
+        window_id.clone(),
+        sample_active_agent_session("tab-1", &window_id),
+    );
+
+    let error_events = runtime.handle_runtime_status(
+        window_id.clone(),
+        WindowProcessStatus::Error,
+        Some("process failed".to_string()),
+    );
+
+    assert!(!runtime.active_agent_sessions.contains_key(&window_id));
+    assert!(error_events.iter().any(|event| matches!(
+        event.event,
+        BackendEvent::WindowState {
+            state: WindowProcessStatus::Error,
             ..
         }
     )));

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -3409,6 +3409,18 @@ mod tests {
                 if id == &shell_id && data_base64 == "aGVsbG8="
         ));
 
+        let _ = runtime.handle_runtime_hook_event(RuntimeHookEvent {
+            kind: RuntimeHookEventKind::RuntimeState,
+            source_event: Some("PreToolUse".to_string()),
+            gwt_session_id: Some("session-1".to_string()),
+            agent_session_id: None,
+            project_root: Some("E:/gwt/test-repo".to_string()),
+            branch: Some("feature/test".to_string()),
+            status: Some("Running".to_string()),
+            tool_name: None,
+            message: None,
+            occurred_at: "2026-04-25T00:00:00Z".to_string(),
+        });
         let error_events = runtime.handle_runtime_status(
             claude_one_id.clone(),
             WindowProcessStatus::Error,
@@ -3417,7 +3429,7 @@ mod tests {
         assert_eq!(error_events.len(), 3);
         assert!(
             runtime.active_agent_sessions.contains_key(&claude_one_id),
-            "PTY Error keeps Agent session ownership so later runtime hooks can recover it"
+            "PTY Error with a live hook state keeps Agent session ownership for recovery"
         );
         assert_eq!(
             runtime

--- a/crates/gwt/src/window_state.rs
+++ b/crates/gwt/src/window_state.rs
@@ -19,7 +19,8 @@ pub fn compose_window_state_with_active_session(
     hook_state: Option<WindowState>,
     has_active_agent_session: bool,
 ) -> WindowState {
-    if has_active_agent_session && uses_agent_hook_state(preset) {
+    if pty_state == WindowState::Error && has_active_agent_session && uses_agent_hook_state(preset)
+    {
         if let Some(hook_state) = hook_state.filter(|state| is_live_agent_hook_state(*state)) {
             return hook_state;
         }
@@ -219,7 +220,7 @@ mod tests {
     }
 
     #[test]
-    fn compose_window_state_recovers_active_agent_from_stale_pty_terminal_state() {
+    fn compose_window_state_recovers_active_agent_from_stale_pty_error_state() {
         assert_eq!(
             compose_window_state_with_active_session(
                 WindowState::Error,
@@ -229,6 +230,10 @@ mod tests {
             ),
             WindowState::Running
         );
+    }
+
+    #[test]
+    fn compose_window_state_keeps_pty_stopped_for_active_agent_recovery() {
         assert_eq!(
             compose_window_state_with_active_session(
                 WindowState::Stopped,
@@ -236,7 +241,7 @@ mod tests {
                 Some(WindowState::Waiting),
                 true,
             ),
-            WindowState::Waiting
+            WindowState::Stopped
         );
         assert_eq!(
             compose_window_state_with_active_session(
@@ -245,7 +250,7 @@ mod tests {
                 Some(WindowState::Idle),
                 true,
             ),
-            WindowState::Idle
+            WindowState::Stopped
         );
     }
 


### PR DESCRIPTION
## Summary
Follow-up for PR #3117 after it was merged before the review fix landed. This PR ships the remaining SPEC #2359 review correction only.

## Changes
- Limit Agent resume recovery to stale PTY `Error` states with an existing live hook state.
- Keep PTY `Stopped` authoritative so stopped Agent panes still follow the auto-close path.
- Stop active Agent ownership on PTY `Error` when there is no live hook evidence.
- Update SPEC #2359 discussion notes to match the narrowed recovery boundary.

## Testing
- `cargo fmt --check` PASS
- `bunx markdownlint-cli2 .gwt/work/discussions.md tasks/todo.md` PASS
- `git diff --check` PASS
- `cargo test -p gwt compose_window_state --all-features` PASS
- `cargo test -p gwt app_runtime_runtime_hook_running_recovers_active_agent_after_pty_error --all-features` PASS
- `cargo test -p gwt app_runtime_runtime_status_error_without_live_hook_stops_active_agent --all-features` PASS
- `cargo test -p gwt app_runtime_runtime_status_stopped_auto_closes_active_agent_window --all-features` PASS
- `cargo test -p gwt runtime_status_helpers_cover_sessions_auto_close_and_launch_errors --all-features` PASS
- `cargo test -p gwt-core -p gwt --all-features` PASS after merging `origin/develop`
- `cargo clippy --all-targets --all-features -- -D warnings` PASS after merging `origin/develop`
- `cargo build -p gwt --bin gwt --bin gwtd` PASS after merging `origin/develop`

## PR Readiness
State: Ready
Known blockers: None
Remaining acceptance: None
User Verification Result: confirmed

## Closing Issues
None

## Related Issues
SPEC #2359, PR #3117

## Checklist
- [x] Releaseable slice with no known blockers
- [x] Tests, lint, and build pass
- [x] User verification confirmed
- [x] PR body has no TODO entries