### PR TITLE
feat(gui): anshin phase 2 activity surfacing + mission convergence

### DIFF
--- a/.gwt/work/memory.md
+++ b/.gwt/work/memory.md
@@ -7157,3 +7157,10 @@ Type: lesson
 Context: Issue #3066 PR verification found that some in-process tests used ScopedHome/std::env::set_var("HOME") while cargo ran tests in parallel, causing unrelated workspace projection tests to write temp project state into the real ~/.gwt/projects.
 Learning: For in-process tests, prefer a thread-local gwt_home override over process-wide HOME mutation. Reserve HOME/USERPROFILE env changes for spawned child processes that must receive an isolated environment.
 Future Action: When adding tests around gwt_core::paths::gwt_home or project storage, use gwt_core::test_support::ScopedGwtHome and only hold env_lock for real environment variables such as GWT_SESSION_ID.
+
+## 2026-06-21 — stop_all_runtimes join-wait test is flaky under parallel full run
+
+Type: project
+Context: Phase 2 検証中、cargo test -p gwt のフルランで app_runtime::tests::app_runtime_stop_all_runtimes_kills_every_pane_before_join_waits が 1 回だけ FAILED したが、tests.rs は HEAD と byte 同一かつ単独実行で 3/3 passed だった
+Learning: app_runtime_stop_all_runtimes_kills_every_pane_before_join_waits は PTY teardown/join-wait の timing に依存する flaky test。並列フルラン下の resource contention で稀に落ちる。単独再実行で緑なら回帰ではない。
+Future Action: このテストがフルランで 1 件落ちたら、まず git diff HEAD で当該ファイルが無変更か確認し、単独 -p gwt で 2-3 回再実行して flaky か判定する。緑なら blocker 扱いしない。

