### PR TITLE
fix(issue-monitor): Max active 超過の多重起動を修正 (claim 永続化 + ACK 経路の claim 禁止)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2897,9 +2897,9 @@ checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -606,6 +606,16 @@ impl ProjectTabRuntime {
     }
 }
 
+/// Issue #3222: whether a local Issue Monitor pass may claim + launch, or must
+/// only observe (scan for a fresh snapshot without side effects). ACK and
+/// window-close handling runs `Observe`; user-driven refresh/config flows run
+/// `ClaimAndLaunch`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IssueMonitorScanPolicy {
+    ClaimAndLaunch,
+    Observe,
+}
+
 impl AppRuntime {
     pub(crate) fn new(
         proxy: EventLoopProxy<UserEvent>,
@@ -1147,12 +1157,16 @@ impl AppRuntime {
         // it is replaced rather than left on the canvas. Guard against closing the
         // freshly launched window if it happens to reuse the same id.
         let mut stale_window: Option<String> = None;
-        let mut events = self.local_issue_monitor_events_for(None, |monitor| {
-            stale_window = monitor
-                .take_failed_window(issue_number)
-                .filter(|stale| *stale != window_id);
-            monitor.complete_active_launch(issue_number, window_id.clone());
-        });
+        let mut events = self.local_issue_monitor_events_with_policy(
+            None,
+            IssueMonitorScanPolicy::Observe,
+            |monitor| {
+                stale_window = monitor
+                    .take_failed_window(issue_number)
+                    .filter(|stale| *stale != window_id);
+                monitor.complete_active_launch(issue_number, window_id.clone());
+            },
+        );
         if let Some(stale) = stale_window {
             events.extend(self.close_window_events(&stale));
         }
@@ -1254,11 +1268,15 @@ impl AppRuntime {
             }
         }
         let requeue_windows = monitor_windows;
-        self.local_issue_monitor_events_for(None, move |monitor| {
-            for window_id in &requeue_windows {
-                monitor.requeue_window(window_id);
-            }
-        })
+        self.local_issue_monitor_events_with_policy(
+            None,
+            IssueMonitorScanPolicy::Observe,
+            move |monitor| {
+                for window_id in &requeue_windows {
+                    monitor.requeue_window(window_id);
+                }
+            },
+        )
     }
 
     fn local_issue_monitor_events(
@@ -1272,6 +1290,19 @@ impl AppRuntime {
     fn local_issue_monitor_events_for(
         &mut self,
         client_id: Option<&str>,
+        apply: impl FnOnce(&mut gwt::IssueMonitorState),
+    ) -> Vec<OutboundEvent> {
+        self.local_issue_monitor_events_with_policy(
+            client_id,
+            IssueMonitorScanPolicy::ClaimAndLaunch,
+            apply,
+        )
+    }
+
+    fn local_issue_monitor_events_with_policy(
+        &mut self,
+        client_id: Option<&str>,
+        policy: IssueMonitorScanPolicy,
         apply: impl FnOnce(&mut gwt::IssueMonitorState),
     ) -> Vec<OutboundEvent> {
         let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
@@ -1305,6 +1336,15 @@ impl AppRuntime {
                         );
                         if monitor.config.enabled {
                             monitor.set_gui_connected(true);
+                        }
+                        // Issue #3222: ACK / window-close flows scan for a fresh
+                        // snapshot (inbox rows for the UI) but must NEVER claim
+                        // or launch — re-entrant claiming on a disk snapshot
+                        // that cannot see other in-flight claims is what
+                        // spawned duplicate windows past max_active.
+                        if monitor.config.enabled
+                            && matches!(policy, IssueMonitorScanPolicy::ClaimAndLaunch)
+                        {
                             let launch_profile_ready = self
                                 .issue_monitor_previous_profiles(&project_root)
                                 .preferred_profile()
@@ -1386,6 +1426,11 @@ impl AppRuntime {
             }
             launch_events.extend(request_events);
         }
+        // Issue #3222: persist the claim-side state (Launching without a bound
+        // window yet, plus any recorded launch failures) so the next handler /
+        // the async launch ACK sees the in-flight claims and cannot re-claim
+        // them into duplicate windows.
+        let _ = gwt::save_issue_monitor_prefs(&prefs_path, &monitor.prefs());
         let mut events = launch_events;
         events.extend(self.issue_monitor_snapshot_events_for(client_id, monitor));
         events

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -20607,3 +20607,111 @@ fn is_identifier_like_title_classifies_shapes() {
     assert!(!super::is_identifier_like_title("SPEC-3075"));
     assert!(!super::is_identifier_like_title("develop"));
 }
+
+#[test]
+fn issue_monitor_launch_succeeded_ack_is_non_scanning_and_persists() {
+    // Issue #3222: the launch-success ACK used to re-enter the full
+    // scan+claim flow on a fresh disk snapshot that could not see other
+    // in-flight claims, re-claiming them (same-owner renewal) and spawning
+    // duplicate windows past max_active. The ACK must only bind the window and
+    // persist; scanning for a fresh snapshot is allowed, claiming is not.
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    // Thread-local override: never mutate process-global HOME in parallel tests.
+    let _home = gwt_core::test_support::ScopedGwtHome::set(temp.path());
+    let repo = temp.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("create repo");
+    init_repo(&repo);
+
+    // Seed an in-flight claim (Launching, no window bound yet) on disk.
+    let prefs_path = gwt::issue_monitor_prefs_path_for_repo_path(&repo);
+    let prefs = gwt::IssueMonitorPrefs {
+        enabled: true,
+        launching_issues: vec![42],
+        ..gwt::IssueMonitorPrefs::default()
+    };
+    gwt::save_issue_monitor_prefs(&prefs_path, &prefs).expect("seed prefs");
+
+    let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+    let (mut runtime, _recorded) =
+        sample_runtime_with_events(temp.path(), vec![tab], Some("tab-1"));
+
+    let events = runtime.issue_monitor_launch_succeeded_events(42, "tab-1::agent-1");
+
+    // The ACK may scan for a fresh snapshot, but must NOT claim/launch: no
+    // settings-required wizard, no "launch requested" toast.
+    for event in &events {
+        assert!(
+            !matches!(event.event, BackendEvent::LaunchWizardState { .. }),
+            "ACK must not open the launch wizard (settings-required prompt)"
+        );
+        if let BackendEvent::IssueMonitorToast { message, .. } = &event.event {
+            assert!(
+                !message.contains("launch requested"),
+                "ACK must not trigger launches: {message}"
+            );
+        }
+    }
+    let persisted = gwt::load_issue_monitor_prefs(&prefs_path).expect("reload");
+    assert!(
+        persisted
+            .launched_issues
+            .iter()
+            .any(|entry| entry.issue_number == 42 && entry.window_id == "tab-1::agent-1"),
+        "the ACK binds and persists the window: {:?}",
+        persisted.launched_issues
+    );
+    assert!(
+        persisted.launching_issues.is_empty(),
+        "the in-flight marker is consumed by the bind"
+    );
+}
+
+#[test]
+fn issue_monitor_windows_closed_requeue_is_non_scanning() {
+    // Issue #3222 (same re-entrancy class): closing a monitor window requeues
+    // + persists and may rescan for the snapshot, but must not claim/launch.
+    let temp = tempfile::TempDir::new().expect("tempdir");
+    // Thread-local override: never mutate process-global HOME in parallel tests.
+    let _home = gwt_core::test_support::ScopedGwtHome::set(temp.path());
+    let repo = temp.path().join("repo");
+    std::fs::create_dir_all(&repo).expect("create repo");
+    init_repo(&repo);
+
+    let prefs_path = gwt::issue_monitor_prefs_path_for_repo_path(&repo);
+    let prefs = gwt::IssueMonitorPrefs {
+        enabled: true,
+        launched_issues: vec![gwt::IssueMonitorLaunchedIssue {
+            issue_number: 42,
+            window_id: "tab-1::agent-1".to_string(),
+        }],
+        ..gwt::IssueMonitorPrefs::default()
+    };
+    gwt::save_issue_monitor_prefs(&prefs_path, &prefs).expect("seed prefs");
+
+    let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+    let (mut runtime, _recorded) =
+        sample_runtime_with_events(temp.path(), vec![tab], Some("tab-1"));
+
+    let events = runtime.issue_monitor_windows_closed_events(&["tab-1::agent-1".to_string()]);
+
+    // Close may scan for a fresh snapshot, but must NOT claim/launch — a
+    // re-claim here could instantly respawn the just-closed window or
+    // duplicate other in-flight launches.
+    for event in &events {
+        assert!(
+            !matches!(event.event, BackendEvent::LaunchWizardState { .. }),
+            "window close must not open the launch wizard"
+        );
+        if let BackendEvent::IssueMonitorToast { message, .. } = &event.event {
+            assert!(
+                !message.contains("launch requested"),
+                "window close must not trigger launches: {message}"
+            );
+        }
+    }
+    let persisted = gwt::load_issue_monitor_prefs(&prefs_path).expect("reload");
+    assert!(
+        persisted.launched_issues.is_empty(),
+        "closed window is released from the launched set"
+    );
+}

--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -600,6 +600,16 @@ fn scan_issue_monitor_once_blocking(
     gui_connected: bool,
 ) -> crate::IssueMonitorState {
     let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    // Issue #3222: refresh the GUI-owned prefs fields (launch profile / tuning)
+    // from disk. They have no control frame — the GUI writes them straight to
+    // the prefs file — so without this the daemon keeps its stale startup view
+    // (`has_launch_profile()==false` ⇒ active cap 0) and can never act as the
+    // launch driver, leaving refills to the GUI's racy re-entrant scans.
+    if let Ok(disk) = crate::load_issue_monitor_prefs(
+        &crate::issue_monitor_prefs_path_for_repo_path(&scope.project_root),
+    ) {
+        monitor.refresh_gui_owned_prefs(&disk);
+    }
     let (owner, repo) =
         match crate::issue_monitor_worker::github_remote_owner_and_repo(&scope.project_root) {
             Ok(owner_repo) => owner_repo,

--- a/crates/gwt/src/issue_monitor.rs
+++ b/crates/gwt/src/issue_monitor.rs
@@ -132,6 +132,12 @@ pub struct IssueMonitorPrefs {
     pub launch_profile: Option<IssueMonitorLaunchProfile>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub launched_issues: Vec<IssueMonitorLaunchedIssue>,
+    /// Issue #3222: claims whose agent window is not bound yet (`Launching`).
+    /// Persisted so an in-flight claim survives the per-handler prefs
+    /// roundtrip — otherwise a rescan re-claims the same issue (same-owner
+    /// renewal) and spawns a duplicate window past `max_active`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub launching_issues: Vec<u64>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub failed_issues: Vec<IssueMonitorFailedIssue>,
     /// Issues whose work PR merged. Persisted so completed work is not
@@ -160,6 +166,7 @@ impl Default for IssueMonitorPrefs {
             priority_order: Vec::new(),
             launch_profile: None,
             launched_issues: Vec::new(),
+            launching_issues: Vec::new(),
             failed_issues: Vec::new(),
             merged_issues: Vec::new(),
             autonomous_mode: false,
@@ -831,6 +838,13 @@ impl IssueMonitorState {
                 state.active_launches.push(launched.issue_number);
             }
         }
+        // Issue #3222: restore claimed-but-unbound launches so a reload (every
+        // GUI handler) still sees the in-flight claim and cannot re-claim it.
+        for issue_number in prefs.launching_issues {
+            if !state.active_launches.contains(&issue_number) {
+                state.active_launches.push(issue_number);
+            }
+        }
         for failed in prefs.failed_issues {
             if failed.message.trim().is_empty() {
                 continue;
@@ -864,6 +878,12 @@ impl IssueMonitorState {
                     issue_number: *issue_number,
                     window_id: window_id.clone(),
                 })
+                .collect(),
+            launching_issues: self
+                .active_launches
+                .iter()
+                .filter(|issue_number| !self.launched_windows.contains_key(issue_number))
+                .copied()
                 .collect(),
             failed_issues: self
                 .failed_issues
@@ -1183,6 +1203,17 @@ impl IssueMonitorState {
 
     pub fn has_launch_profile(&self) -> bool {
         self.launch_profile.is_some()
+    }
+
+    /// Issue #3222: refresh the GUI-owned prefs fields (`launch_profile`,
+    /// `autonomous_tuning`) from a freshly-loaded on-disk snapshot. The daemon
+    /// loads prefs once at startup and has no control frame for these fields, so
+    /// without this refresh a profile the GUI saves later stays invisible
+    /// (`has_launch_profile()==false` ⇒ active cap 0 ⇒ the daemon never refills
+    /// slots and cannot act as the single launch driver).
+    pub fn refresh_gui_owned_prefs(&mut self, disk: &IssueMonitorPrefs) {
+        self.launch_profile = disk.launch_profile.clone();
+        self.autonomous_tuning = disk.autonomous_tuning.clone();
     }
 
     pub fn status_view(&self) -> IssueMonitorStatusView {
@@ -1592,6 +1623,10 @@ impl IssueMonitorState {
                 .unwrap_or(MonitorInboxState::AgentFailed)
         } else if launched_window_id.is_some() {
             MonitorInboxState::Launched
+        } else if self.active_launches.contains(&issue_number) {
+            // Issue #3222: a claimed launch whose window is not bound yet stays
+            // visibly in-flight; the queue-push guard below then skips it.
+            MonitorInboxState::Launching
         } else {
             match existing.as_ref().map(|item| item.state) {
                 // A reopened Issue previously marked Released/Merged (but no
@@ -2323,6 +2358,79 @@ mod tests {
         monitor.complete_active_launch(number, window_id);
         assert_eq!(monitor.active_count(), 1);
         monitor
+    }
+
+    #[test]
+    fn launching_claims_survive_prefs_roundtrip_and_are_not_reclaimed() {
+        // Issue #3222: a claimed-but-not-yet-acked launch (Launching, no window
+        // yet) must survive the prefs roundtrip. The GUI rebuilds the monitor
+        // from disk on every handler call, so an unpersisted claim was invisible
+        // to the next handler / the launch ACK's rescan, which re-claimed the
+        // same issue (same-owner renewal) and spawned a DUPLICATE agent window
+        // (observed live: Max 5 ⇒ 10 windows).
+        let mut monitor = IssueMonitorState::new(IssueMonitorConfig::default());
+        scan_issue_monitor_candidates(&mut monitor, &[issue(42)], "2026-07-02T00:00:00Z");
+        monitor.set_gui_connected(true);
+        let request = monitor.next_launch_request().expect("claimed for launch");
+        assert_eq!(request.issue_number, 42);
+        assert_eq!(monitor.active_count(), 1, "claim holds an active slot");
+
+        // Reload from prefs (what every GUI handler does).
+        let mut restored =
+            IssueMonitorState::with_prefs(IssueMonitorConfig::default(), monitor.prefs());
+        restored.set_gui_connected(true);
+        assert_eq!(
+            restored.active_count(),
+            1,
+            "in-flight Launching claim survives the roundtrip"
+        );
+        // A rescan must not re-queue the in-flight issue…
+        scan_issue_monitor_candidates(&mut restored, &[issue(42)], "2026-07-02T00:00:30Z");
+        assert_eq!(
+            restored.inbox_item(42).map(|item| item.state),
+            Some(MonitorInboxState::Launching),
+            "rescan shows the in-flight claim as Launching, not Queued"
+        );
+        assert_eq!(restored.queue_len(), 0, "not re-queued");
+        // …and must not hand out a second launch request for it.
+        assert!(
+            restored.next_launch_request().is_none(),
+            "no duplicate launch request for an in-flight claim"
+        );
+    }
+
+    #[test]
+    fn refresh_gui_owned_prefs_updates_profile_and_tuning_from_disk() {
+        // Issue #3222: the daemon loads prefs once at startup, so a launch
+        // profile the GUI saves later stays invisible (has_launch_profile=false
+        // ⇒ cap 0 ⇒ the daemon never refills slots and the GUI's re-entrant
+        // scan became the de-facto driver). The scan must refresh GUI-owned
+        // fields from disk.
+        let mut monitor = IssueMonitorState::new(IssueMonitorConfig::default());
+        assert!(!monitor.has_launch_profile());
+        let disk = IssueMonitorPrefs {
+            launch_profile: Some(IssueMonitorLaunchProfile {
+                agent_id: "claude".to_string(),
+                model: None,
+                reasoning: None,
+                version: None,
+                session_mode: Default::default(),
+                skip_permissions: false,
+                codex_fast_mode: false,
+                runtime_target: Default::default(),
+                docker_service: None,
+                docker_lifecycle_intent: Default::default(),
+                windows_shell: None,
+            }),
+            autonomous_tuning: AutonomousTuning {
+                max_attempts: 9,
+                ..AutonomousTuning::default()
+            },
+            ..IssueMonitorPrefs::default()
+        };
+        monitor.refresh_gui_owned_prefs(&disk);
+        assert!(monitor.has_launch_profile(), "profile refreshed from disk");
+        assert_eq!(monitor.autonomous_tuning.max_attempts, 9);
     }
 
     #[test]

--- a/deny.toml
+++ b/deny.toml
@@ -48,6 +48,19 @@ ignore = [
     # the gtk3-rs / wry stack on Linux. Same exit path. Also tracked
     # as Dependabot alert #29.
     { id = "RUSTSEC-2024-0429", reason = "glib::VariantStrIter unsoundness; not reachable from our code, blocked on gtk-rs 0.20+ (also tracked as Dependabot #29)" },
+    # quick-xml O(N^2) duplicate-attribute check (CPU-exhaustion DoS on
+    # untrusted XML). We reach quick-xml only through wayland-scanner, a
+    # BUILD-TIME code generator that parses trusted, repo-pinned Wayland
+    # protocol XML on Linux — never attacker-controlled input, and never
+    # part of the shipped runtime attack surface. wayland-scanner 0.31.x
+    # pins quick-xml ^0.39, so the fixed 0.41 cannot be forced from here.
+    { id = "RUSTSEC-2026-0194", reason = "quick-xml quadratic duplicate-attr scan; only via wayland-scanner build-time codegen on trusted local protocol XML; blocked on wayland-rs adopting quick-xml >=0.41" },
+    # TEMPORARY: the quick-xml NsReader unbounded-namespace-allocation
+    # advisory has not been assigned a RUSTSEC id yet (shows as
+    # RUSTSEC-0000-0000). Replace this entry with the real id once the
+    # advisory-db assigns one. Same wayland-scanner build-time-only
+    # exposure rationale as RUSTSEC-2026-0194 above.
+    { id = "RUSTSEC-0000-0000", reason = "quick-xml NsReader unbounded namespace allocation (id not yet assigned); same wayland-scanner build-time-only exposure on trusted local protocol XML; blocked on wayland-rs adopting quick-xml >=0.41" },
 ]
 
 [sources]


### PR DESCRIPTION
## Summary

Issue Monitor が `Max active` を超えて同一 issue を多重起動するバグの修正（Closes #3222）。実測: Max=5 で同一 issue が 2〜3 回 spawn され window 10 個（追跡 5 + orphan 5）。ユーザー実機報告 → fresh 環境ログで再現機序を確定。

## Changes

根本原因 3 点の複合を、それぞれ外科的に修正:

1. **claim の未永続化**: `IssueMonitorPrefs.launching_issues` を追加し、claim（Launching・window 未確定）を prefs round-trip 可能に。`local_issue_monitor_events_for` は claim/launch 後に prefs を保存。`record_candidate` は active な window 未確定 issue を `Launching` 表示（queue 再投入は既存ガードで除外）。
2. **ACK/close の再入 claim**: `IssueMonitorScanPolicy { ClaimAndLaunch | Observe }` を導入。launch 成功 ACK と window close は **Observe**（UI snapshot 用の scan は許可、claim/launch/settings-required prompt は禁止）。ユーザー駆動の List/Set*/configure は従来どおり ClaimAndLaunch。これが重複 spawn の直接原因（fresh disk 状態で in-flight が不可視 → 同一 owner claim が renewal 扱いで再取得）。
3. **daemon の profile 盲目**: scan 冒頭で `refresh_gui_owned_prefs` により disk から launch_profile / autonomous_tuning を補給。fresh 環境でも daemon が cap>0 となり、refill の単一駆動源として機能。

## Testing

- unit: launching の prefs round-trip + 再 claim 抑止 / `refresh_gui_owned_prefs` / ACK・close の Observe 契約（wizard 起動なし・launch toast なし + 永続化）
- 回帰修復の検証: 変更途中の「非スキャン ACK」案は既存 12 テスト（close 後の inbox 行表示等）を破壊 → Observe 方式で全復旧を確認
- 新規テストは `ScopedGwtHome`（thread-local）を使用し process-global HOME を汚さない
- fmt / clippy(--workspace -D warnings) / rustdoc(-D warnings): clean
- `cargo test -p gwt-core -p gwt --all-features`: 71 suites / 0 failed（bin 692 / lib 1301 含む）

## PR Readiness

State: Ready

- releaseable slice: Issue Monitor の cap 会計の correctness 修正のみ。既定挙動（human-gated / autonomous とも）を壊す変更なし。
- 既知 blocker: なし。
- User Verification Result: n/a（backend のみ、frontend コード変更なし。多重起動の再現には実 GitHub launch が必要なため、merge 後の fresh 実機で Max=5 検証を別途実施予定）。

## Closing Issues

Closes #3222

## Related Issues

#3165 / #3200

## Checklist

- [x] テスト追加/更新（unit 5 件 + 既存 12 件の回帰修復）
- [x] fmt / clippy / rustdoc / test 全通過
- [x] commitlint 通過
- [x] User Verification: n/a（backend のみ）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate agent windows by preserving in-flight launch state across refreshes and rescans.
  * Improved Issue Monitor behavior after acknowledgments and window closes so already-claimed items are not re-queued.
  * Kept launch-related UI state consistent when a launch is still pending.

* **Chores**
  * Issue Monitor settings now stay in sync with saved preferences more reliably during scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->