### PR TITLE
fix(gui): prevent launch wizard pending crash

### DIFF
--- a/.gwt/work/memory.md
+++ b/.gwt/work/memory.md
@@ -7464,7 +7464,7 @@ Future Action: contract test の assertion が『追加』ではなく『反転�
 Type: failure-pattern
 Context: Issue #3192 and Issue #3190 verification used browser-check/fresh HOME. The agent shell HOME pointed to an isolated gwt-fresh-home, so plain cargo/rustup saw no installed/default toolchains even though the real developer HOME had stable installed.
 Learning: When HOME is an isolated verification directory, rustup resolves toolchains under that HOME and cargo commands can fail with 'no default is configured'. This is an environment issue, not a Rust project failure.
-Future Action: Before Cargo/Rust verification after browser-check or isolated HOME work, print HOME/RUSTUP_HOME/CARGO_HOME when cargo cannot find a toolchain. If HOME is isolated, run cargo/rustup with HOME=/Users/akiojin USERPROFILE=/Users/akiojin RUSTUP_HOME=/Users/akiojin/.rustup CARGO_HOME=/Users/akiojin/.cargo or otherwise bridge the real toolchain home.
+Future Action: Before Cargo/Rust verification after browser-check or isolated HOME work, print HOME/RUSTUP_HOME/CARGO_HOME when cargo cannot find a toolchain. If HOME is isolated, resolve the real user home from the pre-isolation environment, OS user lookup, or `getent passwd "$USER" | cut -d: -f6`; then run cargo/rustup with `HOME="$REAL_HOME" USERPROFILE="$REAL_HOME" RUSTUP_HOME="$REAL_HOME/.rustup" CARGO_HOME="$REAL_HOME/.cargo"` or otherwise bridge the real toolchain home.
 
 ## 2026-06-27 — Visual auto-refresh fixtures should not fire timers before initial load settles
 

--- a/.gwt/work/memory.md
+++ b/.gwt/work/memory.md
@@ -7465,3 +7465,10 @@ Type: failure-pattern
 Context: Issue #3192 and Issue #3190 verification used browser-check/fresh HOME. The agent shell HOME pointed to an isolated gwt-fresh-home, so plain cargo/rustup saw no installed/default toolchains even though the real developer HOME had stable installed.
 Learning: When HOME is an isolated verification directory, rustup resolves toolchains under that HOME and cargo commands can fail with 'no default is configured'. This is an environment issue, not a Rust project failure.
 Future Action: Before Cargo/Rust verification after browser-check or isolated HOME work, print HOME/RUSTUP_HOME/CARGO_HOME when cargo cannot find a toolchain. If HOME is isolated, run cargo/rustup with HOME=/Users/akiojin USERPROFILE=/Users/akiojin RUSTUP_HOME=/Users/akiojin/.rustup CARGO_HOME=/Users/akiojin/.cargo or otherwise bridge the real toolchain home.
+
+## 2026-06-27 — Visual auto-refresh fixtures should not fire timers before initial load settles
+
+Type: failure-pattern
+Context: During PR #3193 pre-PR visual verification, the Issue Bridge auto-refresh Playwright fixture fired a 60000ms interval callback via a fixed 50ms timeout. In the full suite, initial knowledge load sometimes still held the busy flag, so the auto-refresh request was dropped and the test timed out although single-test runs passed.
+Learning: Timer-shortening fixtures are flaky when the production callback can legally no-op while state is busy. Tests should expose a deterministic trigger and call it after asserting the state that makes the callback meaningful.
+Future Action: For Playwright fixtures that validate periodic behavior, capture interval callbacks and trigger them explicitly after the initial render/load assertions instead of relying on arbitrary short timeouts.

