### PR TITLE
fix(hook): self-improvement Stop hook を古い gwtd でも graceful degrade + 回帰ガード (#3178)

### DIFF
--- a/crates/gwt/tests/gwtd_cli_test.rs
+++ b/crates/gwt/tests/gwtd_cli_test.rs
@@ -1,6 +1,8 @@
 use std::{
+    collections::BTreeSet,
     fs,
     io::Write,
+    path::Path,
     process::{Command, Stdio},
 };
 
@@ -333,4 +335,168 @@ fn gwtd_gwt_self_improvement_stop_remains_argv_transport_exception() {
         "non-gwt repos must receive no hook output, got: {}",
         String::from_utf8_lossy(&output.stdout)
     );
+}
+
+/// Initialize a worktree whose `origin` is `akiojin/gwt` so generation emits the
+/// repo-owned self-improvement Stop hook alongside the shared managed hooks.
+fn init_gwt_origin_repo(worktree: &Path) {
+    assert!(Command::new("git")
+        .arg("init")
+        .arg("-q")
+        .arg(worktree)
+        .status()
+        .expect("git init")
+        .success());
+    assert!(Command::new("git")
+        .arg("-C")
+        .arg(worktree)
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/akiojin/gwt.git"
+        ])
+        .status()
+        .expect("git remote add")
+        .success());
+}
+
+/// Concatenate every generated text artifact under `dir` (skipping `.git`) so
+/// the gwtd `hook <subcommand>` invocations from Claude/Codex settings and the
+/// OpenCode/OpenClaw/Hermes provider bridges land in one corpus.
+fn collect_generated_text(dir: &Path, out: &mut String) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.file_name().and_then(|name| name.to_str()) == Some(".git") {
+            continue;
+        }
+        if path.is_dir() {
+            collect_generated_text(&path, out);
+        } else if let Ok(content) = fs::read_to_string(&path) {
+            out.push_str(&content);
+            out.push('\n');
+        }
+    }
+}
+
+/// Extract the gwtd `hook <subcommand>` keywords that generated artifacts
+/// invoke. Shell (`"$gwt_bin" hook event Stop`) and JS-array
+/// (`["hook", "provider-event", ...]`) call forms both reduce to the same token
+/// stream once quoting/bracket punctuation is flattened to whitespace, so a
+/// `hook` token whose predecessor references the gwt hook binary yields the
+/// routing subcommand. Anchoring on the binary predecessor keeps prose like the
+/// OpenClaw manifest's "plugin hook events" out of the result set.
+fn generated_hook_subcommands(corpus: &str) -> BTreeSet<String> {
+    let flattened: String = corpus
+        .chars()
+        .map(|c| match c {
+            '"' | '\'' | ',' | '[' | ']' | '(' | ')' | ';' | '{' | '}' | '|' | '=' => ' ',
+            other => other,
+        })
+        .collect();
+    let tokens: Vec<&str> = flattened.split_whitespace().collect();
+    let references_hook_bin = |token: &str| {
+        token.contains("gwtd") || token.contains("gwt_bin") || token.contains("GWT_HOOK_BIN")
+    };
+    let is_subcommand = |token: &str| {
+        let mut chars = token.chars();
+        matches!(chars.next(), Some(first) if first.is_ascii_lowercase())
+            && token.chars().all(|c| c.is_ascii_lowercase() || c == '-')
+    };
+
+    let mut subcommands = BTreeSet::new();
+    for index in 1..tokens.len().saturating_sub(1) {
+        if tokens[index] == "hook"
+            && references_hook_bin(tokens[index - 1])
+            && is_subcommand(tokens[index + 1])
+        {
+            subcommands.insert(tokens[index + 1].to_string());
+        }
+    }
+    subcommands
+}
+
+/// Run `gwtd hook <args>` with an isolated home and report whether the binary
+/// rejected the argv with the legacy-transport error that broke issue #3178.
+fn gwtd_hook_argv_rejected(args: &[&str], stdin: &str) -> (bool, String) {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let cwd = tempfile::tempdir().expect("cwd tempdir");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_gwtd"))
+        .current_dir(cwd.path())
+        .args(args)
+        .env("HOME", home.path())
+        .env("USERPROFILE", home.path())
+        .env_remove("GWT_SESSION_RUNTIME_PATH")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("run gwtd hook argv");
+    child
+        .stdin
+        .take()
+        .expect("stdin")
+        .write_all(stdin.as_bytes())
+        .expect("write hook stdin");
+    let output = child.wait_with_output().expect("wait gwtd hook argv");
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let rejected = stderr.contains("legacy argv invocation is disabled");
+    (rejected, stderr)
+}
+
+/// Regression guard for issue #3178: every managed-hook command that generation
+/// emits must stay inside gwtd's argv transport allowlist. The self-improvement
+/// Stop hook regressed because its generated `hook gwt-self-improvement-stop`
+/// command had no matching `is_allowed_argv_exception` entry, so each Stop hit
+/// the legacy-argv rejection. This test derives the subcommands from the actual
+/// generated artifacts (not a hard-coded list) and runs each through the real
+/// binary, so a new generation site that drifts ahead of the allowlist fails
+/// here instead of silently at runtime.
+#[test]
+fn generated_managed_hook_commands_stay_within_gwtd_argv_allowlist() {
+    let worktree = tempfile::tempdir().expect("worktree tempdir");
+    init_gwt_origin_repo(worktree.path());
+
+    gwt_skills::generate_settings_local(worktree.path()).expect("generate claude settings");
+    gwt_skills::generate_codex_hooks(worktree.path()).expect("generate codex hooks");
+    gwt_skills::generate_opencode_hooks(worktree.path()).expect("generate opencode hooks");
+    gwt_skills::generate_openclaw_hooks(worktree.path()).expect("generate openclaw hooks");
+    gwt_skills::generate_hermes_hooks(worktree.path()).expect("generate hermes hooks");
+
+    let mut corpus = String::new();
+    collect_generated_text(worktree.path(), &mut corpus);
+    let subcommands = generated_hook_subcommands(&corpus);
+
+    for expected in ["event", "provider-event", "gwt-self-improvement-stop"] {
+        assert!(
+            subcommands.contains(expected),
+            "generation must still emit the `hook {expected}` managed-hook command; \
+             discovered subcommands: {subcommands:?}"
+        );
+    }
+
+    for subcommand in &subcommands {
+        let (args, stdin): (Vec<&str>, &str) = match subcommand.as_str() {
+            "event" => (vec!["hook", "event", "SessionStart"], ""),
+            "provider-event" => (
+                vec!["hook", "provider-event", "opencode", "session.created"],
+                "{\"sessionId\":\"guard\"}",
+            ),
+            "gwt-self-improvement-stop" => (vec!["hook", "gwt-self-improvement-stop"], ""),
+            other => panic!(
+                "generation emits an unmapped gwtd hook subcommand `{other}`. Add a representative \
+                 argv here and confirm gwtd's is_allowed_argv_exception accepts it, or the same \
+                 generation↔binary drift that broke issue #3178 will ship undetected."
+            ),
+        };
+        let (rejected, stderr) = gwtd_hook_argv_rejected(&args, stdin);
+        assert!(
+            !rejected,
+            "generated `hook {subcommand}` argv was rejected by gwtd's legacy-argv guard \
+             (issue #3178 regression); stderr: {stderr}"
+        );
+    }
 }


