### PR TITLE
fix(workspace): work event の session 誤付与を store 層で拒否し attach provenance を記録

### DIFF
--- a/crates/gwt-core/src/workspace_projection/persistence.rs
+++ b/crates/gwt-core/src/workspace_projection/persistence.rs
@@ -1786,6 +1786,8 @@ fn synthesize_workspace_work_item_from_legacy(
                 agent_id: Some(agent.agent_id.clone()),
                 display_name: Some(agent.display_name.clone()),
                 updated_at: agent.updated_at,
+                // Synthesized from the projection, not from a work event.
+                attached_by: None,
             }));
         if let Some(details) = projection.git_details.as_ref() {
             item.execution_containers
@@ -1830,6 +1832,8 @@ fn synthesize_workspace_work_item_from_legacy(
                     agent_id: None,
                     display_name: entry.agent_title_summary.clone(),
                     updated_at: entry.updated_at,
+                    // Synthesized from a legacy journal entry, not a work event.
+                    attached_by: None,
                 });
             }
         }

--- a/crates/gwt-core/src/workspace_projection/work_items.rs
+++ b/crates/gwt-core/src/workspace_projection/work_items.rs
@@ -48,6 +48,12 @@ pub struct WorkAgentRef {
     #[serde(default)]
     pub display_name: Option<String>,
     pub updated_at: DateTime<Utc>,
+    /// Issue #3216: kind of the event that first attached this session, kept
+    /// on the ref so mis-attribution stays diagnosable from works.json alone
+    /// after the work-events journal is compacted. `None` for legacy refs and
+    /// synthesized (non-event) attach paths.
+    #[serde(default)]
+    pub attached_by: Option<WorkEventKind>,
 }
 
 /// Reference from a Work item to the branch / worktree / PR it executed in.
@@ -276,6 +282,27 @@ impl WorkItemsProjection {
             self.work_items.len() - 1
         });
 
+        // Issue #3216: FR-348 gives "1 agent session : 1 Work". When an event
+        // would attach a session that another Work already owns AND the two
+        // Works carry conflicting git identities, the pairing is a
+        // mis-attribution (the event's work_item_id and session were assembled
+        // from divergent sources, e.g. the repo-shared current projection vs
+        // the live session). The attach is refused below; the event itself
+        // stays recorded for diagnosis.
+        let stray_session_attach = event
+            .agent_session_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .is_some_and(|session_id| {
+                work_session_attach_conflicts(
+                    &self.work_items,
+                    index,
+                    session_id,
+                    event.execution_container.as_ref(),
+                )
+            });
+
         let item = &mut self.work_items[index];
         // SPEC-2359 Phase W-16 (FR-403): a Backfill event is a synthetic
         // materialization marker, not activity. Applied to an existing item
@@ -352,12 +379,22 @@ impl WorkItemsProjection {
                 agent.agent_id = event.agent_id.clone().or(agent.agent_id.clone());
                 agent.display_name = event.display_name.clone().or(agent.display_name.clone());
                 agent.updated_at = event.updated_at;
+            } else if stray_session_attach {
+                tracing::warn!(
+                    target: "gwt::workspace_projection",
+                    work_item_id = %event.work_item_id,
+                    session_id = %session_id,
+                    event_kind = ?event.kind,
+                    "refused stray session attach: session already bound to a Work \
+                     with a conflicting git identity (Issue #3216)"
+                );
             } else {
                 item.agents.push(WorkAgentRef {
                     session_id,
                     agent_id: event.agent_id.clone(),
                     display_name: event.display_name.clone(),
                     updated_at: event.updated_at,
+                    attached_by: Some(event.kind),
                 });
             }
         }
