### PR TITLE
fix(agent): keep resume recovery across duplicate errors

### DIFF
--- a/.gwt/work/discussions.md
+++ b/.gwt/work/discussions.md
@@ -22,6 +22,7 @@ Evidence:
 - `gwtd pane.list` は pane websocket timeout になり、UI/pane 更新系の詰まりも併発している可能性がある。
 - `crates/gwt/src/window_state.rs` の `compose_window_state_with_active_session` は PTY state が `Error` の場合、Agent hook state を見ずに PTY state を返す。
 - `crates/gwt/src/app_runtime/runtime_events.rs` は PTY status `Error` / `Stopped` で active agent session tracking と runtime tracking を落とすため、その後の hook event が live session を GUI 上で復旧しにくい。
+- PR review で重複 PTY `Error` の境界も確認した。最初の recoverable `Error` で hook state を表示用に消しても、同じ window の duplicate `Error` では active session を保持し続ける必要がある。
 
 Approaches:
 - Approach 1: Agent window に active session と matching live runtime hook がある場合、PTY Error より hook state を優先する。実際の process exit と stale UI state の境界を test で固定できるが、auto-close / stopped 表示の既存期待を壊さないよう Stopped は対象外にする必要がある。
@@ -29,13 +30,13 @@ Approaches:
 - Approach 3: pane websocket timeout / render blank の retry と status refresh を追加する。表示更新の堅牢性は上がるが、Error 固定の根本原因を直接直さない。
 
 Current Recommendation:
-最小の修正対象は Approach 1 を中心に、Agent resume pane の status composition と runtime tracking を SPEC #2359 の resume/restore follow-up として扱うこと。Startup restore が missing worktree を skip する `crates/gwt/src/app_runtime/startup.rs` の US-79 ギャップは関連するが、今回の画像とは別症状として scope を分ける。
+最小の修正対象は Approach 1 を中心に、Agent resume pane の status composition と runtime tracking を SPEC #2359 の resume/restore follow-up として扱うこと。Recoverable `Error` は live hook evidence または同じ window で既に recoverable と判定済みの duplicate `Error` に限定する。Startup restore が missing worktree を skip する `crates/gwt/src/app_runtime/startup.rs` の US-79 ギャップは関連するが、今回の画像とは別症状として scope を分ける。
 
 Open Questions:
 - なし。
 
 Next:
