### PR TITLE
fix(issue-monitor): auto-merge を reviewed head SHA に束縛

### DIFF
--- a/crates/gwt-git/src/pr_status.rs
+++ b/crates/gwt-git/src/pr_status.rs
@@ -751,17 +751,39 @@ fn truncate_diff(diff: &str, max_bytes: usize) -> String {
 /// `--auto` so the merge only proceeds once branch-protection's required checks
 /// pass (a second, GitHub-enforced layer behind our gate). Returns `false` on
 /// any gh failure (fail-closed: never report a merge armed when it was not).
-pub fn merge_pr_auto(repo_path: &Path, number: u64) -> bool {
-    merge_pr_auto_with(repo_path, number, run_gh_command)
+///
+/// `reviewed_head_sha` binds the arm to the exact head the gate reviewed via
+/// `--match-head-commit`: if the PR head advances between review and merge,
+/// GitHub REFUSES to merge the unreviewed commit. This is prevention at the
+/// merge boundary (vs the post-merge layer-4 detection), closing the
+/// review→merge TOCTOU window.
+pub fn merge_pr_auto(repo_path: &Path, number: u64, reviewed_head_sha: &str) -> bool {
+    merge_pr_auto_with(repo_path, number, reviewed_head_sha, run_gh_command)
 }
 
-fn merge_pr_auto_with<F>(repo_path: &Path, number: u64, mut run_gh: F) -> bool
+fn merge_pr_auto_with<F>(
+    repo_path: &Path,
+    number: u64,
+    reviewed_head_sha: &str,
+    mut run_gh: F,
+) -> bool
 where
     F: FnMut(&Path, &[&str]) -> Result<GhCliOutput>,
 {
     let number = number.to_string();
     matches!(
-        run_gh(repo_path, &["pr", "merge", &number, "--auto", "--squash"]),
+        run_gh(
+            repo_path,
+            &[
+                "pr",
+                "merge",
+                &number,
+                "--auto",
+                "--squash",
+                "--match-head-commit",
+                reviewed_head_sha,
+            ],
+        ),
         Ok(output) if output.success
     )
 }
@@ -1327,10 +1349,23 @@ mod tests {
     }
 
     #[test]
-    fn merge_pr_auto_with_arms_and_fails_closed() {
+    fn merge_pr_auto_with_arms_bound_to_head_sha_and_fails_closed() {
         let repo = Path::new("/tmp/repo");
-        let armed = merge_pr_auto_with(repo, 7, |_p, args| {
-            assert_eq!(args, ["pr", "merge", "7", "--auto", "--squash"]);
+        let armed = merge_pr_auto_with(repo, 7, "abc123", |_p, args| {
+            // The arm MUST bind to the reviewed head SHA via --match-head-commit
+            // so a head that advanced past review cannot merge unreviewed.
+            assert_eq!(
+                args,
+                [
+                    "pr",
+                    "merge",
+                    "7",
+                    "--auto",
+                    "--squash",
+                    "--match-head-commit",
+                    "abc123",
+                ]
+            );
             Ok(GhCliOutput {
                 success: true,
                 stdout: String::new(),
@@ -1338,7 +1373,7 @@ mod tests {
             })
         });
         assert!(armed);
-        let failed = merge_pr_auto_with(repo, 7, |_p, _a| {
+        let failed = merge_pr_auto_with(repo, 7, "abc123", |_p, _a| {
             Ok(GhCliOutput {
                 success: false,
                 stdout: String::new(),
@@ -1346,7 +1381,9 @@ mod tests {
             })
         });
         assert!(!failed, "gh failure ⇒ not armed (fail-closed)");
-        let errored = merge_pr_auto_with(repo, 7, |_p, _a| Err(GwtError::Git("x".to_string())));
+        let errored = merge_pr_auto_with(repo, 7, "abc123", |_p, _a| {
+            Err(GwtError::Git("x".to_string()))
+        });
         assert!(!errored);
     }
 

--- a/crates/gwt/src/issue_monitor_worker.rs
+++ b/crates/gwt/src/issue_monitor_worker.rs
@@ -313,7 +313,9 @@ pub fn advance_autonomous_in_flight(
                             "autonomous gate PASS — arming auto-merge"
                         );
                         monitor.begin_delivering(issue_number);
-                        if !gwt_git::pr_status::merge_pr_auto(repo_path, pr) {
+                        // Bind the arm to the reviewed head SHA so GitHub refuses
+                        // to merge if the head advanced past what the gate reviewed.
+                        if !gwt_git::pr_status::merge_pr_auto(repo_path, pr, &inputs.reviewed_sha) {
                             tracing::warn!(issue = issue_number, pr, "auto-merge arm failed");
                         }
                     }

--- a/crates/gwt/tests/autonomous_real_gh_smoke.rs
+++ b/crates/gwt/tests/autonomous_real_gh_smoke.rs
@@ -96,9 +96,9 @@ fn live_autonomous_merge_against_real_github() {
         "route Deliver"
     );
 
-    // 5) REAL merge via the production function.
+    // 5) REAL merge via the production function, bound to the reviewed head SHA.
     assert!(
-        merge_pr_auto(&repo, pr),
+        merge_pr_auto(&repo, pr, &reviewed),
         "real merge_pr_auto armed/succeeded"
     );
 


### PR DESCRIPTION
## Summary

PR #3207 の自律 auto-merge に対する review 指摘（codex P1）を反映する follow-up fix。`gh pr merge --auto` を reviewed head SHA に束縛し、review→merge 間の TOCTOU を merge 境界で塞ぐ。

## Changes

- `merge_pr_auto(repo, number, reviewed_head_sha)`: `gh pr merge --auto --squash` に `--match-head-commit <reviewed_sha>` を付与。PR head が gate のレビュー後に進んでいたら GitHub が merge 自体を拒否する（prevention）。
- これにより、既存の layer-4（post-merge: merged head == reviewed の検出）と合わせて二重防御になる（layer-4 は検出、`--match-head-commit` は予防）。
- call site `issue_monitor_worker.rs` で `inputs.reviewed_sha` を渡す（gate PASS 時に手元にある値）。

## Testing

- `cargo test -p gwt-git merge_pr_auto_with_arms`: GREEN（args が `--match-head-commit <sha>` を含むことを固定）
- `cargo test -p gwt-git -p gwt`: 60 test-binaries OK
- `cargo fmt --all -- --check` / `cargo clippy --workspace --all-targets --all-features -- -D warnings` / `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --document-private-items`: 全 clean
- real-gh smoke（`#[ignore]`）も `reviewed` 引数に更新

## PR Readiness

State: Ready

- releaseable slice: 自律 auto-merge の安全強化のみ。default OFF の autonomous 経路に閉じており、既存挙動への影響なし。
- 既知 blocker: なし。
- User Verification Result: n/a（backend のみ、UI 影響なし）。

## Closing Issues

None

## Related Issues

#3200

## Checklist

- [x] テスト追加/更新（unit + real-gh smoke）
- [x] fmt / clippy / rustdoc / test 全通過（CI 同等を --workspace で実行）
- [x] commitlint 通過
- [x] User Verification: n/a（UI 影響なし）