@@ -433,6 +470,75 @@ fn push_unique(values: &mut Vec<String>, value: String) {
     if !values.iter().any(|existing| existing == &value) {
         values.push(value);
     }
+}
+
+/// Issue #3216: true when `session_id` is already bound to a *different* Work
+/// item whose git identity conflicts with the target item's identity (the
+/// target's recorded containers plus the incoming event's container). Mirrors
+/// the view-layer identity-conflict gate: a match on either dimension clears
+/// the conflict, and a side without any identity never conflicts.
+fn work_session_attach_conflicts(
+    work_items: &[WorkItem],
+    target_index: usize,
+    session_id: &str,
+    event_container: Option<&WorkspaceExecutionContainerRef>,
+) -> bool {
+    let target_containers = work_items[target_index]
+        .execution_containers
+        .iter()
+        .chain(event_container)
+        .collect::<Vec<_>>();
+    work_items.iter().enumerate().any(|(index, other)| {
+        index != target_index
+            && other
+                .agents
+                .iter()
+                .any(|agent| agent.session_id == session_id)
+            && work_container_identities_conflict(&other.execution_containers, &target_containers)
+    })
+}
+
+fn work_container_identities_conflict(
+    owner_containers: &[WorkspaceExecutionContainerRef],
+    target_containers: &[&WorkspaceExecutionContainerRef],
+) -> bool {
+    let owner_branches = owner_containers
+        .iter()
+        .filter_map(|container| normalized_work_branch(container.branch.as_deref()))
+        .collect::<Vec<_>>();
+    let target_branches = target_containers
+        .iter()
+        .filter_map(|container| normalized_work_branch(container.branch.as_deref()))
+        .collect::<Vec<_>>();
+    let owner_worktrees = owner_containers
+        .iter()
+        .filter_map(|container| container.worktree_path.as_deref())
+        .collect::<Vec<_>>();
+    let target_worktrees = target_containers
+        .iter()
+        .filter_map(|container| container.worktree_path.as_deref())
+        .collect::<Vec<_>>();
+
+    let branch_matches = owner_branches
+        .iter()
+        .any(|left| target_branches.iter().any(|right| left == right));
+    let worktree_matches = owner_worktrees
+        .iter()
+        .any(|left| target_worktrees.iter().any(|right| left == right));
+    if branch_matches || worktree_matches {
+        return false;
+    }
+    let branch_conflicts = !owner_branches.is_empty() && !target_branches.is_empty();
+    let worktree_conflicts = !owner_worktrees.is_empty() && !target_worktrees.is_empty();
+    branch_conflicts || worktree_conflicts
+}
+
+fn normalized_work_branch(branch: Option<&str>) -> Option<String> {
+    let value = branch?.trim();
+    if value.is_empty() {
+        return None;
+    }
+    Some(value.strip_prefix("origin/").unwrap_or(value).to_string())
 }
 
 const DERIVED_PROGRESS_SUMMARY_MAX_ITEMS: usize = 6;
@@ -814,5 +920,131 @@ mod tests {
             "first Done timestamp must be preserved on idempotent Done re-apply"
         );
         assert_eq!(item.updated_at, t2, "updated_at should still advance");