-SPEC #2359 US-79B / T-651〜T-655 は完了。ユーザー視覚確認は 2026-06-19 に confirmed。
+SPEC #2359 US-79B / T-651〜T-655 は完了。ユーザー視覚確認は 2026-06-19 に confirmed。PR #3118 merge 直前の review follow-up として duplicate PTY `Error` regression も追加済み。
 
 ## 2026-05-23 — Workspace terminology and durable discussions
 

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -528,6 +528,7 @@ pub struct AppRuntime {
         std::cell::RefCell<HashMap<PathBuf, std::collections::HashSet<String>>>,
     pub(crate) window_pty_statuses: HashMap<String, WindowProcessStatus>,
     pub(crate) window_hook_states: HashMap<String, WindowProcessStatus>,
+    pub(crate) recoverable_agent_error_windows: HashSet<String>,
     pub(crate) hook_forward_target: Option<HookForwardTarget>,
     pub(crate) issue_link_cache_dir: PathBuf,
     /// Cached update state so late-connecting WebView clients get the toast.
@@ -657,6 +658,7 @@ impl AppRuntime {
             local_worktree_branches: std::cell::RefCell::new(HashMap::new()),
             window_pty_statuses: HashMap::new(),
             window_hook_states: HashMap::new(),
+            recoverable_agent_error_windows: HashSet::new(),
             hook_forward_target: None,
             issue_link_cache_dir: gwt_core::paths::gwt_cache_dir(),
             pending_update: None,
@@ -1856,6 +1858,7 @@ impl AppRuntime {
             }
         }
         self.window_hook_states.clear();
+        self.recoverable_agent_error_windows.clear();
     }
 
     fn active_window_for_runtime_event(&self, event: &gwt::RuntimeHookEvent) -> Option<String> {
@@ -1897,6 +1900,7 @@ impl AppRuntime {
     fn remove_window_state_tracking(&mut self, window_id: &str) {
         self.window_pty_statuses.remove(window_id);
         self.window_hook_states.remove(window_id);
+        self.recoverable_agent_error_windows.remove(window_id);
         self.board_all_view_windows.remove(window_id);
     }
 

--- a/crates/gwt/src/app_runtime/runtime_events.rs
+++ b/crates/gwt/src/app_runtime/runtime_events.rs
@@ -130,6 +130,11 @@ impl AppRuntime {
             self.push_workspace_and_active_work_projection_broadcasts(&mut events);
             return events;
         }
+        if keep_active_agent_session_for_recovery {
+            self.recoverable_agent_error_windows.insert(id.clone());
+        } else if status != WindowProcessStatus::Error {
+            self.recoverable_agent_error_windows.remove(&id);
+        }
         if matches!(
             status,
             WindowProcessStatus::Error | WindowProcessStatus::Stopped
@@ -245,10 +250,11 @@ impl AppRuntime {
             && self
                 .window_preset(window_id)
                 .is_some_and(gwt::window_state::uses_agent_hook_state)
-            && self
+            && (self
                 .window_hook_states
                 .get(window_id)
                 .is_some_and(|state| gwt::window_state::is_live_agent_hook_state(*state))
+                || self.recoverable_agent_error_windows.contains(window_id))
     }
 
     fn should_broadcast_runtime_hook_event_to_frontend(event: &gwt::RuntimeHookEvent) -> bool {

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     ffi::OsString,
     fs,
     io::Write,
@@ -1862,6 +1862,7 @@ fn sample_runtime_with_events(
         local_worktree_branches: std::cell::RefCell::new(HashMap::new()),
         window_pty_statuses: HashMap::new(),
         window_hook_states: HashMap::new(),
+        recoverable_agent_error_windows: HashSet::new(),
         hook_forward_target: None,
         issue_link_cache_dir: gwt_cache_dir(),
         pending_update: None,
@@ -6294,6 +6295,55 @@ fn app_runtime_runtime_status_error_without_live_hook_stops_active_agent() {
 
     assert!(!runtime.active_agent_sessions.contains_key(&window_id));
     assert!(error_events.iter().any(|event| matches!(
+        event.event,
+        BackendEvent::WindowState {
+            state: WindowProcessStatus::Error,
+            ..
+        }
+    )));
+}
+
+#[test]
+fn app_runtime_duplicate_pty_error_after_live_hook_keeps_active_agent_for_recovery() {
+    let _env_lock = env_test_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let temp = tempdir().expect("tempdir");
+    let _home = ScopedEnvVar::set("HOME", temp.path());
+    let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+    let tab = sample_project_tab_with_window(
+        "tab-1",
+        "codex-1",
+        WindowPreset::Codex,
+        WindowProcessStatus::Running,
+    );
+    let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+    let window_id = combined_window_id("tab-1", "codex-1");
+    runtime.active_agent_sessions.insert(
+        window_id.clone(),
+        sample_active_agent_session("tab-1", &window_id),
+    );
+    let _ = runtime.handle_runtime_hook_event(runtime_hook_state_for_event(
+        "Running",
+        "PreToolUse",
+        "session-1",
+    ));
+
+    let _ = runtime.handle_runtime_status(
+        window_id.clone(),
+        WindowProcessStatus::Error,
+        Some("transient pty error".to_string()),
+    );
+    assert!(runtime.active_agent_sessions.contains_key(&window_id));
+
+    let duplicate_error_events = runtime.handle_runtime_status(
+        window_id.clone(),
+        WindowProcessStatus::Error,
+        Some("transient pty error".to_string()),
+    );
+
+    assert!(runtime.active_agent_sessions.contains_key(&window_id));
+    assert!(duplicate_error_events.iter().any(|event| matches!(
         event.event,
         BackendEvent::WindowState {
             state: WindowProcessStatus::Error,

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -2277,6 +2277,7 @@ mod tests {
             local_worktree_branches: std::cell::RefCell::new(HashMap::new()),
             window_pty_statuses: HashMap::new(),
             window_hook_states: HashMap::new(),
+            recoverable_agent_error_windows: std::collections::HashSet::new(),
             hook_forward_target: None,
             issue_link_cache_dir: gwt_core::paths::gwt_cache_dir(),
             pending_update: None,


### PR DESCRIPTION
## Summary

- Preserve agent resume recovery when duplicate PTY Error events arrive before the next hook event.
- Keep Stopped and first Error without live hook evidence authoritative so real exits still close/stop sessions.

## Changes

- `crates/gwt/src/app_runtime/runtime_events.rs`: records windows whose PTY Error was recoverable and reuses that evidence for duplicate Error events on the same window.
- `crates/gwt/src/app_runtime/mod.rs`: stores and clears recoverable Error window tracking with the existing runtime state lifecycle.
- `crates/gwt/src/app_runtime/tests.rs`: adds the duplicate PTY Error regression and keeps adjacent Error/Stopped behavior covered.
- `.gwt/work/discussions.md`: records the PR #3118 review follow-up boundary.

## Testing

- [x] `cargo fmt --check` — passed on final HEAD.
- [x] `bunx markdownlint-cli2 .gwt/work/discussions.md tasks/todo.md` — 0 errors on final HEAD.
- [x] `git diff --check` — passed on final HEAD.
- [x] `bunx commitlint --from origin/develop --to HEAD` — passed on final HEAD.
- [x] `cargo test -p gwt app_runtime_duplicate_pty_error_after_live_hook_keeps_active_agent_for_recovery --all-features` — failed before implementation and passed after the fix.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed on final HEAD.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed on final HEAD.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed on final HEAD.
- [x] User verification — confirmed on 2026-06-19.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — this is a narrow regression fix for agent resume recovery state.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- Closes #2359

## Related Issues / Links

- #3118

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `markdownlint`)
- [x] Documentation updated (tracked discussion artifact updated; no user-facing docs change)
- [x] Migration/backfill plan included (N/A: no schema/data migration)
- [x] CHANGELOG impact considered (patch fix via Conventional Commit)

## Context

- PR #3118 review identified that the first recoverable PTY Error clears hook state for display, so a duplicate PTY Error before the next hook could incorrectly drop the active Agent session.

## Risk / Impact

- **Affected areas**: Agent runtime status composition and active Agent session recovery.
- **Rollback plan**: Revert this PR to return duplicate PTY Error handling to the PR #3118 behavior.