### PR TITLE
test(infra): SessionStart テスト hermetic 化 + frontend/WebView E2E を CI 実行

### DIFF
--- a/crates/gwt/tests/workspace_identity_session_start_test.rs
+++ b/crates/gwt/tests/workspace_identity_session_start_test.rs
@@ -12,7 +12,7 @@ use gwt::cli::hook::event_dispatcher;
 use gwt_agent::{session::GWT_SESSION_ID_ENV, AgentId, Session};
 use gwt_core::{
     paths::gwt_sessions_dir,
-    test_support::ScopedGwtHome,
+    test_support::{ScopedEnvVar, ScopedGwtHome},
     workspace_projection::{
         load_workspace_projection, update_workspace_projection_with_journal,
         WorkspaceProjectionUpdate,
@@ -26,9 +26,14 @@ fn env_lock() -> &'static Mutex<()> {
 }
 
 struct EnvGuard {
-    _guard: std::sync::MutexGuard<'static, ()>,
-    _home: ScopedGwtHome,
     previous_session_id: Option<std::ffi::OsString>,
+    _home: ScopedGwtHome,
+    _home_env: ScopedEnvVar,
+    _userprofile_env: ScopedEnvVar,
+    // Declared last so it drops last: the env-lock stays held while the
+    // ScopedEnvVar guards above restore HOME / USERPROFILE, keeping the
+    // process-global env mutation serialized against other tests.
+    _guard: std::sync::MutexGuard<'static, ()>,
 }
 
 impl Drop for EnvGuard {
@@ -45,12 +50,23 @@ fn with_temp_env(home: &Path, session_id: &str) -> EnvGuard {
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let home_guard = ScopedGwtHome::set(home);
+    // Isolate gwt-config's HOME-based resolution as well. `Settings::load()`
+    // (and therefore Board provider selection) reads `$HOME/.gwt/config.toml`,
+    // which `ScopedGwtHome` (a gwt-core thread-local) does not cover. Without
+    // this, a developer machine configured with `board.provider = slack|teams`
+    // makes the SessionStart Board dispatch fail with "<provider> is not signed
+    // in", so the test is non-hermetic. Pointing HOME/USERPROFILE at the temp
+    // home leaves no config there, defaulting the provider to local.
+    let home_env = ScopedEnvVar::set("HOME", home);
+    let userprofile_env = ScopedEnvVar::set("USERPROFILE", home);
     let previous_session_id = std::env::var_os(GWT_SESSION_ID_ENV);
     std::env::set_var(GWT_SESSION_ID_ENV, session_id);
     EnvGuard {
-        _guard: guard,
-        _home: home_guard,
         previous_session_id,
+        _home: home_guard,
+        _home_env: home_env,
+        _userprofile_env: userprofile_env,
+        _guard: guard,
     }
 }
 


### PR DESCRIPTION
## 概要

E2E 検証の徹底化で発覚した **2 つのテスト基盤の実問題**を修正する test-infrastructure PR。

1. **test hermeticity bug（fix, Closes #3139）**: `workspace_identity_session_start_test` の 2 テストが、Board provider に `slack`/`teams` を設定した開発者マシン（＝実運用ユーザー環境）で必ず失敗していた。integration test は gwt の非-test build をリンクするため `board_provider` の `#[cfg(test)]` seam が効かず、`Settings::load()` が実 `$HOME/.gwt/config.toml`(slack) を読むのが根因。`with_temp_env` で `HOME`/`USERPROFILE` を temp に隔離して hermetic 化。
2. **E2E が CI 未実行（ci, Closes #3141）**: frontend unit(885)/smoke(29)/Playwright embedded WebView E2E(98) がどの CI workflow でも走っておらず、UI リグレッションが自動検出されていなかった。`test.yml` に `test-frontend` job を追加し毎 PR で実行（live-gwt 56 specs は base URL 無しで self-skip）。

Closes #3139, #3141 / Refs #2359, #2963, #3014, #1932

## 検証（実行済み・ローカル実機）

- `cargo test -p gwt --test workspace_identity_session_start_test`（Slack 設定環境で）→ 2 pass / 0 fail
- `scripts/test-all.sh`（cargo gwt-core+gwt 全 + smoke + release-flow）→ 全 `test result: ok` / 0 fail
- `cargo clippy -p gwt --tests -- -D warnings` clean / `cargo fmt --check` clean
- `scripts/run-frontend-unit-tests.sh` → 885 pass / 0 fail
- `scripts/run-frontend-smoke-tests.sh` → 29 pass / 0 fail
- `scripts/run-visual-tests.sh`（Playwright embedded）→ 98 pass / 56 skip(live-gwt)
- 本 PR の CI で新 job `Test (Frontend + WebView E2E)` が実際に走り、配線の妥当性を証明

## User Verification

`n/a` — テストコード + CI 設定のみ。UI/visual surface への挙動変更なし。

## Ready PR Gate

単独配信可能（テスト基盤の改善、プロダクト挙動不変、既存 job 不変）。残課題: live-gwt 56 specs の CI 実行は harness が重いため別タスク（#3141 Notes 参照）。
