### PR TITLE
fix(issue-monitor): 自律 daemon の persist/recovery を adversarial review 指摘で堅牢化

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,14 +30,13 @@ dependencies = [
 
 [[package]]
 name = "ammonia"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e913097e1a2124b46746c980134e8c954bc17a6a59bb3fde96f088d126dde6"
+checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
 dependencies = [
  "cssparser",
  "html5ever",
  "maplit",
- "tendril",
  "url",
 ]
 
@@ -517,25 +516,13 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.35.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
 dependencies = [
- "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
  "smallvec",
-]
-
-[[package]]
-name = "cssparser-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
-dependencies = [
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -879,16 +866,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
 ]
 
 [[package]]
@@ -1539,13 +1516,12 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.35.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
 dependencies = [
  "log",
  "markup5ever",
- "match_token",
 ]
 
 [[package]]
@@ -2154,12 +2130,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2167,24 +2137,13 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"
-version = "0.35.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril",
  "web_atoms",
-]
-
-[[package]]
-name = "match_token"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2708,19 +2667,19 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
  "phf_shared",
+ "serde",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -2728,32 +2687,19 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
+ "fastrand",
  "phf_shared",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -2987,7 +2933,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.4",
+ "rand",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3036,21 +2982,12 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -3060,14 +2997,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -3560,22 +3491,21 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "string_cache"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
  "phf_shared",
  "precomputed-hash",
- "serde",
 ]
 
 [[package]]
 name = "string_cache_codegen"
