### PR TITLE
docs(gwt-fix-issue): 調査/検証/完了の規律を SPEC-1935 規定に整合 (IMPLEMENTATION-GAP)

### DIFF
--- a/.claude/skills/gwt-fix-issue/SKILL.md
+++ b/.claude/skills/gwt-fix-issue/SKILL.md
@@ -23,26 +23,83 @@ command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
 
 Do not use this for new work intake. Use `gwt-register-issue` instead.
 
+## Domain model: an Issue is a bug against an existing owner
+
+A GitHub Issue handled here is a bug — a deviation from behavior that some owner
+already defines. Treat the owner SPEC as already existing: identify it, prove
+the deviation (root cause), and restore conformance. Do **not** create a new
+SPEC by default. A SPEC is a specification, authored only when one is genuinely
+missing (a `SPEC-GAP`), and that authoring happens through `gwt-discussion`,
+never as a reflex from this skill.
+
 ## Ownership
 
 - Gather the issue facts and related code context
-- Decide direct-fix vs SPEC-needed
+- Identify the owner SPEC the bug deviates from, and prove the root cause
+- Decide direct-fix vs spec-needed with a structured `Spec Status`
 - Carry direct-fix work through implementation and verification
 - Hand off to the visible SPEC flow only when broader design work is required
 
 ## Workflow
 
-1. Verify that JSON operations `issue.view` and `issue.comments` can access the target issue.
-2. Gather facts with JSON operations `issue.view`, `issue.comments`, `issue.linked_prs`, and `python3 ".claude/skills/gwt-fix-issue/scripts/inspect_issue.py" --repo "." --issue "<number or URL>"`.
-3. Decide direct-fix vs spec-needed. Prefer direct fix for clear corrective work; prefer `gwt-discussion` when behavior design or broader scope definition is required.
-4. If the change is a clear direct fix, implement it. Verification is mandatory and must run in the correct environment via `gwt-verify --mode full`:
-   - When routing through `gwt-build-spec`, its Phase 3 already runs `gwt-verify --mode full`.
-   - When fixing inline without `gwt-build-spec`, run `gwt-verify --mode full` yourself and require `Overall: PASS` before posting the closure comment or handing off. Do not skip verification because the fix looks small; `gwt-verify` self-selects the matrix (cargo / frontend / Playwright / docs) for the changed surfaces.
-5. Post progress and closure comments through JSON operation `issue.comment`. On direct-fix completion the closure comment is mandatory and must follow `.claude/skills/gwt-fix-issue/references/closure-comment.md` (root cause, changed files, commit/PR link, `gwt-verify` result, remaining work). When the work is handed off to the SPEC flow instead of completed, `gwt-build-spec` owns closure; post a short handoff comment only.
-6. Return the result in the current user's language.
+1. **Verify access.** Confirm JSON operations `issue.view` and `issue.comments`
+   can reach the target issue.
+2. **Investigate before deciding (mandatory gate).** Gather facts with JSON
+   operations `issue.view`, `issue.comments`, `issue.linked_prs`, and
+   `python3 ".claude/skills/gwt-fix-issue/scripts/inspect_issue.py" --repo "." --issue "<number or URL>"`.
+   - For BUG / regression issues, produce the structured report in
+     `.claude/skills/gwt-fix-issue/references/analysis-report.md` with a
+     **verified root cause** and Evidence-backed ACTIONABLE items. If the root
+     cause is unproven, do not implement — establish reproduction and root
+     cause first (route to `gwt-discussion` when investigation needs user
+     input). Do not guess-fix.
+   - For FEATURE / ENHANCEMENT issues, extract requirements and acceptance
+     criteria; the full report is optional.
+3. **Route with a structured `Spec Status`.** Classify the issue against its
+   owner SPEC before touching code:
+   - `ALIGNED` / `IMPLEMENTATION-GAP` → direct fix. The owner already defines
+     the intended behavior; implementation is missing, broken, or incomplete.
+   - `SPEC-GAP` / `SPEC-AMBIGUOUS` → stop direct work and route to
+     `gwt-discussion` to settle the owner SPEC first. The existing Issue stays
+     the owner; do not auto-create a SPEC. Prefer `gwt-discussion` whenever
+     behavior design or broader scope definition is required.
+4. **Implement through the build/verify loop.** Prefer delegating execution to
+   `gwt-build-spec` (Standalone mode) so TDD (Red-Green-Refactor) and
+   `gwt-verify` run as designed; its `When to skip tests` rule already exempts
+   docs / chore / typo. Verification is mandatory and runs in the correct
+   environment:
+   - Via `gwt-build-spec`, Phase 3 runs `gwt-verify --mode full` and requires
+     `Overall: PASS`.
+   - If you fix inline without `gwt-build-spec`, you must still write the
+     failing regression test first (TDD) and run `gwt-verify --mode full`
+     yourself to `Overall: PASS` before closing. Do not skip TDD or
+     verification because the fix looks small; `gwt-verify` self-selects the
+     matrix (cargo / frontend / Playwright / docs) for the changed surfaces.
+5. **Gate the PR.** PR work goes through `gwt-manage-pr`, which requires
+   `gwt-verify --mode pre-pr` and a recorded `User Verification Result`. Do not
+   create or update a Ready PR until that result is `confirmed` (UI-affecting
+   changes) or `n/a` (no user-visible surface). Never open a Ready PR on a
+   `pending` verification.
+6. **Close with a durable record.** On direct-fix completion, post the mandatory
+   closure comment through JSON operation `issue.comment` following
+   `.claude/skills/gwt-fix-issue/references/closure-comment.md` (root cause,
+   changed files, commit/PR link, `gwt-verify` result, completion checklist,
+   remaining work), after `gwt-verify` returns `Overall: PASS`. When the work is
+   handed off to the SPEC flow instead of completed, `gwt-build-spec` owns
+   closure; post a short handoff comment only.
+7. Return the result in the current user's language.
+
+## No Stop-block (short-lived skill)
+
+Per SPEC-1935 FR-014s, `gwt-fix-issue` is intentionally a short-lived skill with
+no managed Stop-check hook. This prose is the only lever — there is no runtime
+gate forcing continuation — so the investigation, verification, and completion
+discipline above is self-enforced. Do not add a Stop-check handler for this
+skill.
 
 ## Guardrails
 
 - Agent-facing Issue workflow must use gwtd JSON operations `issue.*` as the canonical surface.
 - Direct `gh issue ...` commands are not part of the normal path.
 - Do not treat the issue body as the source of truth for SPEC artifacts once a SPEC owner exists.
