### PR TITLE
test(playwright): restore embedded visual suite routes

### DIFF
--- a/.gwt/work/memory.md
+++ b/.gwt/work/memory.md
@@ -7095,3 +7095,10 @@ Type: lesson
 Context: Command Rail から Board/Logs を外す作業で frontend unit を回す際、scripts/run-node-tests-with-linkedom.sh / 直接 node --preserve-symlinks --test ともに出力ゼロのまま長時間ハングした。linkedom 直接ロードの素のスクリプトは即終了するのに --test だけが固まった。
 Learning: このランタイムでは node --test がデフォルトで stdin を待ち続けてハングする。`node ... --test <files> < /dev/null` のように stdin を閉じると即実行・完了する。加えて zsh では未クォートの $VAR が単語分割されない(bash と異なる)ため、ファイルリストを node に渡すときは zsh 配列 `${(f)...}` で展開する必要がある。linkedom は bun/npm install が走るため scripts 経由は重い→ /tmp に linkedom を一度入れ crates を symlink し `--preserve-symlinks` で回すと速い。
 Future Action: このリポジトリで frontend unit (web/__tests__/*.mjs) を個別/一括実行するときは必ず `< /dev/null` を付ける。複数ファイルを変数で渡す場合は zsh 配列展開を使う。
+
+## 2026-06-20 — Playwright embedded routes must cover transitive module imports
+
+Type: failure pattern
+Context: Issue #3037: embedded Playwright specs failed before workspace_state rendered because project-shell-surface.js imported /window-list-model.js, but installEmbeddedRoutes only served a hard-coded ROOT_MODULES list and the guard test only checked direct app.js imports.
+Learning: Direct import coverage is insufficient for browser module fixtures. A missing transitive module manifests as unrelated UI timeouts (0 project tabs / windows) because app.js evaluation aborts before the WebSocket fixture can render state.
+Future Action: When adding or moving frontend modules imported by routed Playwright fixtures, ensure the embedded route helper allowlist includes transitive imports and keep the recursive playwright-embedded-routes test green before triaging downstream visual failures.

--- a/crates/gwt/playwright/tests/_helpers/embedded-frontend.ts
+++ b/crates/gwt/playwright/tests/_helpers/embedded-frontend.ts
@@ -94,6 +94,7 @@ const ROOT_MODULES = new Set([
   // Issue #2698 PR 2 (B1) — throttle update_viewport WS sends.
   "viewport-persist-throttle.js",
   "viewport-sync.js",
+  "window-list-model.js",
   "window-geometry-sync.js",
   "window-docking.js",
   "workspace-kanban-surface.js",

--- a/crates/gwt/playwright/tests/agent-window-tab-title.spec.ts
+++ b/crates/gwt/playwright/tests/agent-window-tab-title.spec.ts
@@ -94,26 +94,25 @@ test.describe("Agent window tab hover title", () => {
     const siblingTab = activeWindow.locator(
       ".window-tab[data-window-tab-id='agent-2']",
     );
-    const projectDot = page.locator(
-      ".project-tab[data-project-tab-id='tab-1'] [data-role='project-tab-dot']",
+    const projectCue = page.locator(
+      ".project-tab[data-project-tab-id='tab-1'] [data-role='project-tab-state-cue']",
     );
-    const siblingDot = siblingTab.locator(".window-tab-state");
-    await expect(siblingTab).toHaveAttribute("data-agent-state", "active");
-    await expect(projectDot).toHaveAttribute("data-state", "running");
-    await expect(siblingDot).toHaveCSS("animation-name", /window-tab-state-pulse/);
-    await expect(projectDot).toHaveCSS(
-      "animation-name",
-      /project-tab-agent-running-pulse/,
-    );
+    const siblingCue = siblingTab.locator(".window-tab-state");
+    await expect(siblingTab).toHaveAttribute("data-agent-state", "running");
+    await expect(projectCue).toHaveAttribute("data-state", "run");
+    await expect(projectCue).toHaveText("RUN");
+    await expect(siblingCue).toHaveText("RUN");
+    await expect(siblingCue).toHaveCSS("animation-name", "none");
+    await expect(projectCue).toHaveCSS("animation-name", "none");
 
     await page.evaluate(() => {
       window.__tabbedAgentsFixture?.emitTerminalStatus("agent-2", "idle");
     });
 
     await expect(siblingTab).toHaveAttribute("data-agent-state", "idle");
-    await expect(projectDot).toHaveAttribute("data-state", "");
-    await expect(siblingDot).toHaveCSS("animation-name", "none");
-    await expect(projectDot).toHaveCSS("animation-name", "none");
+    await expect(projectCue).toHaveAttribute("data-state", "");
+    await expect(siblingCue).toHaveCSS("animation-name", "none");
+    await expect(projectCue).toHaveCSS("animation-name", "none");
   });
 });
 

--- a/crates/gwt/playwright/tests/index-status.spec.ts
+++ b/crates/gwt/playwright/tests/index-status.spec.ts
@@ -1,6 +1,6 @@
 /* SPEC-1939 Phase 13+15 — project-bar Index badge withdrawn. The remaining
  * coverage exercises the dedicated Index window health panel (per-cell
- * rebuild IPC) and the separation from the project-tab Agent activity dot
+ * rebuild IPC) and the separation from the project-tab Agent activity cue
  * using the SPEC-2017 Kanban fixture pattern:
  * the embedded frontend is served via `installEmbeddedRoutes`
  * (`_helpers/embedded-frontend.ts`) and the WebSocket is stubbed with a
@@ -24,11 +24,11 @@ test.describe("Project Index status surface", () => {
     await expect(page.locator("#index-status")).toHaveCount(0);
   });
 
-  test("project_index_status does not drive the project tab Agent activity dot", async ({ page }) => {
+  test("project_index_status does not drive the project tab Agent activity cue", async ({ page }) => {
     await installEmbeddedRoutes(page);
 
-    // SPEC-2013 Phase 6 supersedes the old Index-health project-tab dot:
-    // the dot now reflects only running Agent windows. Index health remains
+    // SPEC-2013 Phase 6 supersedes the old Index-health project-tab cue:
+    // the cue now reflects only running Agent windows. Index health remains
     // visible in the dedicated Index window Health surface.
     await installIndexStatusBackend(page, {
       state: "repair_required",
@@ -51,11 +51,13 @@ test.describe("Project Index status surface", () => {
     });
 
     await page.goto(APP_URL);
-    const dot = page.locator(".project-tab .project-tab-dot");
-    await expect(dot).toHaveAttribute("data-state", "", { timeout: 10_000 });
+    const cue = page.locator(
+      ".project-tab [data-role='project-tab-state-cue']",
+    );
+    await expect(cue).toHaveAttribute("data-state", "", { timeout: 10_000 });
 
     // Project Index transitions still update the Index Health surface, but
-    // must not light the project tab activity dot.
+    // must not light the project tab activity cue.
     await page.evaluate(() => {
       window.__gwtFixtureWebSocket.emit({
         kind: "project_index_status",
@@ -82,7 +84,7 @@ test.describe("Project Index status surface", () => {
         },
       });
     });
-    await expect(dot).toHaveAttribute("data-state", "", { timeout: 5_000 });
+    await expect(cue).toHaveAttribute("data-state", "", { timeout: 5_000 });
 
     await page.evaluate(() => {
       window.__gwtFixtureWebSocket.emit({
@@ -107,7 +109,7 @@ test.describe("Project Index status surface", () => {
         },
       });
     });
-    await expect(dot).toHaveAttribute("data-state", "", { timeout: 5_000 });
+    await expect(cue).toHaveAttribute("data-state", "", { timeout: 5_000 });
   });
 
   test("Index window Health renders the scope health table from project_index_status (T-IDX-106)", async ({

--- a/crates/gwt/playwright/tests/project-tabs.spec.ts
+++ b/crates/gwt/playwright/tests/project-tabs.spec.ts
@@ -221,7 +221,7 @@ test.describe("Project tabs", () => {
     await expect(first).not.toHaveAttribute("aria-current", "page");
   });
 
-  test("project tab dot blinks only when the project has a running agent", async ({
+  test("project tab cue appears only when the project has a running agent", async ({
     page,
   }) => {
     await installEmbeddedRoutes(page);
@@ -250,18 +250,20 @@ test.describe("Project tabs", () => {
 
     await page.goto(APP_URL);
 
-    const runningDot = page.locator(
-      '[data-project-tab-id="tab-running"] [data-role="project-tab-dot"]',
+    const runningCue = page.locator(
+      '[data-project-tab-id="tab-running"] [data-role="project-tab-state-cue"]',
     );
-    const shellOnlyDot = page.locator(
-      '[data-project-tab-id="tab-no-agent"] [data-role="project-tab-dot"]',
+    const shellOnlyCue = page.locator(
+      '[data-project-tab-id="tab-no-agent"] [data-role="project-tab-state-cue"]',
     );
 
-    await expect(runningDot).toHaveAttribute("data-state", "running");
-    await expect(shellOnlyDot).toHaveAttribute("data-state", "");
-    await expect(runningDot).toHaveCSS(
+    await expect(runningCue).toHaveAttribute("data-state", "run");
+    await expect(runningCue).toHaveText("RUN");
+    await expect(runningCue).toHaveAttribute("aria-label", "1 running agent");
+    await expect(shellOnlyCue).toHaveAttribute("data-state", "");
+    await expect(runningCue).toHaveCSS(
       "animation-name",
-      "project-tab-agent-running-pulse",
+      "none",
     );
   });
 });

--- a/crates/gwt/web/__tests__/playwright-embedded-routes.test.mjs
+++ b/crates/gwt/web/__tests__/playwright-embedded-routes.test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const here = fileURLToPath(new URL(".", import.meta.url));
 const appSource = readFileSync(resolve(here, "../app.js"), "utf8");
+const webRoot = resolve(here, "..");
 const embeddedRoutesSource = readFileSync(
   resolve(here, "../../playwright/tests/_helpers/embedded-frontend.ts"),
   "utf8",
@@ -17,15 +18,32 @@ function rootModuleImports(source) {
     .sort();
 }
 
+function reachableRootModuleImports(entryModuleName) {
+  const seen = new Set();
+  const pending = [entryModuleName];
+  while (pending.length > 0) {
+    const moduleName = pending.pop();
+    if (seen.has(moduleName)) continue;
+    seen.add(moduleName);
+    const source = readFileSync(resolve(webRoot, moduleName), "utf8");
+    for (const importedModule of rootModuleImports(source)) {
+      if (!seen.has(importedModule)) {
+        pending.push(importedModule);
+      }
+    }
+  }
+  return [...seen].sort();
+}
+
 function playwrightRootModules(source) {
   const declaration = source.match(/const ROOT_MODULES = new Set\(\[([\s\S]*?)\]\);/);
   assert.ok(declaration, "Playwright embedded route helper must declare ROOT_MODULES");
   return [...declaration[1].matchAll(/"([^"]+\.js)"/g)].map((match) => match[1]);
 }
 
-test("Playwright embedded routes serve every app.js root module import", () => {
+test("Playwright embedded routes serve every app.js transitive root module import", () => {
   const modules = new Set(playwrightRootModules(embeddedRoutesSource));
-  const appImports = rootModuleImports(appSource);
+  const appImports = reachableRootModuleImports("app.js");
   const missing = appImports.filter((moduleName) => !modules.has(moduleName));
   assert.deepEqual(missing, []);
   const orphaned = [...modules].filter((moduleName) => !appImports.includes(moduleName));


### PR DESCRIPTION
## Summary

- Restore embedded Playwright routing for transitive frontend modules so visual specs boot the app before asserting workspace state.
- Align Playwright telemetry assertions with the current static project-tab and window-tab cue contract.

## Changes

- `crates/gwt/playwright/tests/_helpers/embedded-frontend.ts`: serve `window-list-model.js` through the embedded frontend helper.
- `crates/gwt/web/__tests__/playwright-embedded-routes.test.mjs`: recursively validate transitive root module imports used by embedded Playwright routes.
- `crates/gwt/playwright/tests/project-tabs.spec.ts`: update project tab cue assertions to the current `project-tab-state-cue` / `run` contract.
- `crates/gwt/playwright/tests/agent-window-tab-title.spec.ts`: update window and project cue telemetry expectations for the current contract.
- `crates/gwt/playwright/tests/index-status.spec.ts`: update the Index-status cue selector and comment.
- `.gwt/work/memory.md`: record the reusable lesson for transitive embedded frontend routes.

## Testing

- [x] `bash scripts/run-frontend-unit-tests.sh` — PASS, 884/884 tests passed.
- [x] `bash scripts/run-frontend-smoke-tests.sh` — PASS, 29/29 tests passed.
- [x] `bash scripts/run-visual-tests.sh` — PASS, 98 passed / 56 skipped.
- [x] `bash scripts/check-frontend-bundle.sh` — PASS.
- [x] `git diff --check origin/develop..HEAD` — PASS.
- [x] `bunx --bun markdownlint-cli .gwt/work/memory.md --config .markdownlint.json` — PASS.
- [x] `bunx commitlint --from origin/develop --to HEAD` — PASS.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes, this is a test-infrastructure and Playwright contract fix for Issue #3037 with no production UI behavior change.
- Known blockers: None
- Remaining acceptance: None
- User Verification Result: n/a, because the PR changes Playwright/frontend test assets and memory only; no production UI behavior changed.

## Closing Issues

- Closes #3037

## Related Issues / Links

- #3037

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (frontend bundle check, diff check, markdownlint, commitlint; Rust/Svelte checks N/A because this PR changes only Playwright/frontend test assets and memory)
- [x] Documentation updated (N/A: no user-facing docs change; `.gwt/work/memory.md` records the reusable lesson)
- [x] Migration/backfill plan included (N/A: no schema/data migration)
- [x] CHANGELOG impact considered (test-only change; no breaking change)

## Context

- Issue #3037 reported deterministic local visual test failures where the embedded app boot aborted before `workspace_state` rendering because a transitive frontend module was not served by the Playwright route helper.

## Risk / Impact

- **Affected areas**: Playwright embedded route helper and visual specs only.
- **Rollback plan**: revert this PR; no data or runtime migration is involved.