+    }
+
+    fn container_for_test(branch: &str, worktree: &str) -> WorkspaceExecutionContainerRef {
+        WorkspaceExecutionContainerRef {
+            branch: Some(branch.to_string()),
+            worktree_path: Some(PathBuf::from(worktree)),
+            pr_number: None,
+            pr_url: None,
+            pr_state: None,
+        }
+    }
+
+    /// Issue #3216: reproduce the works.json corruption behind Issue #3213 —
+    /// a session bound to one branch's Work must not be attached to another
+    /// Work whose branch identity conflicts (FR-348: 1 session : 1 Work).
+    #[test]
+    fn apply_event_rejects_stray_session_attach_to_conflicting_branch_item() {
+        let t0 = Utc.with_ymd_and_hms(2026, 6, 29, 7, 45, 56).unwrap();
+        let t1 = Utc.with_ymd_and_hms(2026, 6, 29, 8, 24, 29).unwrap();
+        let mut projection = WorkItemsProjection::empty(t0);
+
+        let mut owner_start = WorkEvent::new(WorkEventKind::Start, "work-work-issue-3197", t0);
+        owner_start.agent_session_id = Some("session-owner".to_string());
+        owner_start.execution_container = Some(container_for_test(
+            "work/issue-3197",
+            "/repo/work/issue-3197",
+        ));
+        projection.apply_event(owner_start);
+
+        let mut other_start = WorkEvent::new(WorkEventKind::Start, "work-work-issue-3184", t0);
+        other_start.agent_session_id = Some("session-other".to_string());
+        other_start.execution_container = Some(container_for_test(
+            "work/issue-3184",
+            "/repo/work/issue-3184",
+        ));
+        projection.apply_event(other_start);
+
+        // The stray event: the owner's session arrives on the OTHER branch's
+        // item (mis-attributed work_item_id / session pairing).
+        let mut stray = WorkEvent::new(WorkEventKind::Update, "work-work-issue-3184", t1);
+        stray.agent_session_id = Some("session-owner".to_string());
+        projection.apply_event(stray);
+
+        let other = projection
+            .work_items
+            .iter()
+            .find(|item| item.id == "work-work-issue-3184")
+            .expect("other item");
+        assert!(
+            !other
+                .agents
+                .iter()
+                .any(|agent| agent.session_id == "session-owner"),
+            "conflicting-branch item must not gain the stray session ref"
+        );
+        // The suspect event itself stays recorded for diagnosis.
+        assert_eq!(other.events.len(), 2);
+    }
+
+    /// Issue #3216 contract guard: the attach guard fires only on a genuine
+    /// identity conflict. Same-branch duplicates and identity-less items keep
+    /// the historical attach behavior.
+    #[test]
+    fn apply_event_allows_session_attach_without_identity_conflict() {
+        let t0 = Utc.with_ymd_and_hms(2026, 6, 29, 7, 45, 56).unwrap();
+        let mut projection = WorkItemsProjection::empty(t0);
+
+        let mut owner_start = WorkEvent::new(WorkEventKind::Start, "work-owner", t0);
+        owner_start.agent_session_id = Some("session-shared".to_string());
+        owner_start.execution_container = Some(container_for_test("work/same", "/repo/work/same"));
+        projection.apply_event(owner_start);
+
+        // Same-branch duplicate item (resume / backfill shape): attach allowed.
+        let mut same_branch = WorkEvent::new(WorkEventKind::Resume, "work-duplicate", t0);
+        same_branch.agent_session_id = Some("session-shared".to_string());
+        same_branch.execution_container = Some(container_for_test("work/same", "/repo/work/same"));
+        projection.apply_event(same_branch);
+
+        // Identity-less item (synthesized live Work without git_details):
+        // attach allowed.
+        let mut identity_less = WorkEvent::new(WorkEventKind::Update, "work-session-abc", t0);
+        identity_less.agent_session_id = Some("session-shared".to_string());
+        projection.apply_event(identity_less);
+
+        for id in ["work-duplicate", "work-session-abc"] {
+            let item = projection
+                .work_items
+                .iter()
+                .find(|item| item.id == id)
+                .expect("item");
+            assert!(
+                item.agents
+                    .iter()
+                    .any(|agent| agent.session_id == "session-shared"),
+                "{id} must keep the historical session attach behavior"
+            );
+        }
+    }
+
+    /// Issue #3216: attach provenance survives journal compaction by living on
+    /// the WorkAgentRef itself.
+    #[test]
+    fn apply_event_records_attach_provenance_kind() {
+        let t0 = Utc.with_ymd_and_hms(2026, 6, 29, 7, 45, 56).unwrap();
+        let mut projection = WorkItemsProjection::empty(t0);
+
+        let mut start = WorkEvent::new(WorkEventKind::Start, "work-provenance", t0);
+        start.agent_session_id = Some("session-1".to_string());
+        projection.apply_event(start);
+
+        let item = projection
+            .work_items
+            .iter()
+            .find(|item| item.id == "work-provenance")
+            .expect("item");
+        assert_eq!(item.agents[0].attached_by, Some(WorkEventKind::Start));
+    }
+
+    /// Issue #3216: existing works.json (no `attached_by`) must keep
+    /// deserializing.
+    #[test]
+    fn work_agent_ref_deserializes_without_attached_by() {
+        let json = r#"{"session_id":"s","updated_at":"2026-06-29T07:45:56Z"}"#;
+        let agent: WorkAgentRef = serde_json::from_str(json).expect("deserialize legacy ref");
+        assert_eq!(agent.attached_by, None);
+        assert_eq!(agent.session_id, "s");
     }
 }

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -1946,6 +1946,19 @@ fn sample_runtime(
     sample_runtime_with_events(temp_root, tabs, active_tab_id).0
 }
 
