### PR TITLE
fix(issue-monitor): 自律 daemon の launch 失敗 routing と scan 後 prefs 永続化 (codex P2)

### DIFF
--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -1252,6 +1252,68 @@ mod tests {
     }
 
     #[test]
+    fn issue_monitor_launch_failed_control_routes_inflight_autonomous_issue_through_retry() {
+        // SPEC #3200 (review follow-up): when the independent review agent fails
+        // to spawn, the daemon receives a `launch_failed` control. For an
+        // in-flight autonomous issue this must route through the autonomous
+        // retry machinery (attempt counted, re-queued) instead of marking the
+        // inbox `LaunchFailed` and stranding the record in `Reviewing` forever.
+        let mut monitor = crate::IssueMonitorState::new(crate::IssueMonitorConfig {
+            enabled: true,
+            ..crate::IssueMonitorConfig::default()
+        });
+        monitor.set_autonomous_mode(true);
+        monitor.set_gui_connected(true);
+        monitor.record_claimed(
+            crate::IssueMonitorIssue {
+                number: 42,
+                title: "Issue 42".to_string(),
+                labels: Vec::new(),
+                state: crate::IssueMonitorIssueState::Open,
+                body: None,
+                url: None,
+            },
+            "claim-a",
+        );
+        monitor.next_launch_request().expect("launch request");
+        monitor.complete_active_launch(42, "tab-1::agent-1");
+        monitor.set_autonomous_phase(42, crate::AutonomousPhase::Implementing);
+        monitor.begin_review(42, 99, "abc123"); // Implementing → Reviewing
+        assert!(monitor.is_autonomous_in_flight(42));
+
+        let payload = crate::runtime_daemon_events::issue_monitor_payload(
+            "control",
+            serde_json::json!({
+                "launch_failed": {
+                    "issue_number": 42,
+                    "message": "Independent review could not start",
+                }
+            }),
+            std::process::id() + 1,
+        );
+        let control = decode_issue_monitor_control(payload).expect("control");
+
+        let should_scan = apply_issue_monitor_control(&mut monitor, control);
+
+        assert!(should_scan);
+        assert_eq!(
+            monitor.autonomous_record(42).map(|r| r.phase),
+            Some(crate::AutonomousPhase::Idle),
+            "routed back to Idle for retry, not stranded in Reviewing"
+        );
+        assert_eq!(
+            monitor.attempt_count(42),
+            1,
+            "the failed attempt is counted"
+        );
+        assert_eq!(
+            monitor.inbox_item(42).map(|item| item.state),
+            Some(crate::MonitorInboxState::Queued),
+            "re-queued for automatic relaunch"
+        );
+    }
+
+    #[test]
     fn issue_monitor_agent_failed_control_uses_issue_number_hint_when_window_is_unmapped() {
         let mut monitor = crate::IssueMonitorState::new(crate::IssueMonitorConfig {
             enabled: true,

--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -242,7 +242,13 @@ fn spawn_issue_monitor_worker(scope: RuntimeScope, hub: BroadcastHub, shutdown: 
                                 publish_issue_monitor_payloads(&hub, &mut monitor);
                                 if should_scan {
                                     let gui_connected = issue_monitor_gui_connected(&hub);
-                                    monitor = scan_issue_monitor_once(scope.clone(), monitor, gui_connected).await;
+                                    monitor = scan_and_persist_issue_monitor(
+                                        scope.clone(),
+                                        monitor,
+                                        gui_connected,
+                                        &prefs_path,
+                                    )
+                                    .await;
                                     publish_issue_monitor_payloads(&hub, &mut monitor);
                                 }
                             }
@@ -254,7 +260,13 @@ fn spawn_issue_monitor_worker(scope: RuntimeScope, hub: BroadcastHub, shutdown: 
                 }
                 _ = interval.tick() => {
                     let gui_connected = issue_monitor_gui_connected(&hub);
-                    monitor = scan_issue_monitor_once(scope.clone(), monitor, gui_connected).await;
+                    monitor = scan_and_persist_issue_monitor(
+                        scope.clone(),
+                        monitor,
+                        gui_connected,
+                        &prefs_path,
+                    )
+                    .await;
                     publish_issue_monitor_payloads(&hub, &mut monitor);
                 }
             }
@@ -495,6 +507,24 @@ async fn scan_issue_monitor_once(
         );
         monitor
     })
