### PR TITLE
test(playwright): cover relative embedded route imports

### DIFF
--- a/.gwt/work/memory.md
+++ b/.gwt/work/memory.md
@@ -7102,3 +7102,10 @@ Type: failure pattern
 Context: Issue #3037: embedded Playwright specs failed before workspace_state rendered because project-shell-surface.js imported /window-list-model.js, but installEmbeddedRoutes only served a hard-coded ROOT_MODULES list and the guard test only checked direct app.js imports.
 Learning: Direct import coverage is insufficient for browser module fixtures. A missing transitive module manifests as unrelated UI timeouts (0 project tabs / windows) because app.js evaluation aborts before the WebSocket fixture can render state.
 Future Action: When adding or moving frontend modules imported by routed Playwright fixtures, ensure the embedded route helper allowlist includes transitive imports and keep the recursive playwright-embedded-routes test green before triaging downstream visual failures.
+
+## 2026-06-20 — Embedded route graph tests must resolve relative web imports
+
+Type: review-learning
+Context: Codex review on PR #3130 found that playwright-embedded-routes.test.mjs only followed absolute /module.js imports, so relative chains such as project-tabs-renderer.js -> ./window-runtime-state.js -> ./protocol-enums.js could be missed by the recurrence guard.
+Learning: A frontend route-coverage test that validates browser-served modules must resolve import specifiers the same way the browser module graph does, including relative ./ and ../ imports, not just absolute root imports.
+Future Action: When adding or updating embedded frontend route guards, include a focused test for a relative import chain and normalize web module specifiers with POSIX path semantics before comparing against ROOT_MODULES.

--- a/crates/gwt/web/__tests__/playwright-embedded-routes.test.mjs
+++ b/crates/gwt/web/__tests__/playwright-embedded-routes.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { dirname as posixDirname, normalize as posixNormalize } from "node:path/posix";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 
@@ -12,10 +13,33 @@ const embeddedRoutesSource = readFileSync(
   "utf8",
 );
 
-function rootModuleImports(source) {
-  return [...source.matchAll(/from\s+["']\/([^"']+\.js)["']/g)]
-    .map((match) => match[1])
-    .sort();
+function webModuleImports(source, importerModuleName) {
+  const specifiers = [
+    ...source.matchAll(/\bfrom\s+["']([^"']+\.js)["']/g),
+    ...source.matchAll(/\bimport\s+["']([^"']+\.js)["']/g),
+  ];
+  return [
+    ...new Set(
+      specifiers
+        .map((match) => resolveWebModuleSpecifier(importerModuleName, match[1]))
+        .filter(Boolean),
+    ),
+  ].sort();
+}
+
+function resolveWebModuleSpecifier(importerModuleName, specifier) {
+  if (specifier.startsWith("/")) {
+    return specifier.slice(1);
+  }
+  if (!specifier.startsWith("./") && !specifier.startsWith("../")) {
+    return null;
+  }
+  const importerDir = posixDirname(importerModuleName);
+  const resolved = posixNormalize(importerDir === "." ? specifier : `${importerDir}/${specifier}`);
+  if (resolved === ".." || resolved.startsWith("../") || resolved.startsWith("/")) {
+    return null;
+  }
+  return resolved;
 }
 
 function reachableRootModuleImports(entryModuleName) {
@@ -26,7 +50,7 @@ function reachableRootModuleImports(entryModuleName) {
     if (seen.has(moduleName)) continue;
     seen.add(moduleName);
     const source = readFileSync(resolve(webRoot, moduleName), "utf8");
-    for (const importedModule of rootModuleImports(source)) {
+    for (const importedModule of webModuleImports(source, moduleName)) {
       if (!seen.has(importedModule)) {
         pending.push(importedModule);
       }
@@ -51,4 +75,10 @@ test("Playwright embedded routes serve every app.js transitive root module impor
     !orphaned.includes("index-status-controller.js"),
     `removed project-tab Index route must not remain in Playwright helper: ${orphaned.join(", ")}`,
   );
+});
+
+test("Playwright embedded route import graph follows relative web module imports", () => {
+  const imports = reachableRootModuleImports("project-tabs-renderer.js");
+  assert.ok(imports.includes("window-runtime-state.js"));
+  assert.ok(imports.includes("protocol-enums.js"));
 });


### PR DESCRIPTION
## Summary

- Extend the embedded Playwright route-coverage test so it follows relative frontend imports as well as absolute root imports.
- Record the review-learning that route guards must model the browser module graph, including `./` and `../` imports.

## Changes

- `crates/gwt/web/__tests__/playwright-embedded-routes.test.mjs`: resolve absolute and relative `.js` import specifiers with POSIX module paths, then recurse through the full web module graph.
- `crates/gwt/web/__tests__/playwright-embedded-routes.test.mjs`: add a focused regression assertion for `project-tabs-renderer.js -> ./window-runtime-state.js -> ./protocol-enums.js`.
- `.gwt/work/memory.md`: record the review-learning from PR #3130.

## Testing

- [x] `node --test crates/gwt/web/__tests__/playwright-embedded-routes.test.mjs` — PASS, 2/2 tests passed after RED confirmed the old absolute-only parser missed the relative chain.
- [x] `bash scripts/run-frontend-unit-tests.sh` — PASS, 885/885 tests passed.
- [x] `git diff --check origin/develop..HEAD` — PASS.
- [x] `bunx --bun markdownlint-cli .gwt/work/memory.md --config .markdownlint.json` — PASS.
- [x] `bunx commitlint --from origin/develop --to HEAD` — PASS.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes, this is a focused test-guard follow-up for review feedback on PR #3130 with no production UI behavior change.
- Known blockers: None
- Remaining acceptance: None
- User Verification Result: n/a, because the PR changes only a frontend Node test and memory entry.

## Closing Issues

- None

## Related Issues / Links

- #3037
- #3130

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (diff check, markdownlint, commitlint; Rust/Svelte checks N/A because this PR changes only a frontend Node test and memory)
- [x] Documentation updated (N/A: no user-facing docs change; `.gwt/work/memory.md` records the reusable lesson)
- [x] Migration/backfill plan included (N/A: no schema/data migration)
- [x] CHANGELOG impact considered (test-only change; no breaking change)

## Context

- Codex review on PR #3130 correctly identified that the first route guard only recursed through absolute `/module.js` imports and could miss a relative-only dependency chain.

## Risk / Impact

- **Affected areas**: frontend Node test coverage for Playwright embedded route guards only.
- **Rollback plan**: revert this PR; no data or runtime migration is involved.