+/// portable-pty falls back to `$HOME` as the child's cwd when no cwd is given
+/// and `chdir`s to it unchecked. Tests mutate HOME concurrently (and glibc
+/// env access is not thread-safe), so test pane spawns pin an always-existing
+/// cwd that needs no environment lookup — otherwise a pane test racing an
+/// env-mutating test dies with `PtyCreationFailed(ENOENT)` (Issue #3220).
+fn test_pane_cwd() -> Option<PathBuf> {
+    if cfg!(windows) {
+        Some(std::env::temp_dir())
+    } else {
+        Some(PathBuf::from("/"))
+    }
+}
+
 fn long_running_test_pane(id: &str) -> Pane {
     let (command, args) = if cfg!(windows) {
         (
@@ -1963,7 +1976,16 @@ fn long_running_test_pane(id: &str) -> Pane {
             vec!["-lc".to_string(), "sleep 30".to_string()],
         )
     };
-    Pane::new(id.to_string(), command, args, 80, 24, HashMap::new(), None).expect("test pane")
+    Pane::new(
+        id.to_string(),
+        command,
+        args,
+        80,
+        24,
+        HashMap::new(),
+        test_pane_cwd(),
+    )
+    .expect("test pane")
 }
 
 fn insert_test_pane_runtime(runtime: &mut AppRuntime, window_id: &str) {
@@ -2763,7 +2785,7 @@ fn app_runtime_frontend_ready_replays_terminal_snapshot_only_to_requesting_clien
         80,
         24,
         HashMap::new(),
-        None,
+        test_pane_cwd(),
     )
     .expect("pane");
     pane.process_bytes(b"hello from frontend ready\n");
@@ -2827,7 +2849,7 @@ fn app_runtime_frontend_ready_replays_terminal_snapshot_with_sgr_attributes() {
         80,
         24,
         HashMap::new(),
-        None,
+        test_pane_cwd(),
     )
     .expect("pane");
     // Write red foreground + bold "ALERT" then reset, then default-color text.
@@ -2907,7 +2929,7 @@ fn app_runtime_frontend_ready_replays_terminal_snapshot_with_scrollback_history(
         80,
         6,
         HashMap::new(),
-        None,
+        test_pane_cwd(),
     )
     .expect("pane");
     for line in 1..=18 {
@@ -2974,7 +2996,7 @@ fn app_runtime_dock_window_tab_resizes_group_runtimes() {
             80,
             24,
             HashMap::new(),
-            None,
+            test_pane_cwd(),
         )
         .expect("pane");
         runtime.runtimes.insert(
@@ -10917,7 +10939,7 @@ fn app_runtime_status_thread_reports_process_exit_without_reader_eof() {
             80,
             24,
             HashMap::new(),
-            None,
+            test_pane_cwd(),
         )
         .expect("pane"),
     ));

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -596,6 +596,7 @@ fn workspace_work_agent_view_attaches_session_history() {
         agent_id: Some("codex".to_string()),
         display_name: Some("Codex".to_string()),
         updated_at: chrono::Utc::now(),
+        attached_by: None,
     };
     let view = super::workspace_work_agent_view_from_ref(&agent_ref, &index, Path::new("/"));
 
@@ -18873,6 +18874,7 @@ fn agent_view_borrows_identity_from_ledger_when_record_has_none() {
         agent_id: None,
         display_name: None,
         updated_at: chrono::Utc::now(),
+        attached_by: None,
     };
     let view = super::workspace_work_agent_view_from_ref(&agent_ref, &index, Path::new("/"));
     assert_eq!(view.display_name.as_deref(), Some("Claude Code"));
@@ -19139,6 +19141,7 @@ fn agent_view_synthesizes_latest_conversation_when_history_is_empty() {
         agent_id: Some("claude".to_string()),
         display_name: Some("Claude Code".to_string()),
         updated_at: chrono::Utc::now(),
+        attached_by: None,
     };
 
     let view = super::workspace_work_agent_view_from_ref(&agent_ref, &index, temp.path());
@@ -19176,6 +19179,7 @@ fn agent_view_marks_session_history_only_when_worktree_and_branch_are_missing() 
         agent_id: Some("claude".to_string()),
         display_name: Some("Claude Code".to_string()),
         updated_at: chrono::Utc::now(),
+        attached_by: None,
     };
 
     let view = super::workspace_work_agent_view_from_ref(&agent_ref, &index, &repo);
@@ -19212,6 +19216,7 @@ fn agent_view_keeps_session_resumable_when_missing_worktree_branch_exists() {
         agent_id: Some("claude".to_string()),
         display_name: Some("Claude Code".to_string()),
         updated_at: chrono::Utc::now(),
+        attached_by: None,
     };
 
     let view = super::workspace_work_agent_view_from_ref(&agent_ref, &index, &repo);