+- Do not create both a plain Issue and a SPEC for the same work; keep the existing Issue as the owner.

--- a/.claude/skills/gwt-fix-issue/references/analysis-report.md
+++ b/.claude/skills/gwt-fix-issue/references/analysis-report.md
@@ -1,5 +1,10 @@
 # Issue Analysis Report Template
 
+For BUG / regression issues this report is the mandatory investigation gate in
+`gwt-fix-issue`: the root cause must be **verified** here before any
+implementation. An unproven root cause means the fix is not ready — investigate
+further (or route to `gwt-discussion`) instead of guess-fixing.
+
 ## Full Report Structure
 
 Output must use this structure for non-SPEC issues before execution:

--- a/.claude/skills/gwt-fix-issue/references/closure-comment.md
+++ b/.claude/skills/gwt-fix-issue/references/closure-comment.md
@@ -15,7 +15,7 @@ long after the conversation is gone.
 
 ## Required fields
 
-Every closure comment must fill all five fields. Do not omit a field; if a field
+Every closure comment must fill all six fields. Do not omit a field; if a field
 is genuinely empty, state that explicitly (e.g. `Remaining Work: none`).
 
 ### Root Cause
@@ -39,6 +39,14 @@ The exact `gwt-verify --mode full` outcome (`Overall: PASS`) plus the runners it
 selected for the changed surfaces (cargo / frontend / Playwright / docs). Name
 any test or command run beyond the matrix.
 
+### Completion Checklist
+
+The pre-completion self-check, mirroring the project's done criteria. Mark each
+item explicitly; if one does not apply, say so. Cover at least: all relevant
+tests pass, lint / type checks pass, no leftover TODO or unfinished work, the
+owner SPEC / Issue is updated when applicable, and the change is committed and
+pushed.
+
 ### Remaining Work
 
 Any follow-up that is intentionally out of scope, or `none`. Remaining items
@@ -60,6 +68,13 @@ must not be delivery blockers for this fix.
 - Runners: <cargo | frontend | Playwright | docs>
 - Additional: <any extra command/test, or none>
 
