### PR TITLE
fix(knowledge): mark stopped issue sessions as past

### DIFF
--- a/crates/gwt/src/app_runtime/knowledge.rs
+++ b/crates/gwt/src/app_runtime/knowledge.rs
@@ -403,6 +403,7 @@ fn knowledge_related_work_from_session(
     let updated_at = session
         .updated_at
         .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let is_active = session_status_is_active(session.status);
     let sessions = session
         .agent_session_id
         .as_ref()
@@ -410,7 +411,7 @@ fn knowledge_related_work_from_session(
             vec![gwt::KnowledgeRelatedSessionView {
                 agent_session_id: agent_session_id.clone(),
                 started_at: updated_at.clone(),
-                is_active: true,
+                is_active,
                 resumable: session.is_resumable_conversation(agent_session_id),
             }]
         })
@@ -439,6 +440,13 @@ fn session_status_category(status: gwt_agent::AgentStatus) -> &'static str {
         gwt_agent::AgentStatus::Interrupted => "blocked",
         gwt_agent::AgentStatus::Unknown => "unknown",
     }
+}
+
+fn session_status_is_active(status: gwt_agent::AgentStatus) -> bool {
+    matches!(
+        status,
+        gwt_agent::AgentStatus::Running | gwt_agent::AgentStatus::WaitingInput
+    )
 }
 
 fn related_session_count(works: &[gwt::KnowledgeRelatedWorkView]) -> usize {
@@ -596,12 +604,7 @@ fn related_session_rank(
 ) -> RelatedSessionRank {
     let runtime_live = session_index
         .get(agent.session_id.as_str())
-        .is_some_and(|ledger| {
-            matches!(
-                ledger.status,
-                gwt_agent::AgentStatus::Running | gwt_agent::AgentStatus::WaitingInput
-            )
-        });
+        .is_some_and(|ledger| session_status_is_active(ledger.status));
     let recency_millis = [
         parse_related_time_millis(&session.started_at),
         parse_related_time_millis(&agent.updated_at),

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -11128,6 +11128,74 @@ fn app_runtime_load_knowledge_bridge_projects_related_issue_work_sessions() {
 }
 
 #[test]
+fn app_runtime_load_knowledge_bridge_marks_session_only_stopped_related_session_past() {
+    let _env_lock = env_test_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let temp = tempdir().expect("tempdir");
+    let _home = ScopedEnvVar::set("HOME", temp.path());
+    let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+    let repo = temp.path().join("repo");
+    let worktree = temp.path().join("repo-work-issue-3133");
+    fs::create_dir_all(&repo).expect("create repo");
+    fs::create_dir_all(&worktree).expect("create worktree");
+    init_repo(&repo);
+    Cache::new(issue_cache_root(&repo))
+        .write_snapshot(&sample_issue_snapshot(
+            3133,
+            "Resume historical Launch Agent session",
+            &["bug"],
+            "Issue body",
+            "2026-06-20T09:00:00Z",
+        ))
+        .expect("write issue snapshot");
+
+    let tab = sample_project_tab_with_window_at(
+        "tab-1",
+        "issue-1",
+        repo.clone(),
+        WindowPreset::Issue,
+        WindowProcessStatus::Ready,
+    );
+    let runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+
+    let stopped_at = Utc.with_ymd_and_hms(2026, 6, 20, 9, 5, 0).unwrap();
+    let mut session =
+        gwt_agent::Session::new(&worktree, "work/issue-3133", gwt_agent::AgentId::Codex);
+    session.id = "session-issue-3133-stopped".to_string();
+    session.agent_session_id = Some("conv-issue-3133-stopped".to_string());
+    session.status = gwt_agent::AgentStatus::Stopped;
+    session.linked_issue_number = Some(3133);
+    session.created_at = stopped_at;
+    session.updated_at = stopped_at;
+    session.last_activity_at = stopped_at;
+    session.save(&runtime.sessions_dir).expect("save session");
+
+    let events = runtime.load_knowledge_bridge_events(
+        "client-1",
+        KnowledgeLoadRequest {
+            id: &combined_window_id("tab-1", "issue-1"),
+            kind: gwt::KnowledgeKind::Issue,
+            request_id: None,
+            selected_number: Some(3133),
+            refresh: false,
+        },
+    );
+
+    let detail = match &events[1].event {
+        BackendEvent::KnowledgeDetail { detail, .. } => detail,
+        other => panic!("unexpected detail event: {other:?}"),
+    };
+    assert_eq!(detail.related_works.len(), 1);
+    assert_eq!(detail.related_works[0].status_category, "idle");
+    assert_eq!(detail.related_works[0].agents[0].sessions.len(), 1);
+    assert!(
+        !detail.related_works[0].agents[0].sessions[0].is_active,
+        "session-only stopped related sessions must render as Past, not Current"
+    );
+}
+
+#[test]
 fn app_runtime_load_knowledge_bridge_dedupes_related_issue_sessions_by_conversation() {
     let _env_lock = env_test_lock()
         .lock()


### PR DESCRIPTION
## Summary

- Session ledger だけで Issue に関連付いた stopped/idle session を Past として扱うようにしました。
- Related session の live 判定を `Running` / `WaitingInput` に統一し、Current 表示の誤判定を防ぎます。
- PR #3148 の Codex Review thread で指摘された fallback path を regression test で固定しました。

## Changes

- `crates/gwt/src/app_runtime/knowledge.rs`: `KnowledgeRelatedSessionView.is_active` を Session ledger status から算出するように修正。
- `crates/gwt/src/app_runtime/knowledge.rs`: live 判定 helper を追加し、dedupe rank と fallback projection で同じ判定を使うように変更。
- `crates/gwt/src/app_runtime/tests.rs`: WorkItem が無い session-only stopped Issue session が Past になる regression test を追加。

## Testing

- [x] RED: `cargo test -p gwt app_runtime_load_knowledge_bridge_marks_session_only_stopped_related_session_past --all-features` — failed before the fix because `is_active` was always true.
- [x] GREEN: `cargo test -p gwt app_runtime_load_knowledge_bridge_marks_session_only_stopped_related_session_past --all-features` — PASS
- [x] `cargo test -p gwt app_runtime_load_knowledge_bridge --all-features` — PASS, 7 focused tests passed
- [x] `cargo fmt -- --check` — PASS
- [x] `git diff --check` — PASS
- [x] `cargo test -p gwt-core -p gwt --all-features` — PASS
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — PASS
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — PASS
- [x] User verification — N/A; backend projection semantics only, no UI/CSS/frontend surface changed.

## PR Readiness

- State: Ready for review
- Releaseable slice: Yes; this is a targeted correctness fix for related session state in the Issue Bridge payload.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- #1938
- #3148

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (N/A: no user-facing docs change; PR #3148 body and SPEC #1938 already describe the feature)
- [x] Migration/backfill plan included (N/A: no schema/data migration)
- [x] CHANGELOG impact considered (patch fix; no breaking change)

## Context

- PR #3148 was merged after all CI checks passed, but a Codex Review thread appeared at merge time on `knowledge_related_work_from_session`.
- The review identified that session-only fallback rows were setting `is_active: true` even for stopped historical sessions.

## Risk / Impact

- **Affected areas**: Issue Bridge related Work / Session payloads for session-only fallback rows.
- **Rollback plan**: Revert this PR; no persistent state is changed.