--- a/crates/gwt/src/app_runtime/workspace_views.rs
+++ b/crates/gwt/src/app_runtime/workspace_views.rs
@@ -1579,6 +1579,7 @@ pub(super) fn attach_registry_sessions_to_active_works(
                 agent_id: Some(session.agent_id.command().to_string()),
                 display_name: Some(session.display_name.clone()),
                 updated_at: session.last_activity_at,
+                attached_by: None,
             };
             let history_view =
                 workspace_work_agent_view_from_ref(&agent_ref, session_index, project_root);


### PR DESCRIPTION
## Summary

- works.json 上で 1 つの agent session が別 branch の Work item にも誤付与される data 汚染（Issue #3213 / PR #3215 で view 層は耐性化済み）に対し、**書き込み側の store 層 guard** を追加して汚染の発生自体を防ぎ、attach provenance で journal compaction 後の事後診断を可能にする。

## Changes

- `crates/gwt-core/src/workspace_projection/work_items.rs`: `apply_event` に attach guard を追加。event の session が既に**別の** Work item に bind されており、両者の execution container の branch/worktree identity が矛盾する場合は `WorkAgentRef` の push を拒否し `tracing::warn` で記録（FR-348「1 session : 1 Work」の強制）。identity 一致・identity 欠落時は従来どおり付与（resume / branchless 合成の互換維持）。event 自体は診断用に item へ保持。`WorkAgentRef` に `attached_by: Option<WorkEventKind>`（serde default）を追加。
- `crates/gwt-core/src/workspace_projection/persistence.rs`: 合成経路（projection / legacy journal 由来）の `WorkAgentRef` は `attached_by: None` を明示。
- `crates/gwt/src/app_runtime/workspace_views.rs` / `tests.rs`: `WorkAgentRef` 構築箇所へ新 field を追随。
- `crates/gwt/src/app_runtime/tests.rs`（追加 commit / Refs #3220）: CI の Test (Rust, Linux) を断続的に落としていた PTY flaky を解消。portable-pty は cwd 未指定時に `$HOME` へ無検査 chdir するため、HOME を tempdir に差し替えるテストとの並走で `PtyCreationFailed(ENOENT)` になっていた。`test_pane_cwd()` helper で全 6 箇所の test pane spawn の cwd を固定し ambient env 非依存にする。

## Testing

- [x] `cargo test -p gwt-core apply_event` — 新規 guard テストが修正前 RED（stray ref が付与される）→ 修正後 GREEN。同一 branch / identity 無しの互換 guard・provenance 記録・legacy serde 互換の 3 テストも GREEN
- [x] `cargo test -p gwt-core -p gwt --all-features` — 全 suite PASS（exit 0）
- [x] `cargo clippy --all-targets --all-features -- -D warnings` / `cargo fmt --all --check` / `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` — すべて PASS

## PR Readiness

- State: Ready for review
- Releaseable slice: yes — store 層の防御的 guard + optional field 追加のみ。既存データの読み込み互換は serde default + regression テストで担保
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- Closes #3216
- Closes #3220

## Related Issues / Links

- #3213 / PR #3215（view 層の耐性修正。本 PR は上流の発生源を塞ぐ対）
- SPEC #2359 W-12 Slice 2 / FR-348（1 agent session : 1 Work）

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [ ] Documentation updated (if user-facing change) — N/A: user-facing 変更なし
- [ ] Migration/backfill plan included (if schema/data change) — N/A: 追加 field は serde default で後方互換、migration 不要
- [x] CHANGELOG impact considered (breaking change flagged in commit) — fix: のみ、breaking なし

## Context

- 実例: `work-work-issue-3184` に `work/issue-3197` の session `0fe1b919-…` が agent_id 空で付与され（2026-06-29）、view 層 dedup と組み合わさって Workspace 行の silent drop（PR #3205 の孤立）に発展した。誤付与イベント自体は work-events journal の compaction で消えており追跡不能だったため、provenance を ref 自体に持たせて診断可能性を確保する。
- emitter 側（repo 共有 current projection と live session の組で event を作る経路等）は複数候補があり特定困難なため、全経路をカバーする store 層 guard を採用した。

## Risk / Impact

- **Affected areas**: work event の fold（`WorkItemsProjection::apply_event`）における session 付与のみ
- **Rollback plan**: 本 commit の revert のみで復元可能（`attached_by` は optional field のため既存データへの影響なし）