### PR TITLE
feat(gui): add OpenCode launch-wizard options and in-pane setup launcher

### DIFF
--- a/crates/gwt-agent/src/types.rs
+++ b/crates/gwt-agent/src/types.rs
@@ -113,9 +113,10 @@ impl AgentId {
 
     /// Whether this agent takes a free-text model string rather than a fixed
     /// gwt model list, because the available models depend on the chosen
-    /// provider (Hermes). SPEC-3152.
+    /// provider (Hermes `--model`, OpenCode `--model provider/model`).
+    /// SPEC-3152 / SPEC-3151 FR-008.
     pub fn supports_freetext_model(&self) -> bool {
-        matches!(self, Self::Hermes)
+        matches!(self, Self::Hermes | Self::OpenCode)
     }
 }
 
@@ -626,12 +627,12 @@ mod tests {
         assert!(AgentId::Hermes.supports_provider_selection());
         assert!(AgentId::Hermes.supports_profile_selection());
         assert!(AgentId::Hermes.supports_freetext_model());
-        for other in [
-            AgentId::ClaudeCode,
-            AgentId::Codex,
-            AgentId::Gemini,
-            AgentId::OpenCode,
-        ] {
+        // SPEC-3151 FR-008: OpenCode also takes a free-text `provider/model`
+        // string, but it does not expose Hermes-style provider/profile flags.
+        assert!(AgentId::OpenCode.supports_freetext_model());
+        assert!(!AgentId::OpenCode.supports_provider_selection());
+        assert!(!AgentId::OpenCode.supports_profile_selection());
+        for other in [AgentId::ClaudeCode, AgentId::Codex, AgentId::Gemini] {
             assert!(!other.supports_provider_selection());
             assert!(!other.supports_profile_selection());
             assert!(!other.supports_freetext_model());

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -38,7 +38,7 @@ pub use hooks::{
 pub use provider_hooks::{
     generate_hermes_hooks, generate_openclaw_hooks, generate_opencode_hooks, hermes_is_configured,
     hermes_is_configured_global, hermes_provider_choices, hermes_provider_choices_global,
-    hermes_source_home,
+    hermes_source_home, opencode_is_configured, opencode_is_configured_global,
 };
 pub use registry::{EmbeddedSkill, RegistryError, SkillRegistry};
 pub use settings_local::{

--- a/crates/gwt-skills/src/provider_hooks.rs
+++ b/crates/gwt-skills/src/provider_hooks.rs
@@ -41,6 +41,44 @@ pub fn generate_opencode_hooks(worktree: &Path) -> io::Result<()> {
     write_settings_atomically(&skip_permissions_path, &skip_permissions_config)
 }
 
+/// `true` when the user's OpenCode data home has at least one configured AI
+/// provider credential. OpenCode stores global auth in
+/// `$XDG_DATA_HOME/opencode/auth.json` (default `~/.local/share/opencode`) as a
+/// JSON object keyed by provider id; an empty object means "no provider signed
+/// in yet". gwt only redirects `OPENCODE_CONFIG_DIR` (config), never the data
+/// dir, so OpenCode auth is host-global and no credential bridge is required
+/// (unlike Hermes). Used by the launch wizard to surface a non-blocking
+/// "OpenCode has no AI provider configured" hint. SPEC-3151 FR-009.
+pub fn opencode_is_configured(data_home: &Path) -> bool {
+    let Ok(text) = fs::read_to_string(data_home.join("auth.json")) else {
+        return false;
+    };
+    matches!(
+        serde_json::from_str::<Value>(&text),
+        Ok(Value::Object(map)) if !map.is_empty()
+    )
+}
+
+/// `true` when the user's global OpenCode data home has at least one configured
+/// provider credential. Resolves the data home as `$XDG_DATA_HOME/opencode`
+/// else `~/.local/share/opencode`. Convenience wrapper over
+/// [`opencode_is_configured`] for the launch wizard's "OpenCode is not set up"
+/// hint. SPEC-3151 FR-009.
+pub fn opencode_is_configured_global() -> bool {
+    opencode_global_data_home()
+        .map(|home| opencode_is_configured(&home))
+        .unwrap_or(false)
+}
+
+/// The user's global OpenCode data home (`$XDG_DATA_HOME/opencode` else
+/// `~/.local/share/opencode`), where `auth.json` holds provider credentials.
+fn opencode_global_data_home() -> Option<PathBuf> {
+    match env::var_os("XDG_DATA_HOME") {
+        Some(value) if !value.is_empty() => Some(PathBuf::from(value).join("opencode")),
+        _ => home_dir().map(|home| home.join(".local/share/opencode")),
+    }
+}
+
 /// Generate Hermes Agent project-local hook config under `.gwt/hermes` and
 /// bridge the user's real Hermes setup (credentials + provider config) into
 /// the worktree-local HERMES_HOME so the isolated home stays authenticated.
@@ -623,5 +661,35 @@ mod hermes_tests {
         assert!(!dest.join(".env").exists());
         let config = fs::read_to_string(dest.join("config.yaml")).unwrap();
         assert!(config.contains("hooks_auto_accept: true"));
+    }
+}
+
+#[cfg(test)]
+mod opencode_tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn is_configured_false_when_auth_absent() {
+        let data_home = tempfile::tempdir().unwrap();
+        assert!(!opencode_is_configured(data_home.path()));
+    }
+
+    #[test]
+    fn is_configured_false_when_auth_is_empty_object() {
+        let data_home = tempfile::tempdir().unwrap();
+        fs::write(data_home.path().join("auth.json"), "{}").unwrap();
+        assert!(!opencode_is_configured(data_home.path()));
+    }
+
+    #[test]
+    fn is_configured_true_with_at_least_one_credential() {
+        let data_home = tempfile::tempdir().unwrap();
+        fs::write(
+            data_home.path().join("auth.json"),
+            "{\"anthropic\":{\"type\":\"api\",\"key\":\"sk-x\"}}",
+        )
+        .unwrap();
+        assert!(opencode_is_configured(data_home.path()));
     }
 }

--- a/crates/gwt/src/app_runtime/launch_errors.rs
+++ b/crates/gwt/src/app_runtime/launch_errors.rs
@@ -105,6 +105,7 @@ impl AppRuntime {
             gwt::LaunchWizardAction::SetCodexFastMode { .. } => "set_codex_fast_mode",
             gwt::LaunchWizardAction::SetHermesOption { .. } => "set_hermes_option",
             gwt::LaunchWizardAction::SetHermesSafeMode { .. } => "set_hermes_safe_mode",
+            gwt::LaunchWizardAction::RunOpenCodeSetup => "run_opencode_setup",
             gwt::LaunchWizardAction::Submit => "submit",
             gwt::LaunchWizardAction::GotoStep { .. } => "goto_step",
         }

--- a/crates/gwt/src/app_runtime/wizard.rs
+++ b/crates/gwt/src/app_runtime/wizard.rs
@@ -214,6 +214,7 @@ impl AppRuntime {
         );
         wizard.set_hermes_provider_choices(gwt_skills::hermes_provider_choices_global());
         wizard.set_hermes_needs_setup(!gwt_skills::hermes_is_configured_global());
+        wizard.set_opencode_needs_setup(!gwt_skills::opencode_is_configured_global());
         wizard.mark_runtime_context_unresolved();
         self.launch_wizard = Some(LaunchWizardSession {
             tab_id: tab_id.to_string(),
@@ -275,6 +276,7 @@ impl AppRuntime {
         );
         wizard.set_hermes_provider_choices(gwt_skills::hermes_provider_choices_global());
         wizard.set_hermes_needs_setup(!gwt_skills::hermes_is_configured_global());
+        wizard.set_opencode_needs_setup(!gwt_skills::opencode_is_configured_global());
         wizard.mark_runtime_context_unresolved();
         self.launch_wizard = Some(LaunchWizardSession {
             tab_id: tab_id.to_string(),
@@ -1213,6 +1215,7 @@ impl AppRuntime {
         );
         wizard.set_hermes_provider_choices(gwt_skills::hermes_provider_choices_global());
         wizard.set_hermes_needs_setup(!gwt_skills::hermes_is_configured_global());
+        wizard.set_opencode_needs_setup(!gwt_skills::opencode_is_configured_global());
         wizard.mark_runtime_context_unresolved();
         self.launch_wizard = Some(LaunchWizardSession {
             tab_id: tab_id.to_string(),

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -234,17 +234,28 @@ pub fn build_shell_process_launch(
     base_env.apply_to_parts(&mut env, &mut remove_env);
 
     if config.runtime_target != gwt_agent::LaunchRuntimeTarget::Docker {
-        let windows_shell = if cfg!(windows) {
-            config.windows_shell
+        // SPEC-3151 FR-010: an explicit command override (e.g. the OpenCode
+        // setup launcher `bunx opencode-ai@latest auth login`) replaces the
+        // detected interactive shell. `detect_shell_program()` is only called
+        // when there is no override.
+        let shell = if let Some(command) = config.command_override.clone() {
+            gwt::ShellProgram {
+                command,
+                args: config.command_args_override.clone().unwrap_or_default(),
+            }
         } else {
-            None
-        };
-        let shell = match windows_shell {
-            Some(windows_shell) => gwt::ShellProgram {
-                command: windows_shell_process_command(windows_shell).to_string(),
-                args: interactive_windows_shell_args(windows_shell),
-            },
-            None => detect_shell_program().map_err(|error| error.to_string())?,
+            let windows_shell = if cfg!(windows) {
+                config.windows_shell
+            } else {
+                None
+            };
+            match windows_shell {
+                Some(windows_shell) => gwt::ShellProgram {
+                    command: windows_shell_process_command(windows_shell).to_string(),
+                    args: interactive_windows_shell_args(windows_shell),
+                },
+                None => detect_shell_program().map_err(|error| error.to_string())?,
+            }
         };
         env.insert(
             "GWT_PROJECT_ROOT".to_string(),
@@ -2378,6 +2389,8 @@ mod tests {
             windows_shell: Some(gwt_agent::WindowsShellKind::CommandPrompt),
             env_vars: HashMap::new(),
             remove_env: Vec::new(),
+            command_override: None,
+            command_args_override: None,
         };
 
         let launch = build_shell_process_launch(Path::new("/tmp/fallback"), &mut config)

--- a/crates/gwt/src/launch_wizard/launch_request.rs
+++ b/crates/gwt/src/launch_wizard/launch_request.rs
@@ -199,6 +199,8 @@ impl LaunchWizardState {
             windows_shell: self.windows_shell_for_launch(),
             env_vars,
             remove_env: Vec::new(),
+            command_override: None,
+            command_args_override: None,
         })
     }
 
@@ -624,6 +626,185 @@ mod tests {
             agent_id: "claude".to_string(),
         });
         assert!(!state.view().hermes_needs_setup);
+    }
+
+    #[test]
+    fn opencode_options_expose_freetext_model_in_settings_view_for_opencode_only() {
+        // SPEC-3151 FR-008: OpenCode shows a free-text provider/model field
+        // (no fixed gwt model list) only when the OpenCode agent is selected.
+        let mut options = sample_agent_options();
+        options.push(AgentOption {
+            id: "opencode".to_string(),
+            name: "OpenCode".to_string(),
+            available: true,
+            installed_version: Some("1.0.0".to_string()),
+            versions: Vec::new(),
+            custom_agent: None,
+        });
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            options,
+            Vec::new(),
+        );
+        state.mark_runtime_context_unresolved();
+        state.apply(LaunchWizardAction::UseStartMethod {
+            method: LaunchWizardStartMethodKind::ConfigureAndStart,
+        });
+
+        state.apply(LaunchWizardAction::SetAgent {
+            agent_id: "opencode".to_string(),
+        });
+        // Free-text model is accepted without a fixed list (provider/model).
+        state.apply(LaunchWizardAction::SetModel {
+            model: "anthropic/claude-sonnet-4".to_string(),
+        });
+
+        let view = state.view();
+        assert!(
+            view.show_opencode_options,
+            "OpenCode settings section must be shown for the OpenCode agent"
+        );
+        assert_eq!(view.selected_model, "anthropic/claude-sonnet-4");
+        // OpenCode is not a Hermes-style provider/profile agent.
+        assert!(!view.show_hermes_options);
+
+        state.apply(LaunchWizardAction::SetAgent {
+            agent_id: "claude".to_string(),
+        });
+        assert!(
+            !state.view().show_opencode_options,
+            "non-OpenCode agents must not show the OpenCode section"
+        );
+    }
+
+    #[test]
+    fn build_launch_config_maps_opencode_freetext_model() {
+        // SPEC-3151 FR-008: the free-text model reaches the CLI as `--model`.
+        let mut options = sample_agent_options();
+        options.push(AgentOption {
+            id: "opencode".to_string(),
+            name: "OpenCode".to_string(),
+            available: true,
+            installed_version: Some("1.0.0".to_string()),
+            versions: Vec::new(),
+            custom_agent: None,
+        });
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            options,
+            Vec::new(),
+        );
+        state.set_agent_id("opencode");
+        state.apply(LaunchWizardAction::SetModel {
+            model: "anthropic/claude-sonnet-4".to_string(),
+        });
+
+        let config = state.build_launch_config().expect("opencode launch config");
+        assert_eq!(config.agent_id, gwt_agent::AgentId::OpenCode);
+        assert!(config
+            .args
+            .windows(2)
+            .any(|p| p[0] == "--model" && p[1] == "anthropic/claude-sonnet-4"));
+    }
+
+    #[test]
+    fn opencode_needs_setup_flag_is_exposed_only_for_opencode() {
+        // SPEC-3151 FR-009: the non-blocking needs-setup hint only surfaces for
+        // the OpenCode agent.
+        let mut options = sample_agent_options();
+        options.push(AgentOption {
+            id: "opencode".to_string(),
+            name: "OpenCode".to_string(),
+            available: true,
+            installed_version: Some("1.0.0".to_string()),
+            versions: Vec::new(),
+            custom_agent: None,
+        });
+        let mut state = LaunchWizardState::open_with(
+            context(branch("feature/gui"), "feature/gui"),
+            options,
+            Vec::new(),
+        );
+        state.mark_runtime_context_unresolved();
+        state.apply(LaunchWizardAction::UseStartMethod {
+            method: LaunchWizardStartMethodKind::ConfigureAndStart,
+        });
+        state.set_opencode_needs_setup(true);
+
+        state.apply(LaunchWizardAction::SetAgent {
+            agent_id: "opencode".to_string(),
+        });
+        assert!(state.view().opencode_needs_setup);
+
+        // Non-OpenCode agents never surface the needs-setup hint.
+        state.apply(LaunchWizardAction::SetAgent {
+            agent_id: "claude".to_string(),
+        });
+        assert!(!state.view().opencode_needs_setup);
+    }
+
+    #[test]
+    fn run_opencode_setup_yields_shell_completion_with_auth_login_command() {
+        // SPEC-3151 FR-010: the in-pane setup launcher produces a Host shell
+        // launch running `<opencode runner> auth login`.
+        let mut options = sample_agent_options();
+        options.push(AgentOption {
+            id: "opencode".to_string(),
+            name: "OpenCode".to_string(),
+            available: true,
+            installed_version: Some("1.0.0".to_string()),
+            versions: Vec::new(),
+            custom_agent: None,
+        });
+        let mut ctx = context(branch("feature/gui"), "feature/gui");
+        ctx.worktree_path = Some(PathBuf::from("/tmp/repo-feature"));
+        let mut state = LaunchWizardState::open_with(ctx, options, Vec::new());
+        state.set_agent_id("opencode");
+        state.version = "latest".to_string();
+
+        state.apply(LaunchWizardAction::RunOpenCodeSetup);
+
+        match state.completion.as_ref() {
+            Some(LaunchWizardCompletion::Launch(request)) => match request.as_ref() {
+                LaunchWizardLaunchRequest::Shell(config) => {
+                    assert_eq!(config.display_name, "OpenCode Setup");
+                    assert_eq!(config.runtime_target, gwt_agent::LaunchRuntimeTarget::Host);
+                    assert_eq!(
+                        config.working_dir.as_deref(),
+                        Some(Path::new("/tmp/repo-feature"))
+                    );
+                    let runner =
+                        gwt_agent::launch::resolve_runner(&gwt_agent::AgentId::OpenCode, "latest");
+                    assert_eq!(
+                        config.command_override.as_deref(),
+                        Some(runner.executable.as_str())
+                    );
+                    let args = config
+                        .command_args_override
+                        .as_ref()
+                        .expect("command args override");
+                    assert_eq!(&args[args.len() - 2..], &["auth", "login"]);
+                    for base_arg in &runner.base_args {
+                        assert!(
+                            args.contains(base_arg),
+                            "expected base arg {base_arg} in {args:?}"
+                        );
+                    }
+                }
+                other => panic!("expected shell launch request, got {other:?}"),
+            },
+            other => panic!("expected launch completion, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn run_opencode_setup_action_deserializes_from_frontend_wire_tag() {
+        // SPEC-3151 FR-010: the frontend dispatches `{"kind":"run_opencode_setup"}`.
+        // Default snake_case would produce `run_open_code_setup`, so the variant
+        // carries an explicit serde rename; this locks the wire contract.
+        let action: LaunchWizardAction =
+            serde_json::from_str(r#"{"kind":"run_opencode_setup"}"#).expect("deserialize action");
+        assert_eq!(action, LaunchWizardAction::RunOpenCodeSetup);
     }
 
     #[test]

--- a/crates/gwt/src/launch_wizard/mod.rs
+++ b/crates/gwt/src/launch_wizard/mod.rs
@@ -311,6 +311,13 @@ pub struct LaunchWizardView {
     /// profile / advanced) in the Settings form.
     pub show_hermes_options: bool,
     pub hermes_needs_setup: bool,
+    /// SPEC-3151 FR-008: render the OpenCode launch-options section (free-text
+    /// `provider/model`) in the Settings form.
+    pub show_opencode_options: bool,
+    /// SPEC-3151 FR-009: `true` when OpenCode has no AI provider configured, so
+    /// the wizard shows a non-blocking "OpenCode is not set up" hint with an
+    /// in-pane setup launcher. Only meaningful for the OpenCode agent.
+    pub opencode_needs_setup: bool,
     pub hermes_provider: String,
     pub hermes_provider_options: Vec<String>,
     pub hermes_profile: String,
@@ -454,6 +461,13 @@ pub struct ShellLaunchConfig {
     pub windows_shell: Option<gwt_agent::WindowsShellKind>,
     pub env_vars: HashMap<String, String>,
     pub remove_env: Vec<String>,
+    /// SPEC-3151 FR-010: when `Some`, run this command on the host instead of
+    /// the detected interactive shell (e.g. `bunx`/`opencode` for the OpenCode
+    /// setup launcher). `None` keeps the default shell behavior.
+    pub command_override: Option<String>,
+    /// SPEC-3151 FR-010: arguments for `command_override`. Ignored when
+    /// `command_override` is `None`.
+    pub command_args_override: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -650,6 +664,15 @@ pub enum LaunchWizardAction {
     SetHermesSafeMode {
         enabled: bool,
     },
+    /// SPEC-3151 FR-010: launch `<opencode runner> auth login` in an in-pane
+    /// host shell so the user can sign in to an AI provider without leaving the
+    /// wizard. OpenCode auth is host-global, so this always runs on the host.
+    ///
+    /// Explicit serde rename: the default snake_case of `RunOpenCodeSetup` is
+    /// `run_open_code_setup`, but the frontend and the action-label use the
+    /// `opencode` convention, so the wire tag is `run_opencode_setup`.
+    #[serde(rename = "run_opencode_setup")]
+    RunOpenCodeSetup,
     Submit,
     /// SPEC-2014 FR-128: progress rail クリックで指定フェーズへ直接移動する。
     GotoStep {
@@ -704,6 +727,11 @@ pub struct LaunchWizardState {
     /// resolvable credentials, so the wizard shows a non-blocking "Hermes is
     /// not set up" hint. Populated at wizard open; never blocks launch.
     pub hermes_needs_setup: bool,
+    /// SPEC-3151 FR-009: `true` when OpenCode has no AI provider configured in
+    /// its global data home, so the wizard shows a non-blocking "OpenCode is
+    /// not set up" hint with an in-pane setup launcher. Populated at wizard
+    /// open; never blocks launch.
+    pub opencode_needs_setup: bool,
     pub branch_name: String,
     /// SPEC-2359 US-80: optional Start Work intake prompt (always skippable).
     /// Empty string means the step was skipped or left blank.

--- a/crates/gwt/src/launch_wizard/state.rs
+++ b/crates/gwt/src/launch_wizard/state.rs
@@ -77,6 +77,7 @@ impl LaunchWizardState {
             hermes_safe_mode: false,
             hermes_provider_choices: Vec::new(),
             hermes_needs_setup: false,
+            opencode_needs_setup: false,
             branch_name: String::new(),
             initial_prompt: String::new(),
             completion: None,
@@ -457,6 +458,9 @@ impl LaunchWizardState {
             }
             LaunchWizardAction::SetHermesSafeMode { enabled } => {
                 self.hermes_safe_mode = enabled;
+            }
+            LaunchWizardAction::RunOpenCodeSetup => {
+                self.run_opencode_setup();
             }
             LaunchWizardAction::Back => {
                 if self.show_confirm() {
@@ -1429,10 +1433,18 @@ impl LaunchWizardState {
     }
 
     /// SPEC-3152: whether the current agent takes a free-text model string
-    /// rather than a fixed gwt model list (Hermes).
+    /// rather than a fixed gwt model list (Hermes / OpenCode).
     pub(super) fn current_agent_supports_freetext_model(&self) -> bool {
         self.launch_target_is_agent()
             && agent_id_from_key(self.effective_agent_id()).supports_freetext_model()
+    }
+
+    /// SPEC-3151 FR-008: whether the current agent is OpenCode, which exposes a
+    /// free-text `provider/model` field and the in-pane setup launcher in the
+    /// Settings form.
+    pub(super) fn current_agent_is_opencode(&self) -> bool {
+        self.launch_target_is_agent()
+            && agent_id_from_key(self.effective_agent_id()) == gwt_agent::AgentId::OpenCode
     }
 
     /// SPEC-3152: provider choices enumerated from the user's Hermes config,
@@ -1445,6 +1457,48 @@ impl LaunchWizardState {
     /// populated by the app runtime at wizard open.
     pub fn set_hermes_needs_setup(&mut self, needs_setup: bool) {
         self.hermes_needs_setup = needs_setup;
+    }
+
+    /// SPEC-3151 FR-009: whether OpenCode's global data home has no configured
+    /// AI provider, populated by the app runtime at wizard open.
+    pub fn set_opencode_needs_setup(&mut self, needs_setup: bool) {
+        self.opencode_needs_setup = needs_setup;
+    }
+
+    /// SPEC-3151 FR-010: resolve the OpenCode runner for the wizard's selected
+    /// version and produce a Shell launch that runs `<runner> auth login` on the
+    /// host. OpenCode auth is host-global (`$XDG_DATA_HOME/opencode/auth.json`),
+    /// so the setup launcher is forced to the Host runtime regardless of the
+    /// wizard's Docker selection.
+    fn run_opencode_setup(&mut self) {
+        let version = if self.version.is_empty() {
+            "latest"
+        } else {
+            self.version.as_str()
+        };
+        let runner = gwt_agent::launch::resolve_runner(&gwt_agent::AgentId::OpenCode, version);
+        let mut args = runner.base_args.clone();
+        args.push("auth".to_string());
+        args.push("login".to_string());
+
+        self.launch_target = LaunchTargetKind::Shell;
+        let config = ShellLaunchConfig {
+            working_dir: self.context.worktree_path.clone(),
+            branch: (!self.branch_name.is_empty()).then(|| self.branch_name.clone()),
+            base_branch: None,
+            display_name: "OpenCode Setup".to_string(),
+            runtime_target: gwt_agent::LaunchRuntimeTarget::Host,
+            docker_service: None,
+            docker_lifecycle_intent: gwt_agent::DockerLifecycleIntent::default(),
+            windows_shell: self.windows_shell_for_launch(),
+            env_vars: HashMap::new(),
+            remove_env: Vec::new(),
+            command_override: Some(runner.executable),
+            command_args_override: Some(args),
+        };
+        self.completion = Some(LaunchWizardCompletion::Launch(Box::new(
+            LaunchWizardLaunchRequest::Shell(Box::new(config)),
+        )));
     }
 
     /// SPEC-3152: persist a Hermes free-text launch option by field key.

--- a/crates/gwt/src/launch_wizard/view_model.rs
+++ b/crates/gwt/src/launch_wizard/view_model.rs
@@ -26,6 +26,7 @@ impl LaunchWizardState {
             && self.current_agent_supports_fast_mode();
         let fast_mode = self.fast_mode_enabled_for_current_agent();
         let show_hermes_options = show_manual_setup && self.current_agent_supports_hermes_options();
+        let show_opencode_options = show_manual_setup && self.current_agent_is_opencode();
         LaunchWizardView {
             title: if self.wizard_mode == LaunchWizardMode::StartWork {
                 "Start Work".to_string()
@@ -102,6 +103,8 @@ impl LaunchWizardState {
                 && self.agent_is_codex(),
             show_hermes_options,
             hermes_needs_setup: show_hermes_options && self.hermes_needs_setup,
+            show_opencode_options,
+            opencode_needs_setup: show_opencode_options && self.opencode_needs_setup,
             hermes_provider: self.hermes_provider.clone(),
             hermes_provider_options: self.hermes_provider_choices.clone(),
             hermes_profile: self.hermes_profile.clone(),

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -4779,6 +4779,8 @@ mod tests {
             env_vars: HashMap::from([("EXTRA_FLAG".to_string(), "1".to_string())]),
             remove_env: vec!["SECRET".to_string()],
             windows_shell: None,
+            command_override: None,
+            command_args_override: None,
         };
 
         let launch = build_shell_process_launch(&worktree, &mut config).expect("shell launch");
@@ -4816,6 +4818,8 @@ mod tests {
             env_vars: HashMap::new(),
             remove_env: Vec::new(),
             windows_shell: Some(gwt_agent::WindowsShellKind::WindowsPowerShell),
+            command_override: None,
+            command_args_override: None,
         };
 
         let launch = build_shell_process_launch(&worktree, &mut config).expect("shell launch");
@@ -4829,6 +4833,51 @@ mod tests {
             assert_ne!(launch.command, "powershell");
             assert_ne!(launch.command, "cmd.exe");
         }
+    }
+
+    #[test]
+    fn build_shell_process_launch_for_host_uses_command_override() {
+        // SPEC-3151 FR-010: a command override (the OpenCode setup launcher)
+        // replaces the detected interactive shell while keeping the worktree
+        // env and GWT_PROJECT_ROOT.
+        let temp = tempdir().expect("tempdir");
+        let worktree = temp.path().join("repo-feature");
+        fs::create_dir_all(&worktree).expect("create worktree");
+        let mut config = ShellLaunchConfig {
+            working_dir: Some(worktree.clone()),
+            branch: Some("feature/gui".to_string()),
+            base_branch: None,
+            display_name: "OpenCode Setup".to_string(),
+            runtime_target: LaunchRuntimeTarget::Host,
+            docker_service: None,
+            docker_lifecycle_intent: DockerLifecycleIntent::Connect,
+            env_vars: HashMap::new(),
+            remove_env: Vec::new(),
+            windows_shell: None,
+            command_override: Some("bunx".to_string()),
+            command_args_override: Some(vec![
+                "opencode-ai@latest".to_string(),
+                "auth".to_string(),
+                "login".to_string(),
+            ]),
+        };
+
+        let launch = build_shell_process_launch(&worktree, &mut config).expect("shell launch");
+
+        assert_eq!(launch.command, "bunx");
+        assert_eq!(
+            launch.args,
+            vec![
+                "opencode-ai@latest".to_string(),
+                "auth".to_string(),
+                "login".to_string()
+            ]
+        );
+        assert_eq!(launch.cwd.as_deref(), Some(worktree.as_path()));
+        assert_eq!(
+            launch.env.get("GWT_PROJECT_ROOT").map(String::as_str),
+            Some(worktree.display().to_string().as_str())
+        );
     }
 
     #[test]
@@ -5686,6 +5735,8 @@ mod tests {
             env_vars: HashMap::new(),
             remove_env: Vec::new(),
             windows_shell: None,
+            command_override: None,
+            command_args_override: None,
         };
         super::resolve_shell_launch_worktree(&repo, &mut shell_config)
             .expect("shell launch wrapper");

--- a/crates/gwt/web/launch-wizard-surface.js
+++ b/crates/gwt/web/launch-wizard-surface.js
@@ -1455,6 +1455,50 @@ export function createLaunchWizardSurface({
           panel.appendChild(section);
         }
 
+        // SPEC-3151 FR-008/009/010: OpenCode-specific launch options, rendered
+        // only for the OpenCode agent. OpenCode takes a single free-text
+        // `provider/model` string (auth is host-global, so no provider bridge
+        // is needed). When no AI provider is configured, a non-blocking note
+        // offers an in-pane setup launcher that runs `opencode auth login`.
+        if (showSetupForms && launchWizard.show_opencode_options) {
+          const section = createLaunchSection(
+            "OpenCode options",
+            "Model and provider sign-in for the OpenCode agent. Blank model uses your OpenCode config.",
+          );
+          if (launchWizard.opencode_needs_setup) {
+            const note = createNode(
+              "div",
+              "launch-note",
+              "OpenCode has no AI provider configured yet. Run `/connect` inside OpenCode or `opencode auth login` to sign in. You can still launch — OpenCode will prompt for setup.",
+            );
+            const setupButton = createNode(
+              "button",
+              "launch-choice-button",
+              "Run OpenCode setup",
+            );
+            setupButton.type = "button";
+            setupButton.addEventListener("click", () =>
+              sendWizardAction({ kind: "run_opencode_setup" }),
+            );
+            note.appendChild(setupButton);
+            section.appendChild(note);
+          }
+          const grid = createNode("div", "launch-form-grid");
+          appendTextField(
+            grid,
+            "Model",
+            launchWizard.selected_model,
+            "e.g. anthropic/claude-sonnet-4 (blank = config)",
+            (value) =>
+              sendWizardAction({
+                kind: "set_model",
+                model: value,
+              }),
+          );
+          section.appendChild(grid);
+          panel.appendChild(section);
+        }
+
         // SPEC-2014 Amendment 2026-05-20 (FR-057 / FR-058):
         // The Linked issue section renders only when the wizard was opened
         // through the Knowledge Issue Bridge. The issue number is shown as


### PR DESCRIPTION
## Summary

- Gives the OpenCode agent the same Launch-wizard integration that Hermes (SPEC-3152) recently received, so OpenCode is configurable from the wizard, surfaces a non-blocking "no provider configured" hint, and can be set up in-app.
- Unlike Hermes (whose whole `HERMES_HOME` is redirected), **OpenCode auth is host-global** (`~/.local/share/opencode/auth.json`, not moved by `OPENCODE_CONFIG_DIR` — verified), so this needs **no credential bridge / config merge**.

## Changes

- `crates/gwt-agent/src/types.rs`: `supports_freetext_model()` now includes OpenCode (its model is a single free-text `provider/model`).
- `crates/gwt-skills/src/provider_hooks.rs` + `lib.rs`: add `opencode_is_configured(data_home)` / `opencode_is_configured_global()` (auth.json parses to a non-empty object; data home = `$XDG_DATA_HOME/opencode` else `~/.local/share/opencode`), symmetric to `hermes_is_configured`.
- `crates/gwt/src/launch_wizard/{mod,state,view_model,launch_request}.rs`: `opencode_needs_setup` + `show_opencode_options` view fields; `RunOpenCodeSetup` action (wire tag `run_opencode_setup` via explicit serde rename); the setup handler resolves the OpenCode runner for the selected version and produces a Host Shell launch running `<runner> auth login`.
- `crates/gwt/src/launch_runtime.rs` + `mod.rs`: `ShellLaunchConfig` gains `command_override` / `command_args_override`; `build_shell_process_launch` runs the override instead of the detected shell on the host path. (This generic command-pane mechanism also unblocks the deferred Hermes FR-006 launcher — follow-up.)
- `crates/gwt/src/app_runtime/{wizard,launch_errors}.rs`: hydrate `opencode_needs_setup` at the 3 wizard-open sites; add the `run_opencode_setup` telemetry label.
- `crates/gwt/web/launch-wizard-surface.js`: an "OPENCODE OPTIONS" section with a free-text Model field, the needs-setup banner, and a "Run OpenCode setup" button.

## Testing

- [x] `cargo test -p gwt-agent -p gwt-skills -p gwt --all-features` — GREEN (56 suites; new tests for capability, `opencode_is_configured`, shell command_override, the setup completion, and the `run_opencode_setup` wire-tag contract)
- [x] `cargo clippy -p gwt-agent -p gwt-skills -p gwt --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] GUI E2E (Playwright on a live gwt) + **User Verification: confirmed** — OpenCode wizard shows the Model field (value plumbs to `--model`), the needs-setup banner renders with 0 credentials, and "Run OpenCode setup" spawns the `opencode auth login` provider-selection TUI in a pane.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — additive OpenCode wizard surface; no change to other agents, no half-finished behavior.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- None

## Related Issues / Links

- SPEC-3151 (`gwt-spec` Issue #3151) — second slice (first slice merged as #3158)
- #3152 (Hermes 整合 — the wizard pattern mirrored here)

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (if user-facing change) — N/A: no README/doc surface
- [x] Migration/backfill plan included (if schema/data change) — N/A: additive view fields + new action, no persisted schema change
- [x] CHANGELOG impact considered — `feat` (minor); no breaking change

## Notes

- A serde-rename bug (the `RunOpenCodeSetup` wire tag defaulted to `run_open_code_setup`, rejecting the JS `run_opencode_setup`) was caught during the live E2E (unit tests missed it) and fixed with an explicit `#[serde(rename)]` + a wire-contract test.
- Follow-up (non-blocking): the new `command_override` mechanism can power the deferred Hermes #3152 FR-006 in-pane setup launcher.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OpenCode agent now supports free-text model selection alongside existing setup capabilities
  * Added OpenCode configuration detection to automatically display setup status in the launch wizard
  * Integrated OpenCode setup launcher directly into the wizard interface, allowing users to configure OpenCode without leaving the app
  * Added shell command override capability for custom shell execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->