-version = "0.5.4"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -3746,12 +3676,11 @@ dependencies = [
 
 [[package]]
 name = "tendril"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
 dependencies = [
- "futf",
- "mac",
+ "new_debug_unreachable",
  "utf-8",
 ]
 
@@ -4180,7 +4109,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand",
  "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
@@ -4531,9 +4460,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.1.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
 dependencies = [
  "phf",
  "phf_codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ regex = "1"
 
 # Markdown rendering
 pulldown-cmark = "0.13.4"
-ammonia = "4.1.2"
+ammonia = "4.1.3"
 
 [profile.release]
 lto = true

--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -495,18 +495,38 @@ async fn scan_issue_monitor_once(
     monitor: crate::IssueMonitorState,
     gui_connected: bool,
 ) -> crate::IssueMonitorState {
+    // Keep a copy of the prior state so a `spawn_blocking` panic preserves it
+    // instead of collapsing to a fresh default (see `scan_join_failure_fallback`).
+    let preserved = monitor.clone();
     tokio::task::spawn_blocking(move || {
         scan_issue_monitor_once_blocking(scope, monitor, gui_connected)
     })
     .await
     .unwrap_or_else(|error| {
-        let mut monitor = crate::IssueMonitorState::new(crate::IssueMonitorConfig::default());
-        monitor.record_scan_error(
+        scan_join_failure_fallback(
+            preserved,
+            error.to_string(),
             chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-            format!("issue monitor worker join failed: {error}"),
-        );
-        monitor
+        )
     })
+}
+
+/// Fallback state for a `scan_issue_monitor_once` `JoinError` (the scan task
+/// panicked). It preserves the prior in-memory state — the `enabled` flag,
+/// `merged_issues`, autonomous records — and only records the scan error.
+///
+/// Returning a fresh `IssueMonitorState::new(default)` here (the previous
+/// behavior) would let `scan_and_persist_issue_monitor` overwrite good prefs on
+/// disk with empty/default state on a transient scan panic, losing merge
+/// completion and re-launching finished work — and would also reset the GUI's
+/// view (codex P2 review, #3209).
+fn scan_join_failure_fallback(
+    mut preserved: crate::IssueMonitorState,
+    error: String,
+    now: String,
+) -> crate::IssueMonitorState {
+    preserved.record_scan_error(now, format!("issue monitor worker join failed: {error}"));
+    preserved
 }
 
 /// Scan once, then persist the resulting state. The persist step is the SPEC
@@ -1470,6 +1490,44 @@ mod tests {
         assert!(
             persisted.merged_issues.contains(&42),
             "scan-driven merge completion is persisted, so a restart will not re-launch it"
+        );
+    }
+
+    #[test]
+    fn scan_join_failure_fallback_preserves_prior_state_so_persist_is_safe() {
+        // codex P2 (#3209): a scan-task panic (`JoinError`) must NOT collapse to a
+        // fresh `IssueMonitorState::new(default)`. `scan_and_persist` saves the
+        // returned state, so a fresh default would overwrite good prefs with
+        // `enabled=false` / empty merged_issues / empty autonomous records on a
+        // transient panic — losing completion and re-launching finished work. The
+        // fallback preserves the prior state and only records the scan error.
+        let mut monitor = crate::IssueMonitorState::new(crate::IssueMonitorConfig {
+            enabled: true,
+            ..crate::IssueMonitorConfig::default()
+        });
+        monitor.record_merged(42);
+
+        let out = super::scan_join_failure_fallback(
+            monitor,
+            "task panicked".to_string(),
+            "2026-06-30T00:00:00Z".to_string(),
+        );
+
+        assert!(
+            out.config.enabled,
+            "enabled flag preserved across a scan panic"
+        );
+        assert!(
+            out.prefs().merged_issues.contains(&42),
+            "merge completion preserved (not wiped to an empty default)"
+        );
+        let error = out
+            .status_view()
+            .last_error
+            .expect("the scan error is recorded");
+        assert!(
+            error.contains("join failed"),
+            "records the join failure: {error}"
         );
     }
 

--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -225,6 +225,17 @@ fn spawn_issue_monitor_worker(scope: RuntimeScope, hub: BroadcastHub, shutdown: 
         let prefs = crate::load_issue_monitor_prefs(&prefs_path).unwrap_or_default();
         let mut monitor =
             crate::IssueMonitorState::with_prefs(crate::IssueMonitorConfig::default(), prefs);
+        // SPEC #3200 (review follow-up): a record persisted mid-review reloads in
+        // `Reviewing`, but its review-agent dispatch (not persisted) is gone.
+        // Reset such records to `Implementing` so the first scan re-detects the PR
+        // and re-issues the review — restoring the pre-persist self-healing.
+        let resumed = monitor.resume_inflight_reviews_after_restart();
+        if !resumed.is_empty() {
+            tracing::info!(
+                issues = ?resumed,
+                "issue monitor: resumed in-flight reviews after restart (Reviewing → Implementing)"
+            );
+        }
         publish_issue_monitor_payloads(&hub, &mut monitor);
         let mut interval =
             tokio::time::interval(Duration::from_secs(monitor.config.poll_interval_secs));
@@ -238,7 +249,7 @@ fn spawn_issue_monitor_worker(scope: RuntimeScope, hub: BroadcastHub, shutdown: 
                         Ok(DaemonFrame::Event { payload, .. }) => {
                             if let Some(control) = decode_issue_monitor_control(payload) {
                                 let should_scan = apply_issue_monitor_control(&mut monitor, control);
-                                let _ = crate::save_issue_monitor_prefs(&prefs_path, &monitor.prefs());
+                                persist_daemon_issue_monitor_state(&prefs_path, &monitor);
                                 publish_issue_monitor_payloads(&hub, &mut monitor);
                                 if should_scan {
                                     let gui_connected = issue_monitor_gui_connected(&hub);
@@ -543,8 +554,31 @@ async fn scan_and_persist_issue_monitor(
     prefs_path: &Path,
 ) -> crate::IssueMonitorState {
     let monitor = scan_issue_monitor_once(scope, monitor, gui_connected).await;
-    let _ = crate::save_issue_monitor_prefs(prefs_path, &monitor.prefs());
+    persist_daemon_issue_monitor_state(prefs_path, &monitor);
     monitor
+}
+
+/// Persist the daemon's issue-monitor state WITHOUT clobbering GUI-owned config.
+///
+/// The daemon loads prefs once at startup and thereafter only learns config
+/// changes it has a control frame for (`enabled` / `max_active_agents` /
+/// `priority_order` / `autonomous_mode`). `launch_profile` and
+/// `autonomous_tuning` have NO control channel — the GUI process edits them
+/// directly on disk — so the daemon's in-memory copy is authoritative-but-stale
+/// for those two fields. Writing the whole `monitor.prefs()` would overwrite a
+/// newer GUI launch-profile / tuning with the stale startup value, silently
+/// reverting the user's Issue Monitor configuration (adversarial review:
+/// launch_profile clobber). We therefore reload the on-disk prefs and preserve
+/// those two GUI-owned fields, persisting everything else (daemon-owned runtime
+/// state + control-synced config) from memory. If the reload fails, we fall back
+/// to the in-memory values rather than lose the daemon's runtime state.
+fn persist_daemon_issue_monitor_state(prefs_path: &Path, monitor: &crate::IssueMonitorState) {
+    let mut prefs = monitor.prefs();
+    if let Ok(on_disk) = crate::load_issue_monitor_prefs(prefs_path) {
+        prefs.launch_profile = on_disk.launch_profile;
+        prefs.autonomous_tuning = on_disk.autonomous_tuning;
+    }
+    let _ = crate::save_issue_monitor_prefs(prefs_path, &prefs);
 }
 
 /// SPEC #3200 Option A: a per-process secret the daemon uses to sign autonomous
@@ -1528,6 +1562,65 @@ mod tests {
         assert!(
             error.contains("join failed"),
             "records the join failure: {error}"
+        );
+    }
+
+    #[test]
+    fn persist_daemon_state_preserves_gui_owned_launch_profile_and_tuning() {
+        // adversarial review (launch_profile clobber): launch_profile and
+        // autonomous_tuning have no daemon control channel, so the daemon's
+        // stale-since-startup in-memory copy must NOT overwrite the GUI's newer
+        // on-disk values. Only daemon-owned runtime state (merged_issues,
+        // autonomous_records, ...) is persisted from memory.
+        let temp = TempDir::new().expect("tempdir");
+        let prefs_path = temp.path().join("issue-monitor.json");
+
+        // The GUI wrote a launch_profile + custom tuning straight to disk.
+        let on_disk = crate::IssueMonitorPrefs {
+            launch_profile: Some(crate::IssueMonitorLaunchProfile {
+                agent_id: "claude".to_string(),
+                model: None,
+                reasoning: None,
+                version: None,
+                session_mode: Default::default(),
+                skip_permissions: false,
+                codex_fast_mode: false,
+                runtime_target: Default::default(),
+                docker_service: None,
+                docker_lifecycle_intent: Default::default(),
+                windows_shell: None,
+            }),
+            autonomous_tuning: crate::issue_monitor::AutonomousTuning {
+                max_attempts: 9,
+                ..crate::issue_monitor::AutonomousTuning::default()
+            },
+            ..crate::IssueMonitorPrefs::default()
+        };
+        crate::save_issue_monitor_prefs(&prefs_path, &on_disk).expect("seed disk");
+
+        // The daemon's in-memory monitor has NO launch_profile (stale startup)
+        // but has a daemon-owned merge completion to persist.
+        let mut monitor = crate::IssueMonitorState::new(crate::IssueMonitorConfig::default());
+        monitor.record_merged(42);
+        assert!(
+            monitor.prefs().launch_profile.is_none(),
+            "daemon has no profile"
+        );
+
+        super::persist_daemon_issue_monitor_state(&prefs_path, &monitor);
+
+        let persisted = crate::load_issue_monitor_prefs(&prefs_path).expect("reload");
+        assert!(
+            persisted.launch_profile.is_some(),
+            "GUI launch_profile preserved (not clobbered by the daemon's stale None)"
+        );
+        assert_eq!(
+            persisted.autonomous_tuning.max_attempts, 9,
+            "GUI autonomous_tuning preserved"
+        );
+        assert!(
+            persisted.merged_issues.contains(&42),
+            "daemon-owned merge completion is still persisted from memory"
         );
     }
 

--- a/crates/gwt/src/issue_monitor.rs
+++ b/crates/gwt/src/issue_monitor.rs
@@ -724,14 +724,41 @@ pub fn load_issue_monitor_prefs(path: &Path) -> io::Result<IssueMonitorPrefs> {
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
 }
 
+/// Per-process-unique scratch path for the atomic prefs write, placed in the
+/// same directory as `path` (so the final `rename` stays on one filesystem and
+/// is atomic). The daemon (`gwtd`) and GUI (`gwt`) processes both write this same
+/// prefs file; a fixed `*.json.tmp` name let their concurrent writes open and
+/// truncate the SAME scratch file and interleave into torn JSON, which
+/// `load_issue_monitor_prefs` then silently reset to default (adversarial
+/// review). Scoping the scratch name to `{pid}-{uuid}` gives every writer its own
+/// file. Mirrors the gwt-core atomic-write convention.
+fn unique_prefs_tmp_path(path: &Path) -> std::path::PathBuf {
+    let parent = match path.parent() {
+        Some(parent) if !parent.as_os_str().is_empty() => parent.to_path_buf(),
+        _ => std::path::PathBuf::from("."),
+    };
+    let file_name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("issue-monitor.json");
+    parent.join(format!(
+        ".{}.tmp-{}-{}",
+        file_name,
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ))
+}
+
 pub fn save_issue_monitor_prefs(path: &Path, prefs: &IssueMonitorPrefs) -> io::Result<()> {
     if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
     }
     let content = serde_json::to_string_pretty(prefs).map_err(io::Error::other)?;
-    let tmp = path.with_extension("json.tmp");
+    let tmp = unique_prefs_tmp_path(path);
     fs::write(&tmp, content.as_bytes())?;
-    fs::rename(tmp, path)
+    fs::rename(&tmp, path)
 }
 
 pub fn issue_monitor_prefs_path_for_repo_path(repo_path: &Path) -> std::path::PathBuf {
@@ -958,10 +985,13 @@ impl IssueMonitorState {
     }
 
     /// SPEC #3200 T-044/T-035/FR-013: launched autonomous issues whose agent has
-    /// shown no liveness for longer than `stuck_timeout_secs`. Issues already in
-    /// a pipeline-in-flight phase (`Reviewing`/`Delivering`, governed by the
-    /// merge-watch timeout) and terminal phases are excluded. Issues with no
-    /// heartbeat yet are conservatively NOT judged stuck (no liveness data).
+    /// shown no liveness for longer than `stuck_timeout_secs`. Pipeline-in-flight
+    /// phases are excluded because they self-heal without a liveness signal:
+    /// `Reviewing` is resumed on a daemon restart (see
+    /// [`resume_inflight_reviews_after_restart`](Self::resume_inflight_reviews_after_restart)),
+    /// and `Delivering` re-polls the persisted PR for its merge commit. Terminal
+    /// phases are excluded too. Issues with no heartbeat yet are conservatively
+    /// NOT judged stuck (no liveness data).
     pub fn stuck_autonomous_issues(&self, now: &str) -> Vec<u64> {
         let timeout = self.autonomous_tuning.stuck_timeout_secs as i64;
         self.autonomous_records
@@ -1006,6 +1036,39 @@ impl IssueMonitorState {
                 (issue_number, outcome)
             })
             .collect()
+    }
+
+    /// SPEC #3200 (review follow-up): restore self-healing for a `Reviewing`
+    /// record whose review-agent dispatch was lost across a daemon restart.
+    ///
+    /// The review-agent spawn request (`pending_review_dispatches`) is NOT
+    /// persisted, but the record's phase IS. A record reloaded in `Reviewing`
+    /// therefore waits forever for a verdict that no agent will produce (the
+    /// review agent was never re-spawned) — `advance_autonomous_in_flight`'s
+    /// `Reviewing` branch only waits, and the `Implementing` branch (which
+    /// re-detects the open PR and re-issues `begin_review` + the review dispatch)
+    /// is never reached. Resetting the phase to `Implementing` restores exactly
+    /// the pre-persist self-healing (a restart used to revert the in-memory
+    /// phase): the next scan rebuilds the launch plan, re-detects the PR, and
+    /// re-dispatches the review, binding to the current head SHA.
+    ///
+    /// `Delivering` is intentionally left untouched: its watch loop polls the
+    /// persisted `pr_number` for the merge commit, so it self-heals across a
+    /// restart on its own — and its GitHub auto-merge is already armed, so
+    /// re-driving it would double-work and could invalidate the armed merge.
+    ///
+    /// Idempotent and safe to call once right after loading persisted prefs; it
+    /// only touches records already parked in `Reviewing`.
+    pub fn resume_inflight_reviews_after_restart(&mut self) -> Vec<u64> {
+        let mut resumed = Vec::new();
+        for record in self.autonomous_records.values_mut() {
+            if record.phase == AutonomousPhase::Reviewing {
+                record.phase = AutonomousPhase::Implementing;
+                record.review_passed = None;
+                resumed.push(record.issue_number);
+            }
+        }
+        resumed
     }
 
     /// SPEC #3200 FR-027: escalate an issue to the terminal `NeedsHuman` state —
@@ -2327,6 +2390,61 @@ mod tests {
     }
 
     #[test]
+    fn prefs_tmp_path_is_process_unique_not_a_shared_fixed_name() {
+        // adversarial review (shared *.json.tmp race): the daemon and GUI both
+        // write this prefs file, so the atomic-write scratch path must be unique
+        // per writer — never the old fixed `*.json.tmp` that concurrent writers
+        // could truncate into torn JSON.
+        let path = std::path::Path::new("/x/y/issue-monitor.json");
+        let a = super::unique_prefs_tmp_path(path);
+        let b = super::unique_prefs_tmp_path(path);
+        assert_ne!(a, b, "each write gets a distinct scratch path (uuid)");
+        assert_ne!(
+            a,
+            path.with_extension("json.tmp"),
+            "not the old shared fixed name"
+        );
+        assert!(
+            a.to_string_lossy()
+                .contains(&std::process::id().to_string()),
+            "scratch path is scoped to the writing process: {}",
+            a.display()
+        );
+        assert_eq!(
+            a.parent(),
+            path.parent(),
+            "scratch stays in the target's dir so the rename is atomic"
+        );
+    }
+
+    #[test]
+    fn save_issue_monitor_prefs_round_trips_and_leaves_no_scratch_file() {
+        // The unique-scratch atomic write still round-trips and cleans up (the
+        // rename consumes the temp), leaving only the target file.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("issue-monitor.json");
+        let prefs = IssueMonitorPrefs {
+            merged_issues: vec![7, 9],
+            ..IssueMonitorPrefs::default()
+        };
+        save_issue_monitor_prefs(&path, &prefs).expect("save");
+
+        let loaded = load_issue_monitor_prefs(&path).expect("load");
+        assert_eq!(loaded.merged_issues, vec![7, 9]);
+
+        let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+            .expect("read_dir")
+            .filter_map(Result::ok)
+            .map(|entry| entry.file_name().to_string_lossy().into_owned())
+            .filter(|name| name != "issue-monitor.json")
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "no scratch file left behind: {leftovers:?}"
+        );
+    }
+
+    #[test]
     fn autonomous_phase_defaults_idle() {
         // SPEC #3200 T-022: an issue with no autonomous record reports no record,
         // and a freshly created record starts Idle.
@@ -2984,6 +3102,77 @@ mod tests {
         assert!(recovered.is_empty(), "off ⇒ no recovery");
         assert_eq!(monitor.active_count(), 1, "slot untouched when mode off");
         assert_eq!(monitor.attempt_count(42), 0, "no attempt recorded when off");
+    }
+
+    #[test]
+    fn resume_after_restart_reverts_reviewing_to_implementing_for_redispatch() {
+        // review follow-up: a record persisted mid-review reloads in `Reviewing`,
+        // but its (non-persisted) review dispatch is gone, so it would wait forever
+        // for a verdict. Resetting it to `Implementing` lets the next scan re-detect
+        // the PR and re-issue the review — restoring the pre-persist self-healing.
+        // The record is round-tripped through prefs to model an actual restart.
+        let mut monitor = autonomous_state();
+        monitor.set_autonomous_phase(7, AutonomousPhase::Implementing);
+        monitor.begin_review(7, 99, "abc123"); // → Reviewing, verdict pending
+        let restored_prefs = monitor.prefs();
+
+        let mut restarted =
+            IssueMonitorState::with_prefs(IssueMonitorConfig::default(), restored_prefs);
+        assert_eq!(
+            restarted.autonomous_record(7).map(|r| r.phase),
+            Some(AutonomousPhase::Reviewing),
+            "reloads in Reviewing (the strand)"
+        );
+
+        let resumed = restarted.resume_inflight_reviews_after_restart();
+
+        assert_eq!(resumed, vec![7], "the stranded Reviewing record is resumed");
+        let record = restarted.autonomous_record(7).expect("record retained");
+        assert_eq!(
+            record.phase,
+            AutonomousPhase::Implementing,
+            "reset to Implementing so the next scan re-detects the PR + re-dispatches"
+        );
+        assert_eq!(
+            record.review_passed, None,
+            "verdict cleared for the re-review"
+        );
+        // Still counted in-flight (holds its slot); no attempt is spent on a restart.
+        assert_eq!(restarted.autonomous_in_flight_issues(), vec![7]);
+        assert_eq!(
+            restarted.attempt_count(7),
+            0,
+            "a restart is not a failed attempt"
+        );
+    }
+
+    #[test]
+    fn resume_after_restart_leaves_delivering_and_other_phases_untouched() {
+        // Delivering self-heals on its own (its watch polls the persisted pr_number
+        // for the merge commit) and has an armed GitHub auto-merge, so it must NOT
+        // be re-driven. Idle/Implementing/terminal phases are also left alone.
+        let mut monitor = autonomous_state();
+        monitor.set_autonomous_phase(1, AutonomousPhase::Delivering);
+        monitor.set_autonomous_phase(2, AutonomousPhase::Implementing);
+        monitor.set_autonomous_phase(3, AutonomousPhase::NeedsHuman);
+        monitor.set_autonomous_phase(4, AutonomousPhase::Idle);
+
+        let resumed = monitor.resume_inflight_reviews_after_restart();
+
+        assert!(resumed.is_empty(), "no Reviewing records ⇒ nothing resumed");
+        assert_eq!(
+            monitor.autonomous_record(1).map(|r| r.phase),
+            Some(AutonomousPhase::Delivering),
+            "Delivering is left to its own merge-watch self-heal"
+        );
+        assert_eq!(
+            monitor.autonomous_record(2).map(|r| r.phase),
+            Some(AutonomousPhase::Implementing)
+        );
+        assert_eq!(
+            monitor.autonomous_record(3).map(|r| r.phase),
+            Some(AutonomousPhase::NeedsHuman)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

PR #3209 に対する codex review 指摘（scan panic のフォールバック状態を永続化しない）と、それを機に自前の adversarial review workflow（10 agent、独立検証つき）で確定した実バグ 3 件を修正する follow-up。いずれも default-OFF の autonomous 経路・backend のみで、SPEC #3165 の human-gated フローには影響しない。追加で自分の再検査（3 dimension × adversarial verify）も通し、全 finding が却下される状態で提出する。

## Changes

### 0. scan panic 時にフォールバック状態を永続化しない（codex #3209 P2）

- **問題**: `scan_issue_monitor_once` の `JoinError`（spawn_blocking panic）フォールバックが `IssueMonitorState::new(default)`（enabled=false・空の merged_issues / autonomous records）を返し、`scan_and_persist` がその空状態で良好な prefs を上書きしていた。
- **修正**: フォールバックを `scan_join_failure_fallback` に切り出し、spawn_blocking 前に clone した直前の monitor に scan error だけを記録して返す。panic 時も状態を保持し永続化が安全になる。

### 1. Reviewing strand の self-heal（daemon 再起動時の phase reset）

- **問題**: scan-persist が `Reviewing` phase を durable 化する一方、review-agent の spawn 要求（`pending_review_dispatches`）は非永続。review 中に daemon が再起動すると record は `Reviewing` のまま dispatch queue は空になり、来ない verdict を永久に待って滞留する（persist 前は in-memory phase が消えて `Implementing` に戻り self-heal していた regression）。
- **設計経緯**: 当初 `merge_watch_timeout_secs` による timeout recovery を実装したが、自前 adversarial review で「`last_heartbeat` を refresh する liveness heartbeat（`Running` status 経由）が本番で発火しない dead path のため、健全な review/delivery を timeout で誤 reclaim する」欠陥（P1×2）を検出。timeout ではなく **restart 時の phase reset** に是正した。
- **修正**: daemon が prefs を load した直後に `resume_inflight_reviews_after_restart` を呼び、`Reviewing` record を `Implementing` に reset。次 scan が launch plan を再構築 → PR を再検出 → `begin_review` → review 再 dispatch し、現在の head SHA に bind する（persist 前の self-heal を復元）。`Delivering` は persisted `pr_number` で merge commit を poll し自力で self-heal する（かつ GitHub auto-merge が armed 済み）ため touch しない。restart は失敗ではないので attempt を消費しない。

### 2. launch_profile / autonomous_tuning の clobber 防止（persist の reload+merge）

- **問題**: daemon は startup で1度だけ prefs を load し、control channel を持つ field（`enabled` / `max_active_agents` / `priority_order` / `autonomous_mode`）しか同期しない。`launch_profile` と `autonomous_tuning` は control が無く GUI が直接 disk に書くため、daemon の in-memory copy は stale。全 prefs を書き戻すと GUI の新しい設定を stale 値で上書きしていた（pre-existing だが scan-persist が 300s ごとに決定的化）。
- **修正**: `persist_daemon_issue_monitor_state` を追加し、この 2 つの GUI 所有 field を disk から保持しつつ、daemon 所有の runtime state（`merged_issues` / `autonomous_records` 等）と control-synced config のみ memory から永続化。control-frame / scan の両 persist 経路をこれ経由に統一。

### 付随: ammonia 4.1.3 への更新（merge unblocker / `fix(deps)` 別コミット）

- Cargo Deny が `ammonia 4.1.2` の RUSTSEC-2026-0193（MathML annotation-xml 経由の mXSS）を advisory error として検出し、develop 全体・全 PR の CI をブロックしていた。gwt は ammonia を markdown/HTML sanitize に直接使用しているため実影響あり。
- workspace の ammonia を 4.1.3（patch 版）に更新（`cargo deny check advisories` = ok、71 suites 全通過で sanitize 回帰なしを確認）。branch 作成/切替が制約上できないため、独立コミットとして本 PR に同梱する。

### 3. 共有 `*.json.tmp` scratch の race 修正（per-process-unique temp 名）

- **問題**: daemon（gwtd）と GUI（gwt）が同一 prefs ファイルを固定 temp 名で並行 write すると torn JSON になり、load 側が `unwrap_or_default` で全 prefs を silent reset していた。
- **修正**: `unique_prefs_tmp_path` で `.{file}.tmp-{pid}-{uuid}`（gwt-core の atomic-write convention と同形）にし、writer ごとに scratch を分離。

## Testing

- unit: JoinError フォールバックの状態保持、restart-resume（Reviewing→Implementing / Delivering 非対象）、persist の GUI-field 保持、temp path uniqueness + round-trip
- 自前 adversarial review を 2 巡実施（10 agent → 3 dimension）。merge-watch timeout の欠陥（liveness dead path・auto-merge 非 disarm）を検出し restart-resume に是正。最終状態で確定 finding 0
- `cargo fmt --all -- --check` / `cargo clippy --workspace --all-targets --all-features -- -D warnings` / `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --document-private-items`: 全 clean
- `cargo test -p gwt-core -p gwt --all-features`: 全 PASS（71 suites）
- 自前 adversarial review（merge-watch / persist / temp-path の 3 dimension、各 finding を独立 verify）: 確定 finding 0

## PR Readiness

State: Ready

- releaseable slice: autonomous daemon の persist/recovery correctness 強化のみ。default OFF の autonomous 経路に閉じ、既存 human-gated flow への影響なし。各 fix は独立して配信可能。
- 既知 blocker: なし。
- User Verification Result: n/a（backend のみ、UI 影響なし — issue_monitor.rs / issue_monitor_worker.rs / cli/daemon/server.rs のみ変更）。

## Closing Issues

None

## Related Issues

#3200

## Checklist

- [x] テスト追加（unit 6 件）
- [x] fmt / clippy / rustdoc / test 全通過（CI 同等を --workspace で実行）
- [x] commitlint 通過
- [x] 自前 adversarial review で確定 finding 0
- [x] User Verification: n/a（UI 影響なし）
