### PR TITLE
fix(issue-monitor): restart-resume 時に heartbeat を refresh し stuck 誤回収を防ぐ

### DIFF
--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -228,8 +228,11 @@ fn spawn_issue_monitor_worker(scope: RuntimeScope, hub: BroadcastHub, shutdown: 
         // SPEC #3200 (review follow-up): a record persisted mid-review reloads in
         // `Reviewing`, but its review-agent dispatch (not persisted) is gone.
         // Reset such records to `Implementing` so the first scan re-detects the PR
-        // and re-issues the review — restoring the pre-persist self-healing.
-        let resumed = monitor.resume_inflight_reviews_after_restart();
+        // and re-issues the review — restoring the pre-persist self-healing. The
+        // `now` stamp refreshes last_heartbeat so the reset record is not wrongly
+        // reclaimed by stuck detection (which runs before the re-dispatch).
+        let resume_now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+        let resumed = monitor.resume_inflight_reviews_after_restart(&resume_now);
         if !resumed.is_empty() {
             tracing::info!(
                 issues = ?resumed,

--- a/crates/gwt/src/issue_monitor.rs
+++ b/crates/gwt/src/issue_monitor.rs
@@ -1057,14 +1057,26 @@ impl IssueMonitorState {
     /// restart on its own — and its GitHub auto-merge is already armed, so
     /// re-driving it would double-work and could invalidate the armed merge.
     ///
+    /// The resumed record's `last_heartbeat` is refreshed to `now`: a restart is
+    /// not a failed attempt, but the reset to `Implementing` makes the record
+    /// eligible for stuck/idle detection (`stuck_autonomous_issues` covers
+    /// `Idle | Implementing`), which runs BEFORE the re-dispatch on the next scan.
+    /// Without the refresh, a persisted stale `last_heartbeat` (e.g. a review that
+    /// ran longer than `stuck_timeout_secs` before the restart) would trip
+    /// `recover_stuck_autonomous` and wrongly count a failed attempt / backoff
+    /// (or escalate to `NeedsHuman` at the cap) before the review is even
+    /// re-issued. The fresh stamp gives the resumed record a full window to reach
+    /// `Reviewing` again.
+    ///
     /// Idempotent and safe to call once right after loading persisted prefs; it
     /// only touches records already parked in `Reviewing`.
-    pub fn resume_inflight_reviews_after_restart(&mut self) -> Vec<u64> {
+    pub fn resume_inflight_reviews_after_restart(&mut self, now: &str) -> Vec<u64> {
         let mut resumed = Vec::new();
         for record in self.autonomous_records.values_mut() {
             if record.phase == AutonomousPhase::Reviewing {
                 record.phase = AutonomousPhase::Implementing;
                 record.review_passed = None;
+                record.last_heartbeat = Some(now.to_string());
                 resumed.push(record.issue_number);
             }
         }
@@ -3124,7 +3136,7 @@ mod tests {
             "reloads in Reviewing (the strand)"
         );
 
-        let resumed = restarted.resume_inflight_reviews_after_restart();
+        let resumed = restarted.resume_inflight_reviews_after_restart("2026-06-29T00:00:00Z");
 
         assert_eq!(resumed, vec![7], "the stranded Reviewing record is resumed");
         let record = restarted.autonomous_record(7).expect("record retained");
@@ -3157,7 +3169,7 @@ mod tests {
         monitor.set_autonomous_phase(3, AutonomousPhase::NeedsHuman);
         monitor.set_autonomous_phase(4, AutonomousPhase::Idle);
 
-        let resumed = monitor.resume_inflight_reviews_after_restart();
+        let resumed = monitor.resume_inflight_reviews_after_restart("2026-06-29T00:00:00Z");
 
         assert!(resumed.is_empty(), "no Reviewing records ⇒ nothing resumed");
         assert_eq!(
@@ -3172,6 +3184,41 @@ mod tests {
         assert_eq!(
             monitor.autonomous_record(3).map(|r| r.phase),
             Some(AutonomousPhase::NeedsHuman)
+        );
+    }
+
+    #[test]
+    fn resume_after_restart_refreshes_heartbeat_so_stuck_recovery_does_not_fail_it() {
+        // review follow-up (codex #3210): on restart the persisted active slot and
+        // a STALE last_heartbeat are restored. Resetting Reviewing → Implementing
+        // makes the record eligible for stuck/idle detection, which runs BEFORE the
+        // re-dispatch on the next scan. Without refreshing the heartbeat, a review
+        // that ran longer than stuck_timeout_secs before the restart would be
+        // wrongly counted as a failed attempt. The refresh must prevent that.
+        let mut monitor = launched_monitor(42, "tab-1::agent-1");
+        monitor.set_autonomous_mode(true);
+        monitor.set_autonomous_phase(42, AutonomousPhase::Implementing);
+        monitor.begin_review(42, 99, "abc123"); // → Reviewing (holds the active slot)
+        monitor.record_autonomous_heartbeat(42, "2026-06-29T00:00:00Z"); // stale pre-restart
+
+        // Resume, then run stuck recovery in the same scan order as the daemon.
+        let resumed = monitor.resume_inflight_reviews_after_restart("2026-06-29T05:00:00Z");
+        assert_eq!(resumed, vec![42]);
+        let recovered = monitor.recover_stuck_autonomous("2026-06-29T05:00:00Z");
+
+        assert!(
+            recovered.is_empty(),
+            "the resumed record's fresh heartbeat keeps it out of stuck recovery"
+        );
+        assert_eq!(
+            monitor.autonomous_record(42).map(|r| r.phase),
+            Some(AutonomousPhase::Implementing),
+            "still Implementing, ready for the next scan to re-dispatch review"
+        );
+        assert_eq!(
+            monitor.attempt_count(42),
+            0,
+            "a restart is not counted as a failed attempt"
         );
     }
 


### PR DESCRIPTION
## Summary

PR #3210 の codex review 指摘（P2）の follow-up fix。restart-resume（daemon 再起動時に `Reviewing` を `Implementing` へ戻して review を再 dispatch する仕組み）に残っていた stuck 誤回収を修正する。default-OFF の autonomous 経路・backend のみ。

## Changes

- **問題**: daemon 再起動時、persist された active slot と古い `last_heartbeat` も復元される。`resume_inflight_reviews_after_restart` で `Reviewing` を `Implementing` に戻すと、次 scan では `recover_stuck_autonomous` が `advance_autonomous_in_flight` の review 再 dispatch より先に走る。復元された `last_heartbeat` が `stuck_timeout_secs`（30分）より古い（restart 前に review が長く継続した）場合、`stuck_autonomous_issues` に拾われて失敗 attempt / backoff（上限で `NeedsHuman`）へ誤って送られていた。「restart は失敗と数えない」意図に反する。
- **修正**: `resume_inflight_reviews_after_restart` に `now` を渡し、phase reset 時に `last_heartbeat` を `now` へ refresh。reset した `Implementing` record が次 scan の stuck 判定を通り抜け、re-dispatch で `Reviewing` に戻る full window を確保する。

なお #3210 の他 2 件の codex 指摘（P1 Delivering の auto-merge disarm / P2 merge-watch 回収後の backoff）は、対象だった merge-watch timeout コードを restart-resume に置き換えた際に撤去済みで、#3210 の該当スレッドで解消として reply + resolve 済み。

## Testing

- unit: stale heartbeat + restart で stuck 回収が走らず attempt が増えないことを検証
- `cargo fmt --all -- --check` / `cargo clippy -p gwt --all-targets --all-features -- -D warnings` / `RUSTDOCFLAGS=-D warnings cargo doc -p gwt --no-deps --document-private-items`: 全 clean
- `cargo test -p gwt-core -p gwt --all-features`: 全 PASS（71 suites）

## PR Readiness

State: Ready

- releaseable slice: restart-resume の correctness 修正のみ。default OFF の autonomous 経路に閉じ、既存 human-gated flow への影響なし。
- 既知 blocker: なし。
- User Verification Result: n/a（backend のみ、UI 影響なし）。

## Closing Issues

None

## Related Issues

#3200

## Checklist

- [x] テスト追加（unit 1 件 + 既存 resume テスト更新）
- [x] fmt / clippy / rustdoc / test 全通過
- [x] commitlint 通過
- [x] #3210 の codex スレッド 3 件を reply + resolve 済み
- [x] User Verification: n/a（UI 影響なし）