+}
+
+/// Scan once, then persist the resulting state. The persist step is the SPEC
+/// #3200 review follow-up fix: a periodic (interval-tick) scan runs
+/// `reconcile_issue_monitor_merges` + `advance_autonomous_in_flight`, which can
+/// `record_merged` / escalate to `NeedsHuman` without any control frame. Without
+/// saving prefs after the scan, those transitions were lost on a daemon restart
+/// and already-completed work was re-launched. Both worker loop arms route their
+/// scan through here so no scan-driven transition can skip persistence.
+async fn scan_and_persist_issue_monitor(
+    scope: RuntimeScope,
+    monitor: crate::IssueMonitorState,
+    gui_connected: bool,
+    prefs_path: &Path,
+) -> crate::IssueMonitorState {
+    let monitor = scan_issue_monitor_once(scope, monitor, gui_connected).await;
+    let _ = crate::save_issue_monitor_prefs(prefs_path, &monitor.prefs());
+    monitor
 }
 
 /// SPEC #3200 Option A: a per-process secret the daemon uses to sign autonomous
@@ -1414,6 +1444,32 @@ mod tests {
         assert_eq!(
             error,
             "Git origin remote is not a GitHub URL: https://example.com/owner/repo.git"
+        );
+    }
+
+    #[tokio::test]
+    async fn scan_and_persist_issue_monitor_writes_scan_transitions_to_prefs() {
+        // SPEC #3200 (review follow-up): a periodic (interval-tick) scan can
+        // complete a merge / escalate without any control frame. The worker must
+        // persist prefs after every scan so a daemon restart never loses that
+        // completion and re-launches already-finished work. This asserts the
+        // scan→persist seam actually writes the merged state to the prefs file.
+        let temp = TempDir::new().expect("tempdir");
+        init_git_repo(temp.path());
+        let scope = sample_scope(&temp);
+        let prefs_path = temp.path().join("issue-monitor-prefs.json");
+
+        let mut monitor = crate::IssueMonitorState::new(crate::IssueMonitorConfig::default());
+        monitor.record_merged(42); // a scan-driven transition that must survive restart
+        assert!(!prefs_path.exists(), "prefs not written before the scan");
+
+        let _monitor =
+            super::scan_and_persist_issue_monitor(scope, monitor, false, &prefs_path).await;
+
+        let persisted = crate::load_issue_monitor_prefs(&prefs_path).expect("prefs written");
+        assert!(
+            persisted.merged_issues.contains(&42),
+            "scan-driven merge completion is persisted, so a restart will not re-launch it"
         );
     }
 