--- a/.gwt/work/memory.md
+++ b/.gwt/work/memory.md
@@ -7458,3 +7458,10 @@ Type: fix
 Context: Docker起動エラーが TTY 前面に被さる回帰 (SPEC-2014 US-36 / FR-120/121)。terminal-overlay を error 時に表示する形式は commit 1e948b7a0 で廃止 (shouldShowOverlay=false 固定) 済みだったが、無関係な feature commit a93afd199 'feat: complete issue monitor auto queue' が app.js を Boolean(effectiveDetail) && runtimeState==='error' へ revert し、同時に contract test (operator-chrome-structure.test.mjs) と playwright test (agent-window-scroll.spec.ts) の assertion も regressed 側へ書き換えたため CI が素通りした。
 Learning: test rename + assert.equal('false')->assert.match(error) のような『契約の反転』は新規ケース追加と違い regression を隠す。TTY 前面 overlay は .terminal-overlay.visible 1 箇所(app.js shouldShowOverlay)のみで Docker 固有ではなく全 error window で発火する。error は overlay 無しでも inline TTY text(launch_error_terminal_output_event) / status chip tooltip / attention toast / Console docker tab / Logs Process facet の 5 面で可視。
 Future Action: contract test の assertion が『追加』ではなく『反転』している diff は regression の赤信号として扱う。完了済み FR を touch する大型 feature commit では guard test が意味を保っているか必ず確認する。前面 overlay を復活させる変更は SPEC-2014 US-36 違反。
+
+## 2026-06-27 — Browser-check isolated HOME can hide Rust toolchains
+
+Type: failure-pattern
+Context: Issue #3192 verification used browser-check/fresh HOME. The agent process HOME was an isolated gwt-fresh-home, so plain cargo/rustup saw no default toolchain even though the real user HOME had stable installed.
+Learning: When HOME is an isolated verification directory, rustup resolves toolchains under that HOME and cargo commands can fail with 'no default is configured'. This is an environment issue, not a Rust project failure.
+Future Action: Before Rust verification after browser-check or isolated HOME work, check HOME/rustup home. If HOME is isolated, run cargo/rustup with HOME=/Users/akiojin USERPROFILE=/Users/akiojin or otherwise point rustup at the real toolchain home.

