### PR TITLE
fix(issue-monitor): preserve origin error details

### DIFF
--- a/.gwt/work/memory.md
+++ b/.gwt/work/memory.md
@@ -7458,3 +7458,10 @@ Type: fix
 Context: Docker起動エラーが TTY 前面に被さる回帰 (SPEC-2014 US-36 / FR-120/121)。terminal-overlay を error 時に表示する形式は commit 1e948b7a0 で廃止 (shouldShowOverlay=false 固定) 済みだったが、無関係な feature commit a93afd199 'feat: complete issue monitor auto queue' が app.js を Boolean(effectiveDetail) && runtimeState==='error' へ revert し、同時に contract test (operator-chrome-structure.test.mjs) と playwright test (agent-window-scroll.spec.ts) の assertion も regressed 側へ書き換えたため CI が素通りした。
 Learning: test rename + assert.equal('false')->assert.match(error) のような『契約の反転』は新規ケース追加と違い regression を隠す。TTY 前面 overlay は .terminal-overlay.visible 1 箇所(app.js shouldShowOverlay)のみで Docker 固有ではなく全 error window で発火する。error は overlay 無しでも inline TTY text(launch_error_terminal_output_event) / status chip tooltip / attention toast / Console docker tab / Logs Process facet の 5 面で可視。
 Future Action: contract test の assertion が『追加』ではなく『反転』している diff は regression の赤信号として扱う。完了済み FR を touch する大型 feature commit では guard test が意味を保っているか必ず確認する。前面 overlay を復活させる変更は SPEC-2014 US-36 違反。