+**Completion Checklist:**
+- [ ] All relevant tests pass
+- [ ] Lint / type checks pass
+- [ ] No leftover TODO or unfinished work
+- [ ] Owner SPEC / Issue updated if applicable
+- [ ] Committed and pushed
+
 **Remaining Work:** <follow-up items, or none>
 ```
 
@@ -78,7 +93,7 @@ Direct `gh issue comment ...` is not part of the normal path.
 
 ## Anti-patterns
 
-- Omitting any of the five required fields.
+- Omitting any of the six required fields.
 - Speculative root cause ("this might be caused by ...") instead of a verified
   statement.
 - Claiming completion without the `gwt-verify --mode full` `Overall: PASS`

--- a/.codex/skills/gwt-fix-issue/SKILL.md
+++ b/.codex/skills/gwt-fix-issue/SKILL.md
@@ -23,26 +23,83 @@ command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
 
 Do not use this for new work intake. Use `gwt-register-issue` instead.
 
+## Domain model: an Issue is a bug against an existing owner
+
+A GitHub Issue handled here is a bug — a deviation from behavior that some owner
+already defines. Treat the owner SPEC as already existing: identify it, prove
+the deviation (root cause), and restore conformance. Do **not** create a new
+SPEC by default. A SPEC is a specification, authored only when one is genuinely
+missing (a `SPEC-GAP`), and that authoring happens through `gwt-discussion`,
+never as a reflex from this skill.
+
 ## Ownership
 
 - Gather the issue facts and related code context
-- Decide direct-fix vs SPEC-needed
+- Identify the owner SPEC the bug deviates from, and prove the root cause
+- Decide direct-fix vs spec-needed with a structured `Spec Status`
 - Carry direct-fix work through implementation and verification
 - Hand off to the visible SPEC flow only when broader design work is required
 
 ## Workflow
 
-1. Verify that JSON operations `issue.view` and `issue.comments` can access the target issue.
-2. Gather facts with JSON operations `issue.view`, `issue.comments`, `issue.linked_prs`, and `python3 ".codex/skills/gwt-fix-issue/scripts/inspect_issue.py" --repo "." --issue "<number or URL>"`.
-3. Decide direct-fix vs spec-needed. Prefer direct fix for clear corrective work; prefer `gwt-discussion` when behavior design or broader scope definition is required.
-4. If the change is a clear direct fix, implement it. Verification is mandatory and must run in the correct environment via `gwt-verify --mode full`:
-   - When routing through `gwt-build-spec`, its Phase 3 already runs `gwt-verify --mode full`.
-   - When fixing inline without `gwt-build-spec`, run `gwt-verify --mode full` yourself and require `Overall: PASS` before posting the closure comment or handing off. Do not skip verification because the fix looks small; `gwt-verify` self-selects the matrix (cargo / frontend / Playwright / docs) for the changed surfaces.
-5. Post progress and closure comments through JSON operation `issue.comment`. On direct-fix completion the closure comment is mandatory and must follow `.codex/skills/gwt-fix-issue/references/closure-comment.md` (root cause, changed files, commit/PR link, `gwt-verify` result, remaining work). When the work is handed off to the SPEC flow instead of completed, `gwt-build-spec` owns closure; post a short handoff comment only.
-6. Return the result in the current user's language.
+1. **Verify access.** Confirm JSON operations `issue.view` and `issue.comments`
+   can reach the target issue.
+2. **Investigate before deciding (mandatory gate).** Gather facts with JSON
+   operations `issue.view`, `issue.comments`, `issue.linked_prs`, and
+   `python3 ".codex/skills/gwt-fix-issue/scripts/inspect_issue.py" --repo "." --issue "<number or URL>"`.
+   - For BUG / regression issues, produce the structured report in
+     `.codex/skills/gwt-fix-issue/references/analysis-report.md` with a
+     **verified root cause** and Evidence-backed ACTIONABLE items. If the root
+     cause is unproven, do not implement — establish reproduction and root
+     cause first (route to `gwt-discussion` when investigation needs user
+     input). Do not guess-fix.
+   - For FEATURE / ENHANCEMENT issues, extract requirements and acceptance
+     criteria; the full report is optional.
+3. **Route with a structured `Spec Status`.** Classify the issue against its
+   owner SPEC before touching code:
+   - `ALIGNED` / `IMPLEMENTATION-GAP` → direct fix. The owner already defines
+     the intended behavior; implementation is missing, broken, or incomplete.
+   - `SPEC-GAP` / `SPEC-AMBIGUOUS` → stop direct work and route to
+     `gwt-discussion` to settle the owner SPEC first. The existing Issue stays
+     the owner; do not auto-create a SPEC. Prefer `gwt-discussion` whenever
+     behavior design or broader scope definition is required.
+4. **Implement through the build/verify loop.** Prefer delegating execution to
+   `gwt-build-spec` (Standalone mode) so TDD (Red-Green-Refactor) and
+   `gwt-verify` run as designed; its `When to skip tests` rule already exempts
+   docs / chore / typo. Verification is mandatory and runs in the correct
+   environment:
+   - Via `gwt-build-spec`, Phase 3 runs `gwt-verify --mode full` and requires
+     `Overall: PASS`.
+   - If you fix inline without `gwt-build-spec`, you must still write the
+     failing regression test first (TDD) and run `gwt-verify --mode full`
+     yourself to `Overall: PASS` before closing. Do not skip TDD or
+     verification because the fix looks small; `gwt-verify` self-selects the
+     matrix (cargo / frontend / Playwright / docs) for the changed surfaces.
+5. **Gate the PR.** PR work goes through `gwt-manage-pr`, which requires
+   `gwt-verify --mode pre-pr` and a recorded `User Verification Result`. Do not
+   create or update a Ready PR until that result is `confirmed` (UI-affecting
+   changes) or `n/a` (no user-visible surface). Never open a Ready PR on a
+   `pending` verification.
+6. **Close with a durable record.** On direct-fix completion, post the mandatory
+   closure comment through JSON operation `issue.comment` following
+   `.codex/skills/gwt-fix-issue/references/closure-comment.md` (root cause,
+   changed files, commit/PR link, `gwt-verify` result, completion checklist,
+   remaining work), after `gwt-verify` returns `Overall: PASS`. When the work is
+   handed off to the SPEC flow instead of completed, `gwt-build-spec` owns
+   closure; post a short handoff comment only.
+7. Return the result in the current user's language.
+
+## No Stop-block (short-lived skill)
+
+Per SPEC-1935 FR-014s, `gwt-fix-issue` is intentionally a short-lived skill with
+no managed Stop-check hook. This prose is the only lever — there is no runtime
+gate forcing continuation — so the investigation, verification, and completion
+discipline above is self-enforced. Do not add a Stop-check handler for this
+skill.
 
 ## Guardrails
 
 - Agent-facing Issue workflow must use gwtd JSON operations `issue.*` as the canonical surface.
 - Direct `gh issue ...` commands are not part of the normal path.
 - Do not treat the issue body as the source of truth for SPEC artifacts once a SPEC owner exists.
+- Do not create both a plain Issue and a SPEC for the same work; keep the existing Issue as the owner.

--- a/.codex/skills/gwt-fix-issue/references/analysis-report.md
+++ b/.codex/skills/gwt-fix-issue/references/analysis-report.md
@@ -1,5 +1,10 @@
 # Issue Analysis Report Template
 
+For BUG / regression issues this report is the mandatory investigation gate in
+`gwt-fix-issue`: the root cause must be **verified** here before any
+implementation. An unproven root cause means the fix is not ready — investigate
+further (or route to `gwt-discussion`) instead of guess-fixing.
+
 ## Full Report Structure
 
 Output must use this structure for non-SPEC issues before execution:

--- a/.codex/skills/gwt-fix-issue/references/closure-comment.md
+++ b/.codex/skills/gwt-fix-issue/references/closure-comment.md
@@ -15,7 +15,7 @@ long after the conversation is gone.
 
 ## Required fields
 
-Every closure comment must fill all five fields. Do not omit a field; if a field
+Every closure comment must fill all six fields. Do not omit a field; if a field
 is genuinely empty, state that explicitly (e.g. `Remaining Work: none`).
 
 ### Root Cause
@@ -39,6 +39,14 @@ The exact `gwt-verify --mode full` outcome (`Overall: PASS`) plus the runners it
 selected for the changed surfaces (cargo / frontend / Playwright / docs). Name
 any test or command run beyond the matrix.
 
+### Completion Checklist
+
+The pre-completion self-check, mirroring the project's done criteria. Mark each
+item explicitly; if one does not apply, say so. Cover at least: all relevant
+tests pass, lint / type checks pass, no leftover TODO or unfinished work, the
+owner SPEC / Issue is updated when applicable, and the change is committed and
+pushed.
+
 ### Remaining Work
 
 Any follow-up that is intentionally out of scope, or `none`. Remaining items
@@ -60,6 +68,13 @@ must not be delivery blockers for this fix.
 - Runners: <cargo | frontend | Playwright | docs>
 - Additional: <any extra command/test, or none>
 
+**Completion Checklist:**
+- [ ] All relevant tests pass
+- [ ] Lint / type checks pass
+- [ ] No leftover TODO or unfinished work
+- [ ] Owner SPEC / Issue updated if applicable
+- [ ] Committed and pushed
+
 **Remaining Work:** <follow-up items, or none>
 ```
 
