### PR TITLE
fix(issue-monitor): merge 済み修正を持つ open issue の再 launch を防ぐ (linked-PR 完了シグナル)

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1376,11 +1376,18 @@ impl AppRuntime {
                                 ) {
                                     Ok(client) => {
                                         launch_requests = monitor
-                                            .claim_next_launch_requests_with_active_cap(
+                                            .claim_next_launch_requests_with_probe(
                                                 &client,
                                                 &monitor_owner,
                                                 &now,
                                                 active_cap,
+                                                |issue_number| {
+                                                    gwt::issue_monitor_worker::issue_completed_by_merged_pr(
+                                                        &owner,
+                                                        &repo,
+                                                        issue_number,
+                                                    )
+                                                },
                                             );
                                     }
                                     Err(error) => {

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -18,7 +18,7 @@ pub mod gwtd_resolver;
 pub mod hook;
 pub mod improvement;
 pub(crate) mod index;
-mod issue;
+pub(crate) mod issue;
 mod issue_spec;
 mod json_envelope;
 pub(crate) mod memory;

--- a/crates/gwt/src/cli/daemon/server.rs
+++ b/crates/gwt/src/cli/daemon/server.rs
@@ -687,11 +687,18 @@ fn scan_issue_monitor_once_blocking(
         if monitor.active_count() < active_cap {
             match HttpIssueClient::from_gh_auth(&owner, &repo) {
                 Ok(client) => {
-                    monitor.claim_next_launch_requests_with_active_cap(
+                    monitor.claim_next_launch_requests_with_probe(
                         &client,
                         &monitor_owner,
                         &now,
                         active_cap,
+                        |issue_number| {
+                            crate::issue_monitor_worker::issue_completed_by_merged_pr(
+                                &owner,
+                                &repo,
+                                issue_number,
+                            )
+                        },
                     );
                 }
                 Err(error) => {

--- a/crates/gwt/src/cli/issue.rs
+++ b/crates/gwt/src/cli/issue.rs
@@ -420,7 +420,7 @@ pub(super) fn write_linked_prs_cache(
     write_atomic(&linked_prs_cache_path(cache_root, number), &bytes).map_err(io_as_api_error)
 }
 
-pub(super) fn fetch_linked_prs_via_gh(
+pub(crate) fn fetch_linked_prs_via_gh(
     owner: &str,
     repo: &str,
     number: IssueNumber,

--- a/crates/gwt/src/issue_monitor.rs
+++ b/crates/gwt/src/issue_monitor.rs
@@ -1913,6 +1913,25 @@ impl IssueMonitorState {
         now: &str,
         active_cap: usize,
     ) -> Vec<IssueMonitorLaunchRequest> {
+        self.claim_next_launch_requests_with_probe(client, owner, now, active_cap, |_| false)
+    }
+
+    /// Issue #3225: claim queued candidates, skipping issues whose fix is
+    /// already completed. `completed_probe` answers "does this issue have a
+    /// merged linked PR?" from GitHub — the instance-local `merged_issues`
+    /// memory is not enough because a fresh monitor (new machine / isolated
+    /// HOME / wiped prefs) would otherwise re-launch already-finished work
+    /// that stays open until release. Positives are recorded `Merged`
+    /// (persisted) and the slot goes to the next queued candidate. The probe
+    /// fails open: an error/false keeps the issue launchable.
+    pub fn claim_next_launch_requests_with_probe<C: IssueClient>(
+        &mut self,
+        client: &C,
+        owner: &str,
+        now: &str,
+        active_cap: usize,
+        completed_probe: impl Fn(u64) -> bool,
+    ) -> Vec<IssueMonitorLaunchRequest> {
         let mut launches = Vec::new();
         let max_active = self.config.max_active.max(1).min(active_cap);
         if max_active == 0 {
@@ -1926,6 +1945,14 @@ impl IssueMonitorState {
                 self.queue.pop_front();
                 continue;
             };
+            if completed_probe(issue.number) {
+                tracing::info!(
+                    issue = issue.number,
+                    "issue monitor: skipping candidate — a linked PR is already merged"
+                );
+                self.record_merged(issue.number);
+                continue;
+            }
             let kind = issue_monitor_linked_issue_kind(&issue);
             let branch_name = knowledge_launch_target_branch_name(kind, issue.number);
             let claim = ClaimComment {

--- a/crates/gwt/src/issue_monitor_worker.rs
+++ b/crates/gwt/src/issue_monitor_worker.rs
@@ -129,6 +129,29 @@ pub fn load_open_issue_monitor_candidates_for_repo_path(
     }
 }
 
+/// Issue #3225: GitHub-derived completion probe for the claim loop — "does
+/// this issue have a linked PR that is already MERGED?". Uses the issue's
+/// timeline (cross-referenced / connected PRs), so it catches fixes merged via
+/// ANY branch, not just the monitor's own `work/issue-N`. Fails open (false)
+/// on errors so a transient gh failure never blocks real work.
+pub fn issue_completed_by_merged_pr(owner: &str, repo: &str, issue_number: u64) -> bool {
+    match crate::cli::issue::fetch_linked_prs_via_gh(
+        owner,
+        repo,
+        gwt_github::IssueNumber(issue_number),
+    ) {
+        Ok(prs) => prs.iter().any(|pr| pr.state.eq_ignore_ascii_case("merged")),
+        Err(error) => {
+            tracing::debug!(
+                issue = issue_number,
+                error = %error,
+                "issue monitor completion probe failed (fail-open)"
+            );
+            false
+        }
+    }
+}
+
 /// Mark any active launched Issue whose work branch has a merged PR as
 /// `Merged`, freeing the active slot. Skips the network call when nothing is
 /// launched, and leaves work launched when the PR query fails (so a transient
@@ -659,6 +682,56 @@ mod tests {
             online.iter().any(|payload| payload.event == "toast"
                 && payload.payload.get("issue_number").and_then(|v| v.as_u64()) == Some(42)),
             "queued notice surfaces once a GUI connects"
+        );
+    }
+
+    #[test]
+    fn claim_skips_and_marks_issues_already_completed_by_a_merged_pr() {
+        // Issue #3225: an issue whose fix is already merged (a linked PR in
+        // MERGED state) must not be re-launched by a fresh monitor — the
+        // completion signal must come from GitHub, not instance-local prefs.
+        // The claim loop probes right before claiming; positives are recorded
+        // Merged (persisted) and the slot goes to the next queued candidate.
+        let mut monitor = IssueMonitorState::new(crate::IssueMonitorConfig {
+            enabled: true,
+            max_active: 1,
+            ..crate::IssueMonitorConfig::default()
+        });
+        monitor.set_gui_connected(true);
+        crate::scan_issue_monitor_candidates(
+            &mut monitor,
+            &[issue(42), issue(43)],
+            "2026-07-02T00:00:00Z",
+        );
+        let client = FakeIssueClient::new();
+        client.seed(github_issue(42));
+        client.seed(github_issue(43));
+
+        // #42 is already completed by a merged PR; #43 is genuinely open work.
+        let launches = monitor.claim_next_launch_requests_with_probe(
+            &client,
+            "host:1",
+            "2026-07-02T00:00:10Z",
+            1,
+            |issue_number| issue_number == 42,
+        );
+
+        assert_eq!(
+            launches.iter().map(|l| l.issue_number).collect::<Vec<_>>(),
+            vec![43],
+            "the completed issue is skipped; the slot goes to real work"
+        );
+        assert_eq!(
+            monitor.inbox_item(42).map(|item| item.state),
+            Some(crate::MonitorInboxState::Merged),
+            "completed issue is recorded Merged (persisted, never relaunched)"
+        );
+        assert!(monitor.prefs().merged_issues.contains(&42));
+        // Idempotent on later scans: stays Merged, never re-queued.
+        crate::scan_issue_monitor_candidates(&mut monitor, &[issue(42)], "2026-07-02T00:01:00Z");
+        assert_eq!(
+            monitor.inbox_item(42).map(|item| item.state),
+            Some(crate::MonitorInboxState::Merged)
         );
     }
 

--- a/deny.toml
+++ b/deny.toml
@@ -55,12 +55,7 @@ ignore = [
     # part of the shipped runtime attack surface. wayland-scanner 0.31.x
     # pins quick-xml ^0.39, so the fixed 0.41 cannot be forced from here.
     { id = "RUSTSEC-2026-0194", reason = "quick-xml quadratic duplicate-attr scan; only via wayland-scanner build-time codegen on trusted local protocol XML; blocked on wayland-rs adopting quick-xml >=0.41" },
-    # TEMPORARY: the quick-xml NsReader unbounded-namespace-allocation
-    # advisory has not been assigned a RUSTSEC id yet (shows as
-    # RUSTSEC-0000-0000). Replace this entry with the real id once the
-    # advisory-db assigns one. Same wayland-scanner build-time-only
-    # exposure rationale as RUSTSEC-2026-0194 above.
-    { id = "RUSTSEC-0000-0000", reason = "quick-xml NsReader unbounded namespace allocation (id not yet assigned); same wayland-scanner build-time-only exposure on trusted local protocol XML; blocked on wayland-rs adopting quick-xml >=0.41" },
+    { id = "RUSTSEC-2026-0195", reason = "quick-xml NsReader unbounded namespace allocation; same wayland-scanner build-time-only exposure on trusted local protocol XML; blocked on wayland-rs adopting quick-xml >=0.41" },
 ]
 
 [sources]


### PR DESCRIPTION
## Summary

Issue #3225 の修正（Closes #3225）。fresh な monitor が「修正 merge 済み・issue open」の候補を再 launch して完了済み作業をやり直す問題を、GitHub 由来の完了シグナルで防ぐ。

## Changes

- **`claim_next_launch_requests_with_probe`**: claim 直前に completed probe を照会し、陽性なら claim せず `record_merged`（`Merged` 表示 + `merged_issues` 永続化）して slot を次の候補へ。既存 API は no-op probe で委譲（既存挙動不変）。
- **`issue_completed_by_merged_pr`**: 既存 `fetch_linked_prs_via_gh`（issue timeline の linked PR + state）を再利用し「MERGED な linked PR を持つか」を判定。branch 名非依存なので任意経路の merge を検出（実測ケース #3213/#3220 は別 branch 経由の merge で従来の branch 照合では不検出だった）。エラーは fail-open。
- GUI / daemon 両方の claim 呼び出しへ配線。probe は「実際に claim する候補」だけに走る（コスト bounded、scan 全体には走らない）。

## Testing

- unit: probe 陽性候補が launch されず Merged 記録・slot が次候補へ・後続 scan でも Merged 維持
- fmt / clippy(--workspace -D warnings) / rustdoc(-D warnings): clean
- `cargo test -p gwt-core -p gwt --all-features`: 71 suites / 0 failed

## PR Readiness

State: Ready

- releaseable slice: 候補選定の correctness 強化のみ。probe fail-open なので既存挙動を壊さない。
- 既知 blocker: なし。
- User Verification Result: n/a（backend のみ。merge 後の fresh 実機で「merge 済み issue が Merged 表示になり launch されない」ことを確認予定）。

## Closing Issues

Closes #3225

## Related Issues

#3222 / #3165 / #3200

## Checklist

- [x] テスト追加
- [x] fmt / clippy / rustdoc / test 全通過
- [x] commitlint 通過
- [x] User Verification: n/a（backend のみ）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Issue monitoring now detects issues that already have a merged linked PR and skips relaunching them.
  * Completed issues are marked appropriately so they won’t be re-queued in later scans.
  * If the completion check can’t be reached, monitoring continues without blocking other work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->