+
+## 2026-06-27 — cargo verification after browser-check fresh HOME
+
+Type: lesson
+Context: During Issue #3190 verification, the agent shell HOME pointed to a browser-check isolated fresh HOME, so rustup saw no installed/default toolchains and plain cargo failed before using the real developer toolchain.
+Learning: When browser-check/fresh HOME is active but repo verification uses Cargo, run Cargo with the real HOME/RUSTUP_HOME/CARGO_HOME or ensure the toolchain environment is bridged.
+Future Action: Before Cargo verification in gwt worktrees after browser-check, print HOME/RUSTUP_HOME/CARGO_HOME when cargo cannot find a toolchain, then run cargo with HOME=/Users/akiojin RUSTUP_HOME=/Users/akiojin/.rustup CARGO_HOME=/Users/akiojin/.cargo.

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1211,7 +1211,7 @@ impl AppRuntime {
         let mut settings_required_request = None;
 
         match gwt::issue_monitor_worker::github_remote_owner_and_repo(&project_root) {
-            Some((owner, repo)) => {
+            Ok((owner, repo)) => {
                 match gwt::issue_monitor_worker::load_open_issue_monitor_candidates_for_repo_path(
                     &project_root,
                     &owner,
@@ -1273,8 +1273,8 @@ impl AppRuntime {
                     }
                 }
             }
-            None => {
-                monitor.record_scan_error(now.as_str(), "GitHub origin remote is unavailable");
+            Err(error) => {
+                monitor.record_scan_error(now.as_str(), error.to_string());
             }
         }
 
@@ -1353,7 +1353,7 @@ impl AppRuntime {
             gwt::IssueMonitorState::with_prefs(gwt::IssueMonitorConfig::default(), prefs);
 
         match gwt::issue_monitor_worker::github_remote_owner_and_repo(&project_root) {
-            Some((owner, repo)) => {
+            Ok((owner, repo)) => {
                 match gwt::issue_monitor_worker::load_open_issue_monitor_candidates_for_repo_path(
                     &project_root,
                     &owner,
@@ -1368,8 +1368,8 @@ impl AppRuntime {
                     }
                 }
             }
-            None => {
-                monitor.record_scan_error(now.as_str(), "GitHub origin remote is unavailable");
+            Err(error) => {
+                monitor.record_scan_error(now.as_str(), error.to_string());
             }
         }
 

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -236,6 +236,19 @@ fn init_repo(repo_path: &Path) {
     }
 }
 
+fn init_repo_without_origin(repo_path: &Path) {
+    let output = gwt_core::process::hidden_command("git")
+        .args(["init", "-q"])
+        .current_dir(repo_path)
+        .output()
+        .expect("run git init");
+    assert!(
+        output.status.success(),
+        "git init failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 #[cfg(unix)]
 fn init_workspace_home_with_child_bare(workspace_home: &Path) -> PathBuf {
     fs::create_dir_all(workspace_home).expect("create workspace home");
@@ -14299,6 +14312,41 @@ fn app_runtime_issue_monitor_enable_opens_single_settings_wizard_without_launch_
         runtime.window_details.is_empty(),
         "settings-required Start must not spawn an agent window"
     );
+}
+
+#[test]
+fn app_runtime_issue_monitor_enable_reports_missing_origin_detail() {
+    let _env_lock = env_test_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let temp = tempdir().expect("tempdir");
+    let _home = ScopedEnvVar::set("HOME", temp.path());
+    let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+
+    let repo = temp.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    init_repo_without_origin(&repo);
+    let tab = sample_project_tab("tab-1", "Repo", repo, ProjectKind::Git, &[]);
+    let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+
+    let events = runtime.handle_frontend_event(
+        "client-1".to_string(),
+        FrontendEvent::SetIssueMonitorEnabled { enabled: true },
+    );
+
+    let status = events
+        .iter()
+        .find_map(|event| match &event.event {
+            BackendEvent::IssueMonitorStatus { status } => Some(status),
+            _ => None,
+        })
+        .expect("issue monitor status");
+    let error = status.last_error.as_deref().expect("origin error");
+    assert!(
+        error.starts_with("Git origin remote is not configured"),
+        "unexpected error: {error}"
+    );
+    assert_ne!(error, "GitHub origin remote is unavailable");
 }
 
 #[test]

--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -429,12 +429,14 @@ fn scan_issue_monitor_once_blocking(
     gui_connected: bool,
 ) -> crate::IssueMonitorState {
     let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
-    let Some((owner, repo)) =
-        crate::issue_monitor_worker::github_remote_owner_and_repo(&scope.project_root)
-    else {
-        monitor.record_scan_error(now, "GitHub origin remote is unavailable");
-        return monitor;
-    };
+    let (owner, repo) =
+        match crate::issue_monitor_worker::github_remote_owner_and_repo(&scope.project_root) {
+            Ok(owner_repo) => owner_repo,
+            Err(error) => {
+                monitor.record_scan_error(now, error.to_string());
+                return monitor;
+            }
+        };
     let issues = match crate::issue_monitor_worker::load_open_issue_monitor_candidates_for_repo_path(
         &scope.project_root,
         &owner,
@@ -834,6 +836,24 @@ mod tests {
         .expect("scope")
     }
 
+    fn init_git_repo(path: &Path) {
+        let status = gwt_core::process::hidden_command("git")
+            .args(["init", "-q"])
+            .current_dir(path)
+            .status()
+            .expect("git init");
+        assert!(status.success(), "git init must succeed");
+    }
+
+    fn git_remote_add_origin(path: &Path, remote_url: &str) {
+        let status = gwt_core::process::hidden_command("git")
+            .args(["remote", "add", "origin", remote_url])
+            .current_dir(path)
+            .status()
+            .expect("git remote add origin");
+        assert!(status.success(), "git remote add origin must succeed");
+    }
+
     #[test]
     fn build_handshake_response_rejects_protocol_version_mismatch() {
         let temp = TempDir::new().unwrap();
@@ -1079,6 +1099,46 @@ mod tests {
             IssueMonitorControl::PriorityOrder(vec![43, 42]),
         );
         assert!(should_scan);
+    }
+
+    #[test]
+    fn issue_monitor_scan_reports_missing_origin_instead_of_generic_unavailable() {
+        let temp = TempDir::new().expect("tempdir");
+        init_git_repo(temp.path());
+        let scope = sample_scope(&temp);
+        let monitor = crate::IssueMonitorState::new(crate::IssueMonitorConfig::default());
+
+        let monitor = super::scan_issue_monitor_once_blocking(scope, monitor, false);
+
+        let error = monitor
+            .status_view()
+            .last_error
+            .expect("origin resolution error");
+        assert!(
+            error.starts_with("Git origin remote is not configured"),
+            "unexpected error: {error}"
+        );
+        assert_ne!(error, "GitHub origin remote is unavailable");
+    }
+
+    #[test]
+    fn issue_monitor_scan_reports_non_github_origin_instead_of_generic_unavailable() {
+        let temp = TempDir::new().expect("tempdir");
+        init_git_repo(temp.path());
+        git_remote_add_origin(temp.path(), "https://example.com/owner/repo.git");
+        let scope = sample_scope(&temp);
+        let monitor = crate::IssueMonitorState::new(crate::IssueMonitorConfig::default());
+
+        let monitor = super::scan_issue_monitor_once_blocking(scope, monitor, false);
+
+        let error = monitor
+            .status_view()
+            .last_error
+            .expect("origin resolution error");
+        assert_eq!(
+            error,
+            "Git origin remote is not a GitHub URL: https://example.com/owner/repo.git"
+        );
     }
 
     #[tokio::test]

--- a/crates/gwt/src/issue_monitor_worker.rs
+++ b/crates/gwt/src/issue_monitor_worker.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{fmt, path::Path};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -135,21 +135,67 @@ pub fn load_cached_issue_monitor_candidates(
     Ok(issues)
 }
 
-pub fn github_remote_owner_and_repo(repo_path: &Path) -> Option<(String, String)> {
-    let hub = gwt_core::process_console::global();
-    let output = gwt_core::process_console::spawn_logged_blocking(
-        &hub,
-        gwt_core::process_console::ProcessKind::Git,
-        "git",
-        &["remote", "get-url", "origin"],
-        gwt_core::process_console::SpawnOptions::new("git remote get-url origin")
-            .current_dir(repo_path),
-    )
-    .ok()?;
-    if !output.success() {
-        return None;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GitHubRemoteResolutionError {
+    CommandSpawnFailed(String),
+    GitCommandFailed {
+        status_code: Option<i32>,
+        stderr: String,
+    },
+    OriginNotConfigured(String),
+    NonGitHubOrigin(String),
+    InvalidGitHubOrigin(String),
+}
+
+impl fmt::Display for GitHubRemoteResolutionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CommandSpawnFailed(error) => {
+                write!(f, "git remote get-url origin could not be started: {error}")
+            }
+            Self::GitCommandFailed {
+                status_code,
+                stderr,
+            } => {
+                let status = status_code
+                    .map(|code| code.to_string())
+                    .unwrap_or_else(|| "unknown".to_string());
+                write!(
+                    f,
+                    "git remote get-url origin failed with exit status {status}: {stderr}"
+                )
+            }
+            Self::OriginNotConfigured(detail) => {
+                write!(f, "Git origin remote is not configured: {detail}")
+            }
+            Self::NonGitHubOrigin(remote_url) => {
+                write!(f, "Git origin remote is not a GitHub URL: {remote_url}")
+            }
+            Self::InvalidGitHubOrigin(remote_url) => {
+                write!(f, "GitHub origin remote URL is invalid: {remote_url}")
+            }
+        }
     }
-    parse_github_remote_url(output.stdout.trim())
+}
+
+impl std::error::Error for GitHubRemoteResolutionError {}
+
+pub fn github_remote_owner_and_repo(
+    repo_path: &Path,
+) -> Result<(String, String), GitHubRemoteResolutionError> {
+    let output = gwt_core::process::hidden_command("git")
+        .args(["remote", "get-url", "origin"])
+        .current_dir(repo_path)
+        .output()
+        .map_err(|error| GitHubRemoteResolutionError::CommandSpawnFailed(error.to_string()))?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    github_remote_owner_and_repo_from_get_url_output(
+        output.status.success(),
+        output.status.code(),
+        &stdout,
+        &stderr,
+    )
 }
 
 pub fn parse_github_remote_url(remote_url: &str) -> Option<(String, String)> {
@@ -164,6 +210,61 @@ pub fn parse_github_remote_url(remote_url: &str) -> Option<(String, String)> {
         return None;
     }
     Some((owner.to_string(), repo.to_string()))
+}
+
+fn github_remote_owner_and_repo_from_get_url_output(
+    success: bool,
+    status_code: Option<i32>,
+    stdout: &str,
+    stderr: &str,
+) -> Result<(String, String), GitHubRemoteResolutionError> {
+    let stdout = stdout.trim();
+    let stderr = cleaned_process_text(stderr);
+    if !success {
+        if stderr.to_ascii_lowercase().contains("no such remote") && stderr.contains("origin") {
+            return Err(GitHubRemoteResolutionError::OriginNotConfigured(stderr));
+        }
+        return Err(GitHubRemoteResolutionError::GitCommandFailed {
+            status_code,
+            stderr,
+        });
+    }
+    if stdout.is_empty() {
+        return Err(GitHubRemoteResolutionError::OriginNotConfigured(
+            "git remote get-url origin returned an empty URL".to_string(),
+        ));
+    }
+    if let Some(owner_repo) = parse_github_remote_url(stdout) {
+        return Ok(owner_repo);
+    }
+    if has_supported_github_remote_prefix(stdout) {
+        return Err(GitHubRemoteResolutionError::InvalidGitHubOrigin(
+            stdout.to_string(),
+        ));
+    }
+    Err(GitHubRemoteResolutionError::NonGitHubOrigin(
+        stdout.to_string(),
+    ))
+}
+
+fn cleaned_process_text(text: &str) -> String {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        "no stderr".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn has_supported_github_remote_prefix(remote_url: &str) -> bool {
+    [
+        "https://github.com/",
+        "http://github.com/",
+        "git@github.com:",
+        "ssh://git@github.com/",
+    ]
+    .iter()
+    .any(|prefix| remote_url.starts_with(prefix))
 }
 
 #[allow(dead_code)]
@@ -334,6 +435,84 @@ mod tests {
         assert_eq!(
             parse_github_remote_url("https://example.com/owner/repo"),
             None
+        );
+    }
+
+    #[test]
+    fn github_remote_output_resolves_valid_origin() {
+        assert_eq!(
+            github_remote_owner_and_repo_from_get_url_output(
+                true,
+                Some(0),
+                "https://github.com/owner/repo.git\n",
+                ""
+            )
+            .expect("valid origin"),
+            ("owner".to_string(), "repo".to_string())
+        );
+    }
+
+    #[test]
+    fn github_remote_output_classifies_missing_origin() {
+        let error = github_remote_owner_and_repo_from_get_url_output(
+            false,
+            Some(2),
+            "",
+            "error: No such remote 'origin'\n",
+        )
+        .expect_err("missing origin");
+
+        assert_eq!(
+            error.to_string(),
+            "Git origin remote is not configured: error: No such remote 'origin'"
+        );
+    }
+
+    #[test]
+    fn github_remote_output_classifies_git_failure() {
+        let error = github_remote_owner_and_repo_from_get_url_output(
+            false,
+            Some(128),
+            "",
+            "fatal: not a git repository\n",
+        )
+        .expect_err("git failure");
+
+        assert_eq!(
+            error.to_string(),
+            "git remote get-url origin failed with exit status 128: fatal: not a git repository"
+        );
+    }
+
+    #[test]
+    fn github_remote_output_classifies_non_github_origin() {
+        let error = github_remote_owner_and_repo_from_get_url_output(
+            true,
+            Some(0),
+            "https://example.com/owner/repo.git\n",
+            "",
+        )
+        .expect_err("non GitHub origin");
+
+        assert_eq!(
+            error.to_string(),
+            "Git origin remote is not a GitHub URL: https://example.com/owner/repo.git"
+        );
+    }
+
+    #[test]
+    fn github_remote_output_classifies_invalid_github_origin() {
+        let error = github_remote_owner_and_repo_from_get_url_output(
+            true,
+            Some(0),
+            "https://github.com/owner\n",
+            "",
+        )
+        .expect_err("invalid GitHub origin");
+
+        assert_eq!(
+            error.to_string(),
+            "GitHub origin remote URL is invalid: https://github.com/owner"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Preserve specific Issue Monitor GitHub origin resolution errors so users can distinguish missing remotes, non-GitHub remotes, invalid GitHub URLs, and git execution failures.
- Replace the lightweight origin lookup path so it no longer creates a per-call Tokio runtime for `git remote get-url origin`.
- Add focused daemon/runtime regression coverage for Issue #3190 and record the browser-check Cargo HOME verification lesson.

## Changes

- `crates/gwt/src/issue_monitor_worker.rs`: Introduces `GitHubRemoteResolutionError`, returns typed `Result` from origin resolution, classifies git output, and uses `gwt_core::process::hidden_command` for the lightweight git metadata read.
- `crates/gwt/src/app_runtime/mod.rs`: Preserves concrete origin-resolution error messages when runtime Issue Monitor scans fail.
- `crates/gwt/src/app_runtime/tests.rs`: Adds runtime regression coverage that missing origin details are surfaced instead of the generic unavailable banner.
- `crates/gwt/src/cli/daemon/server.rs`: Preserves concrete daemon scan errors and adds missing-origin / non-GitHub-origin regression tests.
- `.gwt/work/memory.md`: Records the browser-check fresh HOME / Cargo toolchain verification lesson.

## Testing

- [x] `cargo test -p gwt github_remote_output --lib` — PASS, 5 origin-resolution classifier tests passed.
- [x] `cargo test -p gwt issue_monitor_scan_reports_ --lib` — PASS, 2 daemon scan regression tests passed.
- [x] `cargo test -p gwt --bin gwt app_runtime_issue_monitor_enable_reports_missing_origin_detail` — PASS, runtime status regression test passed.
- [x] `cargo test -p gwt-core -p gwt --all-features` — PASS.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — PASS.
- [x] `cargo fmt --check` — PASS.
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — PASS.
- [x] Fresh browser-check GUI handoff — HTTP 200 and user verification confirmed.
- [x] `bunx commitlint --from HEAD~1 --to HEAD` — PASS.

## PR Readiness

- State: Ready for review
- Releaseable slice: yes, this is a focused Issue Monitor error-reporting regression fix with tests and no known blockers.
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- Closes #3190

## Related Issues / Links

- #3165

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`; `svelte-check` N/A because no Svelte surface changed)
- [x] Documentation updated (N/A: no README or user-guide surface changed)
- [x] Migration/backfill plan included (N/A: no schema or data migration)
- [x] CHANGELOG impact considered (patch fix; no breaking change)

## Context

- Issue #3190 reported that Issue Monitor could show the generic `GitHub origin remote is unavailable` message even when a GitHub origin was expected to be usable.
- SPEC #3165 owns Issue Monitor behavior, and its tasks were updated with the Issue #3190 regression slice before implementation.

## Risk / Impact

- **Affected areas**: Issue Monitor origin resolution, runtime scan status, and daemon scan status.
- **Rollback plan**: Revert `dd0103845` if this regresses origin resolution or scan error reporting.