### PR DESCRIPTION
## 概要

Issue #3178（self-improvement Stop hook が legacy argv 起動で失敗し、Stop のたびにエラーが agent loop に注入される）を修正します。

`Closes #3178`

## 真因（検証済み）

- hook transport は **「argv でルーティング + stdin で payload」** 設計。`gwt-self-improvement-stop` の argv 例外は `ae058ced5`（**v9.63.0 にのみ含有**、v9.61.0/v9.62.0 には無い）で追加された。
- コミット済みの Stop hook コマンド（`.claude/settings.json` / `.codex/hooks.json`）はこの新しい subcommand に依存しているが、**コマンドは repo に commit されるため開発者がどの gwtd binary を入れていても実行される**。例外を持たない古い binary（インストール済み v9.61.0）では gwtd が exit 2 + stderr の legacy-argv rejection を返し、それが Claude Code の Stop hook feedback として agent loop に注入される（実運用で `/release` 中の Stop ループ実害を確認）。
- Issue 本文の「生成側を stdin JSON envelope 化する」提案は transport 設計と衝突するため不採用。

## 修正

shell ベースの self-improvement Stop hook を、未対応 binary に対して**無音で graceful degrade** させる（OpenCode/OpenClaw の JS bridge は既に `stdio: ignore` でこの挙動）。

- `.claude/settings.json` / `.codex/hooks.json`（committed）: `... hook gwt-self-improvement-stop 2>/dev/null || true`
- `crates/gwt-skills/src/provider_hooks.rs`（Hermes 生成スクリプト）: command substitution に `2>/dev/null`

`HookOutput::StopBlock` は **exit 0 + stdout に decision JSON** を出すため、対応 binary（v9.63.0+）での block 動作は維持される。一方、古い binary の rejection（exit 2 + stderr）は stderr 抑制 + exit 0 化で握りつぶされ、agent loop にエラーが出ない。

| 入力 | 古い v9.61.0 | 新 v9.63.0+ |
|---|---|---|
| graceful 化後の Stop コマンド | exit 0 / stderr 空（無音劣化） | StopBlock の stdout JSON 通過・exit 0 |

## 再発防止テスト（TDD）

- `committed_self_improvement_stop_hook_degrades_on_unsupported_gwtd`: commit 済みコマンドを、旧 binary を模した fake gwtd（exit 2 + stderr）に対して実行し、**exit 0 かつ stderr 空**を検証（RED→GREEN 確認済み）。
- `generated_managed_hook_commands_stay_within_gwtd_argv_allowlist`: 生成される全 managed-hook command を実 gwtd binary に通し、legacy-argv rejection で落ちないことを検証（生成側↔allowlist drift の guard）。

## 検証

- `cargo test -p gwt-core -p gwt --all-features`: PASS（exit 0、失敗ゼロ）
- `cargo test -p gwt-skills`: PASS（215、失敗ゼロ）
- `cargo clippy -p gwt -p gwt-skills --all-targets --all-features -- -D warnings`: 警告ゼロ
- `cargo fmt --check`: PASS / commitlint: PASS
- **実環境検証**: 実コミット済みコマンド × インストール済み v9.61.0 → exit 0・stderr 空（エラー注入なしを確認）

## User Verification Result

`n/a` — ユーザーに見える UI surface は無い。挙動変化は「Stop hook がエラーを出さなくなる」のみで、実環境（v9.61.0）での graceful degradation を実コマンドで確認済み。

## 補足（リリース工程・本 PR 範囲外）

完全に機能する self-improvement（candidate 検出 → Stop-block）を**古い binary でも有効化**するには、`gwt-self-improvement-stop` 例外を含む binary（v9.63.0+）の publish が必要。本 PR は「古い binary でエラーを注入しない」という実害解消を担保し、新 binary では従来どおり機能する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)