--- a/crates/gwt/playwright/tests/anshin-phase2.spec.ts
+++ b/crates/gwt/playwright/tests/anshin-phase2.spec.ts
@@ -1,0 +1,230 @@
+import { expect, test } from "@playwright/test";
+import { APP_URL, installEmbeddedRoutes } from "./_helpers/embedded-frontend";
+
+// SPEC-2356 Anshin Addendum — Phase 2 activity surfacing + mission convergence.
+//
+// Drives the embedded frontend against a deterministic WebSocket stub (mirroring
+// kill-switch.spec.ts / fleet-minimap.spec.ts) and asserts the FR-045 / FR-047
+// behaviours that the Phase 2 implementation added on the always-visible
+// surfaces (Fleet Minimap, Window Switcher, Status Strip):
+//
+//   - FR-047: the MISSION convergence cell (`#op-strip-mission`) shows
+//     `done/agents` and flips `.op-status-strip__cell--complete` once every
+//     agent has converged (done === agents > 0). Driven by emitting
+//     `window_state` transitions that map to telemetry `active` vs `done`.
+//   - FR-045: a window's `dynamic_title_detail` surfaces as the Fleet Minimap
+//     cell tooltip (`title` = "Title · detail") and as a `.window-list-activity`
+//     line inside the Window Switcher row.
+//
+// Runtime-state -> telemetry mapping used to seed `done` vs `active`
+// (mapAgentTelemetryState in window-runtime-state.js):
+//   - status/state "running"        -> telemetry "active"
+//   - window_state state "stopped"  -> telemetry "done" (also "exited")
+//   - "idle"/"ready"/unknown        -> telemetry "idle"
+// recomputeOperatorTelemetry counts every live agent pane (preset agent/claude/
+// codex) as `agents`, and increments `done` for each pane whose telemetry state
+// is "done".
+
+test.describe("Anshin Phase 2 activity surfacing + mission convergence", () => {
+  test.use({ deviceScaleFactor: 1, viewport: { width: 1440, height: 900 } });
+
+  test("FR-047: MISSION cell trends done/agents and flips complete on convergence", async ({
+    page,
+  }) => {
+    await installEmbeddedRoutes(page);
+    await installPhase2Backend(page);
+    await page.goto(APP_URL);
+
+    // Three agent panes boot "running" -> telemetry active -> 0/3, not complete.
+    const mission = page.locator("#op-strip-mission");
+    const missionCell = page.locator(".op-status-strip__cell--mission");
+    await expect(mission).toHaveText("0/3", { timeout: 10_000 });
+    await expect(missionCell).not.toHaveClass(/op-status-strip__cell--complete/);
+
+    // Two agents finish (stopped -> telemetry done): in-progress 2/3, still not
+    // complete because one agent is still active.
+    await page.evaluate(() => {
+      window.__emit({ kind: "window_state", window_id: "agent-1", state: "stopped" });
+      window.__emit({ kind: "window_state", window_id: "agent-2", state: "stopped" });
+    });
+    await expect(mission).toHaveText("2/3");
+    await expect(missionCell).not.toHaveClass(/op-status-strip__cell--complete/);
+
+    // The last agent finishes -> every agent converged -> 3/3 + complete state.
+    await page.evaluate(() => {
+      window.__emit({ kind: "window_state", window_id: "agent-3", state: "stopped" });
+    });
+    await expect(mission).toHaveText("3/3");
+    await expect(missionCell).toHaveClass(/op-status-strip__cell--complete/);
+  });
+
+  test("FR-045: dynamic_title_detail surfaces in the minimap tooltip and the switcher row", async ({
+    page,
+  }) => {
+    await installEmbeddedRoutes(page);
+    await installPhase2Backend(page);
+    await page.goto(APP_URL);
+
+    // (a) Fleet Minimap cell tooltip: title attribute reads "Title · detail".
+    const minimap = page.locator("#fleet-minimap");
+    await expect(minimap).toBeVisible({ timeout: 10_000 });
+    const detailCell = minimap.locator(
+      '.fleet-minimap__cell[data-window-id="agent-3"]',
+    );
+    await expect(detailCell).toHaveCount(1);
+    await expect(detailCell).toHaveAttribute(
+      "title",
+      "Refactor auth · editing src/auth/login.rs",
+    );
+
+    // (b) Window Switcher row: opening the popover surfaces the live activity
+    // detail as a .window-list-activity line in the agent's row.
+    await page.locator("#window-list-button").click();
+    const panel = page.locator("#window-list-panel");
+    await expect(panel).toBeVisible();
+    const row = panel
+      .locator(".window-list-row", { hasText: "Refactor auth" })
+      .first();
+    await expect(row).toBeVisible();
+    await expect(row.locator(".window-list-activity")).toHaveText(
+      "editing src/auth/login.rs",
+    );
+  });
+});
+
+// Deterministic backend: a single project tab with three canvas agent panes.
+// agent-3 carries a live activity detail (dynamic_title_detail) for the FR-045
+// surfaces; all three feed the FR-047 MISSION convergence count.
+async function installPhase2Backend(page) {
+  await page.addInitScript(() => {
+    window.__sent = [];
+    window.__sentKinds = [];
+
+    function agentWindow(id, overrides) {
+      return {
+        id,
+        title: id,
+        preset: "agent",
+        geometry: { x: 120, y: 100, width: 480, height: 320 },
+        geometry_revision: 0,
+        z_index: 1,
+        status: "running",
+        persist: true,
+        purpose_title: null,
+        dynamic_title: null,
+        dynamic_title_detail: null,
+        agent_id: id,
+        agent_color: "cyan",
+        tab_group_id: null,
+        tab_group_active: false,
+        session_id: `session-${id}`,
+        placement: null,
+        ...overrides,
+      };
+    }
+
+    const windows = [
+      agentWindow("agent-1", { geometry: { x: 100, y: 100, width: 480, height: 320 } }),
+      agentWindow("agent-2", { geometry: { x: 640, y: 100, width: 480, height: 320 } }),
+      // Canvas agent with a live activity detail for the FR-045 surfaces.
+      agentWindow("agent-3", {
+        title: "Refactor auth",
+        geometry: { x: 1180, y: 100, width: 480, height: 320 },
+        dynamic_title: "Refactor auth",
+        dynamic_title_detail: "editing src/auth/login.rs",
+      }),
+    ];
+
+    function stateMsg() {
+      return {
+        kind: "workspace_state",
+        workspace: {
+          app_version: "playwright",
+          tabs: [
+            {
+              id: "tab-1",
+              title: "Anshin Phase 2 Fixture",
+              project_root: "/fixture",
+              kind: "git",
+              workspace: {
+                viewport: { x: 0, y: 0, zoom: 1 },
+                windows: windows.map((w) => ({ ...w })),
+              },
+            },
+          ],
+          active_tab_id: "tab-1",
+          recent_projects: [],
+        },
+      };
+    }
+
+    function windowListMsg() {
+      return {
+        kind: "window_list",
+        windows: windows.map((w) => ({ id: w.id, title: w.title })),
+      };
+    }
+
+    let socketRef = null;
+
+    class FixtureWebSocket extends EventTarget {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+
+      constructor(url) {
+        super();
+        this.url = url;
+        this.readyState = FixtureWebSocket.CONNECTING;
+        socketRef = this;
+        setTimeout(() => {
+          this.readyState = FixtureWebSocket.OPEN;
+          this.dispatchEvent(new Event("open"));
+          this.emit(stateMsg());
+        }, 0);
+      }
+
+      send(data) {
+        let msg;
+        try {
+          msg = JSON.parse(data);
+        } catch {
+          return;
+        }
+        window.__sent.push(msg);
+        window.__sentKinds.push(msg.kind);
+        // The Window Switcher requests a window_list snapshot when opened; reply
+        // with the live id set so the popover renders the seeded rows.
+        if (msg.kind === "list_windows") {
+          this.emit(windowListMsg());
+        }
+      }
+
+      close() {
+        this.readyState = FixtureWebSocket.CLOSED;
+        this.dispatchEvent(new CloseEvent("close"));
+      }
+
+      emit(payload) {
+        setTimeout(() => {
+          this.dispatchEvent(
+            new MessageEvent("message", { data: JSON.stringify(payload) }),
+          );
+        }, 0);
+      }
+    }
+
+    // Lets a test push backend events (bare window_state transitions) directly,
+    // mirroring exactly what the daemon sends when an agent finishes / errors /
+    // starts waiting while keeping its window (no workspace_state follows).
+    window.__emit = (payload) => {
+      if (socketRef) socketRef.emit(payload);
+    };
+
+    Object.defineProperty(window, "WebSocket", {
+      configurable: true,
+      value: FixtureWebSocket,
+    });
+  });
+}

