### PR TITLE
fix(agent): clear resume recovery marker after hook

### DIFF
--- a/.gwt/work/discussions.md
+++ b/.gwt/work/discussions.md
@@ -23,6 +23,7 @@ Evidence:
 - `crates/gwt/src/window_state.rs` の `compose_window_state_with_active_session` は PTY state が `Error` の場合、Agent hook state を見ずに PTY state を返す。
 - `crates/gwt/src/app_runtime/runtime_events.rs` は PTY status `Error` / `Stopped` で active agent session tracking と runtime tracking を落とすため、その後の hook event が live session を GUI 上で復旧しにくい。
 - PR review で重複 PTY `Error` の境界も確認した。最初の recoverable `Error` で hook state を表示用に消しても、同じ window の duplicate `Error` では active session を保持し続ける必要がある。
+- PR review で marker lifetime の境界も確認した。live hook recovery 後も duplicate 用 marker が残ると、後続の本物の `Error` まで recoverable と誤判定し得るため、次の hook state 受信時点で marker を消す必要がある。
 
 Approaches:
 - Approach 1: Agent window に active session と matching live runtime hook がある場合、PTY Error より hook state を優先する。実際の process exit と stale UI state の境界を test で固定できるが、auto-close / stopped 表示の既存期待を壊さないよう Stopped は対象外にする必要がある。
@@ -30,13 +31,13 @@ Approaches:
 - Approach 3: pane websocket timeout / render blank の retry と status refresh を追加する。表示更新の堅牢性は上がるが、Error 固定の根本原因を直接直さない。
 
 Current Recommendation:
-最小の修正対象は Approach 1 を中心に、Agent resume pane の status composition と runtime tracking を SPEC #2359 の resume/restore follow-up として扱うこと。Recoverable `Error` は live hook evidence または同じ window で既に recoverable と判定済みの duplicate `Error` に限定する。Startup restore が missing worktree を skip する `crates/gwt/src/app_runtime/startup.rs` の US-79 ギャップは関連するが、今回の画像とは別症状として scope を分ける。
+最小の修正対象は Approach 1 を中心に、Agent resume pane の status composition と runtime tracking を SPEC #2359 の resume/restore follow-up として扱うこと。Recoverable `Error` は live hook evidence または同じ window で既に recoverable と判定済みの duplicate `Error` に限定し、duplicate 用 marker は次の hook state 受信で終了させる。Startup restore が missing worktree を skip する `crates/gwt/src/app_runtime/startup.rs` の US-79 ギャップは関連するが、今回の画像とは別症状として scope を分ける。
 
 Open Questions:
 - なし。
 
 Next:
-SPEC #2359 US-79B / T-651〜T-655 は完了。ユーザー視覚確認は 2026-06-19 に confirmed。PR #3118 merge 直前の review follow-up として duplicate PTY `Error` regression も追加済み。
+SPEC #2359 US-79B / T-651〜T-655 は完了。ユーザー視覚確認は 2026-06-19 に confirmed。PR #3118 / #3119 merge 直前の review follow-up として duplicate PTY `Error` regression と marker-clear regression も追加済み。
 
 ## 2026-05-23 — Workspace terminology and durable discussions
 

--- a/crates/gwt/src/app_runtime/runtime_events.rs
+++ b/crates/gwt/src/app_runtime/runtime_events.rs
@@ -195,6 +195,7 @@ impl AppRuntime {
         let Some(hook_state) = gwt::window_state::runtime_hook_window_state(&event) else {
             return events;
         };
+        self.recoverable_agent_error_windows.remove(&window_id);
         if self.window_hook_states.get(&window_id).copied() == Some(hook_state) {
             return events;
         }

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -6353,6 +6353,64 @@ fn app_runtime_duplicate_pty_error_after_live_hook_keeps_active_agent_for_recove
 }
 
 #[test]