--- a/crates/gwt/playwright/tests/kanban.spec.ts
+++ b/crates/gwt/playwright/tests/kanban.spec.ts
@@ -123,6 +123,10 @@ test.describe("Issue Bridge load recovery", () => {
     await expect(
       page.locator(".surface-knowledge .knowledge-detail-pane"),
     ).toContainText("Issue #3095");
+    await page.waitForFunction(
+      () => typeof window.__triggerKnowledgeAutoRefresh === "function",
+    );
+    await page.evaluate(() => window.__triggerKnowledgeAutoRefresh());
     await page.waitForFunction(() =>
       window.__knowledgeLoadMessages?.filter(
         (message) => message.kind === "load_knowledge_bridge",
@@ -393,10 +397,17 @@ async function installIssueBridgeBackend(
     }) => {
       window.__knowledgeLoadMessages = [];
       if (shouldTriggerAutoRefreshOnce) {
+        window.__knowledgeAutoRefreshCallbacks = [];
+        window.__triggerKnowledgeAutoRefresh = () => {
+          const callbacks = window.__knowledgeAutoRefreshCallbacks || [];
+          for (const callback of callbacks) {
+            callback();
+          }
+        };
         const originalSetInterval = window.setInterval.bind(window);
         window.setInterval = (callback, delay, ...args) => {
           if (delay === 60000) {
-            setTimeout(() => callback(...args), 50);
+            window.__knowledgeAutoRefreshCallbacks.push(() => callback(...args));
           }
           return originalSetInterval(callback, delay, ...args);
         };

--- a/crates/gwt/playwright/tests/launch-wizard-start-work-pending.spec.ts
+++ b/crates/gwt/playwright/tests/launch-wizard-start-work-pending.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "@playwright/test";
+import { APP_URL, installEmbeddedRoutes } from "./_helpers/embedded-frontend";
+
+test.describe("Launch Wizard Start Work pending state", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test("Start Work opens the local pending wizard before backend state arrives", async ({
+    page,
+  }) => {
+    const pageErrors: string[] = [];
+    page.on("pageerror", (error) => {
+      pageErrors.push(error.message);
+    });
+
+    await installEmbeddedRoutes(page);
+    await installWorkspaceFixture(page);
+    await page.goto(APP_URL);
+    await keepLaunchWizardModalVisible(page);
+
+    await expect(page.locator(".project-tab")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.locator('.op-rail__item[data-cmd="start-work"]').click();
+
+    const wizard = page.locator("#wizard-modal");
+    await expect(wizard).toHaveClass(/open/);
+    await expect(wizard).not.toHaveAttribute("aria-hidden", "true");
+    await expect(wizard).toContainText("Preparing Plan Agent...");
+    await expect(wizard.locator("#wizard-submit-button")).toBeHidden();
+
+    await expect
+      .poll(() => page.evaluate(() => (window as any).__sentKinds))
+      .toContain("open_start_work");
+    expect(pageErrors).toEqual([]);
+  });
+});
+
+async function keepLaunchWizardModalVisible(page: any): Promise<void> {
+  await page.addStyleTag({
+    content: `
+      #wizard-modal[aria-hidden="false"],
+      #wizard-modal.open {
+        display: flex !important;
+        pointer-events: auto !important;
+      }
+      #wizard-modal[aria-hidden="true"] {
+        display: none !important;
+        pointer-events: none !important;
+      }
+    `,
+  });
+}
+
+async function installWorkspaceFixture(page: any): Promise<void> {
+  await page.addInitScript(() => {
+    (window as any).__sent = [];
+    (window as any).__sentKinds = [];
+
+    const workspaceState = {
+      kind: "workspace_state",
+      workspace: {
+        app_version: "playwright",
+        tabs: [
+          {
+            id: "tab-1",
+            title: "Fixture Project",
+            project_root: "/fixture",
+            kind: "git",
+            workspace: {
+              viewport: { x: 0, y: 0, zoom: 1 },
+              windows: [],
+            },
+          },
+        ],
+        active_tab_id: "tab-1",
+        recent_projects: [],
+      },
+    };
+
+    class FixtureWebSocket extends EventTarget {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+
+      url: string;
+      readyState: number;
+
+      constructor(url: string) {
+        super();
+        this.url = url;
+        this.readyState = FixtureWebSocket.CONNECTING;
+        setTimeout(() => {
+          this.readyState = FixtureWebSocket.OPEN;
+          this.dispatchEvent(new Event("open"));
+          this.emit(workspaceState);
+        }, 0);
+      }
+
+      send(raw: string): void {
+        let message: any;
+        try {
+          message = JSON.parse(raw);
+        } catch {
+          return;
+        }
+        (window as any).__sent.push(message);
+        (window as any).__sentKinds.push(message.kind);
+        if (message.kind === "frontend_ready") {
+          this.emit(workspaceState);
+        }
+      }
+
+      close(): void {
+        this.readyState = FixtureWebSocket.CLOSED;
+        this.dispatchEvent(new CloseEvent("close"));
+      }
+
+      emit(payload: any): void {
+        setTimeout(() => {
+          this.dispatchEvent(
+            new MessageEvent("message", { data: JSON.stringify(payload) }),
+          );
+        }, 0);
+      }
+    }
+
+    Object.defineProperty(window, "WebSocket", {
+      configurable: true,
+      value: FixtureWebSocket,
+    });
+  });
+}

--- a/crates/gwt/web/__tests__/wizard-interaction-guard-wiring.test.mjs
+++ b/crates/gwt/web/__tests__/wizard-interaction-guard-wiring.test.mjs
@@ -212,8 +212,13 @@ test("wizard backend launch materialization state preserves pending feedback", (
   );
   assert.match(
     wizardSource,
-    /const\s+isLaunchMaterializationPending\s*=\s*Boolean\(\s*launchWizard\.launch_materialization_pending,?\s*\)/,
-    "expected renderer to derive backend launch materialization pending state",
+    /const\s+isLaunchMaterializationPending\s*=\s*Boolean\(\s*launchWizard\?\.launch_materialization_pending,?\s*\)/,
+    "renderer must read backend launch materialization pending state null-safely",
+  );
+  assert.doesNotMatch(
+    wizardSource,
+    /Boolean\(\s*launchWizard\.launch_materialization_pending,?\s*\)/,
+    "renderer must not dereference launchWizard while local opening state has no backend wizard",
   );
   assert.match(
     wizardSource,

--- a/crates/gwt/web/launch-wizard-surface.js
+++ b/crates/gwt/web/launch-wizard-surface.js
@@ -770,8 +770,10 @@ export function createLaunchWizardSurface({
 
         syncWizardDraftState();
         closeModal();
+        // Local opening states reach this point before backend wizard state
+        // exists, so any value shared across states must stay null-safe.
         const isLaunchMaterializationPending = Boolean(
-          launchWizard.launch_materialization_pending,
+          launchWizard?.launch_materialization_pending,
         );
         const isLaunchActionPending =
           Boolean(launchWizardPendingAction) || isLaunchMaterializationPending;


### PR DESCRIPTION
## Summary

- Prevent the Launch Wizard pending renderer from crashing when Start Work opens before backend wizard state arrives.
- Add regression coverage so Start Work shows the local pending wizard and still sends `open_start_work`.
- Record the isolated-HOME verification lesson for future browser-check runs.

## Changes

- `crates/gwt/web/launch-wizard-surface.js`: make the materialization-pending read null-safe while local opening state exists.
- `crates/gwt/web/__tests__/wizard-interaction-guard-wiring.test.mjs`: require the null-safe renderer contract and reject the unsafe dereference.
- `crates/gwt/playwright/tests/launch-wizard-start-work-pending.spec.ts`: cover Start Work opening the pending modal before backend state arrives.
- `.gwt/work/memory.md`: record that browser-check isolated `HOME` can hide rustup toolchains.

## Testing

- [x] `bun test crates/gwt/web/__tests__/wizard-interaction-guard-wiring.test.mjs` — RED before fix, PASS after fix.
- [x] `bash scripts/run-node-tests-with-linkedom.sh crates/gwt/web/__tests__/wizard-interaction-guard-wiring.test.mjs crates/gwt/web/__tests__/operator-chrome-structure.test.mjs crates/gwt/web/__tests__/playwright-embedded-routes.test.mjs` — PASS.
- [x] `bash scripts/check-frontend-bundle.sh` — PASS.
- [x] `bash scripts/run-frontend-unit-tests.sh` — PASS, 967 passed.
- [x] `bash scripts/run-frontend-smoke-tests.sh` — PASS, 30 passed.
- [x] `bash scripts/run-visual-tests.sh --workers=1` — PASS, 140 passed / 70 skipped live-backend specs.
- [x] `HOME=/Users/akiojin USERPROFILE=/Users/akiojin cargo fmt --check` — PASS.
- [x] `HOME=/Users/akiojin USERPROFILE=/Users/akiojin cargo build -p gwt --bin gwt --bin gwtd` — PASS.
- [x] `HOME=/Users/akiojin USERPROFILE=/Users/akiojin cargo test -p gwt-core -p gwt --all-features` — PASS.
- [x] `HOME=/Users/akiojin USERPROFILE=/Users/akiojin cargo clippy --all-targets --all-features -- -D warnings` — PASS.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — PASS.
- [x] Manual browser-check: user confirmed Start Work verification on a fresh local gwt instance.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — the change is a narrow regression fix for Start Work / launch pending UI and includes automated plus manual verification.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- Closes #3192

## Related Issues / Links

- #2014
- #3170

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`, frontend checks)
- [x] Documentation updated (N/A — no user-facing documentation changed)
- [x] Migration/backfill plan included (N/A — no schema/data migration)
- [x] CHANGELOG impact considered (patch fix, no breaking change)

## Context

- Issue #3192 reported Start Work doing nothing because the launch wizard renderer dereferenced `launchWizard.launch_materialization_pending` while `launchWizard` was intentionally `null` during local pending state.
- Owner behavior is covered by existing Launch Wizard / launch materialization feedback specs (#2014 and #3170); this PR closes the implementation gap.

## Risk / Impact

- **Affected areas**: Start Work, Launch Agent, and other launch wizard entry points that use the local pending wizard path.
- **Rollback plan**: revert `9a2ba6a2e` if a launch wizard regression appears.

## Screenshots

| Before | After |
|--------|-------|
| Start Work click crashed before the modal opened. | Start Work opens the `Preparing Plan Agent...` pending modal; verified by Playwright and user confirmation. |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Launch Wizard’s stability during loading and pending states.
  * Prevented a crash when pending-state data isn’t available yet.
  * Ensured the wizard displays “Preparing Plan Agent...” and keeps submit controls hidden until ready.
  * Fixed null-safe handling for materialization pending state to avoid invalid dereferences.
* **Tests**
  * Added Playwright coverage for the Launch Wizard “start-work” pending UX.
  * Made Issue auto-refresh tests more deterministic when using the fixture backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->