### PR TITLE
ci(test): frontend unit/smoke と Playwright WebView E2E を CI で実行する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,3 +94,31 @@ jobs:
       - name: Run release asset contract tests
         run: node scripts/test_release_assets.cjs
         timeout-minutes: 15
+
+  test-frontend:
+    name: Test (Frontend + WebView E2E)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+      - uses: oven-sh/setup-bun@v2
+      - name: Run frontend unit tests
+        run: bash scripts/run-frontend-unit-tests.sh
+        timeout-minutes: 10
+      - name: Run frontend smoke tests
+        run: bash scripts/run-frontend-smoke-tests.sh
+        timeout-minutes: 10
+      # Browsers must match run-visual-tests.sh's pinned Playwright version
+      # (GWT_PLAYWRIGHT_VERSION default). The shared ~/.cache/ms-playwright is
+      # reused by the script's temp-dir Playwright install of the same version.
+      - name: Install Playwright chromium + system deps
+        run: npx --yes playwright@1.49.1 install --with-deps chromium
+        timeout-minutes: 10
+      # Embedded-frontend specs stub WebSocket + serve crates/gwt/web via
+      # page.route, so they run without a live gwt. live-gwt specs self-skip
+      # when GWT_PLAYWRIGHT_BASE_URL is unset.
+      - name: Run WebView E2E (embedded Playwright specs)
+        run: bash scripts/run-visual-tests.sh
+        timeout-minutes: 15


### PR DESCRIPTION
## 概要

frontend unit(885)/smoke(29)/Playwright embedded WebView E2E(98) がどの CI workflow でも実行されておらず、UI/WebView リグレッションが自動検出されていなかった（CI の JS は構文チェックと release asset contract のみ）。`test.yml` に `test-frontend` job を追加し、毎 PR で実行・enforce する。

Closes #3141 / Refs #3014, #1932

## 変更内容

`.github/workflows/test.yml` に `test-frontend` job を追加:
- `scripts/run-frontend-unit-tests.sh`（frontend unit）
- `scripts/run-frontend-smoke-tests.sh`（frontend smoke）
- Playwright chromium + system deps install（pinned 1.49.1、run-visual-tests.sh と整合）
- `scripts/run-visual-tests.sh`（embedded WebView E2E。live-gwt specs は GWT_PLAYWRIGHT_BASE_URL 未設定で self-skip）

既存 job（Rust/Python/e5/Windows）は不変。untrusted input を run: に渡さない静的 job。

## 検証

- ローカル実機: unit 885 pass / smoke 29 pass / Playwright embedded 98 pass / 56 skip(live-gwt)
- YAML 妥当性確認済み（5 jobs）
- **本 PR の CI で新 job `Test (Frontend + WebView E2E)` が実際に実行され green になることが配線の証明**

## User Verification

`n/a` — CI 設定のみ。プロダクト挙動への影響なし。

## Ready PR Gate

単独配信可能（CI 配線追加、既存挙動不変）。残: live-gwt 56 specs の CI 実行は別タスク（harness が重いため段階的）。