+fn app_runtime_live_hook_recovery_clears_recoverable_pty_error_marker() {
+    let _env_lock = env_test_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let temp = tempdir().expect("tempdir");
+    let _home = ScopedEnvVar::set("HOME", temp.path());
+    let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+    let tab = sample_project_tab_with_window(
+        "tab-1",
+        "codex-1",
+        WindowPreset::Codex,
+        WindowProcessStatus::Running,
+    );
+    let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+    let window_id = combined_window_id("tab-1", "codex-1");
+    runtime.active_agent_sessions.insert(
+        window_id.clone(),
+        sample_active_agent_session("tab-1", &window_id),
+    );
+    let _ = runtime.handle_runtime_hook_event(runtime_hook_state_for_event(
+        "Running",
+        "PreToolUse",
+        "session-1",
+    ));
+    let _ = runtime.handle_runtime_status(
+        window_id.clone(),
+        WindowProcessStatus::Error,
+        Some("transient pty error".to_string()),
+    );
+    let _ = runtime.handle_runtime_status(
+        window_id.clone(),
+        WindowProcessStatus::Error,
+        Some("transient pty error".to_string()),
+    );
+    assert!(runtime.recoverable_agent_error_windows.contains(&window_id));
+
+    let _ = runtime.handle_runtime_hook_event(runtime_hook_state_for_event(
+        "Running",
+        "PreToolUse",
+        "session-1",
+    ));
+
+    assert!(
+        !runtime.recoverable_agent_error_windows.contains(&window_id),
+        "live hook recovery must end the stale PTY Error duplicate window"
+    );
+    runtime.window_hook_states.remove(&window_id);
+
+    let _ = runtime.handle_runtime_status(
+        window_id.clone(),
+        WindowProcessStatus::Error,
+        Some("process exited".to_string()),
+    );
+
+    assert!(!runtime.active_agent_sessions.contains_key(&window_id));
+}
+
+#[test]
 fn app_runtime_active_work_projection_filters_stale_saved_agents_when_no_agent_is_live() {
     let _env_lock = env_test_lock()
         .lock()


### PR DESCRIPTION
## Summary

- Clear the recoverable PTY Error marker as soon as the next runtime hook state arrives.
- Preserve duplicate PTY Error recovery while preventing stale markers from keeping later real Error exits active.

## Changes

- `crates/gwt/src/app_runtime/runtime_events.rs`: removes the duplicate-error recovery marker when a runtime hook state is received for the window.
- `crates/gwt/src/app_runtime/tests.rs`: adds a regression proving hook recovery ends the stale PTY Error duplicate window.
- `.gwt/work/discussions.md`: records the PR #3119 review follow-up boundary.

## Testing

- [x] RED: `app_runtime_live_hook_recovery_clears_recoverable_pty_error_marker` failed before the fix.
- [x] `cargo test -p gwt app_runtime_live_hook_recovery_clears_recoverable_pty_error_marker --all-features` — passed.
- [x] `cargo test -p gwt app_runtime_runtime --all-features` — passed.
- [x] `cargo test -p gwt app_runtime_duplicate_pty_error_after_live_hook_keeps_active_agent_for_recovery --all-features` — passed.
- [x] `cargo fmt --check` — passed on final HEAD.
- [x] `bunx markdownlint-cli2 .gwt/work/discussions.md tasks/todo.md` — 0 errors on final HEAD.
- [x] `git diff --check` — passed on final HEAD.
- [x] `bunx commitlint --from origin/develop --to HEAD` — passed on final HEAD.
- [x] `cargo test -p gwt-core -p gwt --all-features` — passed on final HEAD.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passed on final HEAD.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — passed on final HEAD.
- [x] User verification — confirmed on 2026-06-19.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — this only tightens the lifetime of the recoverable PTY Error marker.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- Closes #2359

## Related Issues / Links

- #3119

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, `markdownlint`)
- [x] Documentation updated (tracked discussion artifact updated; no user-facing docs change)
- [x] Migration/backfill plan included (N/A: no schema/data migration)
- [x] CHANGELOG impact considered (patch fix via Conventional Commit)

## Context

- PR #3119 review identified that the duplicate PTY Error marker could survive hook recovery and later make a separate Error recoverable without fresh evidence.

## Risk / Impact

- **Affected areas**: Agent runtime status composition and active Agent session recovery.
- **Rollback plan**: Revert this PR to restore PR #3119 marker lifetime behavior.