### PR TITLE
feat(gui): Operator Anshin Phase 1 — needs-input alerting + agent kill-switch

### DIFF
--- a/crates/gwt/playwright/tests/kill-switch.spec.ts
+++ b/crates/gwt/playwright/tests/kill-switch.spec.ts
@@ -1,0 +1,250 @@
+import { expect, test } from "@playwright/test";
+import { APP_URL, installEmbeddedRoutes } from "./_helpers/embedded-frontend";
+
+// SPEC-2356 Anshin Addendum — Phase 1 kill-switch + attention UI.
+//
+// Drives the embedded frontend against a WebSocket stub that captures every
+// event the frontend sends. Asserts the FR-040..044 controls:
+//   - FR-041: window-chrome STOP sends stop_window (window stays on canvas)
+//   - FR-044: a stopped window swaps STOP for RESTART -> restart_window
+//   - FR-042: STOP ALL rail item confirms then sends stop_all_windows
+//   - FR-043: the palette send-input entry routes pane_send_input by session_id
+//   - FR-040: a needs_input transition pops an in-app attention toast that
+//     frames the window on click
+test.describe("Anshin Phase 1 kill-switch + attention", () => {
+  test.use({ deviceScaleFactor: 1, viewport: { width: 1440, height: 900 } });
+
+  test("STOP sends stop_window and the window stays on canvas", async ({ page }) => {
+    await installEmbeddedRoutes(page);
+    await installKillSwitchBackend(page);
+    await page.goto(APP_URL);
+
+    const win = page.locator('.workspace-window[data-id="agent-1"]');
+    await expect(win).toBeVisible({ timeout: 10_000 });
+
+    const stop = win.locator('[data-action="stop"]');
+    await expect(stop).toBeVisible();
+    await stop.click();
+
+    await expect
+      .poll(() => page.evaluate(() => window.__sentKinds))
+      .toContain("stop_window");
+    // The window must remain on the canvas after stopping its runtime.
+    await expect(win).toBeVisible();
+    const sent = await page.evaluate(() => window.__sent);
+    const stopEvent = sent.find((e) => e.kind === "stop_window");
+    expect(stopEvent.id).toBe("agent-1");
+  });
+
+  test("a stopped window exposes RESTART -> restart_window", async ({ page }) => {
+    await installEmbeddedRoutes(page);
+    await installKillSwitchBackend(page);
+    await page.goto(APP_URL);
+
+    const win = page.locator('.workspace-window[data-id="agent-1"]');
+    await expect(win).toBeVisible({ timeout: 10_000 });
+
+    // Push a Stopped runtime state; the chrome must swap STOP for RESTART.
+    await page.evaluate(() => window.__emit({ kind: "window_state", window_id: "agent-1", state: "stopped" }));
+
+    const restart = win.locator('[data-action="restart"]');
+    await expect(restart).toBeVisible();
+    await expect(win.locator('[data-action="stop"]')).toBeHidden();
+    await restart.click();
+
+    await expect
+      .poll(() => page.evaluate(() => window.__sentKinds))
+      .toContain("restart_window");
+    const sent = await page.evaluate(() => window.__sent);
+    expect(sent.find((e) => e.kind === "restart_window").id).toBe("agent-1");
+  });
+
+  test("STOP ALL confirms then sends stop_all_windows", async ({ page }) => {
+    await installEmbeddedRoutes(page);
+    await installKillSwitchBackend(page);
+    await page.goto(APP_URL);
+
+    await expect(page.locator('.workspace-window[data-id="agent-1"]')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const stopAll = page.locator('.op-rail__item[data-cmd="stop-all-windows"]');
+    await expect(stopAll).toBeVisible();
+    page.once("dialog", (dialog) => dialog.accept());
+    await stopAll.click();
+
+    await expect
+      .poll(() => page.evaluate(() => window.__sentKinds))
+      .toContain("stop_all_windows");
+  });
+
+  test("the palette send-input entry routes pane_send_input by session_id", async ({ page }) => {
+    await installEmbeddedRoutes(page);
+    await installKillSwitchBackend(page);
+    await page.goto(APP_URL);
+
+    const win = page.locator('.workspace-window[data-id="agent-1"]');
+    await expect(win).toBeVisible({ timeout: 10_000 });
+    // Focus the agent window so the focused-pane helper has a target.
+    await win.locator(".titlebar .title-text").click();
+
+    await page.evaluate(() => {
+      window.prompt = () => "hello agent";
+    });
+    await page.keyboard.press("Meta+K");
+    const paletteInput = page.locator("#op-palette-input");
+    await expect(paletteInput).toBeVisible();
+    await paletteInput.fill("Send Input");
+    await page.locator("#op-palette-list .op-palette__row", { hasText: "Send Input" }).first().click();
+
+    await expect
+      .poll(() => page.evaluate(() => window.__sentKinds))
+      .toContain("pane_send_input");
+    const sent = await page.evaluate(() => window.__sent);
+    const inj = sent.find((e) => e.kind === "pane_send_input");
+    expect(inj.session_id).toBe("session-agent-1");
+    expect(inj.text).toBe("hello agent");
+  });
+
+  test("a needs_input transition pops an attention toast that frames on click", async ({ page }) => {
+    await installEmbeddedRoutes(page);
+    await installKillSwitchBackend(page);
+    await page.goto(APP_URL);
+
+    await expect(page.locator('.workspace-window[data-id="agent-2"]')).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // agent-2 enters waiting -> needs_input attention toast.
+    await page.evaluate(() => window.__emit({ kind: "window_state", window_id: "agent-2", state: "waiting" }));
+
+    const toast = page.locator('#attention-toast-agent-2');
+    await expect(toast).toBeVisible();
+    await expect(toast).toHaveAttribute("data-flavor", "needs_input");
+
+    const stage = page.locator("#canvas-stage");
+    const before = await stage.evaluate((el) => el.style.transform);
+    await toast.locator(".attention-toast__jump").click();
+    await page.waitForTimeout(500);
+    await expect.poll(() => stage.evaluate((el) => el.style.transform)).not.toBe(before);
+    await expect(toast).toHaveCount(0);
+  });
+});
+
+async function installKillSwitchBackend(page) {
+  await page.addInitScript(() => {
+    window.__sent = [];
+    window.__sentKinds = [];
+
+    function agentWindow(id, x, y, z) {
+      return {
+        id,
+        title: id,
+        preset: "agent",
+        geometry: { x, y, width: 480, height: 320 },
+        geometry_revision: 0,
+        z_index: z,
+        status: "running",
+        persist: true,
+        purpose_title: null,
+        dynamic_title: null,
+        dynamic_title_detail: null,
+        agent_id: id,
+        agent_color: "cyan",
+        tab_group_id: null,
+        tab_group_active: false,
+        session_id: `session-${id}`,
+      };
+    }
+
+    const windows = [
+      agentWindow("agent-1", 120, 100, 1),
+      agentWindow("agent-2", 1600, 1200, 2),
+    ];
+
+    function stateMsg() {
+      return {
+        kind: "workspace_state",
+        workspace: {
+          app_version: "playwright",
+          tabs: [
+            {
+              id: "tab-1",
+              title: "Kill Switch Fixture",
+              project_root: "/fixture",
+              kind: "git",
+              workspace: {
+                viewport: { x: 0, y: 0, zoom: 1 },
+                windows: windows.map((w) => ({ ...w })),
+              },
+            },
+          ],
+          active_tab_id: "tab-1",
+          recent_projects: [],
+        },
+      };
+    }
+
+    let socketRef = null;
+
+    class FixtureWebSocket extends EventTarget {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+
+      constructor(url) {
+        super();
+        this.url = url;
+        this.readyState = FixtureWebSocket.CONNECTING;
+        socketRef = this;
+        setTimeout(() => {
+          this.readyState = FixtureWebSocket.OPEN;
+          this.dispatchEvent(new Event("open"));
+          this.emit(stateMsg());
+        }, 0);
+      }
+
+      send(data) {
+        let msg;
+        try {
+          msg = JSON.parse(data);
+        } catch {
+          return;
+        }
+        window.__sent.push(msg);
+        window.__sentKinds.push(msg.kind);
+        if (msg.kind === "focus_window") {
+          const target = windows.find((w) => w.id === msg.id);
+          if (target) {
+            target.z_index += 100;
+            this.emit(stateMsg());
+          }
+        }
+      }
+
+      close() {
+        this.readyState = FixtureWebSocket.CLOSED;
+        this.dispatchEvent(new CloseEvent("close"));
+      }
+
+      emit(payload) {
+        setTimeout(() => {
+          this.dispatchEvent(
+            new MessageEvent("message", { data: JSON.stringify(payload) }),
+          );
+        }, 0);
+      }
+    }
+
+    // Lets a test push backend events (e.g. window_state transitions) directly.
+    window.__emit = (payload) => {
+      if (socketRef) socketRef.emit(payload);
+    };
+
+    Object.defineProperty(window, "WebSocket", {
+      configurable: true,
+      value: FixtureWebSocket,
+    });
+  });
+}

--- a/crates/gwt/src/app_runtime/frontend_action_log.rs
+++ b/crates/gwt/src/app_runtime/frontend_action_log.rs
@@ -225,6 +225,15 @@ pub(super) fn frontend_user_action_log(event: &FrontendEvent) -> Option<Frontend
         FrontendEvent::CloseWindow { id } => {
             FrontendUserActionLog::new("close_window", "window").window(id)
         }
+        FrontendEvent::StopWindow { id } => {
+            FrontendUserActionLog::new("stop_window", "window").window(id)
+        }
+        FrontendEvent::StopAllWindows {} => {
+            FrontendUserActionLog::new("stop_all_windows", "window")
+        }
+        FrontendEvent::RestartWindow { id } => {
+            FrontendUserActionLog::new("restart_window", "window").window(id)
+        }
         FrontendEvent::LoadFileTree { id, path } => {
             FrontendUserActionLog::new("load_file_tree", "file")
                 .window(id)

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1157,6 +1157,9 @@ impl AppRuntime {
                 base_geometry_revision,
             ),
             FrontendEvent::CloseWindow { id } => self.close_window_events(&id),
+            FrontendEvent::StopWindow { id } => self.stop_window_events(&id),
+            FrontendEvent::StopAllWindows {} => self.stop_all_windows_events(),
+            FrontendEvent::RestartWindow { id } => self.restart_window_events(&id),
             FrontendEvent::TerminalInput { id, data } => self.terminal_input_events(&id, &data),
             FrontendEvent::PaneSendInput { session_id, text } => {
                 self.pane_send_input_events(client_id, &session_id, &text)

--- a/crates/gwt/src/app_runtime/startup.rs
+++ b/crates/gwt/src/app_runtime/startup.rs
@@ -331,6 +331,46 @@ impl AppRuntime {
         }
     }
 
+    /// SPEC-2356 安心 Addendum (FR-044): relaunch a stopped/errored `Agent`
+    /// window in place. Reuses the same persisted-Session resume primitive the
+    /// startup window restore uses ([`Self::spawn_restored_agent_session`]),
+    /// which removes the paused placeholder and re-spawns the agent into the
+    /// reused window id, preserving the window and appending to its prior
+    /// output. Returns an empty event list when the window has no resumable
+    /// Session (e.g. a never-launched placeholder) so the kill-switch UI can
+    /// surface "nothing to restart" instead of spawning a blank agent.
+    pub(crate) fn restart_agent_window_in_place(
+        &mut self,
+        tab_id: &str,
+        raw_id: &str,
+        fallback_geometry: WindowGeometry,
+    ) -> Vec<OutboundEvent> {
+        let Some(session_id) = self
+            .tab(tab_id)
+            .and_then(|tab| tab.workspace.window(raw_id))
+            .and_then(|window| window.session_id.clone())
+        else {
+            return Vec::new();
+        };
+        let path = self.sessions_dir.join(format!("{session_id}.toml"));
+        let Ok(session) = gwt_agent::Session::load_and_migrate(&path) else {
+            return Vec::new();
+        };
+        let workspace_resume_context = Some(workspace_resume_context_for_work_item(
+            &session.worktree_path,
+            Some(session.branch.as_str()),
+            &session.worktree_path,
+        ));
+        let mut events = vec![self.workspace_state_broadcast()];
+        events.append(&mut self.spawn_restored_agent_session(
+            tab_id,
+            session,
+            workspace_resume_context,
+            fallback_geometry,
+        ));
+        events
+    }
+
     /// Restore every process window the user did not explicitly close in a
     /// freshly opened/restored project tab (Issue #2942). Closing a window
     /// removes it from the persisted workspace, so the persisted process

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -10167,6 +10167,259 @@ fn app_runtime_start_window_registers_running_process_runtime_and_pty_writer() {
     runtime.stop_window_runtime(&window_id);
 }
 
+// SPEC-2356 安心 Addendum (FR-041): StopWindow tears down the runtime but KEEPS
+// the window on the canvas, rendered as Stopped, unlike CloseWindow.
+#[test]
+fn stop_window_events_keeps_window_and_marks_stopped() {
+    let temp = tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    let tab = sample_project_tab(
+        "tab-1",
+        "Repo",
+        repo,
+        ProjectKind::NonRepo,
+        &[WindowPreset::Shell],
+    );
+    let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+    let window = runtime.tabs[0].workspace.persisted().windows[0].clone();
+    let window_id = combined_window_id("tab-1", &window.id);
+    runtime.register_window("tab-1", &window.id);
+    insert_test_pane_runtime(&mut runtime, &window_id);
+    runtime
+        .window_pty_statuses
+        .insert(window_id.clone(), WindowProcessStatus::Running);
+
+    let events = runtime.stop_window_events(&window_id);
+
+    // The runtime is gone (PTY killed) but the window record survives.
+    assert!(!runtime.runtimes.contains_key(&window_id));
+    assert!(runtime.window_lookup.contains_key(&window_id));
+    assert!(
+        runtime.tabs[0].workspace.window(&window.id).is_some(),
+        "StopWindow must keep the window on the canvas, unlike CloseWindow"
+    );
+    assert_eq!(
+        runtime.window_status(&window_id),
+        Some(WindowProcessStatus::Stopped),
+        "stopped window must render as Stopped"
+    );
+    assert!(events.iter().any(|event| matches!(
+        &event.event,
+        BackendEvent::WindowState { window_id: id, state }
+            if id == &window_id && *state == WindowProcessStatus::Stopped
+    )));
+}
+
+// SPEC-2356 安心 Addendum (FR-041): StopWindow is idempotent — stopping an
+// already-stopped window keeps it on the canvas and stays Stopped.
+#[test]
+fn stop_window_events_is_idempotent_when_already_stopped() {
+    let temp = tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    let tab = sample_project_tab_with_window_at(
+        "tab-1",
+        "shell-1",
+        repo,
+        WindowPreset::Shell,
+        WindowProcessStatus::Stopped,
+    );
+    let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+    let window_id = combined_window_id("tab-1", "shell-1");
+    runtime.register_window("tab-1", "shell-1");
+
+    let events = runtime.stop_window_events(&window_id);
+
+    assert!(runtime.tabs[0].workspace.window("shell-1").is_some());
+    assert_eq!(
+        runtime.window_status(&window_id),
+        Some(WindowProcessStatus::Stopped)
+    );
+    // Idempotent: it still emits the authoritative Stopped status, never an error.
+    assert!(events.iter().all(|event| !matches!(
+        &event.event,
+        BackendEvent::WindowState { state, .. } if *state == WindowProcessStatus::Error
+    )));
+}
+
+// SPEC-2356 安心 Addendum (FR-041): CloseWindow vs StopWindow contract — Close
+// removes the window, Stop keeps it. This guards the distinction directly.
+#[test]
+fn close_window_removes_while_stop_window_keeps() {
+    let temp = tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    let tab = sample_project_tab(
+        "tab-1",
+        "Repo",
+        repo,
+        ProjectKind::NonRepo,
+        &[WindowPreset::Shell, WindowPreset::Shell],
+    );
+    let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+    let windows: Vec<_> = runtime.tabs[0]
+        .workspace
+        .persisted()
+        .windows
+        .iter()
+        .map(|window| window.id.clone())
+        .collect();
+    let stop_raw = windows[0].clone();
+    let close_raw = windows[1].clone();
+    let stop_id = combined_window_id("tab-1", &stop_raw);
+    let close_id = combined_window_id("tab-1", &close_raw);
+    runtime.register_window("tab-1", &stop_raw);
+    runtime.register_window("tab-1", &close_raw);
+
+    runtime.stop_window_events(&stop_id);
+    runtime.close_window_events(&close_id);
+
+    assert!(
+        runtime.tabs[0].workspace.window(&stop_raw).is_some(),
+        "StopWindow keeps the window"
+    );
+    assert!(
+        runtime.tabs[0].workspace.window(&close_raw).is_none(),
+        "CloseWindow removes the window"
+    );
+}
+
+// SPEC-2356 安心 Addendum (FR-042): StopAllWindows stops every running agent
+// window's runtime while keeping all windows on the canvas.
+#[test]
+fn stop_all_windows_events_stops_every_runtime_keeping_windows() {
+    let temp = tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    let tab = sample_project_tab(
+        "tab-1",
+        "Repo",
+        repo,
+        ProjectKind::NonRepo,
+        &[WindowPreset::Claude, WindowPreset::Codex],
+    );
+    let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+    let raw_ids: Vec<_> = runtime.tabs[0]
+        .workspace
+        .persisted()
+        .windows
+        .iter()
+        .map(|window| window.id.clone())
+        .collect();
+    for raw in &raw_ids {
+        let window_id = combined_window_id("tab-1", raw);
+        runtime.register_window("tab-1", raw);
+        insert_test_pane_runtime(&mut runtime, &window_id);
+        runtime
+            .window_pty_statuses
+            .insert(window_id.clone(), WindowProcessStatus::Running);
+    }
+
+    runtime.stop_all_windows_events();
+
+    for raw in &raw_ids {
+        let window_id = combined_window_id("tab-1", raw);
+        assert!(
+            !runtime.runtimes.contains_key(&window_id),
+            "every agent runtime must be torn down"
+        );
+        assert!(
+            runtime.tabs[0].workspace.window(raw).is_some(),
+            "StopAllWindows must keep all windows on the canvas"
+        );
+        assert_eq!(
+            runtime.window_status(&window_id),
+            Some(WindowProcessStatus::Stopped)
+        );
+    }
+}
+
+// SPEC-2356 安心 Addendum (FR-044): RestartWindow relaunches a stopped process
+// preset in place, preserving the window id and re-registering its runtime.
+#[test]
+fn restart_window_events_relaunches_stopped_process_window_in_place() {
+    let temp = tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    let tab = sample_project_tab_with_window_at(
+        "tab-1",
+        "shell-1",
+        repo,
+        WindowPreset::Shell,
+        WindowProcessStatus::Stopped,
+    );
+    let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+    let window_id = combined_window_id("tab-1", "shell-1");
+    runtime.register_window("tab-1", "shell-1");
+    assert!(!runtime.runtimes.contains_key(&window_id));
+
+    let events = runtime.restart_window_events(&window_id);
+
+    // Same window id, freshly-running runtime + PTY writer registered.
+    assert!(
+        runtime.tabs[0].workspace.window("shell-1").is_some(),
+        "RestartWindow must preserve the window id"
+    );
+    assert!(runtime.runtimes.contains_key(&window_id));
+    assert_eq!(
+        runtime.window_status(&window_id),
+        Some(WindowProcessStatus::Running)
+    );
+    assert!(events.iter().any(|event| matches!(
+        &event.event,
+        BackendEvent::WindowState { window_id: id, state }
+            if id == &window_id && *state == WindowProcessStatus::Running
+    )));
+
+    runtime.stop_window_runtime(&window_id);
+}
+
+// SPEC-2356 安心 Addendum (FR-044): RestartWindow only acts on stopped/errored
+// windows — restarting a window that is already running is a no-op so a live
+// agent is never double-spawned.
+#[test]
+fn restart_window_events_is_noop_when_window_already_running() {
+    let temp = tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    let tab = sample_project_tab(
+        "tab-1",
+        "Repo",
+        repo,
+        ProjectKind::NonRepo,
+        &[WindowPreset::Shell],
+    );
+    let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+    let window = runtime.tabs[0].workspace.persisted().windows[0].clone();
+    let window_id = combined_window_id("tab-1", &window.id);
+    runtime.register_window("tab-1", &window.id);
+    insert_test_pane_runtime(&mut runtime, &window_id);
+    runtime
+        .window_pty_statuses
+        .insert(window_id.clone(), WindowProcessStatus::Running);
+    let original_pane = runtime
+        .runtimes
+        .get(&window_id)
+        .map(|runtime| Arc::as_ptr(&runtime.pane) as usize)
+        .expect("runtime present");
+
+    let events = runtime.restart_window_events(&window_id);
+
+    assert!(events.is_empty(), "restarting a running window is a no-op");
+    let after_pane = runtime
+        .runtimes
+        .get(&window_id)
+        .map(|runtime| Arc::as_ptr(&runtime.pane) as usize)
+        .expect("runtime still present");
+    assert_eq!(
+        original_pane, after_pane,
+        "running window's runtime must not be replaced"
+    );
+
+    runtime.stop_window_runtime(&window_id);
+}
+
 #[test]
 fn app_runtime_stop_all_runtimes_kills_every_pane_before_join_waits() {
     let temp = tempdir().expect("tempdir");

--- a/crates/gwt/src/app_runtime/window.rs
+++ b/crates/gwt/src/app_runtime/window.rs
@@ -23,7 +23,7 @@ use gwt::{AgentKanbanLane, ArrangeMode, CanvasViewport, FocusCycleDirection};
 
 use super::{
     close_window_from_workspace, combined_window_id, AppRuntime, BackendEvent, OutboundEvent,
-    WindowGeometry, WindowPreset,
+    WindowGeometry, WindowPreset, WindowProcessStatus,
 };
 
 impl AppRuntime {
@@ -422,6 +422,107 @@ impl AppRuntime {
             events.push(event);
         }
         events
+    }
+
+    /// SPEC-2356 安心 Addendum (FR-041): stop a single window's agent runtime
+    /// (kill the PTY through the existing stop path) but keep the window and its
+    /// terminal output on the canvas, rendered as `Stopped`. Unlike
+    /// [`Self::close_window_events`], the window record is never removed, so the
+    /// operator keeps the prior output and can later relaunch it through
+    /// [`Self::restart_window_events`]. Idempotent: stopping an already-stopped
+    /// window simply re-broadcasts the authoritative `Stopped` status.
+    pub(crate) fn stop_window_events(&mut self, id: &str) -> Vec<OutboundEvent> {
+        let Some(address) = self.window_lookup.get(id).cloned() else {
+            return Vec::new();
+        };
+        // Tear down the live runtime (kills the PTY + joins reader/status
+        // threads + deregisters the writer). This reuses the exact same stop
+        // primitive that `close_window_events` uses, so no PTY management is
+        // reimplemented. `stop_window_runtime` also persists the Paused Work
+        // marker for an agent session via `mark_agent_session_stopped`.
+        self.stop_window_runtime(id);
+        // Render the surviving window as Stopped. `stop_window_runtime` already
+        // removed the pty/hook tracking, so the workspace record is the source
+        // of truth for the post-stop status.
+        self.set_window_status(
+            &address.tab_id,
+            &address.raw_id,
+            WindowProcessStatus::Stopped,
+        );
+        let _ = self.persist();
+        let mut events = vec![self.workspace_state_broadcast()];
+        events.extend(Self::status_events(
+            id.to_string(),
+            WindowProcessStatus::Stopped,
+            None,
+        ));
+        if let Some(event) = self.active_work_projection_broadcast_for_active_tab() {
+            events.push(event);
+        }
+        events
+    }
+
+    /// SPEC-2356 安心 Addendum (FR-042): stop every running agent window's
+    /// runtime, keeping all windows on the canvas. Iterates the open windows
+    /// and applies the per-window [`Self::stop_window_events`] stop to each
+    /// window that currently has a live runtime, so the confirm-on-frontend
+    /// "stop all" button resolves to the same kept-but-stopped state as the
+    /// single-window kill switch.
+    pub(crate) fn stop_all_windows_events(&mut self) -> Vec<OutboundEvent> {
+        let running_ids: Vec<String> = self.runtimes.keys().cloned().collect();
+        let mut events = Vec::new();
+        for window_id in running_ids {
+            events.extend(self.stop_window_events(&window_id));
+        }
+        events
+    }
+
+    /// SPEC-2356 安心 Addendum (FR-044): relaunch a window's agent in place. The
+    /// window id, geometry, and placement are preserved; the prior terminal
+    /// output is appended to (never wiped) because the window record — and the
+    /// frontend's xterm buffer bound to its id — survive the restart. Only acts
+    /// on a window that is currently `Stopped` or `Error`; restarting a running
+    /// window is a no-op so a live agent is never double-spawned.
+    ///
+    /// Process-spec presets (`Shell` / `Claude` / `Codex`) re-spawn through the
+    /// existing [`Self::start_window`] primitive. `Agent` windows re-spawn
+    /// through the persisted Session (the same resume path the Workspace /
+    /// Board resume buttons use) bound to the existing window id.
+    pub(crate) fn restart_window_events(&mut self, id: &str) -> Vec<OutboundEvent> {
+        let Some(address) = self.window_lookup.get(id).cloned() else {
+            return Vec::new();
+        };
+        let Some(tab) = self.tab(&address.tab_id) else {
+            return Vec::new();
+        };
+        let Some(window) = tab.workspace.window(&address.raw_id) else {
+            return Vec::new();
+        };
+        if !window.preset.requires_process() {
+            return Vec::new();
+        }
+        // Idempotency / safety guard: only relaunch a window that is actually
+        // stopped or errored. A running agent must never be double-spawned.
+        match self.window_status(id) {
+            Some(WindowProcessStatus::Stopped) | Some(WindowProcessStatus::Error) => {}
+            _ => return Vec::new(),
+        }
+
+        let preset = window.preset;
+        let geometry = window.geometry.clone();
+
+        if preset == WindowPreset::Agent {
+            return self.restart_agent_window_in_place(&address.tab_id, &address.raw_id, geometry);
+        }
+
+        // Clear any stale "restored window is paused" detail before relaunching
+        // so the new PTY's status is the authoritative one.
+        self.window_details.remove(id);
+        let events = self.start_window(&address.tab_id, &address.raw_id, preset, geometry);
+        let _ = self.persist();
+        let mut all = vec![self.workspace_state_broadcast()];
+        all.extend(events);
+        all
     }
 
     pub(crate) fn list_windows_event(&self) -> BackendEvent {

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -290,6 +290,27 @@ pub enum FrontendEvent {
     CloseWindow {
         id: String,
     },
+    /// SPEC-2356 安心 Addendum (FR-041): stop the window's agent runtime (kill
+    /// the PTY through the existing stop path) but KEEP the window and its
+    /// terminal output on the canvas, rendered as `Stopped`. Distinct from
+    /// [`Self::CloseWindow`], which removes the window. Idempotent if the
+    /// window is already stopped. The stopped window stays restartable through
+    /// [`Self::RestartWindow`].
+    StopWindow {
+        id: String,
+    },
+    /// SPEC-2356 安心 Addendum (FR-042): stop every running agent window's
+    /// runtime, keeping all windows on the canvas. The confirm-before-stop
+    /// prompt is the frontend's responsibility; the backend just executes the
+    /// per-window stop for each currently-running agent window.
+    StopAllWindows {},
+    /// SPEC-2356 安心 Addendum (FR-044): relaunch the window's agent in place
+    /// using its existing preset / persisted Session, preserving the window id
+    /// and appending to (never wiping) the prior terminal output. Works for a
+    /// window that is currently `Stopped` or `Error`.
+    RestartWindow {
+        id: String,
+    },
     TerminalInput {
         id: String,
         data: String,
@@ -4274,5 +4295,49 @@ mod tests {
         let value = serde_json::to_value(&event).expect("serialize");
         assert_eq!(value["kind"], "ui_trace_error");
         assert_eq!(value["message"], "trace payload missing entries");
+    }
+
+    // SPEC-2356 安心 Addendum (FR-041): StopWindow is a distinct kill-switch
+    // event that carries the window id only — it never removes the window.
+    #[test]
+    fn stop_window_deserializes_kill_switch_contract() {
+        let event = serde_json::from_value::<FrontendEvent>(serde_json::json!({
+            "kind": "stop_window",
+            "id": "tab-1::agent-1"
+        }))
+        .expect("deserialize stop_window");
+
+        assert!(matches!(
+            event,
+            FrontendEvent::StopWindow { id } if id == "tab-1::agent-1"
+        ));
+    }
+
+    // SPEC-2356 安心 Addendum (FR-042): StopAllWindows carries no payload; the
+    // backend decides which windows are running agents.
+    #[test]
+    fn stop_all_windows_deserializes_empty_payload_contract() {
+        let event = serde_json::from_value::<FrontendEvent>(serde_json::json!({
+            "kind": "stop_all_windows"
+        }))
+        .expect("deserialize stop_all_windows");
+
+        assert!(matches!(event, FrontendEvent::StopAllWindows {}));
+    }
+
+    // SPEC-2356 安心 Addendum (FR-044): RestartWindow carries the window id of a
+    // stopped/errored window to relaunch in place.
+    #[test]
+    fn restart_window_deserializes_relaunch_contract() {
+        let event = serde_json::from_value::<FrontendEvent>(serde_json::json!({
+            "kind": "restart_window",
+            "id": "tab-1::agent-1"
+        }))
+        .expect("deserialize restart_window");
+
+        assert!(matches!(
+            event,
+            FrontendEvent::RestartWindow { id } if id == "tab-1::agent-1"
+        ));
     }
 }

--- a/crates/gwt/web/__tests__/agent-completion-notifications.test.mjs
+++ b/crates/gwt/web/__tests__/agent-completion-notifications.test.mjs
@@ -3,7 +3,10 @@ import test from "node:test";
 
 import { parseHTML } from "linkedom";
 
-import { createAgentCompletionNotifier } from "../agent-completion-notifications.js";
+import {
+  createAgentCompletionNotifier,
+  createAgentAttentionToaster,
+} from "../agent-completion-notifications.js";
 
 function setupDocument({ hidden = true, focused = false } = {}) {
   const { document } = parseHTML("<main></main>");
@@ -182,4 +185,85 @@ test("notifier reports stopped and error transitions as separate categories", ()
     notices.map((notice) => notice.kind),
     ["agent_stopped", "agent_error"],
   );
+});
+
+// SPEC-2356 Anshin Addendum (FR-040) — in-app attention toaster.
+function collectAttentionToaster() {
+  const toasts = [];
+  const toaster = createAgentAttentionToaster({
+    showToast: (notice) => toasts.push(notice),
+    now: () => 1000,
+  });
+  return { toaster, toasts };
+}
+
+test("FR-040: needs_input (waiting) fires an in-app toast even while present", () => {
+  const { toaster, toasts } = collectAttentionToaster();
+  const notice = toaster.handleRuntimeState({
+    windowId: "w-1",
+    runtimeState: "waiting",
+    windowData: { title: "codex-1" },
+  });
+  assert.ok(notice, "waiting must produce a toast");
+  assert.equal(notice.flavor, "needs_input");
+  assert.equal(notice.windowId, "w-1");
+  assert.match(notice.body, /codex-1/);
+  assert.equal(toasts.length, 1);
+});
+
+test("FR-040: blocked/error and done states also toast", () => {
+  const { toaster, toasts } = collectAttentionToaster();
+  toaster.handleRuntimeState({ windowId: "w-err", runtimeState: "error", windowData: { title: "a" } });
+  toaster.handleRuntimeState({ windowId: "w-done", runtimeState: "stopped", windowData: { title: "b" } });
+  toaster.handleRuntimeState({ windowId: "w-exit", runtimeState: "exited", windowData: { title: "c" } });
+  assert.deepEqual(
+    toasts.map((t) => t.flavor),
+    ["error", "done", "done"],
+  );
+});
+
+test("FR-040: running / starting / idle never toast", () => {
+  const { toaster, toasts } = collectAttentionToaster();
+  for (const state of ["running", "starting", "idle", "ready"]) {
+    toaster.handleRuntimeState({ windowId: "w-1", runtimeState: state, windowData: {} });
+  }
+  assert.equal(toasts.length, 0);
+});
+
+test("FR-040: the same flavor does not re-toast across repeated frames", () => {
+  const { toaster, toasts } = collectAttentionToaster();
+  toaster.handleRuntimeState({ windowId: "w-1", runtimeState: "waiting", windowData: {} });
+  toaster.handleRuntimeState({ windowId: "w-1", runtimeState: "waiting", windowData: {} });
+  toaster.handleRuntimeState({ windowId: "w-1", runtimeState: "waiting", windowData: {} });
+  assert.equal(toasts.length, 1, "repeated waiting frames must not spam");
+});
+
+test("FR-040: leaving and re-entering an attention state toasts again", () => {
+  const { toaster, toasts } = collectAttentionToaster();
+  toaster.handleRuntimeState({ windowId: "w-1", runtimeState: "waiting", windowData: {} });
+  toaster.handleRuntimeState({ windowId: "w-1", runtimeState: "running", windowData: {} });
+  toaster.handleRuntimeState({ windowId: "w-1", runtimeState: "waiting", windowData: {} });
+  assert.equal(toasts.length, 2, "re-entry into waiting after running must toast again");
+});
+
+test("FR-040: error -> done transition toasts each distinct flavor", () => {
+  const { toaster, toasts } = collectAttentionToaster();
+  toaster.handleRuntimeState({ windowId: "w-1", runtimeState: "error", windowData: {} });
+  toaster.handleRuntimeState({ windowId: "w-1", runtimeState: "stopped", windowData: {} });
+  assert.deepEqual(toasts.map((t) => t.flavor), ["error", "done"]);
+});
+
+test("FR-040: forgetWindow clears dedupe so a fresh window toasts", () => {
+  const { toaster, toasts } = collectAttentionToaster();
+  toaster.handleRuntimeState({ windowId: "w-1", runtimeState: "waiting", windowData: {} });
+  toaster.forgetWindow("w-1");
+  toaster.handleRuntimeState({ windowId: "w-1", runtimeState: "waiting", windowData: {} });
+  assert.equal(toasts.length, 2);
+});
+
+test("FR-040: missing windowId yields no toast", () => {
+  const { toaster, toasts } = collectAttentionToaster();
+  const notice = toaster.handleRuntimeState({ windowId: "", runtimeState: "waiting" });
+  assert.equal(notice, null);
+  assert.equal(toasts.length, 0);
 });

--- a/crates/gwt/web/__tests__/contrast.test.mjs
+++ b/crates/gwt/web/__tests__/contrast.test.mjs
@@ -76,6 +76,8 @@ const STRIP_PALETTE = {
   active: "#22d3ee",
   idle: "#94a3b8",
   blocked: "#f87171",
+  // FR-039 (安心) — WAITING cell uses the bright amber on the dark strip band.
+  "needs-input": "#fbbf24",
 };
 
 for (const themeName of ["dark", "light"]) {
@@ -102,6 +104,7 @@ const STATE_TEXT_TOKENS = [
   "--color-state-idle",
   "--color-state-blocked",
   "--color-state-done",
+  "--color-state-needs-input",
 ];
 // State colors are used as TEXT inside cards / status chips that sit on
 // surface bg. They are NOT used directly on canvas as text — canvas text
@@ -139,6 +142,7 @@ test("components.css scopes the on-strip state palette to bright on-dark variant
   assert.match(stripBlock[1], /--color-state-active:\s*#22d3ee/i);
   assert.match(stripBlock[1], /--color-state-idle:\s*#94a3b8/i);
   assert.match(stripBlock[1], /--color-state-blocked:\s*#f87171/i);
+  assert.match(stripBlock[1], /--color-state-needs-input:\s*#fbbf24/i);
 });
 
 // SPEC-2356 — Focus ring is a UI component, so WCAG 2.2 SC 1.4.11

--- a/crates/gwt/web/__tests__/fleet-minimap.test.mjs
+++ b/crates/gwt/web/__tests__/fleet-minimap.test.mjs
@@ -132,6 +132,19 @@ test("cells carry agent color and telemetry datasets only when present", () => {
   assert.equal(plainCell.dataset.telemetry, undefined, "non-agent cell omits telemetry");
 });
 
+test("FR-039 (安心): a needs_input telemetry surfaces as its own minimap dataset", () => {
+  // The minimap dot color/pulse keys off data-telemetry, so the loud
+  // needs_input state must round-trip onto the cell rather than collapse.
+  const { container } = setupDom();
+  const windows = [windowAt("w-wait", 0, 0, 100, 80, { agent_color: "amber", telemetry: "needs_input" })];
+  const { minimap } = makeMinimap(container, windows);
+
+  minimap.renderCells();
+
+  const cell = container.querySelector('[data-window-id="w-wait"]');
+  assert.equal(cell.dataset.telemetry, "needs_input");
+});
+
 test("the focused window's cell gets the is-focused class", () => {
   const { container } = setupDom();
   const windows = [windowAt("w-1", 0, 0), windowAt("w-2", 300, 0)];

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -197,6 +197,7 @@ test("index.html declares Operator chrome scaffold", () => {
     "#op-strip-clock",
     "#op-strip-active",
     "#op-strip-idle",
+    "#op-strip-waiting",
     "#op-strip-blocked",
     "#op-briefing",
     "#op-palette-backdrop",
@@ -1119,6 +1120,7 @@ test("Status Strip is exposed as a live region with semantic value labels", () =
   for (const id of [
     "op-strip-active",
     "op-strip-idle",
+    "op-strip-waiting",
     "op-strip-blocked",
     "op-strip-branches",
     "op-strip-runtime-health-value",
@@ -3101,30 +3103,52 @@ test("mapAgentTelemetryState emits only Living Telemetry states CSS handles", ()
   for (const m of mapperBlock[0].matchAll(/return\s+"([^"]+)"/g)) {
     returnedStates.add(m[1]);
   }
-  const allowed = new Set(["active", "not_started", "idle", "blocked", "done"]);
+  // FR-039 (安心): needs_input joins the Living Telemetry vocabulary as the
+  // LOUD "your turn" state CSS renders via [data-agent-state="needs_input"].
+  const allowed = new Set(["active", "not_started", "idle", "blocked", "done", "needs_input"]);
   for (const state of returnedStates) {
     assert.ok(allowed.has(state), `mapAgentTelemetryState returned undeclared state: ${state}`);
   }
-  // And the four design states must all be reachable, not just allowed.
+  // And every design state must be reachable, not just allowed.
   for (const required of allowed) {
     assert.ok(returnedStates.has(required), `Living Telemetry state never emitted: ${required}`);
   }
 });
 
-test("Status Strip ACTIVE / IDLE / BLOCKED cells all tint with their state color", () => {
+test("Status Strip ACTIVE / IDLE / WAITING / BLOCKED cells all tint with their state color", () => {
   const css = readFileSync(resolve(here, "../styles/components.css"), "utf8");
   // The ACTIVE / IDLE cells previously had no tonal hint — only BLOCKED did.
-  // Add parallel symmetry so the three count cells render with matching state
-  // colors (cyan / gray / red) for at-a-glance scanning.
+  // Add parallel symmetry so the count cells render with matching state colors
+  // (cyan / gray / amber / red) for at-a-glance scanning. FR-039 (安心) adds the
+  // WAITING cell tinted with the needs-input amber.
   assert.match(css, /\.op-status-strip__cell--active\s+\.op-status-strip__value\s*\{[^}]*--color-state-active/);
   assert.match(css, /\.op-status-strip__cell--idle\s+\.op-status-strip__value\s*\{[^}]*--color-state-idle/);
+  assert.match(css, /\.op-status-strip__cell--waiting\s+\.op-status-strip__value\s*\{[^}]*--color-state-needs-input/);
   assert.match(css, /\.op-status-strip__cell--blocked\s+\.op-status-strip__value\s*\{[^}]*--color-state-blocked/);
   // Markup also needs the modifiers wired so the CSS selectors actually match.
   const indexHtml = readFileSync(resolve(here, "../index.html"), "utf8");
   assert.match(indexHtml, /op-status-strip__cell\s+op-status-strip__cell--active/);
   assert.match(indexHtml, /op-status-strip__cell\s+op-status-strip__cell--idle/);
+  assert.match(indexHtml, /op-status-strip__cell\s+op-status-strip__cell--waiting/);
   assert.match(indexHtml, /op-status-strip__cell\s+op-status-strip__cell--runtime-health/);
   assert.match(css, /\.op-status-strip__cell--runtime-health\[data-state="warn"\]/);
+});
+
+test("FR-039 (安心): WAITING cell drives a LOUD needs_input alert pulse like BLOCKED", () => {
+  const css = readFileSync(resolve(here, "../styles/components.css"), "utf8");
+  // The WAITING cell must pulse via the same op-status-strip alert mechanism the
+  // BLOCKED cell uses, so "agents waiting for input" reads just as loud.
+  assert.match(
+    css,
+    /\.op-status-strip__cell--waiting\.op-status-strip__cell--alert\s+\.op-status-strip__value/,
+    "WAITING cell needs an --alert pulse rule mirroring BLOCKED",
+  );
+  // The window rim + minimap dot must render the needs_input telemetry state.
+  assert.match(css, /\[data-agent-state="needs_input"\]\s*\{/);
+  assert.match(css, /\.fleet-minimap__cell\[data-telemetry="needs_input"\]::after/);
+  // applyTelemetryCounts must route the needs_input count into the WAITING cell.
+  assert.match(operatorShellSource, /op-strip-waiting/);
+  assert.match(operatorShellSource, /needs_input/);
 });
 
 test("Work surface lifecycle badge styles every agent-session state (SPEC-2359 W-12 FR-351)", () => {

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -328,11 +328,12 @@ test("Sidebar retires the Active Works overview in favor of the Work surface (SP
   );
 });
 
-test("Command Rail groups items into Navigate / Windows / System (SPEC-3038 US-1)", () => {
+test("Command Rail groups items into Navigate / Windows / Agents / System (SPEC-3038 US-1)", () => {
   // SPEC-3038 US-1: the rail is the single always-visible home for navigation
   // (Start Work / Work / Board / Logs), window operations (Tile / Stack /
   // Align / Windows / Add), and system actions (Palette / Update) — in that
-  // order. Groups carry aria-labels instead of visual headings.
+  // order. Groups carry aria-labels instead of visual headings. SPEC-2356
+  // Anshin (FR-042) inserts an Agents group (STOP ALL) before System.
   const groups = Array.from(document.querySelectorAll(".op-rail > .op-rail__group")).map(
     (group) => group.getAttribute("aria-label"),
   );
@@ -340,8 +341,8 @@ test("Command Rail groups items into Navigate / Windows / System (SPEC-3038 US-1
   // bottom-right home, so the sidebar no longer carries an Update section.
   assert.deepEqual(
     groups,
-    ["Navigate", "Windows", "System"],
-    "Rail order must be Navigate → Windows → System",
+    ["Navigate", "Windows", "Agents", "System"],
+    "Rail order must be Navigate → Windows → Agents → System",
   );
 });
 
@@ -3151,6 +3152,54 @@ test("FR-039 (安心): WAITING cell drives a LOUD needs_input alert pulse like B
   assert.match(operatorShellSource, /needs_input/);
 });
 
+test("FR-041/044 (安心): window chrome carries STOP + RESTART kill-switch controls", () => {
+  // The window titlebar actions must expose STOP and RESTART alongside close,
+  // both starting hidden (visibility is driven per render from runtime state).
+  assert.match(appSource, /data-action="stop"[^>]*aria-label="Stop agent"/);
+  assert.match(appSource, /data-action="restart"[^>]*aria-label="Restart agent"/);
+  // STOP click sends stop_window (PTY halts, window stays); RESTART sends
+  // restart_window (relaunch in place).
+  assert.match(appSource, /kind:\s*"stop_window",\s*id:\s*windowData\.id/);
+  assert.match(appSource, /kind:\s*"restart_window",\s*id:\s*windowData\.id/);
+  // The render path toggles the controls based on runtime state.
+  assert.match(appSource, /updateWindowKillSwitchControls/);
+});
+
+test("FR-042 (安心): STOP ALL is reachable from the rail and the palette with a confirm", () => {
+  const railItem = document.querySelector('.op-rail__item[data-cmd="stop-all-windows"]');
+  assert.ok(railItem, "expected a Stop all agents rail item");
+  assert.equal(railItem.getAttribute("aria-label"), "Stop all agents");
+  // op:command + palette both route to requestStopAllWindows, which confirms
+  // and emits stop_all_windows.
+  assert.match(appSource, /case "stop-all-windows":/);
+  assert.match(appSource, /id:\s*"stop-all-agents"/);
+  assert.match(appSource, /kind:\s*"stop_all_windows"/);
+  assert.match(appSource, /function requestStopAllWindows\(\)/);
+});
+
+test("FR-043 (安心): send-input routes to the focused agent pane via session_id", () => {
+  // The palette entry + helper inject one line into the focused agent pane
+  // using pane_send_input scoped to the window's session_id.
+  assert.match(appSource, /id:\s*"send-input-focused-agent"/);
+  assert.match(appSource, /kind:\s*"pane_send_input",\s*session_id:/);
+  assert.match(appSource, /function sendFocusedPaneInput\(/);
+});
+
+test("FR-040 (安心): in-app attention toasts are wired with click-to-jump", () => {
+  // The attention toaster fires in-app toasts (no away gate); the renderer
+  // frames the window on click and respects reduced-motion via the CSS layer.
+  assert.match(appSource, /createAgentAttentionToaster/);
+  assert.match(appSource, /agentAttentionToaster\.handleRuntimeState/);
+  assert.match(appSource, /function showAttentionToast/);
+  assert.match(appSource, /frameWindow\(notice\.windowId\)/);
+  assert.match(inlineStyle, /\.attention-toast\s*\{/);
+  assert.match(
+    inlineStyle,
+    /@media \(prefers-reduced-motion: reduce\)[\s\S]*?\.attention-toast\s*\{[\s\S]*?animation:\s*none/,
+    "attention toast must drop its entrance animation under reduced motion",
+  );
+});
+
 test("Work surface lifecycle badge styles every agent-session state (SPEC-2359 W-12 FR-351)", () => {
   const css = readFileSync(resolve(here, "../styles/components.css"), "utf8");
   // Slice 3 retires the sidebar `op-agent-card` states; the Work surface now
@@ -4654,10 +4703,20 @@ test("window template restores the manual resize handle as a window-body sibling
     /<div class="window-body"><\/div>\s*<div class="resize-handle"><\/div>/,
     "the resize handle must be a sibling div after the window body",
   );
-  assert.match(
-    ensureWindowBody,
-    /<div class="window-actions">\s*<button class="icon-button" data-action="close"[\s\S]*?<\/div>/,
-    "window-actions must stay close-only (no maximize/minimize buttons)",
+  // SPEC-2008 retired maximize/minimize; SPEC-2356 Anshin (FR-041/044) added
+  // the STOP + RESTART kill-switch alongside close. Window-actions may carry
+  // those, but never maximize/minimize.
+  const windowActions = ensureWindowBody.match(
+    /<div class="window-actions">[\s\S]*?<\/div>/,
+  );
+  assert.ok(windowActions, "window-actions block must exist");
+  assert.match(windowActions[0], /data-action="close"/, "close must remain");
+  assert.match(windowActions[0], /data-action="stop"/, "STOP kill-switch must be present");
+  assert.match(windowActions[0], /data-action="restart"/, "RESTART must be present");
+  assert.doesNotMatch(
+    windowActions[0],
+    /data-action="(maximize|minimize)"/,
+    "window-actions must never reintroduce maximize/minimize buttons",
   );
   // The handle is wired to begin a local geometry edit and arm the resize state
   // (camera is untouched; only the window geometry changes).

--- a/crates/gwt/web/__tests__/operator-rail.test.mjs
+++ b/crates/gwt/web/__tests__/operator-rail.test.mjs
@@ -70,6 +70,32 @@ test("rail window badge: applyTelemetryCounts が windows 数を badge に反映
   assert.equal(badge.hidden, true);
 });
 
+test("FR-039 (安心): applyTelemetryCounts が needs_input を WAITING cell に反映しアラート点滅する", async () => {
+  // The WAITING cell mirrors BLOCKED: needs_input drives both the count value
+  // and the --alert pulse so an agent waiting for the operator stays loud.
+  const { applyTelemetryCounts } = await importOperatorShell();
+  const { document } = parseHTML(html);
+  const value = document.getElementById("op-strip-waiting");
+  const cell = document.querySelector(".op-status-strip__cell--waiting");
+  assert.ok(value, "expected #op-strip-waiting value in the strip");
+  assert.ok(cell, "expected .op-status-strip__cell--waiting cell in the strip");
+  assert.equal(value.getAttribute("aria-label"), "Agents waiting for input");
+
+  applyTelemetryCounts(document, { needs_input: 2 });
+  assert.equal(value.textContent, "2");
+  assert.ok(
+    cell.classList.contains("op-status-strip__cell--alert"),
+    "WAITING cell pulses while agents wait for input",
+  );
+
+  applyTelemetryCounts(document, { needs_input: 0 });
+  assert.equal(value.textContent, "0");
+  assert.ok(
+    !cell.classList.contains("op-status-strip__cell--alert"),
+    "WAITING cell stops pulsing once no agent is waiting",
+  );
+});
+
 test("migration: 起動時に旧 localStorage キーが removeItem される", async () => {
   const fixture = await mountFixture();
   try {

--- a/crates/gwt/web/__tests__/window-runtime-state.test.mjs
+++ b/crates/gwt/web/__tests__/window-runtime-state.test.mjs
@@ -87,7 +87,8 @@ test("telemetry mapping projects runtime states to semantic states", () => {
   assert.equal(mapAgentTelemetryState("starting"), "not_started");
   assert.equal(mapAgentTelemetryState("ready"), "idle");
   assert.equal(mapAgentTelemetryState("idle"), "idle");
-  assert.equal(mapAgentTelemetryState("waiting"), "idle");
+  // FR-039 (安心): waiting is its own LOUD telemetry state, not quiet idle.
+  assert.equal(mapAgentTelemetryState("waiting"), "needs_input");
   assert.equal(mapAgentTelemetryState("stopped"), "done");
   assert.equal(mapAgentTelemetryState("exited"), "done");
   assert.equal(mapAgentTelemetryState("error"), "blocked");

--- a/crates/gwt/web/agent-completion-notifications.js
+++ b/crates/gwt/web/agent-completion-notifications.js
@@ -180,3 +180,96 @@ export function createAgentCompletionNotifier({
     forgetWindow,
   };
 }
+
+// SPEC-2356 Anshin Addendum (FR-040) — in-app attention toaster.
+//
+// Distinct from createAgentCompletionNotifier above, which only fires DESKTOP
+// notifications when the operator is AWAY for a sustained run. This is the
+// in-app, always-on counterpart: the moment an agent transitions into a state
+// that wants the operator's eyes (needs_input / blocked / error / done), a
+// quiet in-app toast appears even while the operator is present. Clicking a
+// toast flies the camera to that window (frameWindow), so attention is one
+// click from action. Pure controller: DOM rendering is injected via
+// `showToast`. The mapping keys off the runtime wire state, not the Living
+// Telemetry projection, so this stays independent of CSS state names.
+const ATTENTION_STATES = Object.freeze({
+  waiting: "needs_input",
+  error: "error",
+  stopped: "done",
+  exited: "done",
+});
+
+function attentionNoticeForFlavor({ flavor, windowData, windowId }) {
+  const agentName = windowLabel(windowData);
+  switch (flavor) {
+    case "needs_input":
+      return {
+        flavor,
+        title: "Waiting for input",
+        body: `${agentName} is waiting for your input.`,
+        windowId,
+      };
+    case "error":
+      return {
+        flavor,
+        title: "Agent error",
+        body: `${agentName} hit an error.`,
+        windowId,
+      };
+    case "done":
+      return {
+        flavor,
+        title: "Agent finished",
+        body: `${agentName} stopped.`,
+        windowId,
+      };
+    default:
+      return null;
+  }
+}
+
+export function createAgentAttentionToaster({
+  showToast = () => {},
+  now = () => Date.now(),
+} = {}) {
+  // Last toasted flavor per window. We only fire when the flavor CHANGES, so a
+  // string of waiting status frames does not spam the operator. Leaving the
+  // attention set (e.g. back to running/idle) clears the entry so the next
+  // entry into the same flavor toasts again.
+  const lastFlavor = new Map();
+
+  function handleRuntimeState({ windowId, runtimeState, windowData = null }) {
+    if (!windowId) {
+      return null;
+    }
+    const state = normalizeState(runtimeState);
+    const flavor = ATTENTION_STATES[state] || null;
+
+    if (!flavor) {
+      lastFlavor.delete(windowId);
+      return null;
+    }
+
+    if (lastFlavor.get(windowId) === flavor) {
+      return null;
+    }
+    lastFlavor.set(windowId, flavor);
+
+    const notice = attentionNoticeForFlavor({ flavor, windowData, windowId });
+    if (!notice) {
+      return null;
+    }
+    notice.createdAt = now();
+    showToast(notice);
+    return notice;
+  }
+
+  function forgetWindow(windowId) {
+    lastFlavor.delete(windowId);
+  }
+
+  return {
+    handleRuntimeState,
+    forgetWindow,
+  };
+}

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -34,7 +34,12 @@
       import { createLaunchPendingController } from "/launch-pending-controller.js";
       import { createConnectionOverlay } from "/connection-overlay.js";
       import { createUpdateCtaController } from "/update-cta.js";
-      import { createAgentCompletionNotifier } from "/agent-completion-notifications.js";
+      // SPEC-2356 Anshin Addendum (FR-040): the in-app attention toaster ships
+      // alongside the away-only desktop notifier in the same module.
+      import {
+        createAgentCompletionNotifier,
+        createAgentAttentionToaster,
+      } from "/agent-completion-notifications.js";
       import { createReleaseNotesWindow } from "/release-notes-window.js";
       import { createConsoleWindow } from "/console-window.js";
       import { createTerminalWheelScrollController } from "/terminal-wheel-scroll.js";
@@ -837,6 +842,75 @@
             }
           },
         });
+        // SPEC-2356 Anshin Addendum (FR-042): STOP ALL is reachable from the
+        // palette as well as the rail.
+        window.__operatorShell.palette.register({
+          id: "stop-all-agents",
+          label: "Agents: Stop All Running Agents",
+          group: "Agents",
+          handler: () => {
+            requestStopAllWindows();
+          },
+        });
+        // SPEC-2356 Anshin Addendum (FR-043): send a line of input to the focused
+        // agent pane from the palette.
+        window.__operatorShell.palette.register({
+          id: "send-input-focused-agent",
+          label: "Agent: Send Input to Focused Agent",
+          group: "Agents",
+          handler: () => {
+            promptSendFocusedPaneInput();
+          },
+        });
+      }
+
+      // SPEC-2356 Anshin Addendum (FR-043): inject one line of input into the
+      // focused agent pane. Targets the window's session_id (not its window id)
+      // so the backend can scope the injection to the caller's own pane. Returns
+      // true when a line was actually dispatched.
+      function focusedAgentWindowData() {
+        if (!focusedId) return null;
+        const windowData = workspaceWindowById(focusedId);
+        if (!windowData || !presetSupportsWaitingStatus(windowData.preset)) {
+          return null;
+        }
+        return windowData;
+      }
+
+      function sendPaneInput(sessionId, text) {
+        const session = String(sessionId || "").trim();
+        const line = String(text ?? "");
+        if (!session || line.length === 0) {
+          return false;
+        }
+        send({ kind: "pane_send_input", session_id: session, text: line });
+        return true;
+      }
+
+      function sendFocusedPaneInput(text) {
+        const windowData = focusedAgentWindowData();
+        const sessionId = windowData?.session_id;
+        return sendPaneInput(sessionId, text);
+      }
+
+      // SPEC-2356 Anshin Addendum (FR-043): the Command Palette entry prompts for
+      // a single line and routes it to the focused agent pane.
+      function promptSendFocusedPaneInput() {
+        const windowData = focusedAgentWindowData();
+        if (!windowData) {
+          window.alert("Focus an agent window first to send it input.");
+          return;
+        }
+        if (!String(windowData.session_id || "").trim()) {
+          window.alert("This agent has no active session to send input to.");
+          return;
+        }
+        const label = windowDisplayTitle(windowData);
+        const text = window.prompt(`Send a line of input to ${label}:`);
+        if (text === null) {
+          return;
+        }
+        sendFocusedPaneInput(text);
       }
 
       // SPEC-2809 — registry of Console window controllers keyed by windowId.
@@ -2768,6 +2842,15 @@
               windowData,
               projectTab: windowContext?.tab || activeProjectTab(),
             });
+            // SPEC-2356 Anshin Addendum (FR-040): only agent panes (the presets
+            // that carry a waiting state) raise in-app attention toasts.
+            if (windowData && presetSupportsWaitingStatus(windowData.preset)) {
+              agentAttentionToaster.handleRuntimeState({
+                windowId,
+                runtimeState,
+                windowData,
+              });
+            }
             if (detail) {
               detailMap.set(windowId, detail);
             } else if (
@@ -2816,6 +2899,11 @@
             // SPEC-2356 — Living Telemetry: project the runtime state onto a stable
             // `data-agent-state` attribute the components.css layer animates.
             element.dataset.agentState = mapAgentTelemetryState(runtimeState);
+            // SPEC-2356 Anshin Addendum (FR-041/FR-044): toggle the kill-switch
+            // chrome. STOP shows for a live agent runtime; RESTART replaces it
+            // once the runtime is stopped or errored. Non-agent windows never
+            // expose either control.
+            updateWindowKillSwitchControls(element, windowData, runtimeState);
             recomputeOperatorTelemetry();
             refreshWindowTabTelemetry(windowData);
             label.textContent = windowRuntimeLabel(runtimeState);
@@ -2849,6 +2937,27 @@
             refreshProjectTabStateCues();
           },
         );
+      }
+
+      // SPEC-2356 Anshin Addendum (FR-041/FR-044): a stopped/errored agent runtime
+      // shows RESTART; a live one shows STOP. Non-agent windows hide both.
+      const STOPPED_RUNTIME_STATES = new Set(["stopped", "exited", "error"]);
+
+      function updateWindowKillSwitchControls(element, windowData, runtimeState) {
+        const stopButton = element.querySelector("[data-action='stop']");
+        const restartButton = element.querySelector("[data-action='restart']");
+        if (!stopButton || !restartButton) {
+          return;
+        }
+        const isAgentWindow = shouldShowRuntimeStatus(windowData);
+        if (!isAgentWindow) {
+          stopButton.hidden = true;
+          restartButton.hidden = true;
+          return;
+        }
+        const isStopped = STOPPED_RUNTIME_STATES.has(runtimeState);
+        stopButton.hidden = isStopped;
+        restartButton.hidden = !isStopped;
       }
 
       function stopSpinnerAnimation(overlay) {
@@ -2960,6 +3069,40 @@
           running: isAgentWindow && runtimeState === "running",
         };
         renderWindowCloseConfirm();
+      }
+
+      // SPEC-2356 Anshin Addendum (FR-042): STOP ALL halts every live agent
+      // runtime, leaving windows on the canvas. Count the live agent windows so
+      // the confirm is specific, and no-op when nothing is running.
+      function countRunningAgentWindows() {
+        let count = 0;
+        for (const [windowId, element] of windowMap.entries()) {
+          if (!element) continue;
+          const windowData = workspaceWindowById(windowId);
+          if (!windowData || !presetSupportsWaitingStatus(windowData.preset)) continue;
+          const runtimeState =
+            windowRuntimeStateMap.get(windowId) ||
+            normalizeWindowRuntimeState(windowData.status, windowData.preset);
+          if (!STOPPED_RUNTIME_STATES.has(runtimeState)) {
+            count += 1;
+          }
+        }
+        return count;
+      }
+
+      function requestStopAllWindows() {
+        const running = countRunningAgentWindows();
+        if (running === 0) {
+          return;
+        }
+        const plural = running === 1 ? "agent" : "agents";
+        if (
+          window.confirm(
+            `Stop all ${running} running ${plural}? Their windows and output stay on the canvas; you can restart each one in place.`,
+          )
+        ) {
+          send({ kind: "stop_all_windows" });
+        }
       }
 
       // SPEC-3038 US-2: tabs carry the same Living Telemetry the window chrome
@@ -3795,6 +3938,63 @@
         }, 12_000);
       }
 
+      // SPEC-2356 Anshin Addendum (FR-040): in-app attention toast. Distinct from
+      // the away-only desktop notification above — this surfaces even while the
+      // operator is present. Click flies the camera to the window (frameWindow);
+      // a dismiss control and an auto-hide keep it from lingering. needs_input /
+      // error toasts hold longer than the quiet "done" toast.
+      function showAttentionToast(notice) {
+        const flavor = notice.flavor || "needs_input";
+        const existing = document.getElementById(`attention-toast-${notice.windowId}`);
+        existing?.remove();
+        const toast = createNode("div", "attention-toast");
+        toast.id = `attention-toast-${notice.windowId}`;
+        toast.dataset.flavor = flavor;
+        toast.setAttribute("role", "status");
+        toast.setAttribute("aria-live", "polite");
+
+        const jump = createNode("button", "attention-toast__jump");
+        jump.type = "button";
+        jump.title = notice.title || "Agent attention";
+        jump.setAttribute("aria-label", `${notice.title}: ${notice.body} (jump to window)`);
+        const title = createNode("span", "attention-toast__title", notice.title || "Agent attention");
+        const body = createNode("span", "attention-toast__body", notice.body || "");
+        jump.append(title, body);
+        jump.addEventListener("click", () => {
+          frameWindow(notice.windowId);
+          toast.remove();
+        });
+
+        const dismiss = createNode("button", "attention-toast__dismiss", "×");
+        dismiss.type = "button";
+        dismiss.setAttribute("aria-label", "Dismiss notification");
+        dismiss.addEventListener("click", (event) => {
+          event.stopPropagation();
+          toast.remove();
+        });
+
+        toast.append(jump, dismiss);
+        attentionToastStack().appendChild(toast);
+        const holdMs = flavor === "done" ? 8_000 : 14_000;
+        window.setTimeout(() => {
+          if (toast.isConnected) {
+            toast.remove();
+          }
+        }, holdMs);
+      }
+
+      // The attention toasts stack in a fixed column so multiple windows can
+      // ask for attention at once without overlapping.
+      function attentionToastStack() {
+        let stackEl = document.getElementById("attention-toast-stack");
+        if (!stackEl) {
+          stackEl = createNode("div", "attention-toast-stack");
+          stackEl.id = "attention-toast-stack";
+          document.body.appendChild(stackEl);
+        }
+        return stackEl;
+      }
+
       function createKnowledgeMarkdownBody(section, className = "knowledge-section-body") {
         const node = createNode("div", `${className} knowledge-markdown-body`);
         const html = typeof section?.body_html === "string" ? section.body_html.trim() : "";
@@ -4232,6 +4432,8 @@
                 </span>
               </div>
               <div class="window-actions">
+                <button class="icon-button" data-action="restart" aria-label="Restart agent" title="Restart agent" hidden>↻</button>
+                <button class="icon-button" data-action="stop" aria-label="Stop agent" title="Stop agent" hidden>■</button>
                 <button class="icon-button" data-action="close" aria-label="Close window">×</button>
               </div>
             </div>
@@ -4244,7 +4446,23 @@
 
           const titlebar = element.querySelector(".titlebar");
           const closeButton = element.querySelector("[data-action='close']");
+          const stopButton = element.querySelector("[data-action='stop']");
+          const restartButton = element.querySelector("[data-action='restart']");
           const resizeHandle = element.querySelector(".resize-handle");
+
+          // SPEC-2356 Anshin Addendum (FR-041/FR-044): the kill-switch lives in
+          // the window chrome next to close. STOP halts the agent runtime but
+          // keeps the window + its output; RESTART relaunches the same preset
+          // in place. Both target the window id; visibility is driven per
+          // render from the runtime state by the status-apply path.
+          stopButton.addEventListener("click", (event) => {
+            event.stopPropagation();
+            send({ kind: "stop_window", id: windowData.id });
+          });
+          restartButton.addEventListener("click", (event) => {
+            event.stopPropagation();
+            send({ kind: "restart_window", id: windowData.id });
+          });
 
           // SPEC-2008 camera-focus: minimize/maximize buttons were removed
           // (focusing a window flies the camera to frame it). The close (×)
@@ -4526,6 +4744,8 @@
               detailMap.delete(windowId);
               windowRuntimeStateMap.delete(windowId);
               agentCompletionNotifier.forgetWindow(windowId);
+              agentAttentionToaster.forgetWindow(windowId);
+              document.getElementById(`attention-toast-${windowId}`)?.remove();
               renderedWindowElementKeys.delete(windowId);
               renderedRuntimeStatusKeys.delete(windowId);
               renderedAgentKanbanBodyKeys.delete(windowId);
@@ -4643,6 +4863,11 @@
         onProjectUnread: (projectId) => {
           projectWorkspaceShell.markProjectUnread(projectId);
         },
+      });
+
+      // SPEC-2356 Anshin Addendum (FR-040): the always-on, in-app counterpart.
+      const agentAttentionToaster = createAgentAttentionToaster({
+        showToast: showAttentionToast,
       });
 
       const workspaceWindowManager = Object.freeze({
@@ -6014,6 +6239,9 @@
             frontendUnits.socketTransport.send({
               kind: "open_start_work",
             });
+            return;
+          case "stop-all-windows":
+            requestStopAllWindows();
             return;
           case "theme-cycle": {
             const tm = window.__operatorShell?.themeManager;

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -2552,6 +2552,10 @@
         appendRenderKeyPart(parts, counts?.active ?? null);
         appendRenderKeyPart(parts, "idle");
         appendRenderKeyPart(parts, counts?.idle ?? null);
+        // FR-039 (anshin): the WAITING cell refreshes when the needs_input count
+        // changes; include it in the render key so the strip is not skipped.
+        appendRenderKeyPart(parts, "needs_input");
+        appendRenderKeyPart(parts, counts?.needs_input ?? null);
         appendRenderKeyPart(parts, "blocked");
         appendRenderKeyPart(parts, counts?.blocked ?? null);
         appendRenderKeyPart(parts, "done");
@@ -2613,6 +2617,10 @@
         const counts = {
           active: 0,
           idle: 0,
+          // FR-039 (anshin): needs_input is its own LOUD telemetry state for
+          // agents waiting on the operator. It used to collapse into idle;
+          // now it drives the WAITING strip cell instead.
+          needs_input: 0,
           blocked: 0,
           done: 0,
           agents: 0,

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -185,6 +185,18 @@
             </button>
           </div>
           <div class="op-rail__spacer" aria-hidden="true"></div>
+          <div class="op-rail__group" role="group" aria-label="Agents">
+            <!-- SPEC-2356 Anshin Addendum (FR-042): STOP ALL kill-switch. Halts
+                 every running agent runtime (windows stay on canvas) after a
+                 confirm. The op:command handler in app.js owns the prompt. -->
+            <button class="op-rail__item op-rail__item--stop-all" type="button" data-cmd="stop-all-windows" aria-label="Stop all agents" title="Stop all agents">
+              <span class="op-rail__icon" aria-hidden="true">⏹</span>
+              <span class="op-rail__flyout" aria-hidden="true">
+                <span class="op-rail__flyout-label">Stop all agents</span>
+              </span>
+            </button>
+          </div>
+          <div class="op-rail__divider" aria-hidden="true"></div>
           <div class="op-rail__group op-rail__group--system" role="group" aria-label="System">
             <button
               class="op-rail__item"

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -282,6 +282,10 @@
             <span class="op-status-strip__label">IDLE</span>
             <span class="op-status-strip__value" id="op-strip-idle" aria-label="Idle agents">0</span>
           </div>
+          <div class="op-status-strip__cell op-status-strip__cell--waiting">
+            <span class="op-status-strip__label">WAITING</span>
+            <span class="op-status-strip__value" id="op-strip-waiting" aria-label="Agents waiting for input">0</span>
+          </div>
           <div class="op-status-strip__cell op-status-strip__cell--blocked">
             <span class="op-status-strip__label">BLOCKED</span>
             <span class="op-status-strip__value" id="op-strip-blocked" aria-label="Blocked agents">0</span>

--- a/crates/gwt/web/operator-shell.js
+++ b/crates/gwt/web/operator-shell.js
@@ -181,19 +181,24 @@ export function applyTelemetryCounts(doc, counts = {}) {
     if (el) el.textContent = String(v);
   };
   // SPEC-2356 — toggle the blocked alert state so the BLOCKED cell pulses when
-  // anything actually needs attention, and stays still otherwise.
-  if ("blocked" in counts) {
-    const blockedCell = doc.querySelector(".op-status-strip__cell--blocked");
-    if (blockedCell) {
-      if ((counts.blocked ?? 0) > 0) blockedCell.classList.add("op-status-strip__cell--alert");
-      else blockedCell.classList.remove("op-status-strip__cell--alert");
-    }
-  }
+  // anything actually needs attention, and stays still otherwise. FR-039 (anshin)
+  // applies the same alert toggle to the WAITING cell so "agents waiting for
+  // input" is just as loud as blocked.
+  const toggleAlert = (modifier, count) => {
+    const cell = doc.querySelector(`.op-status-strip__cell--${modifier}`);
+    if (!cell) return;
+    if ((count ?? 0) > 0) cell.classList.add("op-status-strip__cell--alert");
+    else cell.classList.remove("op-status-strip__cell--alert");
+  };
+  if ("blocked" in counts) toggleAlert("blocked", counts.blocked);
+  if ("needs_input" in counts) toggleAlert("waiting", counts.needs_input);
   // SPEC-2356 operator chrome cleanup: the dead Sidebar Layers rows and their
   // per-layer counters are removed; telemetry now lives solely in the Status
   // Strip cells below.
   setText("op-strip-active", counts.active ?? 0);
   setText("op-strip-idle", counts.idle ?? 0);
+  // FR-039 (anshin): WAITING cell counts agents waiting on the operator.
+  setText("op-strip-waiting", counts.needs_input ?? 0);
   setText("op-strip-blocked", counts.blocked ?? 0);
   if ("branches" in counts) setText("op-strip-branches", counts.branches ?? "—");
   // SPEC-3038 AS-1.4: the rail Windows item badges the open-window count.

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -3391,6 +3391,95 @@ body {
   color: var(--color-text-muted);
 }
 
+/* SPEC-2356 Anshin Addendum (FR-040): in-app attention toasts. They stack in a
+   fixed bottom-right column above the completion toast slot, each carrying a
+   left accent rim keyed to its flavor (needs_input amber / error red / done
+   muted). */
+.attention-toast-stack {
+  position: fixed;
+  right: 18px;
+  bottom: 122px;
+  z-index: 1001;
+  display: grid;
+  gap: 8px;
+  justify-items: end;
+  pointer-events: none;
+}
+
+.attention-toast {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: stretch;
+  gap: 4px;
+  max-width: min(420px, calc(100vw - 36px));
+  border: 1px solid var(--color-border-strong);
+  border-left: 3px solid var(--color-state-needs-input);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-elevated);
+  box-shadow: var(--shadow-3);
+  pointer-events: auto;
+  animation: attention-toast-in var(--motion-medium) var(--motion-curve);
+}
+
+.attention-toast[data-flavor="error"] {
+  border-left-color: var(--color-state-blocked);
+}
+
+.attention-toast[data-flavor="done"] {
+  border-left-color: var(--color-state-done);
+}
+
+.attention-toast__jump {
+  display: grid;
+  gap: 2px;
+  min-height: 44px;
+  padding: 10px 12px;
+  border: 0;
+  background: transparent;
+  color: var(--color-text);
+  font-family: var(--font-body);
+  font-size: var(--type-sm);
+  text-align: left;
+  cursor: pointer;
+}
+
+.attention-toast__title {
+  font-weight: 700;
+  color: var(--color-text-strong);
+}
+
+.attention-toast__body {
+  color: var(--color-text-muted);
+}
+
+.attention-toast__dismiss {
+  align-self: stretch;
+  width: 32px;
+  border: 0;
+  border-left: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.attention-toast__dismiss:hover {
+  color: var(--color-text-strong);
+  background: color-mix(in oklab, var(--color-text-strong) 8%, transparent);
+}
+
+@keyframes attention-toast-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .attention-toast {
+    animation: none;
+  }
+}
+
 .attachment-progress {
   position: absolute;
   right: 12px;

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -1097,9 +1097,17 @@ body {
   animation: none;
 }
 
+/* FR-039 (anshin): waiting maps to the LOUD needs-input state, so the WAIT cue
+   stays prominent on an inactive tab through amber text + an amber tab edge —
+   the same loud-but-static treatment blocked gets, so "your turn" is never
+   lost in the quiet idle palette. */
 .window-tab[data-agent-state="waiting"] .window-tab-state {
-  color: var(--color-state-idle);
+  color: var(--color-state-needs-input);
   animation: none;
+}
+
+.window-tab[data-agent-state="waiting"] {
+  border-color: color-mix(in oklab, var(--color-state-needs-input) 55%, var(--color-border));
 }
 
 /* AS-2.3: blocked stays loud even on an inactive tab through red text,

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -805,6 +805,8 @@ body::after {
   --color-state-active: #22d3ee;
   --color-state-idle: #94a3b8;
   --color-state-blocked: #f87171;
+  /* FR-039 (anshin) — WAITING cell amber, bright enough for the dark strip. */
+  --color-state-needs-input: #fbbf24;
 }
 
 .op-status-strip__cell {
@@ -851,6 +853,12 @@ body::after {
 
 .op-status-strip__cell--idle .op-status-strip__value {
   color: var(--color-state-idle);
+}
+
+/* FR-039 (anshin) — WAITING count tints amber so "agents waiting for input"
+   reads as your-turn attention, not error. */
+.op-status-strip__cell--waiting .op-status-strip__value {
+  color: var(--color-state-needs-input);
 }
 
 .op-status-strip__cell--blocked .op-status-strip__value {
@@ -1247,6 +1255,17 @@ button.op-runtime-health-detail__process {
   animation: op-rim-blocked calc(var(--motion-pulse) * 0.5) ease-in-out infinite;
 }
 
+/* FR-039 (anshin) — "needs input" is a LOUD your-turn rim: it pulses like
+   blocked (so the operator notices it) but uses the warm amber state colour
+   instead of error red. Reuses the op-rim-blocked keyframe, which is driven
+   by --agent-color, so the glow tracks the needs-input token. */
+[data-agent-state="needs_input"] {
+  --agent-color: var(--color-state-needs-input);
+  box-shadow: 0 0 0 1px var(--agent-color),
+              0 0 14px 0 color-mix(in oklab, var(--agent-color) 50%, transparent);
+  animation: op-rim-blocked calc(var(--motion-pulse) * 0.5) ease-in-out infinite;
+}
+
 [data-agent-state="done"] {
   --agent-color: var(--color-state-done);
   box-shadow: 0 0 0 1px var(--agent-color);
@@ -1269,7 +1288,8 @@ button.op-runtime-health-detail__process {
 
 @media (prefers-reduced-motion: reduce) {
   [data-agent-state="active"],
-  [data-agent-state="blocked"] {
+  [data-agent-state="blocked"],
+  [data-agent-state="needs_input"] {
     animation: none;
   }
   /* SPEC-2356 — Status Strip live dot pulses to signal "system is alive".
@@ -3441,26 +3461,30 @@ button.workspace-board-ref:focus-visible {
 }
 
 /* SPEC-2356 — when blocked count > 0 the BLOCKED cell pulses subtly so
-   the user notices something needs attention. The animation is keyframed
-   on opacity (no shadow / repaint cost) and disabled by reduced-motion
-   and forced-colors. */
+   the user notices something needs attention. FR-039 (anshin) extends the same
+   alert pulse to the WAITING cell so "agents waiting for input" is just as
+   loud as blocked. The animation is keyframed on opacity (no shadow / repaint
+   cost) and disabled by reduced-motion and forced-colors. */
 @keyframes op-status-strip-blocked-pulse {
   0%, 100% { opacity: 1; }
   50%      { opacity: 0.55; }
 }
 
-:root[data-theme] .op-status-strip__cell--blocked.op-status-strip__cell--alert .op-status-strip__value {
+:root[data-theme] .op-status-strip__cell--blocked.op-status-strip__cell--alert .op-status-strip__value,
+:root[data-theme] .op-status-strip__cell--waiting.op-status-strip__cell--alert .op-status-strip__value {
   animation: op-status-strip-blocked-pulse var(--motion-pulse) ease-in-out infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  :root[data-theme] .op-status-strip__cell--blocked.op-status-strip__cell--alert .op-status-strip__value {
+  :root[data-theme] .op-status-strip__cell--blocked.op-status-strip__cell--alert .op-status-strip__value,
+  :root[data-theme] .op-status-strip__cell--waiting.op-status-strip__cell--alert .op-status-strip__value {
     animation: none;
   }
 }
 
 @media (forced-colors: active) {
-  :root[data-theme] .op-status-strip__cell--blocked.op-status-strip__cell--alert .op-status-strip__value {
+  :root[data-theme] .op-status-strip__cell--blocked.op-status-strip__cell--alert .op-status-strip__value,
+  :root[data-theme] .op-status-strip__cell--waiting.op-status-strip__cell--alert .op-status-strip__value {
     animation: none;
   }
 }
@@ -5877,6 +5901,13 @@ button.workspace-board-ref:focus-visible {
   animation: op-live-pulse var(--motion-pulse) ease-in-out infinite;
 }
 
+/* FR-039 (anshin) — needs-input dot pulses (loud) in amber so the minimap
+   surfaces "this pane is waiting for you" the same way it surfaces blocked. */
+.fleet-minimap__cell[data-telemetry="needs_input"]::after {
+  background: var(--color-state-needs-input);
+  animation: op-live-pulse var(--motion-pulse) ease-in-out infinite;
+}
+
 .fleet-minimap__cell[data-telemetry="done"]::after {
   background: var(--color-state-done);
 }
@@ -5894,7 +5925,8 @@ button.workspace-board-ref:focus-visible {
 
 @media (prefers-reduced-motion: reduce) {
   .fleet-minimap__cell[data-telemetry="active"]::after,
-  .fleet-minimap__cell[data-telemetry="blocked"]::after {
+  .fleet-minimap__cell[data-telemetry="blocked"]::after,
+  .fleet-minimap__cell[data-telemetry="needs_input"]::after {
     animation: none;
   }
 }

--- a/crates/gwt/web/styles/tokens.css
+++ b/crates/gwt/web/styles/tokens.css
@@ -57,6 +57,10 @@
   --color-state-idle: #828c9b;
   --color-state-blocked: #f87171;
   --color-state-done: #94a3b8;
+  /* FR-039 (anshin) — "needs input" / your-turn attention state. LOUD but not
+     error-red: warm amber (amber-400) clears WCAG AA as text on every dark
+     surface (11.04 / 9.89) and stays distinct from blocked (#f87171). */
+  --color-state-needs-input: #fbbf24;
 
   /* Agent colors — SPEC-2133 semantic mapping, dark-tuned */
   --agent-claude: #fbbf24;
@@ -146,6 +150,10 @@
   --color-state-idle: #4b5563;
   --color-state-blocked: #991b1b;
   --color-state-done: #334155;
+  /* FR-039 (anshin) — "needs input" / your-turn attention state. A deep amber
+     gold (amber-700) clears WCAG AA as text on bone surfaces (5.02 / 4.62)
+     and reads as warm attention, clearly distinct from blocked red. */
+  --color-state-needs-input: #b45309;
 
   /* Agent colors — dark-tuned chroma for bone background */
   --agent-claude: #92400e;
@@ -236,6 +244,7 @@
     --color-state-idle: GrayText;
     --color-state-blocked: Mark;
     --color-state-done: GrayText;
+    --color-state-needs-input: Highlight;
 
     --agent-claude: Highlight;
     --agent-codex: Highlight;

--- a/crates/gwt/web/window-runtime-state.js
+++ b/crates/gwt/web/window-runtime-state.js
@@ -56,18 +56,25 @@ export function windowRuntimeLabel(status) {
 }
 
 // SPEC-2356 — translate legacy runtime state vocabulary to Living
-// Telemetry semantic states (`active|idle|blocked|done`). The mapping is
-// intentionally narrow so future runtime states surface as
+// Telemetry semantic states (`active|idle|blocked|done|needs_input`). The
+// mapping is intentionally narrow so future runtime states surface as
 // `idle` until the design language explicitly handles them.
+//
+// FR-039 (anshin): `waiting` (the agent is blocked on the operator's input)
+// is its own LOUD state `needs_input` — an attention / "your turn" cue —
+// instead of collapsing into quiet `idle`. The wire `"waiting"` value is
+// only emitted for agent/claude/codex presets (gated in
+// normalizeWindowRuntimeState), so non-agent windows never reach here.
 export function mapAgentTelemetryState(runtimeState) {
   switch (runtimeState) {
     case "running":
       return "active";
     case "starting":
       return "not_started";
+    case "waiting":
+      return "needs_input";
     case "ready":
     case "idle":
-    case "waiting":
       return "idle";
     case "stopped":
     case "exited":


### PR DESCRIPTION
## 概要

Operator が自律 AI エージェント群を**安心して任せられる**ように、キャンバスを「管制室」へ近づける **Operator Anshin Phase 1**（SPEC-2356 Anshin Addendum, FR-039〜044）。狙いは「制御を失わない／見落とさない」確信。設計の肝は**既存プリミティブの配線・surfacing**で、新規構築を最小化。

camera-focus（#3147, merged）の次段。Fleet Minimap / telemetry の上に乗る。

## 主な変更

- **needs_input を独立 loud telemetry に**（FR-039）: `WaitingInput` を idle から分離（amber、blocked=red / active=cyan と区別）。status strip に **WAITING** セル、Fleet Minimap pulse、window rim/tab pulse。「入力待ちが idle に埋もれて見落とす」最大ギャップを解消。
- **in-app attention トースト + click-to-jump**（FR-040）: needs_input/blocked/error/done への遷移で在席中でもトースト（既存 desktop 通知ロジックは維持）。click でそのエージェントへ camera framing。
- **キルスイッチ**（FR-041/042/044）: `StopWindow`（PTY 停止・window と出力は残す、status=Stopped）/ `StopAllWindows`（全停止・confirm）/ `RestartWindow`（`spawn_restored_agent_session` で同 preset in-place 再起動）。window chrome に STOP/RESTART、rail に STOP ALL。
- **send-input**（FR-043）: focused エージェントへ 1 行注入（`pane_send_input`、palette 経由）。

## 検証（Overall: PASS）

- `cargo fmt --check` clean / `cargo clippy --all-targets --all-features -- -D warnings` 0 warning
- `cargo test -p gwt-core -p gwt --all-features`: **2819 passed / 0 failed**（kill-switch protocol deserialize/handler、embedded_web english-only contract 含む）
- JS: `run-frontend-unit-tests.sh` **917**、smoke **29**
- Playwright: **32**（`kill-switch.spec.ts`: STOP→stop_window+window 残存 / STOP ALL / RESTART / send-input / needs_input→toast→click→frame、dark+light）
- browser-check（隔離起動）で WAITING セル・STOP ALL・window STOP/RESTART・配信を実機確認

**User Verification Result: confirmed**

## SPEC

- SPEC-2356 Operator Anshin Addendum（US-9〜12 / FR-039〜047）。本 PR = **Phase 1（FR-039〜044）**。

## セルフチェック

- [x] SPEC 更新済み（SPEC-2356 Addendum）
- [x] 全テスト通過・lint / fmt 成功
- [x] 未実装・TODO なし（Phase 1 スコープ）
- [x] ユーザー視覚検証 confirmed
- [x] commitlint PASS / english-only contract 維持

## 補足

Phase 2（FR-045〜047: 各エージェントの last activity surfacing + Agent Kanban を状態駆動 + 収束インジケータ）は本 PR とは別の follow-up。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stop and Restart controls for individual agent windows; stopped windows remain visible on canvas
  * Added Stop All command to halt all running agents simultaneously
  * Added in-app attention toasts to notify when agents are waiting for input; clicking navigates to the agent
  * Added Send Input action to route text input to the focused agent
  * New "Waiting" status indicator on operator status strip tracks agents needing input
  * Updated waiting state visual styling with distinct amber coloring

* **Tests**
  * Added comprehensive test coverage for window control, attention notifications, and telemetry state behaviors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->