### PR TITLE
fix(issue-monitor): launching claim に TTL を付与し daemon と会計を統合 (codex #3223)

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1317,6 +1317,9 @@ impl AppRuntime {
         let mut monitor =
             gwt::IssueMonitorState::with_prefs(gwt::IssueMonitorConfig::default(), prefs);
         apply(&mut monitor);
+        // #3223 follow-up: release claimed-but-never-acked launches whose claim
+        // anchor exceeded claim_ttl_secs so a crash cannot leak a slot forever.
+        monitor.expire_stale_unbound_launches(&now);
         let _ = gwt::save_issue_monitor_prefs(&prefs_path, &monitor.prefs());
         let mut launch_requests = Vec::new();
         let mut settings_required_request = None;

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -20626,7 +20626,10 @@ fn issue_monitor_launch_succeeded_ack_is_non_scanning_and_persists() {
     let prefs_path = gwt::issue_monitor_prefs_path_for_repo_path(&repo);
     let prefs = gwt::IssueMonitorPrefs {
         enabled: true,
-        launching_issues: vec![42],
+        launching_issues: vec![gwt::IssueMonitorLaunchingIssue {
+            issue_number: 42,
+            claimed_at: None,
+        }],
         ..gwt::IssueMonitorPrefs::default()
     };
     gwt::save_issue_monitor_prefs(&prefs_path, &prefs).expect("seed prefs");

--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -609,7 +609,14 @@ fn scan_issue_monitor_once_blocking(
         &crate::issue_monitor_prefs_path_for_repo_path(&scope.project_root),
     ) {
         monitor.refresh_gui_owned_prefs(&disk);
+        // #3223 follow-up (codex P1): absorb the GUI process's in-flight
+        // launching/launched claims so max-active accounting is unified and the
+        // daemon's persist cannot drop them.
+        monitor.merge_inflight_launches_from_disk(&disk);
     }
+    // #3223 follow-up (codex P2): expire claimed-but-never-acked launches past
+    // claim_ttl_secs so a crashed launch cannot hold a slot forever.
+    monitor.expire_stale_unbound_launches(&now);
     let (owner, repo) =
         match crate::issue_monitor_worker::github_remote_owner_and_repo(&scope.project_root) {
             Ok(owner_repo) => owner_repo,
@@ -1251,7 +1258,9 @@ mod tests {
             },
             "claim-a",
         );
-        monitor.next_launch_request().expect("launch request");
+        monitor
+            .next_launch_request("2026-07-02T00:00:00Z")
+            .expect("launch request");
         let payload = crate::runtime_daemon_events::issue_monitor_payload(
             "control",
             serde_json::json!({
@@ -1292,7 +1301,9 @@ mod tests {
             },
             "claim-a",
         );
-        monitor.next_launch_request().expect("launch request");
+        monitor
+            .next_launch_request("2026-07-02T00:00:00Z")
+            .expect("launch request");
         let payload = crate::runtime_daemon_events::issue_monitor_payload(
             "control",
             serde_json::json!({
@@ -1333,7 +1344,9 @@ mod tests {
             },
             "claim-a",
         );
-        monitor.next_launch_request().expect("launch request");
+        monitor
+            .next_launch_request("2026-07-02T00:00:00Z")
+            .expect("launch request");
         monitor.complete_active_launch(42, "tab-1::agent-1");
         let payload = crate::runtime_daemon_events::issue_monitor_payload(
             "control",
@@ -1389,7 +1402,9 @@ mod tests {
             },
             "claim-a",
         );
-        monitor.next_launch_request().expect("launch request");
+        monitor
+            .next_launch_request("2026-07-02T00:00:00Z")
+            .expect("launch request");
         monitor.complete_active_launch(42, "tab-1::agent-1");
         monitor.set_autonomous_phase(42, crate::AutonomousPhase::Implementing);
         monitor.begin_review(42, 99, "abc123"); // Implementing → Reviewing
@@ -1445,7 +1460,9 @@ mod tests {
             },
             "claim-a",
         );
-        monitor.next_launch_request().expect("launch request");
+        monitor
+            .next_launch_request("2026-07-02T00:00:00Z")
+            .expect("launch request");
         let payload = crate::runtime_daemon_events::issue_monitor_payload(
             "control",
             serde_json::json!({

--- a/crates/gwt/src/issue_monitor.rs
+++ b/crates/gwt/src/issue_monitor.rs
@@ -136,8 +136,12 @@ pub struct IssueMonitorPrefs {
     /// Persisted so an in-flight claim survives the per-handler prefs
     /// roundtrip — otherwise a rescan re-claims the same issue (same-owner
     /// renewal) and spawns a duplicate window past `max_active`.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub launching_issues: Vec<u64>,
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        deserialize_with = "deserialize_launching_issues"
+    )]
+    pub launching_issues: Vec<IssueMonitorLaunchingIssue>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub failed_issues: Vec<IssueMonitorFailedIssue>,
     /// Issues whose work PR merged. Persisted so completed work is not
@@ -180,6 +184,44 @@ impl Default for IssueMonitorPrefs {
 pub struct IssueMonitorLaunchedIssue {
     pub issue_number: u64,
     pub window_id: String,
+}
+
+/// #3223 follow-up: one claimed-but-unbound launch with its claim anchor.
+/// `claimed_at` lets a restored claim EXPIRE after `claim_ttl_secs` instead of
+/// holding a max-active slot forever when the process died before the ACK.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IssueMonitorLaunchingIssue {
+    pub issue_number: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub claimed_at: Option<String>,
+}
+
+/// Backward-compat: the first shipped shape was a bare id array. A parse
+/// failure here would `unwrap_or_default()` into a full prefs wipe, so both
+/// shapes must deserialize.
+fn deserialize_launching_issues<'de, D>(
+    deserializer: D,
+) -> Result<Vec<IssueMonitorLaunchingIssue>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Compat {
+        Bare(u64),
+        Full(IssueMonitorLaunchingIssue),
+    }
+    let entries = Vec::<Compat>::deserialize(deserializer)?;
+    Ok(entries
+        .into_iter()
+        .map(|entry| match entry {
+            Compat::Bare(issue_number) => IssueMonitorLaunchingIssue {
+                issue_number,
+                claimed_at: None,
+            },
+            Compat::Full(full) => full,
+        })
+        .collect())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -463,6 +505,8 @@ pub struct IssueMonitorState {
     /// (bounded) while no GUI is connected so unattended events surface on the
     /// next connect.
     pending_autonomous_notices: VecDeque<AutonomousNotice>,
+    /// #3223 follow-up: claim anchors for unbound launches (issue → RFC3339).
+    launching_claimed_at: BTreeMap<u64, String>,
 }
 
 pub fn is_auto_improve_candidate(issue: &IssueMonitorIssue, config: &IssueMonitorConfig) -> bool {
@@ -818,6 +862,7 @@ impl IssueMonitorState {
             pending_launches: VecDeque::new(),
             pending_review_dispatches: VecDeque::new(),
             pending_autonomous_notices: VecDeque::new(),
+            launching_claimed_at: BTreeMap::new(),
         }
     }
 
@@ -840,9 +885,14 @@ impl IssueMonitorState {
         }
         // Issue #3222: restore claimed-but-unbound launches so a reload (every
         // GUI handler) still sees the in-flight claim and cannot re-claim it.
-        for issue_number in prefs.launching_issues {
-            if !state.active_launches.contains(&issue_number) {
-                state.active_launches.push(issue_number);
+        for entry in prefs.launching_issues {
+            if !state.active_launches.contains(&entry.issue_number) {
+                state.active_launches.push(entry.issue_number);
+            }
+            if let Some(claimed_at) = entry.claimed_at {
+                state
+                    .launching_claimed_at
+                    .insert(entry.issue_number, claimed_at);
             }
         }
         for failed in prefs.failed_issues {
@@ -883,7 +933,10 @@ impl IssueMonitorState {
                 .active_launches
                 .iter()
                 .filter(|issue_number| !self.launched_windows.contains_key(issue_number))
-                .copied()
+                .map(|issue_number| IssueMonitorLaunchingIssue {
+                    issue_number: *issue_number,
+                    claimed_at: self.launching_claimed_at.get(issue_number).cloned(),
+                })
                 .collect(),
             failed_issues: self
                 .failed_issues
@@ -1214,6 +1267,80 @@ impl IssueMonitorState {
     pub fn refresh_gui_owned_prefs(&mut self, disk: &IssueMonitorPrefs) {
         self.launch_profile = disk.launch_profile.clone();
         self.autonomous_tuning = disk.autonomous_tuning.clone();
+    }
+
+    /// #3223 follow-up (codex P1): absorb the OTHER process's in-flight launch
+    /// accounting from disk. The GUI and the daemon both claim launches; the
+    /// daemon only refreshed profile/tuning, so GUI-written `launching`/
+    /// `launched` entries were invisible to it — it saw free slots (over-cap
+    /// claims) and its next persist dropped the GUI's in-flight claims.
+    /// Union-merge: entries already known in memory win; removals propagate via
+    /// the existing control frames (Launched / LaunchFailed / WindowClosed).
+    pub fn merge_inflight_launches_from_disk(&mut self, disk: &IssueMonitorPrefs) {
+        for launched in &disk.launched_issues {
+            if launched.window_id.is_empty() {
+                continue;
+            }
+            self.launched_windows
+                .entry(launched.issue_number)
+                .or_insert_with(|| launched.window_id.clone());
+            if !self.active_launches.contains(&launched.issue_number) {
+                self.active_launches.push(launched.issue_number);
+            }
+        }
+        for entry in &disk.launching_issues {
+            if !self.active_launches.contains(&entry.issue_number) {
+                self.active_launches.push(entry.issue_number);
+                if let Some(claimed_at) = &entry.claimed_at {
+                    self.launching_claimed_at
+                        .insert(entry.issue_number, claimed_at.clone());
+                }
+            }
+        }
+    }
+
+    /// #3223 follow-up (codex P2 / coderabbit): release claimed-but-unbound
+    /// launches whose claim anchor is older than `claim_ttl_secs`. A crash
+    /// between the claim-save and the launch ACK would otherwise hold a
+    /// max-active slot forever. Entries restored without an anchor (legacy
+    /// bare-id shape) are stamped `now` so their clock starts here. Released
+    /// issues return to `Queued` and re-enter the queue so the next scan can
+    /// relaunch them (mirroring the expired GitHub claim, which lapses after
+    /// the same TTL).
+    pub fn expire_stale_unbound_launches(&mut self, now: &str) -> Vec<u64> {
+        let ttl = self.config.claim_ttl_secs as i64;
+        let unbound: Vec<u64> = self
+            .active_launches
+            .iter()
+            .filter(|issue_number| !self.launched_windows.contains_key(issue_number))
+            .copied()
+            .collect();
+        let mut expired = Vec::new();
+        for issue_number in unbound {
+            match self.launching_claimed_at.get(&issue_number) {
+                Some(claimed_at) => {
+                    let stale =
+                        rfc3339_elapsed_secs(claimed_at, now).is_some_and(|elapsed| elapsed >= ttl);
+                    if stale {
+                        self.active_launches
+                            .retain(|active| *active != issue_number);
+                        self.launching_claimed_at.remove(&issue_number);
+                        self.set_inbox_state(issue_number, MonitorInboxState::Queued);
+                        if !self.queue.contains(&issue_number) {
+                            self.queue.push_back(issue_number);
+                            self.apply_priority_order_to_queue();
+                        }
+                        expired.push(issue_number);
+                    }
+                }
+                None => {
+                    // Legacy entry without an anchor: start its clock now.
+                    self.launching_claimed_at
+                        .insert(issue_number, now.to_string());
+                }
+            }
+        }
+        expired
     }
 
     pub fn status_view(&self) -> IssueMonitorStatusView {
@@ -1735,7 +1862,7 @@ impl IssueMonitorState {
         });
     }
 
-    pub fn next_launch_request(&mut self) -> Option<IssueMonitorLaunchRequest> {
+    pub fn next_launch_request(&mut self, now: &str) -> Option<IssueMonitorLaunchRequest> {
         let max_active = self.config.max_active.max(1);
         if !self.gui_connected || self.active_launches.len() >= max_active {
             return None;
@@ -1744,6 +1871,10 @@ impl IssueMonitorState {
         if !self.active_launches.contains(&issue_number) {
             self.active_launches.push(issue_number);
         }
+        // #3223 follow-up: anchor the claim so a restored-but-never-acked
+        // launch can expire after claim_ttl_secs instead of leaking the slot.
+        self.launching_claimed_at
+            .insert(issue_number, now.to_string());
         let linked_issue_kind = if let Some(item) = self
             .inbox
             .iter_mut()
@@ -1811,7 +1942,7 @@ impl IssueMonitorState {
             match acquire_claim(client, IssueNumber(issue.number), claim, now) {
                 Ok(ClaimAcquireOutcome::Acquired(claim)) => {
                     self.record_claimed(issue, claim.claim_id);
-                    if let Some(request) = self.next_launch_request() {
+                    if let Some(request) = self.next_launch_request(now) {
                         self.pending_launches.push_back(request.clone());
                         launches.push(request);
                     }
@@ -1962,6 +2093,7 @@ impl IssueMonitorState {
 
     pub fn complete_active_launch(&mut self, issue_number: u64, window_id: impl Into<String>) {
         let window_id = window_id.into();
+        self.launching_claimed_at.remove(&issue_number);
         if !self.active_launches.contains(&issue_number) {
             self.active_launches.push(issue_number);
         }
@@ -2050,6 +2182,7 @@ impl IssueMonitorState {
     fn clear_active_tracking(&mut self, issue_number: u64) {
         self.active_launches
             .retain(|active| *active != issue_number);
+        self.launching_claimed_at.remove(&issue_number);
         self.launched_windows.remove(&issue_number);
         self.launched_branches.remove(&issue_number);
         // #3165 error-window lifecycle: terminal transitions (merged / released /
@@ -2347,7 +2480,9 @@ mod tests {
             Some("tab-1::agent-1")
         );
         assert!(
-            monitor.next_launch_request().is_none(),
+            monitor
+                .next_launch_request("2026-07-02T00:00:00Z")
+                .is_none(),
             "max_active=1 must keep the next queued issue waiting while launched work is active"
         );
     }
@@ -2371,7 +2506,9 @@ mod tests {
         let mut monitor = IssueMonitorState::new(IssueMonitorConfig::default());
         scan_issue_monitor_candidates(&mut monitor, &[issue(42)], "2026-07-02T00:00:00Z");
         monitor.set_gui_connected(true);
-        let request = monitor.next_launch_request().expect("claimed for launch");
+        let request = monitor
+            .next_launch_request("2026-07-02T00:00:00Z")
+            .expect("claimed for launch");
         assert_eq!(request.issue_number, 42);
         assert_eq!(monitor.active_count(), 1, "claim holds an active slot");
 
@@ -2394,9 +2531,125 @@ mod tests {
         assert_eq!(restored.queue_len(), 0, "not re-queued");
         // …and must not hand out a second launch request for it.
         assert!(
-            restored.next_launch_request().is_none(),
+            restored
+                .next_launch_request("2026-07-02T00:00:00Z")
+                .is_none(),
             "no duplicate launch request for an in-flight claim"
         );
+    }
+
+    #[test]
+    fn launching_prefs_accept_legacy_bare_ids_and_timestamped_entries() {
+        // #3223 follow-up (codex P2): the launching entries gained a
+        // `claimed_at` anchor. Files written by the first shipped shape (bare
+        // ids) must still parse — a parse failure would `unwrap_or_default()`
+        // into a FULL prefs wipe.
+        let legacy = r#"{"enabled":true,"max_active_agents":2,"priority_order":[],"launching_issues":[42,43]}"#;
+        let prefs: IssueMonitorPrefs = serde_json::from_str(legacy).expect("legacy parses");
+        assert_eq!(
+            prefs
+                .launching_issues
+                .iter()
+                .map(|entry| entry.issue_number)
+                .collect::<Vec<_>>(),
+            vec![42, 43]
+        );
+        let timed = r#"{"enabled":true,"max_active_agents":2,"priority_order":[],"launching_issues":[{"issue_number":7,"claimed_at":"2026-07-02T00:00:00Z"}]}"#;
+        let prefs: IssueMonitorPrefs = serde_json::from_str(timed).expect("timed parses");
+        assert_eq!(prefs.launching_issues[0].issue_number, 7);
+        assert_eq!(
+            prefs.launching_issues[0].claimed_at.as_deref(),
+            Some("2026-07-02T00:00:00Z")
+        );
+    }
+
+    #[test]
+    fn stale_unbound_launching_claims_expire_after_claim_ttl() {
+        // #3223 follow-up (codex P2 / coderabbit): a crash between the
+        // claim-save and the launch ACK leaves a restored `Launching` claim
+        // with no window. Without an expiry it holds a max-active slot
+        // forever. After claim_ttl_secs it must be released so the next scan
+        // can re-queue and relaunch the issue.
+        let mut monitor = IssueMonitorState::new(IssueMonitorConfig::default());
+        scan_issue_monitor_candidates(&mut monitor, &[issue(42)], "2026-07-02T00:00:00Z");
+        monitor.set_gui_connected(true);
+        assert!(monitor
+            .next_launch_request("2026-07-02T00:00:00Z")
+            .is_some());
+        assert_eq!(monitor.active_count(), 1);
+
+        // Restart (roundtrip) mid-launch: claim restored, still unbound.
+        let mut restored =
+            IssueMonitorState::with_prefs(IssueMonitorConfig::default(), monitor.prefs());
+        restored.set_gui_connected(true);
+        assert_eq!(restored.active_count(), 1);
+
+        // Before the TTL: retained.
+        let expired = restored.expire_stale_unbound_launches("2026-07-02T00:10:00Z");
+        assert!(expired.is_empty(), "not expired before claim_ttl_secs");
+        assert_eq!(restored.active_count(), 1);
+
+        // After the TTL (default 1800s): released and re-queueable.
+        let expired = restored.expire_stale_unbound_launches("2026-07-02T00:31:00Z");
+        assert_eq!(expired, vec![42], "stale unbound claim expires");
+        assert_eq!(restored.active_count(), 0, "slot released");
+        scan_issue_monitor_candidates(&mut restored, &[issue(42)], "2026-07-02T00:31:10Z");
+        assert!(
+            restored
+                .next_launch_request("2026-07-02T00:31:20Z")
+                .is_some(),
+            "the issue is claimable again after expiry"
+        );
+        // Bound launches never expire this way.
+        monitor.complete_active_launch(42, "tab-1::agent-1");
+        assert!(monitor
+            .expire_stale_unbound_launches("2026-07-03T00:00:00Z")
+            .is_empty());
+    }
+
+    #[test]
+    fn merge_inflight_launches_from_disk_unifies_cross_process_accounting() {
+        // #3223 follow-up (codex P1): the daemon only refreshed profile/tuning
+        // from disk, so GUI-written launching/launched claims were invisible —
+        // the daemon saw free slots (over-cap claims) and its next persist
+        // dropped the GUI's in-flight entries. The merge must absorb both.
+        let mut daemon = IssueMonitorState::with_prefs(
+            IssueMonitorConfig {
+                enabled: true,
+                max_active: 2,
+                ..IssueMonitorConfig::default()
+            },
+            IssueMonitorPrefs {
+                enabled: true,
+                max_active_agents: 2,
+                ..IssueMonitorPrefs::default()
+            },
+        );
+        let disk = IssueMonitorPrefs {
+            launching_issues: vec![IssueMonitorLaunchingIssue {
+                issue_number: 42,
+                claimed_at: Some("2026-07-02T00:00:00Z".to_string()),
+            }],
+            launched_issues: vec![IssueMonitorLaunchedIssue {
+                issue_number: 43,
+                window_id: "tab-1::agent-2".to_string(),
+            }],
+            ..IssueMonitorPrefs::default()
+        };
+        daemon.merge_inflight_launches_from_disk(&disk);
+        assert_eq!(daemon.active_count(), 2, "both in-flight claims absorbed");
+        assert!(daemon.launched_window_issue("tab-1::agent-2").is_some());
+        // The daemon persist now round-trips them instead of dropping them.
+        let prefs = daemon.prefs();
+        assert!(prefs
+            .launching_issues
+            .iter()
+            .any(|entry| entry.issue_number == 42
+                && entry.claimed_at.as_deref() == Some("2026-07-02T00:00:00Z")));
+        assert!(prefs
+            .launched_issues
+            .iter()
+            .any(|entry| entry.issue_number == 43));
     }
 
     #[test]

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -95,8 +95,8 @@ pub use issue_monitor::{
     IssueMonitorConfig, IssueMonitorFailedIssue, IssueMonitorInboxItem, IssueMonitorIssue,
     IssueMonitorIssueState, IssueMonitorLaunchPlan, IssueMonitorLaunchProfile,
     IssueMonitorLaunchProfileSource, IssueMonitorLaunchRequest, IssueMonitorLaunchedIssue,
-    IssueMonitorPrefs, IssueMonitorScanSummary, IssueMonitorState, IssueMonitorStatusView,
-    MonitorInboxState,
+    IssueMonitorLaunchingIssue, IssueMonitorPrefs, IssueMonitorScanSummary, IssueMonitorState,
+    IssueMonitorStatusView, MonitorInboxState,
 };
 pub use knowledge_bridge::{
     load_knowledge_bridge, refresh_knowledge_bridge_cache, search_knowledge_bridge,

--- a/crates/gwt/tests/issue_monitor_test.rs
+++ b/crates/gwt/tests/issue_monitor_test.rs
@@ -80,7 +80,9 @@ fn monitor_maps_gwt_spec_label_to_spec_launch_kind() {
     monitor.set_gui_connected(true);
     monitor.record_claimed(issue(3165, &["gwt-spec"]), "claim-spec");
 
-    let launch = monitor.next_launch_request().expect("spec launch request");
+    let launch = monitor
+        .next_launch_request("2026-07-02T00:00:00Z")
+        .expect("spec launch request");
 
     assert_eq!(launch.issue_number, 3165);
     assert_eq!(launch.linked_issue_kind, LinkedIssueKind::Spec);
@@ -108,7 +110,9 @@ fn claimed_issue_waits_in_queue_until_gui_is_connected() {
     monitor.record_claimed(issue(42, &["auto-improve"]), "claim-a");
 
     assert_eq!(monitor.queue_len(), 1);
-    assert!(monitor.next_launch_request().is_none());
+    assert!(monitor
+        .next_launch_request("2026-07-02T00:00:00Z")
+        .is_none());
     assert_eq!(
         monitor.inbox_item(42).expect("inbox item").state,
         MonitorInboxState::Queued
@@ -125,7 +129,9 @@ fn monitor_runs_one_active_launch_and_keeps_remaining_items_queued() {
     monitor.record_claimed(issue(42, &["auto-improve"]), "claim-a");
     monitor.record_claimed(issue(43, &["auto-improve"]), "claim-b");
 
-    let first = monitor.next_launch_request().expect("first launch");
+    let first = monitor
+        .next_launch_request("2026-07-02T00:00:00Z")
+        .expect("first launch");
     assert_eq!(first.issue_number, 42);
     assert_eq!(first.branch_name, "work/issue-42");
     assert_eq!(
@@ -133,7 +139,9 @@ fn monitor_runs_one_active_launch_and_keeps_remaining_items_queued() {
         "$gwt-fix-issue #42"
     );
     assert_eq!(monitor.queue_len(), 1);
-    assert!(monitor.next_launch_request().is_none());
+    assert!(monitor
+        .next_launch_request("2026-07-02T00:00:00Z")
+        .is_none());
 
     monitor.complete_active_launch(42, "tab::agent-42");
     assert_eq!(monitor.active_count(), 1);
@@ -142,12 +150,16 @@ fn monitor_runs_one_active_launch_and_keeps_remaining_items_queued() {
         MonitorInboxState::Launched
     );
     assert!(
-        monitor.next_launch_request().is_none(),
+        monitor
+            .next_launch_request("2026-07-02T00:00:00Z")
+            .is_none(),
         "launched work still consumes the configured active capacity"
     );
 
     monitor.set_max_active_agents(2);
-    let second = monitor.next_launch_request().expect("second launch");
+    let second = monitor
+        .next_launch_request("2026-07-02T00:00:00Z")
+        .expect("second launch");
     assert_eq!(second.issue_number, 43);
     assert_eq!(second.branch_name, "work/issue-43");
 }
@@ -164,14 +176,20 @@ fn monitor_allows_active_launches_up_to_configured_max() {
     monitor.record_claimed(issue(43, &["enhancement"]), "claim-b");
     monitor.record_claimed(issue(44, &["question"]), "claim-c");
 
-    let first = monitor.next_launch_request().expect("first launch");
-    let second = monitor.next_launch_request().expect("second launch");
+    let first = monitor
+        .next_launch_request("2026-07-02T00:00:00Z")
+        .expect("first launch");
+    let second = monitor
+        .next_launch_request("2026-07-02T00:00:00Z")
+        .expect("second launch");
 
     assert_eq!(first.issue_number, 42);
     assert_eq!(second.issue_number, 43);
     assert_eq!(monitor.active_count(), 2);
     assert_eq!(monitor.queue_len(), 1);
-    assert!(monitor.next_launch_request().is_none());
+    assert!(monitor
+        .next_launch_request("2026-07-02T00:00:00Z")
+        .is_none());
 }
 
 #[test]
@@ -184,22 +202,26 @@ fn monitor_reorders_queued_issues_without_preempting_active_launches() {
     monitor.record_claimed(issue(42, &["bug"]), "claim-a");
     monitor.record_claimed(issue(43, &["enhancement"]), "claim-b");
     monitor.record_claimed(issue(44, &["question"]), "claim-c");
-    let active = monitor.next_launch_request().expect("active launch");
+    let active = monitor
+        .next_launch_request("2026-07-02T00:00:00Z")
+        .expect("active launch");
     assert_eq!(active.issue_number, 42);
 
     monitor.reorder_queued_issues(&[44, 43, 42]);
 
-    let next = monitor.next_launch_request();
+    let next = monitor.next_launch_request("2026-07-02T00:00:00Z");
     assert!(next.is_none(), "active launch should not be preempted");
     monitor.complete_active_launch(42, "tab::agent-42");
     assert!(
-        monitor.next_launch_request().is_none(),
+        monitor
+            .next_launch_request("2026-07-02T00:00:00Z")
+            .is_none(),
         "launched work should not free the active slot until capacity changes or the work stops"
     );
     monitor.set_max_active_agents(2);
     assert_eq!(
         monitor
-            .next_launch_request()
+            .next_launch_request("2026-07-02T00:00:00Z")
             .expect("next launch")
             .issue_number,
         44
@@ -248,7 +270,9 @@ fn claimed_active_launch_stays_launching_when_scan_refreshes_claim() {
     });
     monitor.set_gui_connected(true);
     monitor.record_claimed(issue(42, &["auto-improve"]), "claim-a");
-    let first = monitor.next_launch_request().expect("launch request");
+    let first = monitor
+        .next_launch_request("2026-07-02T00:00:00Z")
+        .expect("launch request");
     assert_eq!(first.issue_number, 42);
 
     monitor.record_claimed(issue(42, &["auto-improve"]), "claim-a-refresh");
@@ -268,7 +292,9 @@ fn failed_launch_marks_inbox_failed_and_clears_active_launch() {
     });
     monitor.set_gui_connected(true);
     monitor.record_claimed(issue(42, &["auto-improve"]), "claim-a");
-    let first = monitor.next_launch_request().expect("launch request");
+    let first = monitor
+        .next_launch_request("2026-07-02T00:00:00Z")
+        .expect("launch request");
     assert_eq!(first.issue_number, 42);
 
     monitor.record_launch_auth_required("2026-06-23T10:02:00Z");
@@ -305,7 +331,9 @@ fn agent_runtime_failure_marks_launched_issue_failed_and_persists_error() {
     monitor.set_gui_connected(true);
     monitor.record_claimed(issue(42, &["auto-improve"]), "claim-a");
     monitor.record_claimed(issue(43, &["bug"]), "claim-b");
-    let first = monitor.next_launch_request().expect("launch request");
+    let first = monitor
+        .next_launch_request("2026-07-02T00:00:00Z")
+        .expect("launch request");
     assert_eq!(first.issue_number, 42);
     monitor.complete_active_launch(42, "tab::agent-42");
 
@@ -364,7 +392,9 @@ fn agent_runtime_failure_matches_raw_and_combined_window_ids() {
     });
     monitor.set_gui_connected(true);
     monitor.record_claimed(issue(42, &["auto-improve"]), "claim-a");
-    monitor.next_launch_request().expect("launch request");
+    monitor
+        .next_launch_request("2026-07-02T00:00:00Z")
+        .expect("launch request");
     monitor.complete_active_launch(42, "tab-1::agent-42");
 
     let failed_issue = monitor.record_agent_window_failed("agent-42", "Stop-block hit an error");
@@ -390,17 +420,21 @@ fn max_active_increase_allows_more_queued_launches_without_rescan() {
     monitor.record_claimed(issue(43, &["auto-improve"]), "claim-b");
     monitor.record_claimed(issue(44, &["auto-improve"]), "claim-c");
 
-    let first = monitor.next_launch_request().expect("first launch");
+    let first = monitor
+        .next_launch_request("2026-07-02T00:00:00Z")
+        .expect("first launch");
     assert_eq!(first.issue_number, 42);
-    assert!(monitor.next_launch_request().is_none());
+    assert!(monitor
+        .next_launch_request("2026-07-02T00:00:00Z")
+        .is_none());
 
     monitor.set_max_active_agents(3);
 
     let second = monitor
-        .next_launch_request()
+        .next_launch_request("2026-07-02T00:00:00Z")
         .expect("second launch after max increase");
     let third = monitor
-        .next_launch_request()
+        .next_launch_request("2026-07-02T00:00:00Z")
         .expect("third launch after max increase");
     assert_eq!(second.issue_number, 43);
     assert_eq!(third.issue_number, 44);


### PR DESCRIPTION
## Summary

merged 済み PR #3223 への codex / coderabbit review 指摘 3 件（P1×1 / P2×1 / Major×1）の follow-up fix。launching claim の TTL 失効と、GUI/daemon 間の launch 会計統合。

## Changes

1. **daemon の会計分裂（codex P1）**: `merge_inflight_launches_from_disk` を追加し、daemon scan 冒頭で GUI が書いた launching/launched claim を union-merge（memory 既知が優先、削除は既存 control frame で伝播）。over-cap claim と persist による in-flight drop を解消。
2. **unbound claim の slot 永久リーク（codex P2 / coderabbit Major）**: launching entry に `claimed_at` anchor を追加（`next_launch_request` が刻印）。`expire_stale_unbound_launches` が `claim_ttl_secs` 超過の unbound claim を解放して `Queued` に戻す（GitHub claim の TTL 失効とミラー）。GUI handler 冒頭と daemon scan 冒頭の両方で実行。anchor 無しの legacy entry は初回に刻印して時計を開始。
3. **schema 互換**: `launching_issues` は bare id 配列（#3223 初出形）と `{issue_number, claimed_at}` の両形を受理する untagged deserializer（parse 失敗＝`unwrap_or_default` の全 prefs 消失を防止）。

## Testing

- unit 4 件: legacy/timed 両形 parse / TTL 前保持・TTL 後解放+再 claim / bound 対象外 / daemon merge 吸収+persist round-trip
- `next_launch_request(now)` への署名変更に伴う全呼び出し元更新
- fmt / clippy(--workspace -D warnings) / rustdoc(-D warnings): clean
- `cargo test -p gwt-core -p gwt --all-features`: 71 suites / 0 failed

## PR Readiness

State: Ready

- releaseable slice: cap 会計の correctness 補強のみ。既定挙動不変。
- 既知 blocker: なし。
- User Verification Result: n/a（backend のみ）。

## Closing Issues

None

## Related Issues

#3222 / #3165 / #3200

## Checklist

- [x] テスト追加（unit 4）
- [x] fmt / clippy / rustdoc / test 全通過
- [x] commitlint 通過
- [x] User Verification: n/a（backend のみ）