@@ -78,7 +93,7 @@ Direct `gh issue comment ...` is not part of the normal path.
 
 ## Anti-patterns
 
-- Omitting any of the five required fields.
+- Omitting any of the six required fields.
 - Speculative root cause ("this might be caused by ...") instead of a verified
   statement.
 - Claiming completion without the `gwt-verify --mode full` `Overall: PASS`


### PR DESCRIPTION
## 概要

`gwt-fix-issue` skill の prose が Owner SPEC #1935 の規定（FR-022 / FR-014s / T-191）からドリフトしていた **IMPLEMENTATION-GAP** を修正し、解決のための「調査」「実行チェック(TDD)」「完了チェック」「gwt-verify/PR gate」の規律を SKILL.md prose に明文化する。

ドメインモデル: Issue = バグ = 既存 Owner 仕様（SPEC）への逸脱。バグには必ず owner SPEC が既にあるため、`gwt-fix-issue` は owner を特定し root cause を直す。新規 SPEC は既定で作らない。これは #1935（CLOSED/done）に対するバグ修正であり、新規 SPEC 化しない。

Closes #3133 / Refs #1935, #2972

## 変更内容（5 gap → 解消）

- **G1 調査ゲート**: BUG/regression は `inspect_issue.py` + `references/analysis-report.md` で **root cause 証明を必須化**。未証明なら実装に進ませない。死蔵していた `analysis-report.md`（grep 参照 0 だった）を本文から wire-in。
- **G5 routing**: `Spec Status`（ALIGNED / IMPLEMENTATION-GAP / SPEC-GAP / SPEC-AMBIGUOUS）相当の構造化判定を明文化。曖昧なら `gwt-discussion` 先行、SPEC は既定で作らない。
- **G2 実行/TDD**: `gwt-build-spec` 委譲で TDD + `gwt-verify --mode full` を継承。inline 修正時も失敗テスト先行と `gwt-verify` を必須化。
- **G4 gwt-verify / PR gate**: 実行は build-spec Phase 3（`--mode full`）→ Phase 4（`gwt-manage-pr` → `--mode pre-pr` + **User Verification confirmed/n/a の PR gate**）を通る旨を明記。
- **G3 完了チェック**: `closure-comment.md` に完了セルフチェックリスト（全テスト/lint/型/TODO無/commit&push）を追加。

