### PR TITLE
fix(issue-monitor): armed 通知の正直化と kill switch 能動 disarm の実装 (codex #3217)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -290,24 +290,18 @@ opt-in** が必要です:
 上限つきの試行回数を使い切っていない Issue だけが適格になります。それ以外は
 従来どおり human-gated のまま扱われます。
 
-安全モデル（要約）: マージ判断を実装エージェント自身には決して委ねません。
-独立レビューエージェント（fresh session。`review model` 設定で実装側と別の
-モデルを強制可能）が受け入れ基準に対して diff をレビューし、強いゲートが
-branch protection・必須 CI チェック・レビュー済みコミット SHA を再検証します。
-auto-merge はそのレビュー済み SHA に束縛して arm されるため、以後 head が
-進むと GitHub 側がマージを拒否し、マージ後にも「マージされたものがレビュー
-されたものと同一か」の同一性検証を行います。失敗は上限つき指数バックオフで
-再試行し、terminal な失敗や試行上限到達は可視の `NeedsHuman` 状態に
-エスカレーションして自動再起動しません。`Autonomous` トグルは kill switch と
-して機能し、無効化時は GitHub 側の pending auto-merge も能動的に解除します。
+安全モデルを一行で: マージ判断を実装エージェント自身には決して委ねません —
+独立レビューと強い自動ゲートの通過が必須で、失敗は可視の `NeedsHuman` 状態に
+エスカレーションし、`Autonomous` トグルは monitor が arm した auto-merge を
+能動的に解除する kill switch として機能します。ゲート設計と脅威モデルの全体は
+SPEC [#3200](https://github.com/akiojin/gwt/issues/3200) を参照してください。
 
 無人運転中のライフサイクルイベント（マージ完了・再試行予約・ゲート通過・
 NeedsHuman エスカレーション）はトーストとして表示され、永続的なスクロール可能
 通知スタックに蓄積されるため、離席中のイベントも失われません。
 
 調整可能な上限（試行回数・stuck/idle タイムアウト・再試行バックオフ・レビュー
-モデル）はプロジェクト単位で永続化されます。要件全体と脅威モデルは SPEC
-[#3200](https://github.com/akiojin/gwt/issues/3200)、human-gated の基礎は SPEC
+モデル）はプロジェクト単位で永続化されます。human-gated の基礎は SPEC
 [#3165](https://github.com/akiojin/gwt/issues/3165) を参照してください。
 
 ## Knowledge、Search、Managed Skills

--- a/README.md
+++ b/README.md
@@ -299,26 +299,20 @@ criteria (an `## Acceptance Criteria` checklist in the body), the base
 branch's protection rules are verifiable, and its bounded attempt budget is
 not exhausted. Anything else stays on the human-gated path unchanged.
 
-Safety model (summary): the merge decision never belongs to the implementing
-agent. An independent review agent (fresh session; optionally a different
-model via the `review model` setting) reviews the diff against the acceptance
-criteria; a strong gate then re-verifies branch protection, the required CI
-checks, and the reviewed commit SHA. Auto-merge is armed bound to that exact
-reviewed SHA, so GitHub refuses the merge if the head moves afterwards, and a
-post-merge identity check verifies what merged is what was reviewed. Failures
-retry with bounded exponential backoff; terminal failures and exhausted
-budgets escalate to a visible `NeedsHuman` state and never auto-relaunch. The
-`Autonomous` toggle acts as a kill switch, and disarming actively cancels the
-pending GitHub auto-merge.
+Safety model in one line: the merge decision never belongs to the
+implementing agent — an independent review plus a strong automated gate must
+pass first, failures escalate to a visible `NeedsHuman` state, and the
+`Autonomous` toggle is a kill switch that actively cancels any auto-merge the
+monitor armed. The full gate design and threat model live in SPEC
+[#3200](https://github.com/akiojin/gwt/issues/3200).
 
 Unattended lifecycle events (merge completed, retry scheduled, gate passed,
 needs-human escalations) surface as toasts and accumulate in a persistent,
 scrollable notification stack so nothing is lost while you are away.
 
 Tunable bounds (attempt cap, stuck/idle timeout, retry backoff, review model)
-persist per project. Full requirements and the threat model live in SPEC
-[#3200](https://github.com/akiojin/gwt/issues/3200); the human-gated baseline
-is SPEC [#3165](https://github.com/akiojin/gwt/issues/3165).
+persist per project. The human-gated baseline is SPEC
+[#3165](https://github.com/akiojin/gwt/issues/3165).
 
 ## Knowledge, Search, and Managed Skills
 

--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -633,6 +633,21 @@ fn scan_issue_monitor_once_blocking(
         &now,
     );
     monitor.recover_stuck_autonomous(&now);
+    // SPEC #3200 kill switch (codex #3217 review): with autonomous mode OFF, any
+    // record still Delivering has a live GitHub auto-merge that must be ACTIVELY
+    // cancelled — abandoning it locally would let the old PR merge later while
+    // nobody is watching. Runs AFTER reconcile so a PR that already merged was
+    // recorded as merged instead of pointlessly disarmed. No-op while mode is ON.
+    for (issue_number, pr_number) in monitor.take_kill_switch_disarms() {
+        let disarmed = gwt_git::pr_status::disable_pr_auto_merge(&scope.project_root, pr_number);
+        tracing::info!(
+            issue = issue_number,
+            pr = pr_number,
+            disarmed,
+            "kill switch: auto-merge disarm attempted"
+        );
+        monitor.record_kill_switch_disarm_result(issue_number, pr_number, disarmed);
+    }
     // SPEC #3200 Option A: advance in-flight autonomous issues through the loop
     // (PR detect → review → gate → merge → watch). No-op unless autonomous mode
     // is on; default OFF keeps the SPEC #3165 flow unchanged.

--- a/crates/gwt/src/issue_monitor.rs
+++ b/crates/gwt/src/issue_monitor.rs
@@ -1456,7 +1456,13 @@ impl IssueMonitorState {
     /// (the auto-merge is being armed).
     pub fn begin_delivering(&mut self, issue_number: u64) {
         self.set_autonomous_phase(issue_number, AutonomousPhase::Delivering);
-        // FR-034: the gate passing (auto-merge armed) is a key unattended event.
+    }
+
+    /// SPEC #3200 FR-034 (codex #3217 review): announce a SUCCESSFUL auto-merge
+    /// arm. Called by the worker only after `gh pr merge --auto` actually
+    /// succeeded — never before — so the operator toast cannot claim an arm
+    /// that failed (the merge helper's fail-closed contract).
+    pub fn record_auto_merge_armed(&mut self, issue_number: u64) {
         self.push_autonomous_notice(
             "info",
             issue_number,
@@ -1840,6 +1846,79 @@ impl IssueMonitorState {
     /// are retained until someone can see them.
     pub fn take_autonomous_notices(&mut self) -> Vec<AutonomousNotice> {
         self.pending_autonomous_notices.drain(..).collect()
+    }
+
+    /// Queue an operator notice that must surface even though autonomous mode is
+    /// already OFF — the kill-switch disarm results. Bypasses the fail-closed
+    /// mode gate deliberately: these notices are feedback ABOUT turning the mode
+    /// off, so gating them on the mode would silence exactly the events the
+    /// operator just asked for.
+    fn push_kill_switch_notice(&mut self, level: &str, issue_number: u64, message: String) {
+        while self.pending_autonomous_notices.len() >= AUTONOMOUS_NOTICE_CAP {
+            self.pending_autonomous_notices.pop_front();
+        }
+        self.pending_autonomous_notices.push_back(AutonomousNotice {
+            level: level.to_string(),
+            issue_number,
+            message,
+        });
+    }
+
+    /// SPEC #3200 kill switch (codex #3217 review): with autonomous mode OFF,
+    /// drain every record still in `Delivering` — each has an armed GitHub
+    /// auto-merge that must be ACTIVELY cancelled (`gh pr merge --disable-auto`),
+    /// not just abandoned locally. Returns `(issue_number, pr_number)` pairs for
+    /// the caller (the daemon scan, which owns the repo path) to disarm; each
+    /// drained record is escalated to `NeedsHuman` so the halted delivery stays
+    /// visible and is never silently resumed. No-op while the mode is ON.
+    pub fn take_kill_switch_disarms(&mut self) -> Vec<(u64, u64)> {
+        if self.autonomous_mode {
+            return Vec::new();
+        }
+        let delivering: Vec<(u64, Option<u64>)> = self
+            .autonomous_records
+            .values()
+            .filter(|record| record.phase == AutonomousPhase::Delivering)
+            .map(|record| (record.issue_number, record.pr_number))
+            .collect();
+        let mut disarms = Vec::new();
+        for (issue_number, pr_number) in delivering {
+            self.escalate_to_needs_human(
+                issue_number,
+                "autonomous mode disabled — delivery halted; auto-merge disarm requested",
+            );
+            if let Some(pr) = pr_number {
+                disarms.push((issue_number, pr));
+            }
+        }
+        disarms
+    }
+
+    /// Record the outcome of a kill-switch auto-merge disarm attempt as an
+    /// operator notice (ungated: the mode is OFF by definition here).
+    pub fn record_kill_switch_disarm_result(
+        &mut self,
+        issue_number: u64,
+        pr_number: u64,
+        disarmed: bool,
+    ) {
+        if disarmed {
+            self.push_kill_switch_notice(
+                "warn",
+                issue_number,
+                format!(
+                    "Issue #{issue_number}: auto-merge on PR #{pr_number} disarmed (kill switch)"
+                ),
+            );
+        } else {
+            self.push_kill_switch_notice(
+                "error",
+                issue_number,
+                format!(
+                    "Issue #{issue_number}: failed to disarm auto-merge on PR #{pr_number} — verify on GitHub manually"
+                ),
+            );
+        }
     }
 
     pub fn complete_active_launch(&mut self, issue_number: u64, window_id: impl Into<String>) {
@@ -3286,9 +3365,11 @@ mod tests {
             "review spawn blip",
             "2026-07-02T00:10:00Z",
         );
-        // Gate pass → Delivering (auto-merge armed) → info notice.
+        // Gate pass → Delivering; the info notice fires only once the arm
+        // actually SUCCEEDS (codex #3217: no success toast for a failed arm).
         monitor.set_autonomous_phase(7, AutonomousPhase::Reviewing);
         monitor.begin_delivering(7);
+        monitor.record_auto_merge_armed(7);
         // Merge completion → done notice.
         monitor.record_merged(7);
         // A second issue escalates → error notice.
@@ -3341,6 +3422,53 @@ mod tests {
             monitor.take_autonomous_notices().is_empty(),
             "default-OFF merge emits no autonomous notice"
         );
+    }
+
+    #[test]
+    fn kill_switch_drains_delivering_records_for_active_disarm() {
+        // codex #3217 review: turning autonomous mode OFF must actively disarm
+        // GitHub auto-merges armed by the monitor — abandoning a Delivering
+        // record locally would let the old PR merge later unwatched. The drain
+        // returns (issue, pr) pairs for the daemon to `--disable-auto`, and each
+        // halted delivery escalates to NeedsHuman (visible, never auto-resumed).
+        let mut monitor = autonomous_state();
+        scan_issue_monitor_candidates(&mut monitor, &[issue(7)], "2026-07-02T00:00:00Z");
+        monitor.set_autonomous_phase(7, AutonomousPhase::Implementing);
+        monitor.begin_review(7, 99, "abc123");
+        monitor.begin_delivering(7);
+
+        // Mode ON ⇒ no drain (deliveries are still owned by the loop).
+        assert!(monitor.take_kill_switch_disarms().is_empty());
+
+        monitor.set_autonomous_mode(false);
+        let disarms = monitor.take_kill_switch_disarms();
+        assert_eq!(
+            disarms,
+            vec![(7, 99)],
+            "delivering PR handed over for disarm"
+        );
+        assert_eq!(
+            monitor.autonomous_record(7).map(|r| r.phase),
+            Some(AutonomousPhase::NeedsHuman),
+            "halted delivery escalates instead of silently resuming later"
+        );
+        assert_eq!(
+            monitor.inbox_item(7).map(|item| item.state),
+            Some(MonitorInboxState::NeedsHuman)
+        );
+        // Idempotent: a second pass finds nothing.
+        assert!(monitor.take_kill_switch_disarms().is_empty());
+
+        // The disarm RESULT surfaces even though the mode is OFF (ungated).
+        monitor.record_kill_switch_disarm_result(7, 99, true);
+        monitor.record_kill_switch_disarm_result(7, 99, false);
+        let notices = monitor.take_autonomous_notices();
+        assert!(notices
+            .iter()
+            .any(|n| n.level == "warn" && n.message.contains("disarmed")));
+        assert!(notices
+            .iter()
+            .any(|n| n.level == "error" && n.message.contains("manually")));
     }
 
     #[test]

--- a/crates/gwt/src/issue_monitor_worker.rs
+++ b/crates/gwt/src/issue_monitor_worker.rs
@@ -329,8 +329,18 @@ pub fn advance_autonomous_in_flight(
                         monitor.begin_delivering(issue_number);
                         // Bind the arm to the reviewed head SHA so GitHub refuses
                         // to merge if the head advanced past what the gate reviewed.
-                        if !gwt_git::pr_status::merge_pr_auto(repo_path, pr, &inputs.reviewed_sha) {
+                        // codex #3217 review: announce the arm ONLY on success —
+                        // a failed arm must not leave a success toast while the
+                        // record would otherwise sit in Delivering with nothing
+                        // armed. Fail closed: escalate so the operator acts.
+                        if gwt_git::pr_status::merge_pr_auto(repo_path, pr, &inputs.reviewed_sha) {
+                            monitor.record_auto_merge_armed(issue_number);
+                        } else {
                             tracing::warn!(issue = issue_number, pr, "auto-merge arm failed");
+                            monitor.escalate_to_needs_human(
+                                issue_number,
+                                "auto-merge arming failed after gate pass — arm manually or relaunch",
+                            );
                         }
                     }
                     crate::issue_monitor_gate::GateAction::WaitForCi => {}

--- a/crates/gwt/tests/autonomous_e2e.rs
+++ b/crates/gwt/tests/autonomous_e2e.rs
@@ -334,6 +334,7 @@ fn fr_family_decision_boundaries_are_observable() {
     // SHA-identity check, and completion are observable; the operator notices
     // for retry / arming / completion are queued for the GUI.
     monitor.begin_delivering(42);
+    monitor.record_auto_merge_armed(42); // arm succeeded ⇒ info notice
     assert_eq!(
         monitor.autonomous_record(42).unwrap().phase,
         AutonomousPhase::Delivering


### PR DESCRIPTION
## Summary

merged 済み PR #3217 への codex / coderabbit review 指摘 3 件の follow-up fix。いずれも Issue Monitor autonomous 経路（default-OFF）+ README のみ。

## Changes

### fix: armed 通知を arm 成功時のみ発行（codex P2）

- `begin_delivering` が `merge_pr_auto` 実行前に「auto-merge armed」info 通知を出しており、arm 失敗時も成功トーストが残り record が Delivering に沈黙したまま残り得た。
- 通知発行を `record_auto_merge_armed` に分離し、worker は **arm 成功時のみ**発行。失敗時は fail-closed に `NeedsHuman` へ escalate（error 通知 + inbox 表示）。

### fix: kill switch の能動 disarm を実装（codex P2）

- SPEC #3200 plan は「kill switch は `gh pr merge --disable-auto` の能動発行で構造的に解決」と規定するが、`disable_pr_auto_merge` に本番呼び出しが無かった（implemented-but-not-wired）。Delivering 中に mode OFF にすると armed auto-merge が GitHub に残り、無人で旧 PR がマージされ得た。
- `take_kill_switch_disarms`（mode OFF 時に Delivering record を drain → NeedsHuman escalate → (issue, pr) 返却）を追加し、daemon scan が reconcile 後に `--disable-auto` を発行。結果は ungated 通知（mode OFF でも操作者 feedback を silence しない）。

### docs: README 安全モデル段落を1行要約+SPEC リンクに縮約（coderabbit）

- 内部機構の詳細記述を SPEC #3200 リンクに置換（en/ja 同等）。kill switch の記述は本 PR で実装と一致。

## Testing

- unit: kill-switch drain（mode ON no-op / drain+escalate / 冪等 / 結果通知 ungated）、armed 通知の成功時のみ発行（既存 2 テスト更新）
- fmt / clippy(--workspace -D warnings) / rustdoc(-D warnings) / markdownlint: 全 clean
- `cargo test -p gwt-core -p gwt --all-features`: 全 PASS（71 suites）

## PR Readiness

State: Ready

- releaseable slice: default-OFF の autonomous 経路 + docs のみ。既定挙動不変。
- 既知 blocker: なし。
- User Verification Result: n/a（frontend コード変更なし、backend + docs のみ）。

## Closing Issues

None

## Related Issues

#3200

## Checklist

- [x] テスト追加/更新
- [x] fmt / clippy / rustdoc / test / markdownlint 全通過
- [x] #3217 の review スレッド 3 件を reply + resolve 済み
- [x] commitlint 通過
- [x] User Verification: n/a（frontend 変更なし）
