### PR TITLE
docs(gwt-verify): E2E 選定を acceptance-aware にして全環境の検証取りこぼしを解消

### DIFF
--- a/.claude/skills/gwt-verify/SKILL.md
+++ b/.claude/skills/gwt-verify/SKILL.md
@@ -27,7 +27,7 @@ Playwright recipe. Instead it executes the following four-part contract:
    `references/surface-taxonomy.md`.
 2. **Appropriate Test Selection** — detect the project's actual test runners
    from its manifests (Cargo.toml, package.json, pyproject.toml, go.mod,
-   ProjectSettings/ProjectVersion.txt, *.sln / *.csproj, Gemfile, pom.xml,
+   ProjectSettings/ProjectVersion.txt, `*.sln` / `*.csproj`, Gemfile, pom.xml,
    build.gradle, Makefile) and choose the right unit / integration / E2E /
    visual commands for each changed surface. See
    `references/runner-detection.md`.
@@ -50,8 +50,8 @@ the generic matrix in this skill. The matrix here is the fallback frame.
 | Mode | When to use | Scope |
 |---|---|---|
 | `--mode quick` (default) | TDD loop, narrow check during implementation | Only surfaces touched by uncommitted / working-tree changes; the narrowest representative command per runner (e.g. single-package test invocation). Skip heavy integration / E2E / visual unless the diff explicitly touches them. |
-| `--mode full` | gwt-build-spec Phase 3, standalone completion gate | Full matched matrix per changed surface, including integration / E2E / visual when a UI surface changed. User Verification Handoff is required (see below). |
-| `--mode pre-pr` | gwt-manage-pr before PR create / update | `full` matrix + release-flow tests when a release surface changed; visual / UI regression always included if any UI surface changed. User Verification Handoff is required. |
+| `--mode full` | gwt-build-spec Phase 3, standalone completion gate | Full matched matrix per changed surface, including integration / E2E / visual when a UI surface is in scope — by the diff, or by acceptance-aware escalation (`references/surface-taxonomy.md`). User Verification Handoff is required (see below). |
+| `--mode pre-pr` | gwt-manage-pr before PR create / update | `full` matrix + release-flow tests when a release surface changed; visual / UI regression always included if any UI surface is in scope by diff or by acceptance-aware escalation. User Verification Handoff is required. |
 | `--headed` (flag) | Manual UI / design verification | When supplied alongside any mode that runs a browser-based test runner (Playwright / Cypress / Selenium / WinAppDriver / Unity Editor headed), launch the runner in headed mode so the user can watch. Default is headless to match CI. |
 
 Additional flag:
@@ -104,10 +104,15 @@ gwt-verify
      finalize Overall once the user response is recorded.
 ```
 
-The skill does not invoke Playwright when no WebView / browser UI surface
-changed. This is a hard contract from SPEC-1935 FR-124. The same restraint
-applies to other UI runners (Cypress / Selenium / WinAppDriver / Unity Editor
-headed): they are only invoked when a UI surface is in scope.
+The skill does not invoke Playwright — or any other UI runner (Cypress /
+Selenium / WinAppDriver / Unity Editor headed) — when no user-facing surface
+is in scope. A UI surface is in scope either by the diff touching WebView /
+browser UI files, or by `references/surface-taxonomy.md`'s acceptance-aware
+escalation promoting a backend-only diff whose acceptance manifests in a
+user-facing surface. A change with no user-facing surface in scope by diff or
+acceptance does not invoke Playwright. This restraint is part of the
+gwt-verify verification contract that prevents over-eager UI-runner
+invocation; it is not an external SPEC requirement.
 
 ## Evidence Bundle
 
@@ -119,6 +124,7 @@ Output to stdout in the following shape (Markdown):
 Mode: <quick|full|pre-pr>
 Baseline: merge-base HEAD..origin/develop (<N> commits, <M> files)
 Changed surfaces: <abstract surface list>
+Acceptance Surface: <user-facing surface the change is escalated to, or `non-user-facing(<justification>)`>
 
 ### Plan
 Detected runners: <e.g. Cargo, pnpm, Playwright | Unity Test Framework | dotnet test | pytest | go test>
@@ -243,8 +249,8 @@ Stop and surface a blocker to the caller when:
   snapshots.
 - The agent attempts to invoke Playwright (or any other browser UI runner)
   for a surface not classified as a UI surface under
-  `references/surface-taxonomy.md`. This is a contract violation, not a
-  runtime error.
+  `references/surface-taxonomy.md` (including its acceptance-aware
+  escalation). This is a contract violation, not a runtime error.
 - The User Verification phase is required but no platform question tool
   and no plain-text channel are available to ask the user.
 

--- a/.claude/skills/gwt-verify/references/runner-detection.md
+++ b/.claude/skills/gwt-verify/references/runner-detection.md
@@ -44,9 +44,17 @@ approach explicitly.
    names as they appear instead of guessing. Same for `Makefile` targets.
 
 3. **Visual / UI runners.** Playwright / Cypress / Selenium /
-   WinAppDriver / Unity Editor headed are only invoked when a UI surface
-   is in scope. Even if the manifest is present, do not invoke a UI
-   runner for non-UI changes.
+   WinAppDriver / Unity Editor headed are invoked when a UI surface is in
+   scope — either because the diff touches UI files, or because
+   `surface-taxonomy.md`'s acceptance-aware escalation promoted a
+   backend-only diff whose acceptance manifests in a user-facing surface.
+   Even if the manifest is present, do not invoke a UI runner for a change
+   with no user-facing surface in scope by diff or acceptance. When the
+   user-facing surface is an Interactive CLI / TUI surface (not a graphical
+   UI), select the project's CLI integration / E2E runner for that surface
+   (e.g. a `cargo test` integration suite that drives the binary, a pexpect
+   / expect-style TUI test, a `go test` CLI harness) instead of a browser /
+   GUI runner.
 
 4. **Long-running runners and `--mode quick`.** Some runners (Unity Editor
    batch, large `mvn verify`, full `dotnet test` solution) take many

--- a/.claude/skills/gwt-verify/references/surface-taxonomy.md
+++ b/.claude/skills/gwt-verify/references/surface-taxonomy.md
@@ -38,6 +38,30 @@ different classification, that wins.
    matched surfaces.** Required > Recommended > Skipped.
 6. **No changed files** → `Changed surfaces: (none)` and User Verification
    is `skipped(no-change)`.
+7. **Acceptance-aware escalation (acceptance over diff path).**
+   Classification is not limited to the diff's file paths. When a change's
+   acceptance — the behavior the Issue / reproduction says must hold —
+   manifests in a **user-facing surface** (UI surface, or Interactive CLI /
+   TUI surface), classify it as that user-facing surface even if every
+   changed file is backend / business logic. This catches backend changes
+   that drive a user-facing surface (e.g. a server / protocol layer that
+   renders into a WebView, or a service whose output a CLI prints).
+   - **Default to user-facing.** If the Issue or reproduction references
+     visible / rendered / screen behavior, CLI output, or an interaction,
+     or the diff touches a seam that drives a user-facing surface, the
+     acceptance surface defaults to that user-facing surface.
+   - **Rebuttal burden.** Declaring the acceptance as non-user-facing
+     requires an explicit justification recorded in the evidence bundle's
+     `Acceptance Surface` field. Do not silently downgrade to skip the
+     user-facing runner.
+   - **Runner-agnostic.** This rule sets only the abstract surface. The
+     concrete E2E / integration / visual runner is chosen by
+     `runner-detection.md` per project (Playwright / Cypress / Selenium /
+     WinAppDriver / Unity Editor for a graphical UI surface; the project's
+     CLI integration / E2E runner for an Interactive CLI / TUI surface —
+     never a browser / GUI runner for a CLI surface).
+   - **Scope.** Escalation applies in `--mode full` and `--mode pre-pr`
+     only; `--mode quick` keeps the diff-path classification.
 
 ## Per-project specialization hints
 

--- a/.claude/skills/gwt-verify/references/test-matrix.md
+++ b/.claude/skills/gwt-verify/references/test-matrix.md
@@ -43,11 +43,15 @@ the project-specific recipe.
 1. **Multiple surfaces match** — run the union of all matched commands.
    Skip duplicates (e.g. only run `cargo clippy --all-targets` once per
    invocation).
-2. **Browser column is empty → do not invoke Playwright.** This is the
-   strong constraint inherited from SPEC-1935 FR-124: only WebView /
-   browser UI surfaces are eligible for Playwright. The same rule applies
-   to any other UI runner (Cypress / Selenium / WinAppDriver) in
-   future-arriving projects.
+2. **Browser column is empty → do not invoke Playwright** unless
+   acceptance-aware escalation (`surface-taxonomy.md`) promotes a
+   backend-only diff to a UI surface because its acceptance manifests in
+   the WebView. Only WebView / browser UI surfaces — by diff or by
+   acceptance — are eligible for Playwright. The same rule applies to any
+   other UI runner (Cypress / Selenium / WinAppDriver) in future-arriving
+   projects. This is part of the gwt-verify verification contract that
+   prevents over-eager Playwright invocation, not an external SPEC
+   requirement.
 3. **`crates/gwt/web/**` ambiguity** — if any of `*.html`, `*.css`,
    `theme-*.js`, or visible UI assets changed, treat the surface as
    "UI / CSS / HTML" and include `pnpm test:visual`. If only non-visual
@@ -59,6 +63,34 @@ the project-specific recipe.
    `Changed surfaces: (none)` and no executed commands. User
    Verification is `skipped(no-change)`. The caller decides whether
    that means "nothing to verify" or "baseline drift".
+6. **WebView-driving backend seam (acceptance-aware).** Changes under
+   `crates/gwt/src/**` (the server / WebSocket protocol / app runtime that
+   renders into the WebView) classify as business logic by path. But when
+   the Issue / repro acceptance is a WebView behavior, acceptance-aware
+   escalation (`surface-taxonomy.md`) promotes them to UI surface and
+   `pnpm test:visual` is included. A pure-backend change here with no
+   WebView acceptance keeps the business-logic classification (no
+   Playwright).
+
+### Worked example: acceptance-aware escalation (gwt repo)
+
+A bug fix lands only in `crates/gwt/src/app_runtime.rs` (no `web/**` file
+changed), but the Issue says "the workspace list fails to re-render after a
+viewport update." The acceptance is a WebView behavior. By diff path this is
+business logic (Browser column empty), but acceptance-aware escalation
+promotes it to UI surface:
+
+```text
+Changed surfaces: business logic (crates/gwt/src/**)
+Acceptance Surface: UI surface (escalated — repro is a WebView re-render)
+Executed: cargo test -p gwt, pnpm test:visual
+User Verification: required
+```
+
+The reverse holds too: a pure refactor under `crates/gwt/src/**` with no
+WebView-visible acceptance records `Acceptance Surface:
+non-user-facing(internal refactor, no rendered behavior change)` and skips
+`pnpm test:visual`.
 
 ### Mode → Subset (gwt repo)
 

--- a/.claude/skills/gwt-verify/references/user-verification-guide.md
+++ b/.claude/skills/gwt-verify/references/user-verification-guide.md
@@ -3,7 +3,11 @@
 After automated tests pass, `gwt-verify` hands off to the user for manual
 confirmation when `--mode full` or `--mode pre-pr` is active and the
 changed surfaces include any `Required` or `Recommended` user-check
-entries (per `surface-taxonomy.md`).
+entries (per `surface-taxonomy.md`). This includes a backend-only diff that
+`surface-taxonomy.md`'s acceptance-aware escalation promotes to a
+user-facing surface because its acceptance manifests in the UI / CLI: the
+handoff fires for the escalated surface even though no UI / CLI file
+changed.
 
 The handoff has two halves:
 

--- a/.codex/skills/gwt-verify/SKILL.md
+++ b/.codex/skills/gwt-verify/SKILL.md
@@ -27,7 +27,7 @@ Playwright recipe. Instead it executes the following four-part contract:
    `references/surface-taxonomy.md`.
 2. **Appropriate Test Selection** — detect the project's actual test runners
    from its manifests (Cargo.toml, package.json, pyproject.toml, go.mod,
-   ProjectSettings/ProjectVersion.txt, *.sln / *.csproj, Gemfile, pom.xml,
+   ProjectSettings/ProjectVersion.txt, `*.sln` / `*.csproj`, Gemfile, pom.xml,
    build.gradle, Makefile) and choose the right unit / integration / E2E /
    visual commands for each changed surface. See
    `references/runner-detection.md`.
@@ -50,8 +50,8 @@ the generic matrix in this skill. The matrix here is the fallback frame.
 | Mode | When to use | Scope |
 |---|---|---|
 | `--mode quick` (default) | TDD loop, narrow check during implementation | Only surfaces touched by uncommitted / working-tree changes; the narrowest representative command per runner (e.g. single-package test invocation). Skip heavy integration / E2E / visual unless the diff explicitly touches them. |
-| `--mode full` | gwt-build-spec Phase 3, standalone completion gate | Full matched matrix per changed surface, including integration / E2E / visual when a UI surface changed. User Verification Handoff is required (see below). |
-| `--mode pre-pr` | gwt-manage-pr before PR create / update | `full` matrix + release-flow tests when a release surface changed; visual / UI regression always included if any UI surface changed. User Verification Handoff is required. |
+| `--mode full` | gwt-build-spec Phase 3, standalone completion gate | Full matched matrix per changed surface, including integration / E2E / visual when a UI surface is in scope — by the diff, or by acceptance-aware escalation (`references/surface-taxonomy.md`). User Verification Handoff is required (see below). |
+| `--mode pre-pr` | gwt-manage-pr before PR create / update | `full` matrix + release-flow tests when a release surface changed; visual / UI regression always included if any UI surface is in scope by diff or by acceptance-aware escalation. User Verification Handoff is required. |
 | `--headed` (flag) | Manual UI / design verification | When supplied alongside any mode that runs a browser-based test runner (Playwright / Cypress / Selenium / WinAppDriver / Unity Editor headed), launch the runner in headed mode so the user can watch. Default is headless to match CI. |
 
 Additional flag:
@@ -104,10 +104,15 @@ gwt-verify
      finalize Overall once the user response is recorded.
 ```
 
-The skill does not invoke Playwright when no WebView / browser UI surface
-changed. This is a hard contract from SPEC-1935 FR-124. The same restraint
-applies to other UI runners (Cypress / Selenium / WinAppDriver / Unity Editor
-headed): they are only invoked when a UI surface is in scope.
+The skill does not invoke Playwright — or any other UI runner (Cypress /
+Selenium / WinAppDriver / Unity Editor headed) — when no user-facing surface
+is in scope. A UI surface is in scope either by the diff touching WebView /
+browser UI files, or by `references/surface-taxonomy.md`'s acceptance-aware
+escalation promoting a backend-only diff whose acceptance manifests in a
+user-facing surface. A change with no user-facing surface in scope by diff or
+acceptance does not invoke Playwright. This restraint is part of the
+gwt-verify verification contract that prevents over-eager UI-runner
+invocation; it is not an external SPEC requirement.
 
 ## Evidence Bundle
 
@@ -119,6 +124,7 @@ Output to stdout in the following shape (Markdown):
 Mode: <quick|full|pre-pr>
 Baseline: merge-base HEAD..origin/develop (<N> commits, <M> files)
 Changed surfaces: <abstract surface list>
+Acceptance Surface: <user-facing surface the change is escalated to, or `non-user-facing(<justification>)`>
 
 ### Plan
 Detected runners: <e.g. Cargo, pnpm, Playwright | Unity Test Framework | dotnet test | pytest | go test>
@@ -243,8 +249,8 @@ Stop and surface a blocker to the caller when:
   snapshots.
 - The agent attempts to invoke Playwright (or any other browser UI runner)
   for a surface not classified as a UI surface under
-  `references/surface-taxonomy.md`. This is a contract violation, not a
-  runtime error.
+  `references/surface-taxonomy.md` (including its acceptance-aware
+  escalation). This is a contract violation, not a runtime error.
 - The User Verification phase is required but no platform question tool
   and no plain-text channel are available to ask the user.
 

--- a/.codex/skills/gwt-verify/references/runner-detection.md
+++ b/.codex/skills/gwt-verify/references/runner-detection.md
@@ -44,9 +44,17 @@ approach explicitly.
    names as they appear instead of guessing. Same for `Makefile` targets.
 
 3. **Visual / UI runners.** Playwright / Cypress / Selenium /
-   WinAppDriver / Unity Editor headed are only invoked when a UI surface
-   is in scope. Even if the manifest is present, do not invoke a UI
-   runner for non-UI changes.
+   WinAppDriver / Unity Editor headed are invoked when a UI surface is in
+   scope — either because the diff touches UI files, or because
+   `surface-taxonomy.md`'s acceptance-aware escalation promoted a
+   backend-only diff whose acceptance manifests in a user-facing surface.
+   Even if the manifest is present, do not invoke a UI runner for a change
+   with no user-facing surface in scope by diff or acceptance. When the
+   user-facing surface is an Interactive CLI / TUI surface (not a graphical
+   UI), select the project's CLI integration / E2E runner for that surface
+   (e.g. a `cargo test` integration suite that drives the binary, a pexpect
+   / expect-style TUI test, a `go test` CLI harness) instead of a browser /
+   GUI runner.
 
 4. **Long-running runners and `--mode quick`.** Some runners (Unity Editor
    batch, large `mvn verify`, full `dotnet test` solution) take many

--- a/.codex/skills/gwt-verify/references/surface-taxonomy.md
+++ b/.codex/skills/gwt-verify/references/surface-taxonomy.md
@@ -38,6 +38,30 @@ different classification, that wins.
    matched surfaces.** Required > Recommended > Skipped.
 6. **No changed files** → `Changed surfaces: (none)` and User Verification
    is `skipped(no-change)`.
+7. **Acceptance-aware escalation (acceptance over diff path).**
+   Classification is not limited to the diff's file paths. When a change's
+   acceptance — the behavior the Issue / reproduction says must hold —
+   manifests in a **user-facing surface** (UI surface, or Interactive CLI /
+   TUI surface), classify it as that user-facing surface even if every
+   changed file is backend / business logic. This catches backend changes
+   that drive a user-facing surface (e.g. a server / protocol layer that
+   renders into a WebView, or a service whose output a CLI prints).
+   - **Default to user-facing.** If the Issue or reproduction references
+     visible / rendered / screen behavior, CLI output, or an interaction,
+     or the diff touches a seam that drives a user-facing surface, the
+     acceptance surface defaults to that user-facing surface.
+   - **Rebuttal burden.** Declaring the acceptance as non-user-facing
+     requires an explicit justification recorded in the evidence bundle's
+     `Acceptance Surface` field. Do not silently downgrade to skip the
+     user-facing runner.
+   - **Runner-agnostic.** This rule sets only the abstract surface. The
+     concrete E2E / integration / visual runner is chosen by
+     `runner-detection.md` per project (Playwright / Cypress / Selenium /
+     WinAppDriver / Unity Editor for a graphical UI surface; the project's
+     CLI integration / E2E runner for an Interactive CLI / TUI surface —
+     never a browser / GUI runner for a CLI surface).
+   - **Scope.** Escalation applies in `--mode full` and `--mode pre-pr`
+     only; `--mode quick` keeps the diff-path classification.
 
 ## Per-project specialization hints
 

--- a/.codex/skills/gwt-verify/references/test-matrix.md
+++ b/.codex/skills/gwt-verify/references/test-matrix.md
@@ -43,11 +43,15 @@ the project-specific recipe.
 1. **Multiple surfaces match** — run the union of all matched commands.
    Skip duplicates (e.g. only run `cargo clippy --all-targets` once per
    invocation).
-2. **Browser column is empty → do not invoke Playwright.** This is the
-   strong constraint inherited from SPEC-1935 FR-124: only WebView /
-   browser UI surfaces are eligible for Playwright. The same rule applies
-   to any other UI runner (Cypress / Selenium / WinAppDriver) in
-   future-arriving projects.
+2. **Browser column is empty → do not invoke Playwright** unless
+   acceptance-aware escalation (`surface-taxonomy.md`) promotes a
+   backend-only diff to a UI surface because its acceptance manifests in
+   the WebView. Only WebView / browser UI surfaces — by diff or by
+   acceptance — are eligible for Playwright. The same rule applies to any
+   other UI runner (Cypress / Selenium / WinAppDriver) in future-arriving
+   projects. This is part of the gwt-verify verification contract that
+   prevents over-eager Playwright invocation, not an external SPEC
+   requirement.
 3. **`crates/gwt/web/**` ambiguity** — if any of `*.html`, `*.css`,
    `theme-*.js`, or visible UI assets changed, treat the surface as
    "UI / CSS / HTML" and include `pnpm test:visual`. If only non-visual
@@ -59,6 +63,34 @@ the project-specific recipe.
    `Changed surfaces: (none)` and no executed commands. User
    Verification is `skipped(no-change)`. The caller decides whether
    that means "nothing to verify" or "baseline drift".
+6. **WebView-driving backend seam (acceptance-aware).** Changes under
+   `crates/gwt/src/**` (the server / WebSocket protocol / app runtime that
+   renders into the WebView) classify as business logic by path. But when
+   the Issue / repro acceptance is a WebView behavior, acceptance-aware
+   escalation (`surface-taxonomy.md`) promotes them to UI surface and
+   `pnpm test:visual` is included. A pure-backend change here with no
+   WebView acceptance keeps the business-logic classification (no
+   Playwright).
+
+### Worked example: acceptance-aware escalation (gwt repo)
+
+A bug fix lands only in `crates/gwt/src/app_runtime.rs` (no `web/**` file
+changed), but the Issue says "the workspace list fails to re-render after a
+viewport update." The acceptance is a WebView behavior. By diff path this is
+business logic (Browser column empty), but acceptance-aware escalation
+promotes it to UI surface:
+
+```text
+Changed surfaces: business logic (crates/gwt/src/**)
+Acceptance Surface: UI surface (escalated — repro is a WebView re-render)
+Executed: cargo test -p gwt, pnpm test:visual
+User Verification: required
+```
+
+The reverse holds too: a pure refactor under `crates/gwt/src/**` with no
+WebView-visible acceptance records `Acceptance Surface:
+non-user-facing(internal refactor, no rendered behavior change)` and skips
+`pnpm test:visual`.
 
 ### Mode → Subset (gwt repo)
 

--- a/.codex/skills/gwt-verify/references/user-verification-guide.md
+++ b/.codex/skills/gwt-verify/references/user-verification-guide.md
@@ -3,7 +3,11 @@
 After automated tests pass, `gwt-verify` hands off to the user for manual
 confirmation when `--mode full` or `--mode pre-pr` is active and the
 changed surfaces include any `Required` or `Recommended` user-check
-entries (per `surface-taxonomy.md`).
+entries (per `surface-taxonomy.md`). This includes a backend-only diff that
+`surface-taxonomy.md`'s acceptance-aware escalation promotes to a
+user-facing surface because its acceptance manifests in the UI / CLI: the
+handoff fires for the escalated surface even though no UI / CLI file
+changed.
 
 The handoff has two halves:
 


### PR DESCRIPTION
## 概要

`gwt-verify` の E2E/visual runner 選定が **diff のファイルパスベース**で、user-facing surface を駆動する **backend 修正の取りこぼし**（自動 E2E 不実行・User Check が Recommended 止まり）を生んでいた。判定を **acceptance ベース**に拡張し、**抽象 surface 層**に置くことで全環境（ブラウザ/Unity/.NET/**CLI-TUI**）を一様にカバーする。あわせて実在しない **「SPEC-1935 FR-124」phantom citation を修正**。

Closes #3137 / Refs #1935, #3133

## 背景

- E2E/visual runner（Playwright/Cypress/Selenium/WinAppDriver/Unity Editor）は `runner-detection.md` Rule3 で **UI surface が diff 在圏のときのみ**起動。
- WebView を駆動する `crates/gwt/src/**` は business logic 扱い → UI バグの backend 修正で **自動 E2E が走らない**。
- 根本: 検証選定が diff パスベースで acceptance ベースでない。「UI」はブラウザ/Unity/.NET/**CLI/TUI** と環境により様々で一様カバーが必要。
- 調査で **「SPEC-1935 FR-124」は実在しない**ことが判明（#1935 本文に無し、他 SPEC の FR-124 は別物）。gwt-verify skill-asset の phantom citation。

## 変更内容（project-agnostic・全環境カバー）

設計の本丸は抽象 surface 層。具体 runner は既存 `runner-detection.md` が各環境向けに選ぶ。

- **surface-taxonomy.md**: `Acceptance-aware escalation` ルール追加。変更の acceptance/再現が user-facing surface（UI surface ＋ Interactive CLI/TUI surface）に出るなら backend diff でも該当 surface へ昇格。デフォルト user-facing 推定 + 反証責任（非 user-facing 宣言は evidence に根拠必須）。**runner 非依存**、full/pre-pr のみ。
- **runner-detection.md**: Rule3 を「diff 在圏 **OR** acceptance escalation」で UI runner 起動に拡張。CLI/TUI surface は **CLI integration/E2E** を選定（browser/GUI runner ではない）。
- **SKILL.md**: Evidence Bundle に `Acceptance Surface` フィールド追加、phantom FR-124 修正、Playwright 固有でなく全 UI runner に一般化、modes/stop-conditions 整合、MD037（glob backtick 化）修正。
- **test-matrix.md**（gwt の 1 例）: WebView 駆動 seam（`crates/gwt/src/**`）+ acceptance-aware worked example、phantom 修正。
- **user-verification-guide.md**: backend diff でも escalation で handoff 発火を明記。

純 backend（user-facing acceptance 無し）は従来通り UI runner スキップ（過剰実行抑止の意図維持）。build-spec / gwt-fix-issue 本体は無変更。`.claude` / `.codex` byte-identical。

## 検証

- `cargo test -p gwt-skills`: **195 + 7 passed, 0 failed**（`repo_keeps_managed_claude_and_codex_skill_assets_in_parity`、`gwt_verify_skill_md_documents_surface_matrix_contract` 含む）
- `markdownlint`（変更 10 ファイル）: **0 errors**
- `.claude` / `.codex` byte-identical（全 5 ファイル diff 0）、phantom FR-124 残存 0
- commitlint: exit 0

## User Verification

`n/a` — skill-guidance markdown のみで UI/visual surface への影響なし。

## Ready PR Gate

単独配信可能（gwt-verify ガイダンス改善のみ、既存挙動を壊さず、純 backend のスキップ簡約も維持）。残課題なし。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced verification contract to intelligently select tests based on whether changes affect user-facing surfaces, including backend-only code changes when acceptance criteria manifest in the UI or CLI.
  * Clarified verification report output to document which user-facing surface was verified or provide justification when changes remain non-user-facing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->