### PR TITLE
docs(gwt-fix-issue): SPEC-gap バグの routing を関連付け/新規作成の分岐で明確化

### DIFF
--- a/.claude/skills/gwt-fix-issue/SKILL.md
+++ b/.claude/skills/gwt-fix-issue/SKILL.md
@@ -23,14 +23,16 @@ command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
 
 Do not use this for new work intake. Use `gwt-register-issue` instead.
 
-## Domain model: an Issue is a bug against an existing owner
+## Domain model: an Issue is a bug against a specification
 
-A GitHub Issue handled here is a bug — a deviation from behavior that some owner
-already defines. Treat the owner SPEC as already existing: identify it, prove
-the deviation (root cause), and restore conformance. Do **not** create a new
-SPEC by default. A SPEC is a specification, authored only when one is genuinely
-missing (a `SPEC-GAP`), and that authoring happens through `gwt-discussion`,
-never as a reflex from this skill.
+A GitHub Issue handled here is a bug — a deviation from intended behavior. Most
+bugs deviate from an owner SPEC that already exists: identify it, prove the
+deviation (root cause), and restore conformance. Some bugs fall in a gap that no
+SPEC covers; resolving those means settling ownership first — either associating
+the behavior with an existing SPEC whose bounded context it belongs to (extend
+that SPEC), or authoring a new SPEC when it is a genuinely new context with no
+fitting owner. Creating a new SPEC is the last resort, decided through
+`gwt-discussion`, never a reflex from this skill.
 
 ## Ownership
 
@@ -57,14 +59,19 @@ never as a reflex from this skill.
      investigation needs user input). Do not guess-fix.
    - For FEATURE / ENHANCEMENT issues, extract requirements and acceptance
      criteria; the full report is optional.
-3. **Route with a structured `Spec Status`.** Classify the issue against its
-   owner SPEC before touching code:
-   - `ALIGNED` / `IMPLEMENTATION-GAP` → direct fix. The owner already defines
-     the intended behavior; implementation is missing, broken, or incomplete.
-   - `SPEC-GAP` / `SPEC-AMBIGUOUS` → stop direct work and route to
-     `gwt-discussion` to settle the owner SPEC first. The existing Issue stays
-     the owner; do not auto-create a SPEC. Prefer `gwt-discussion` whenever
-     behavior design or broader scope definition is required.
+3. **Route with a structured `Spec Status`.** Classify the issue against the
+   SPEC space before touching code:
+   - `ALIGNED` / `IMPLEMENTATION-GAP` → direct fix. An owner SPEC already
+     defines the intended behavior; implementation is missing, broken, or
+     incomplete.
+   - `SPEC-GAP` (no SPEC covers the behavior) → stop direct work and route to
+     `gwt-discussion` to settle ownership first. There, decide by domain fit:
+     associate the behavior with an existing SPEC whose bounded context it
+     belongs to (extend that SPEC's requirements / acceptance), or author a new
+     SPEC only when it is a genuinely new context with no fitting owner. Do not
+     create a SPEC as a reflex; the Issue stays the work item either way.
+   - `SPEC-AMBIGUOUS` (existing SPECs overlap or conflict) → route to
+     `gwt-discussion` to resolve which owner applies before fixing.
 4. **Implement through the build/verify loop.** Prefer delegating execution to
    `gwt-build-spec` (Standalone mode) so TDD (Red-Green-Refactor) and
    `gwt-verify` run as designed; its `When to skip tests` rule already exempts

--- a/.codex/skills/gwt-fix-issue/SKILL.md
+++ b/.codex/skills/gwt-fix-issue/SKILL.md
@@ -23,14 +23,16 @@ command as `"$GWT_BIN" ...`; if none exists, stop with an actionable
 
 Do not use this for new work intake. Use `gwt-register-issue` instead.
 
-## Domain model: an Issue is a bug against an existing owner
+## Domain model: an Issue is a bug against a specification
 
-A GitHub Issue handled here is a bug — a deviation from behavior that some owner
-already defines. Treat the owner SPEC as already existing: identify it, prove
-the deviation (root cause), and restore conformance. Do **not** create a new
-SPEC by default. A SPEC is a specification, authored only when one is genuinely
-missing (a `SPEC-GAP`), and that authoring happens through `gwt-discussion`,
-never as a reflex from this skill.
+A GitHub Issue handled here is a bug — a deviation from intended behavior. Most
+bugs deviate from an owner SPEC that already exists: identify it, prove the
+deviation (root cause), and restore conformance. Some bugs fall in a gap that no
+SPEC covers; resolving those means settling ownership first — either associating
+the behavior with an existing SPEC whose bounded context it belongs to (extend
+that SPEC), or authoring a new SPEC when it is a genuinely new context with no
+fitting owner. Creating a new SPEC is the last resort, decided through
+`gwt-discussion`, never a reflex from this skill.
 
 ## Ownership
 
@@ -57,14 +59,19 @@ never as a reflex from this skill.
      investigation needs user input). Do not guess-fix.
    - For FEATURE / ENHANCEMENT issues, extract requirements and acceptance
      criteria; the full report is optional.