--- a/crates/gwt/src/issue_monitor.rs
+++ b/crates/gwt/src/issue_monitor.rs
@@ -1262,16 +1262,31 @@ impl IssueMonitorState {
     pub fn autonomous_in_flight_issues(&self) -> Vec<u64> {
         self.autonomous_records
             .values()
-            .filter(|record| {
-                matches!(
-                    record.phase,
-                    AutonomousPhase::Implementing
-                        | AutonomousPhase::Reviewing
-                        | AutonomousPhase::Delivering
-                )
-            })
+            .filter(|record| Self::is_in_flight_phase(record.phase))
             .map(|record| record.issue_number)
             .collect()
+    }
+
+    fn is_in_flight_phase(phase: AutonomousPhase) -> bool {
+        matches!(
+            phase,
+            AutonomousPhase::Implementing
+                | AutonomousPhase::Reviewing
+                | AutonomousPhase::Delivering
+        )
+    }
+
+    /// SPEC #3200 (review follow-up): true when `issue_number` has an autonomous
+    /// record actively in flight (`Implementing` / `Reviewing` / `Delivering`).
+    /// A launch/agent failure for such an issue must be routed through the
+    /// autonomous retry/backoff/escalation machinery rather than the plain
+    /// human-gated launch-failed path, or the record strands in a non-`Idle`
+    /// phase forever (e.g. `Reviewing` after a failed review-agent spawn, where
+    /// the daemon waits for a verdict that will never arrive).
+    pub fn is_autonomous_in_flight(&self, issue_number: u64) -> bool {
+        self.autonomous_records
+            .get(&issue_number)
+            .is_some_and(|record| Self::is_in_flight_phase(record.phase))
     }
 
     /// SPEC #3200: transition Implementing→Reviewing once the implementation
@@ -1877,6 +1892,18 @@ impl IssueMonitorState {
         state: MonitorInboxState,
     ) {
         let message = message.into();
+        // SPEC #3200 (review follow-up): a failure for an in-flight autonomous
+        // issue (e.g. the independent review agent could not spawn, leaving the
+        // record in `Reviewing`) must funnel through the autonomous
+        // retry/backoff/escalation machinery — otherwise the record strands in a
+        // non-`Idle` phase forever and the daemon waits for a verdict that will
+        // never arrive. The plain human-gated `LaunchFailed`/`AgentFailed` path
+        // below is preserved for every non-autonomous issue.
+        if self.autonomous_mode && self.is_autonomous_in_flight(issue_number) {
+            let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+            self.record_autonomous_failure(issue_number, FailureClass::Transient, message, &now);
+            return;
+        }
         self.active_launches
             .retain(|active| *active != issue_number);
         // #3165 error-window lifecycle: retain the stale agent window id so an
@@ -2991,6 +3018,92 @@ mod tests {
         monitor.record_merged(7);
         assert!(monitor.autonomous_record(7).is_none());
         assert!(monitor.autonomous_in_flight_issues().is_empty());
+    }
+
+    #[test]
+    fn launch_failure_routes_inflight_autonomous_issue_through_retry() {
+        // SPEC #3200 (review follow-up): a launch/agent failure for an in-flight
+        // autonomous issue — e.g. the independent review agent could not spawn —
+        // must funnel through the autonomous retry machinery (count an attempt,
+        // schedule backoff, re-queue) instead of stranding the record in
+        // `Reviewing` forever, waiting for a verdict that will never arrive.
+        let mut monitor = autonomous_state();
+        scan_issue_monitor_candidates(&mut monitor, &[issue(7)], "2026-06-30T00:00:00Z");
+        monitor.complete_active_launch(7, "tab-1::agent-7");
+        monitor.set_autonomous_phase(7, AutonomousPhase::Implementing);
+        monitor.begin_review(7, 99, "abc123"); // Implementing → Reviewing
+        assert_eq!(
+            monitor.autonomous_record(7).map(|r| r.phase),
+            Some(AutonomousPhase::Reviewing)
+        );
+        assert!(monitor.is_autonomous_in_flight(7));
+
+        monitor.record_launch_failed(7, "Independent review could not start");
+
+        let record = monitor.autonomous_record(7).expect("record retained");
+        assert_eq!(
+            record.phase,
+            AutonomousPhase::Idle,
+            "routed back to Idle for retry, not stranded in Reviewing"
+        );
+        assert_eq!(monitor.attempt_count(7), 1, "the failed attempt is counted");
+        assert!(
+            record.retry_not_before.is_some(),
+            "a retry backoff is scheduled"
+        );
+        assert_eq!(
+            monitor.inbox_item(7).map(|item| item.state),
+            Some(MonitorInboxState::Queued),
+            "re-queued for automatic relaunch (not parked in LaunchFailed)"
+        );
+    }
+
+    #[test]
+    fn launch_failure_at_cap_escalates_inflight_autonomous_issue_to_needs_human() {
+        // SPEC #3200 (review follow-up): once the in-flight autonomous issue's
+        // attempts are exhausted, a further launch failure escalates to
+        // NeedsHuman through the same routing rather than silently retrying.
+        let mut monitor = autonomous_state();
+        monitor.autonomous_tuning.max_attempts = 1;
+        scan_issue_monitor_candidates(&mut monitor, &[issue(7)], "2026-06-30T00:00:00Z");
+        monitor.complete_active_launch(7, "tab-1::agent-7");
+        monitor.set_autonomous_phase(7, AutonomousPhase::Implementing);
+        monitor.begin_review(7, 99, "abc123");
+
+        monitor.record_launch_failed(7, "review spawn failed at cap");
+
+        assert_eq!(
+            monitor.autonomous_record(7).map(|r| r.phase),
+            Some(AutonomousPhase::NeedsHuman),
+            "attempts exhausted ⇒ escalated, not retried"
+        );
+        assert_eq!(
+            monitor.inbox_item(7).map(|item| item.state),
+            Some(MonitorInboxState::NeedsHuman)
+        );
+    }
+
+    #[test]
+    fn launch_failure_for_non_autonomous_issue_keeps_plain_failed_state() {
+        // Non-regression: with no in-flight autonomous record, the launch failure
+        // stays on the human-gated LaunchFailed path (SPEC #3165), untouched by
+        // the autonomous routing.
+        let mut monitor = autonomous_state(); // mode on, but no record for #7
+        scan_issue_monitor_candidates(&mut monitor, &[issue(7)], "2026-06-30T00:00:00Z");
+        assert!(!monitor.is_autonomous_in_flight(7));
+
+        monitor.record_launch_failed(7, "binary missing");
+
+        assert_eq!(
+            monitor.inbox_item(7).map(|item| item.state),
+            Some(MonitorInboxState::LaunchFailed),
+            "plain launch-failed path is preserved when no autonomous attempt is in flight"
+        );
+        assert_eq!(
+            monitor.attempt_count(7),
+            0,
+            "no autonomous attempt is counted"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

PR #3207 の codex review で挙がった P2 指摘 2 件（SPEC #3200 Issue Monitor 自律モードの daemon ライフサイクル）の follow-up fix。どちらも default-OFF の autonomous 経路に閉じた backend のみの修正で、既存の human-gated（SPEC #3165）フローには影響しない。

## Changes

### P2-a: in-flight autonomous の launch 失敗を retry に route する (`issue_monitor.rs`)

独立レビューエージェントの spawn に失敗すると、GUI は `launch_failed` control を daemon に送るだけで、daemon の autonomous record は `Reviewing` のまま放置されていた。`autonomous_gate_inputs` は verdict 到着まで `None` を返し、stuck 検出も `Idle | Implementing` のみが対象のため、来ない verdict を永久に待ち続けて issue が滞留していた。

- 単一の失敗 choke point `record_failed_issue` に分岐を追加し、in-flight な autonomous record（Implementing / Reviewing / Delivering）に対する launch / agent 失敗を `record_autonomous_failure(Transient)` に route。既存の attempt 加算・backoff 付き再 queue・max 到達時 NeedsHuman escalation 機構に乗せる。
- `is_autonomous_in_flight(issue_number)` を追加（in-flight phase 判定を共有）。
- 非 autonomous の issue は従来どおり LaunchFailed / AgentFailed の human-gated パスを維持。review-launch だけでなく impl-launch・agent-error も同経路でカバー。

### P2-b: daemon scan 後に prefs を永続化 (`cli/daemon/server.rs`)

daemon worker の periodic scan（interval tick）は `reconcile_issue_monitor_merges` + `advance_autonomous_in_flight` を実行し、control frame 無しで `record_merged` / NeedsHuman escalation を起こし得る。だが scan 後に prefs を保存していなかったため、daemon 再起動で merged_issues / autonomous 完了状態を失い、完了済みの作業を再 launch していた（control 経由の遷移は保存済みだったが、scan 駆動の遷移だけ取りこぼし）。

- scan + 永続化を `scan_and_persist_issue_monitor` という単一 seam に抽出し、worker loop の両 arm（should_scan / interval tick）をこの seam 経由に統一。scan 駆動のどの遷移も保存をスキップできない。

## Testing

- unit (issue_monitor): retry route / cap で escalation / 非 autonomous は不変 の 3 件
- daemon control test: `launch_failed` control → in-flight autonomous を retry route
- daemon tokio test: scan→persist seam が merged 状態を prefs ファイルへ書き出す（save を外すと fail する真の配線テスト）
- `cargo fmt --all -- --check` / `cargo clippy --workspace --all-targets --all-features -- -D warnings` / `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --document-private-items`: 全 clean
- `cargo test -p gwt-core -p gwt --all-features`: 全 PASS

## PR Readiness

State: Ready

- releaseable slice: autonomous daemon ライフサイクルの correctness 強化のみ。default OFF の autonomous 経路に閉じており、既存挙動への影響なし。各 fix は独立して配信可能。
- 既知 blocker: なし。
- User Verification Result: n/a（backend のみ、UI 影響なし — server.rs / issue_monitor.rs のみ変更）。

## Closing Issues

None

## Related Issues

#3200

## Checklist

- [x] テスト追加/更新（unit 3 + daemon control 1 + daemon tokio 配線 1）
- [x] fmt / clippy / rustdoc / test 全通過（CI 同等を --workspace で実行）
- [x] commitlint 通過（HEAD~3..HEAD）
- [x] User Verification: n/a（UI 影響なし）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue handling for autonomous tasks so in-flight failures now retry automatically instead of getting stuck in a failed state.
  * Added clearer escalation when retries are exhausted, routing issues to human review.
  * Issue-monitor scans now save updated preferences after each run, so scan results and state changes persist more reliably.
  * Improved handling for launch and agent failures to keep queue status and retry counts accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->