--- a/crates/gwt/web/__tests__/fleet-minimap.test.mjs
+++ b/crates/gwt/web/__tests__/fleet-minimap.test.mjs
@@ -82,6 +82,37 @@ test("renderCells creates one cell per window keyed by window id", () => {
   }
 });
 
+test("FR-045 (anshin): cellTooltip overrides the cell title/aria-label", () => {
+  // The minimap cell tooltip surfaces the agent's live activity (title ·
+  // detail) when an app-provided cellTooltip factory is wired, instead of
+  // the plain display title.
+  const { container } = setupDom();
+  const windows = [windowAt("w-1", 0, 0), windowAt("w-2", 300, 0)];
+  const { minimap } = makeMinimap(container, windows, {
+    cellTooltip: (w) => `Title ${w.id} · doing thing ${w.id}`,
+  });
+
+  minimap.renderCells();
+
+  const cell = container.querySelector('[data-window-id="w-1"]');
+  assert.equal(cell.title, "Title w-1 · doing thing w-1");
+  assert.equal(cell.getAttribute("aria-label"), "Title w-1 · doing thing w-1");
+});
+
+test("FR-045 (anshin): cellTooltip falls back to windowDisplayTitle when absent", () => {
+  // Back-compat: callers that do not pass cellTooltip keep the display title
+  // on both the tooltip and aria-label.
+  const { container } = setupDom();
+  const windows = [windowAt("w-1", 0, 0)];
+  const { minimap } = makeMinimap(container, windows);
+
+  minimap.renderCells();
+
+  const cell = container.querySelector('[data-window-id="w-1"]');
+  assert.equal(cell.title, "Title w-1");
+  assert.equal(cell.getAttribute("aria-label"), "Title w-1");
+});
+
 test("data-empty flips with the window count", () => {
   const { container } = setupDom();
   const windows = [windowAt("w-1", 0, 0)];

--- a/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
+++ b/crates/gwt/web/__tests__/operator-chrome-structure.test.mjs
@@ -887,9 +887,17 @@ test("Agent window chrome resolves dynamic purpose titles before legacy titles",
     /function\s+windowDisplayTitle\(windowData\)[\s\S]+dynamic_title[\s\S]+purpose_title[\s\S]+title/,
     "expected a shared display-title helper with dynamic > purpose > legacy title precedence",
   );
+  // FR-045 (anshin): the row now derives `displayTitle` from the shared helper
+  // (so the activity line can compare against it) and escapes that value into
+  // the title node. Assert both the helper binding and the escaped render.
   assert.match(
     projectShellSurfaceSource,
-    /window-list-title">\$\{escapeHtml\(windowDisplayTitle\(entry\)\)\}/,
+    /const\s+displayTitle\s*=\s*windowDisplayTitle\(entry\)/,
+    "expected the Windows dropdown to bind the shared display-title helper",
+  );
+  assert.match(
+    projectShellSurfaceSource,
+    /window-list-title">\$\{escapeHtml\(displayTitle\)\}/,
     "expected the Windows dropdown to escape the shared display-title helper output",
   );
   assert.match(

--- a/crates/gwt/web/__tests__/operator-shell-runtime.test.mjs
+++ b/crates/gwt/web/__tests__/operator-shell-runtime.test.mjs
@@ -110,6 +110,52 @@ test("Operator shell keeps the Command Rail always visible with no reveal state 
   }
 });
 
+test("FR-047 (anshin): MISSION cell shows done/total and converges to complete", async () => {
+  const { applyTelemetryCounts } = await importOperatorShell();
+  assert.equal(typeof applyTelemetryCounts, "function");
+  const { document } = parseHTML(html);
+
+  const missionCell = () =>
+    document.querySelector(".op-status-strip__cell--mission");
+  const missionValue = () => document.getElementById("op-strip-mission");
+
+  // In-progress mission: 2 of 5 agents done.
+  applyTelemetryCounts(document, { done: 2, agents: 5 });
+  assert.equal(missionValue()?.textContent, "2/5");
+  assert.equal(
+    missionCell()?.classList.contains("op-status-strip__cell--complete"),
+    false,
+    "in-progress mission must not be marked complete",
+  );
+
+  // No agents: the cell collapses to the em dash placeholder.
+  applyTelemetryCounts(document, { agents: 0 });
+  assert.equal(missionValue()?.textContent, "—");
+  assert.equal(
+    missionCell()?.classList.contains("op-status-strip__cell--complete"),
+    false,
+    "an empty fleet is not a converged mission",
+  );
+
+  // Full convergence: every agent done flips the positive complete state.
+  applyTelemetryCounts(document, { done: 4, agents: 4 });
+  assert.equal(missionValue()?.textContent, "4/4");
+  assert.equal(
+    missionCell()?.classList.contains("op-status-strip__cell--complete"),
+    true,
+    "all agents done marks the mission complete",
+  );
+
+  // Regressing away from convergence clears the complete state again.
+  applyTelemetryCounts(document, { done: 1, agents: 4 });
+  assert.equal(missionValue()?.textContent, "1/4");
+  assert.equal(
+    missionCell()?.classList.contains("op-status-strip__cell--complete"),
+    false,
+    "dropping below full convergence removes the complete state",
+  );
+});
+
 test("Runtime health renderer updates severity-first compact PERF values", async () => {
   const { applyRuntimeHealth } = await importOperatorShell();
   assert.equal(typeof applyRuntimeHealth, "function");

--- a/crates/gwt/web/app.js
+++ b/crates/gwt/web/app.js
@@ -1464,6 +1464,17 @@
         return windowDisplayTitle(windowData);
       }
 
+      // FR-045 (anshin): a glanceable "what is this agent doing now" label.
+      // Pairs the display title with the live activity detail
+      // (dynamic_title_detail) so glanceable surfaces (Fleet Minimap cells,
+      // switcher rows) read like "title · detail". Collapses to just the
+      // title when there is no distinct detail.
+      function windowActivityLabel(windowData) {
+        const title = windowDisplayTitle(windowData);
+        const detail = String(windowData?.dynamic_title_detail || "").trim();
+        return detail && detail !== title ? `${title} · ${detail}` : title;
+      }
+
       // SPEC-3064 Phase 3 (E7): escapeHtml moved to
       // /project-shell-surface.js with the Window List renderer (its only
       // remaining caller).
@@ -5912,6 +5923,10 @@
         getFocusedId: () => focusedId,
         frameWindow,
         windowDisplayTitle,
+        // FR-045 (anshin): the cell tooltip/aria-label surfaces each agent's
+        // live activity (title · detail) so the operator can read what every
+        // pane is doing now without focusing it.
+        cellTooltip: windowActivityLabel,
         // windowData.agent_color already IS the data-agent-color value.
         cellAgentColor: (windowData) => windowData?.agent_color || "",
         // Only agent panes carry a Living Telemetry state; other surfaces

--- a/crates/gwt/web/fleet-minimap.js
+++ b/crates/gwt/web/fleet-minimap.js
@@ -34,6 +34,10 @@ export function createFleetMinimap({
   getFocusedId,
   frameWindow,
   windowDisplayTitle,
+  // FR-045 (anshin): optional factory for the per-cell tooltip / aria-label so
+  // the minimap can surface each agent's live activity (title · detail) at a
+  // glance. Falls back to windowDisplayTitle for back-compat.
+  cellTooltip,
   cellAgentColor,
   cellTelemetryState,
 }) {
@@ -52,6 +56,12 @@ export function createFleetMinimap({
   cameraFrame.className = "fleet-minimap__camera";
   cameraFrame.setAttribute("aria-hidden", "true");
   container.appendChild(cameraFrame);
+
+  // FR-045 (anshin): resolve a cell's tooltip / aria-label. Prefer the
+  // app-provided activity label (title · detail); fall back to the plain
+  // display title when no factory was wired.
+  const resolveCellTooltip =
+    typeof cellTooltip === "function" ? cellTooltip : windowDisplayTitle;
 
   // Cells are keyed by window id so unchanged windows keep their node across
   // renders (avoids losing hover/tooltip mid-interaction).
@@ -184,9 +194,9 @@ export function createFleetMinimap({
       }
 
       cell.classList.toggle("is-focused", windowData.id === focusedId);
-      const title = windowDisplayTitle(windowData);
-      cell.setAttribute("aria-label", title);
-      cell.title = title;
+      const tooltip = resolveCellTooltip(windowData);
+      cell.setAttribute("aria-label", tooltip);
+      cell.title = tooltip;
     }
 
     // Drop cells for windows that left the workspace.

--- a/crates/gwt/web/index.html
+++ b/crates/gwt/web/index.html
@@ -302,6 +302,10 @@
             <span class="op-status-strip__label">BLOCKED</span>
             <span class="op-status-strip__value" id="op-strip-blocked" aria-label="Blocked agents">0</span>
           </div>
+          <div class="op-status-strip__cell op-status-strip__cell--mission">
+            <span class="op-status-strip__label">MISSION</span>
+            <span class="op-status-strip__value" id="op-strip-mission" aria-label="Agents completed out of total">—</span>
+          </div>
           <div class="op-status-strip__cell">
             <span class="op-status-strip__label">WORK</span>
             <span class="op-status-strip__value" id="op-strip-branches" aria-label="Work">—</span>

--- a/crates/gwt/web/operator-shell.js
+++ b/crates/gwt/web/operator-shell.js
@@ -192,6 +192,21 @@ export function applyTelemetryCounts(doc, counts = {}) {
   };
   if ("blocked" in counts) toggleAlert("blocked", counts.blocked);
   if ("needs_input" in counts) toggleAlert("waiting", counts.needs_input);
+  // FR-047 (anshin): MISSION convergence indicator. Shows done/total agents so
+  // the operator can see the fleet trending toward completion at a glance, and
+  // flips a positive "complete" state (not an alert pulse) when every agent has
+  // converged (done === agents > 0).
+  const agents = Number(counts.agents ?? 0);
+  const done = Number(counts.done ?? 0);
+  setText("op-strip-mission", agents > 0 ? `${done}/${agents}` : "—");
+  const missionCell = doc.querySelector(".op-status-strip__cell--mission");
+  if (missionCell) {
+    if (agents > 0 && done === agents) {
+      missionCell.classList.add("op-status-strip__cell--complete");
+    } else {
+      missionCell.classList.remove("op-status-strip__cell--complete");
+    }
+  }
   // SPEC-2356 operator chrome cleanup: the dead Sidebar Layers rows and their
   // per-layer counters are removed; telemetry now lives solely in the Status
   // Strip cells below.

--- a/crates/gwt/web/project-shell-surface.js
+++ b/crates/gwt/web/project-shell-surface.js
@@ -555,9 +555,20 @@ export function createProjectShellSurface({
         const roleBadge = roleBadgeLabel
           ? `<span class="window-role-badge window-list-role">${escapeHtml(roleBadgeLabel)}</span>`
           : "";
+        // FR-045 (anshin): surface the agent's live activity detail
+        // (dynamic_title_detail) as a glanceable line when it differs from the
+        // display title, so the operator can read what each pane is doing now
+        // without focusing it.
+        const displayTitle = windowDisplayTitle(entry);
+        const activityDetail = String(entry?.dynamic_title_detail || "").trim();
+        const activityLine =
+          activityDetail && activityDetail !== displayTitle
+            ? `<div class="window-list-activity">${escapeHtml(activityDetail)}</div>`
+            : "";
         row.innerHTML = `
           <div class="window-list-copy">
-            <div class="window-list-title">${escapeHtml(windowDisplayTitle(entry))}</div>
+            <div class="window-list-title">${escapeHtml(displayTitle)}</div>
+            ${activityLine}
             <div class="window-list-meta">
               ${roleBadge}
               <span class="window-list-geometry">${geometryLabel}</span>

--- a/crates/gwt/web/styles/app.css
+++ b/crates/gwt/web/styles/app.css
@@ -609,6 +609,18 @@ body {
   white-space: nowrap;
 }
 
+/* FR-045 (anshin) — the agent's live activity detail under the title. Muted
+   single line that ellipsis-truncates so long activity text never wraps. */
+.window-list-activity {
+  margin-top: 3px;
+  font-family: var(--font-body);
+  font-size: var(--type-xs);
+  color: var(--color-text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .window-list-meta {
   margin-top: 4px;
   display: flex;

--- a/crates/gwt/web/styles/components.css
+++ b/crates/gwt/web/styles/components.css
@@ -865,6 +865,18 @@ body::after {
   color: var(--color-state-blocked);
 }
 
+/* FR-047 (anshin) — MISSION convergence (done/total agents). Reads neutral
+   while in progress; when every agent has converged the value tints to the
+   positive done colour as a calm, glanceable "mission complete" cue (no loud
+   pulse, so it never competes with the BLOCKED/WAITING alerts). */
+.op-status-strip__cell--mission .op-status-strip__value {
+  color: var(--color-status-strip-fg);
+}
+
+.op-status-strip__cell--mission.op-status-strip__cell--complete .op-status-strip__value {
+  color: var(--color-state-done);
+}
+
 .op-status-strip__cell--runtime-health {
   cursor: default;
   position: relative;


### PR DESCRIPTION
## 概要

Operator が自律 AI エージェント群を**安心して任せられる**ように、キャンバスを管制室へ近づける **Operator Anshin Phase 2**（SPEC-2356 Anshin Addendum）。Phase 1（#3150, FR-039〜044: needs_input alerting + kill-switch）の次段として、残る「ambient awareness（今何してる）」と「mission progress（収束）」を**常時可視サーフェス**（Fleet Minimap / Window Switcher / Status Strip）に surface する。

## 主な変更

- **FR-045 — last activity surfacing**: 各エージェントの `dynamic_title_detail`（今何しているか）を glanceable に。Fleet Minimap セルの tooltip を `title · detail` に拡張（`cellTooltip`）、Window Switcher 行に `window-list-activity` 行を追加。既存 projection のデータを surface するだけで backend 変更なし。
- **FR-047 — mission convergence indicator**: Status Strip に **MISSION** セル（`done/total agents`）を追加（BLOCKED と WORK の間）。全エージェントが収束したら complete 表示（subtle positive tint、loud pulse なし）。`done` は telemetry `stopped`（プロセス終了）のみカウントする現状維持仕様（**ユーザー確認済み**）。カウントは既存 `recomputeOperatorTelemetry` を流用。

## FR-046（状態駆動 Agent Kanban）を drop

当初 Phase 2 に含めていた FR-046（状態駆動 Agent Kanban）は **drop** した。調査の結果、`agent-kanban-surface.js` は commit `71b95913a` の 1 コミットでしか触られていない **vestigial（実験の残骸）surface** で、preset picker から意図的に除外され launcher も無く未到達だった。agent をレーンで整理する役割は SPEC-2359 で刷新された **Workspace overview**（`work` preset）に統合・superseded 済み。死んだ surface を resurrect しないため drop（ユーザー判断）。状態駆動の価値を再導入する場合は Workspace overview 側の follow-up SPEC で扱う。

## 検証（Overall: PASS）

- JS unit (`run-frontend-unit-tests.sh`): **920 passed / 0 failed**
- Playwright `anshin-phase2.spec.ts`: **4 passed**（FR-045 minimap tooltip + switcher 行 / FR-047 MISSION `0/3→2/3→3/3` + complete、dark+light）
- `embedded_web_shared_bundle_keeps_user_facing_copy_english_only`: PASS（english-only contract 維持）
- Rust backend は本 PR で無変更（HEAD と byte 同一）。フルランで `stop_all_runtimes` 系テストが 1 度落ちたが、無変更ファイル + 単独 3/3 passed の既知 flaky と確認・memory 記録済み。
- browser-check（隔離起動）で MISSION セル・status strip レイアウト・preset picker から Agent Kanban 消滅を実機確認

**User Verification Result: confirmed**（MISSION セルを実機で確認、stopped/total 仕様を確定。FR-045 は playwright 実証 + reduced-scope build に存在を確認）

## SPEC

- SPEC-2356 Operator Anshin Addendum。本 PR = **Phase 2（FR-045 / FR-047）**。FR-046 drop の理由も Addendum に追記済み（roundtrip 検証済み）。

## Closing Issues

None

## セルフチェック

- [x] SPEC 更新済み（SPEC-2356 Addendum、FR-046 drop 反映）
- [x] 全テスト通過（JS 920/0・playwright 4/4・english-only PASS）
- [x] 未実装・TODO なし（FR-046 は意図的に drop）
- [x] ユーザー視覚検証 confirmed（MISSION 実機確認）
- [x] commitlint PASS / english-only contract 維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Window activity indicators now display in minimap tooltips and window switcher, showing what each agent is currently doing
  * Mission convergence status cell added to the operator status strip, tracking agent completion progress

* **Tests**
  * Added end-to-end tests for mission convergence and activity surfacing
  * Added unit tests for tooltip and status cell behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->