**FR-014s 準拠**: `gwt-fix-issue` は意図的に Stop-check を持たない short-lived skill のため、強制 hook は追加せず prose のみを lever とする。`.claude` / `.codex` は byte 同期（path 文字列のみ差分）。build-spec / gwt-verify 本体は無変更。

## 検証（gwt-verify 相当: skill-asset surface）

- `markdownlint`（変更 4 ファイル）: **0 errors**
- `cargo test -p gwt-skills`: **195 + 6 passed, 0 failed**（asset / distribution / parity / idempotency 含む）
- `.claude` / `.codex` parity: references 完全一致・SKILL.md は path 行 3 箇所のみ差分・stray path 混入 0
- commitlint: exit 0

## User Verification

`n/a` — pure skill-guidance markdown 変更で UI / visual surface への影響なし（gwt-verify surface taxonomy では skill-asset = docs-only 相当）。視覚検証対象なし。

## Ready PR Gate

単独配信可能（skill ガイダンス改善のみ、既存挙動を壊さず、UI 中途半端表示なし）。残課題なし。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured issue-fix workflow with explicit investigation gates and clearer routing logic.
  * Added mandatory verification requirements before closure; root causes must be proven.
  * Updated closure-comment template with six required fields and a completion checklist.
  * Enhanced guidance distinguishing between direct fixes and spec-gap issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->