-3. **Route with a structured `Spec Status`.** Classify the issue against its
-   owner SPEC before touching code:
-   - `ALIGNED` / `IMPLEMENTATION-GAP` → direct fix. The owner already defines
-     the intended behavior; implementation is missing, broken, or incomplete.
-   - `SPEC-GAP` / `SPEC-AMBIGUOUS` → stop direct work and route to
-     `gwt-discussion` to settle the owner SPEC first. The existing Issue stays
-     the owner; do not auto-create a SPEC. Prefer `gwt-discussion` whenever
-     behavior design or broader scope definition is required.
+3. **Route with a structured `Spec Status`.** Classify the issue against the
+   SPEC space before touching code:
+   - `ALIGNED` / `IMPLEMENTATION-GAP` → direct fix. An owner SPEC already
+     defines the intended behavior; implementation is missing, broken, or
+     incomplete.
+   - `SPEC-GAP` (no SPEC covers the behavior) → stop direct work and route to
+     `gwt-discussion` to settle ownership first. There, decide by domain fit:
+     associate the behavior with an existing SPEC whose bounded context it
+     belongs to (extend that SPEC's requirements / acceptance), or author a new
+     SPEC only when it is a genuinely new context with no fitting owner. Do not
+     create a SPEC as a reflex; the Issue stays the work item either way.
+   - `SPEC-AMBIGUOUS` (existing SPECs overlap or conflict) → route to
+     `gwt-discussion` to resolve which owner applies before fixing.
 4. **Implement through the build/verify loop.** Prefer delegating execution to
    `gwt-build-spec` (Standalone mode) so TDD (Red-Green-Refactor) and
    `gwt-verify` run as designed; its `When to skip tests` rule already exempts


### PR DESCRIPTION
## 概要

PR #3134（#3133 本体）に続く小さな follow-up。`gwt-fix-issue` の routing(G5) で **`SPEC-GAP`（どの SPEC にも帰属しないバグ＝仕様の隙間）の解決経路**が「`gwt-discussion` へ送る」までしか書かれておらず、その先の分岐——**既存 SPEC への関連付け（スコープ拡張）か、新規 SPEC 作成か**——が不明確だった点を補う。

Refs #3133, #1935

## 背景（ユーザー指摘）

「どの SPEC にも帰属しないバグもある。それは SPEC の隙間。その場合は SPEC を作成するのか、他の SPEC に関連付けするのかが必要」。

→ バグと SPEC の帰属は 3 分類:
1. `ALIGNED` / `IMPLEMENTATION-GAP`: owner SPEC が既にあり挙動を規定 → 直す
2. `SPEC-GAP`: どの SPEC も覆っていない隙間 → **ドメイン適合で判断**: 既存 SPEC の bounded context に収まるなら**関連付け（拡張）**、新ドメインなら**新規作成**（最終手段）
3. `SPEC-AMBIGUOUS`: 既存 SPEC が重複/衝突 → どの owner かを先に解決

## 変更内容

- **Domain model**: 「全バグが既存 owner を持つ」前提を改め、SPEC の隙間に落ちるバグの存在と、ドメイン適合に基づく「既存 SPEC へ関連付け or 新規作成（最終手段）」を明記。
- **routing step 3**: `SPEC-GAP` を bounded context 適合で判断（既存 SPEC 拡張 / 新規作成）し、`SPEC-AMBIGUOUS` を独立分岐に分離。反射的な SPEC 作成を禁止し、Issue を work item に保つ。

`.claude` / `.codex` は byte-identical。

## 検証

- `.claude`/`.codex` byte-identical parity ✓
- `markdownlint`（2 files）: 0 errors
- `cargo test -p gwt-skills --test managed_assets_contract_test`: 7 passed, 0 failed（`repo_keeps_managed_claude_and_codex_skill_assets_in_parity` 含む）
- commitlint: exit 0

## User Verification

`n/a` — skill-guidance markdown のみで UI / visual surface 影響なし。

## Ready PR Gate

単独配信可能（#3134 とは独立した routing 文言の追補、既存挙動を壊さない）。残課題なし。
