### PR TITLE
fix(issue-monitor): 完了 probe を issue を close する merged PR に限定 (codex #3226)

### DIFF
--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -60,11 +60,7 @@ pub struct LinkedPrSummary {
     pub title: String,
     pub state: String,
     pub url: String,
-    /// Issue #3226 review: whether merging this PR closes the issue
-    /// (GraphQL `willCloseTarget`; manually connected PRs count as closing).
-    /// The completion probe must only trust MERGED PRs with this set — a
-    /// merged PR that merely REFERENCES the issue must not mark it done.
-    #[serde(default)]
+    #[serde(default)] // closes-the-issue flag; gates the completion probe (#3226)
     pub will_close_target: bool,
 }
 

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -60,6 +60,12 @@ pub struct LinkedPrSummary {
     pub title: String,
     pub state: String,
     pub url: String,
+    /// Issue #3226 review: whether merging this PR closes the issue
+    /// (GraphQL `willCloseTarget`; manually connected PRs count as closing).
+    /// The completion probe must only trust MERGED PRs with this set — a
+    /// merged PR that merely REFERENCES the issue must not mark it done.
+    #[serde(default)]
+    pub will_close_target: bool,
 }
 
 /// Compact PR check entry used by `pr.checks`.
@@ -811,6 +817,7 @@ mod tests {
                 title: "Enforce coverage".to_string(),
                 state: "OPEN".to_string(),
                 url: pr.url.clone(),
+                will_close_target: true,
             }],
         );
         crate::cli::pr::render_pr(&mut out, &pr);
@@ -878,6 +885,7 @@ mod tests {
             title: "Hook coverage".to_string(),
             state: "MERGED".to_string(),
             url: "https://github.com/akiojin/gwt/pull/9".to_string(),
+            will_close_target: true,
         }];
 
         assert!(

--- a/crates/gwt/src/cli/env/tests.rs
+++ b/crates/gwt/src/cli/env/tests.rs
@@ -249,6 +249,7 @@ fn test_env_records_io_and_pr_side_effects() {
             title: "Coverage".to_string(),
             state: "OPEN".to_string(),
             url: "https://example.test/pr/128".to_string(),
+            will_close_target: true,
         }],
     );
     assert_eq!(

--- a/crates/gwt/src/cli/issue.rs
+++ b/crates/gwt/src/cli/issue.rs
@@ -433,6 +433,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
         nodes {
           __typename
           ... on CrossReferencedEvent {
+            willCloseTarget
             source {
               __typename
               ... on PullRequest {
@@ -490,6 +491,15 @@ query($owner: String!, $repo: String!, $number: Int!) {
 
     let value: serde_json::Value = serde_json::from_str(&output.stdout)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err.to_string()))?;
+    Ok(parse_linked_pr_nodes(&value))
+}
+
+/// Parse the issue-timeline GraphQL response into linked-PR summaries.
+/// `will_close_target` comes from `CrossReferencedEvent.willCloseTarget`;
+/// `ConnectedEvent` (a manually linked PR) closes the issue on merge, so it
+/// counts as closing. Duplicate PR numbers OR-merge the closing flag so a PR
+/// seen as both a plain reference and a closing link keeps `true`.
+pub(crate) fn parse_linked_pr_nodes(value: &serde_json::Value) -> Vec<LinkedPrSummary> {
     let nodes = value
         .get("data")
         .and_then(|v| v.get("repository"))
@@ -500,17 +510,22 @@ query($owner: String!, $repo: String!, $number: Int!) {
         .cloned()
         .unwrap_or_default();
 
-    let mut seen = std::collections::BTreeSet::new();
-    let mut out = Vec::new();
+    let mut index: std::collections::BTreeMap<u64, usize> = std::collections::BTreeMap::new();
+    let mut out: Vec<LinkedPrSummary> = Vec::new();
     for node in nodes {
         let typename = node
             .get("__typename")
             .and_then(|v| v.as_str())
             .unwrap_or_default();
-        let pr = match typename {
-            "CrossReferencedEvent" => node.get("source"),
-            "ConnectedEvent" => node.get("subject"),
-            _ => None,
+        let (pr, will_close_target) = match typename {
+            "CrossReferencedEvent" => (
+                node.get("source"),
+                node.get("willCloseTarget")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false),
+            ),
+            "ConnectedEvent" => (node.get("subject"), true),
+            _ => (None, false),
         };
         let Some(pr) = pr else { continue };
         if pr.get("__typename").and_then(|v| v.as_str()) != Some("PullRequest") {
@@ -519,11 +534,14 @@ query($owner: String!, $repo: String!, $number: Int!) {
         let Some(pr_number) = pr.get("number").and_then(serde_json::Value::as_u64) else {
             continue;
         };
-        if !seen.insert(pr_number) {
+        if let Some(existing) = index.get(&pr_number) {
+            out[*existing].will_close_target |= will_close_target;
             continue;
         }
+        index.insert(pr_number, out.len());
         out.push(LinkedPrSummary {
             number: pr_number,
+            will_close_target,
             title: pr
                 .get("title")
                 .and_then(|v| v.as_str())
@@ -541,7 +559,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
                 .to_string(),
         });
     }
-    Ok(out)
+    out
 }
 
 #[cfg(test)]
@@ -553,6 +571,46 @@ mod tests {
 
     fn s(value: &str) -> String {
         value.to_string()
+    }
+
+    #[test]
+    fn parse_linked_pr_nodes_tracks_will_close_target() {
+        // codex #3226 review: the completion probe must distinguish PRs that
+        // actually CLOSE the issue from mere cross-references.
+        let value = serde_json::json!({"data":{"repository":{"issue":{"timelineItems":{"nodes":[
+            {"__typename":"CrossReferencedEvent","willCloseTarget":true,
+             "source":{"__typename":"PullRequest","number":10,"title":"closes it","state":"MERGED","url":"u10"}},
+            {"__typename":"CrossReferencedEvent","willCloseTarget":false,
+             "source":{"__typename":"PullRequest","number":11,"title":"refs only","state":"MERGED","url":"u11"}},
+            {"__typename":"ConnectedEvent",
+             "subject":{"__typename":"PullRequest","number":12,"title":"manually linked","state":"OPEN","url":"u12"}}
+        ]}}}}});
+        let prs = parse_linked_pr_nodes(&value);
+        let get = |n: u64| prs.iter().find(|pr| pr.number == n).expect("pr");
+        assert!(get(10).will_close_target, "closing cross-reference");
+        assert!(!get(11).will_close_target, "plain reference must NOT close");
+        assert!(
+            get(12).will_close_target,
+            "manually connected PR closes on merge"
+        );
+    }
+
+    #[test]
+    fn parse_linked_pr_nodes_or_merges_duplicate_pr_flags() {
+        // The same PR seen first as a plain reference and later as a closing
+        // link must keep will_close_target=true.
+        let value = serde_json::json!({"data":{"repository":{"issue":{"timelineItems":{"nodes":[
+            {"__typename":"CrossReferencedEvent","willCloseTarget":false,
+             "source":{"__typename":"PullRequest","number":10,"title":"t","state":"MERGED","url":"u"}},
+            {"__typename":"CrossReferencedEvent","willCloseTarget":true,
+             "source":{"__typename":"PullRequest","number":10,"title":"t","state":"MERGED","url":"u"}}
+        ]}}}}});
+        let prs = parse_linked_pr_nodes(&value);
+        assert_eq!(prs.len(), 1);
+        assert!(
+            prs[0].will_close_target,
+            "closing flag OR-merges across events"
+        );
     }
 
     #[test]
@@ -643,6 +701,7 @@ mod tests {
                 title: "Enforce coverage".to_string(),
                 state: "OPEN".to_string(),
                 url: "https://github.com/akiojin/gwt/pull/128".to_string(),
+                will_close_target: true,
             }],
         );
         let linked =

--- a/crates/gwt/src/issue_monitor_worker.rs
+++ b/crates/gwt/src/issue_monitor_worker.rs
@@ -140,7 +140,12 @@ pub fn issue_completed_by_merged_pr(owner: &str, repo: &str, issue_number: u64) 
         repo,
         gwt_github::IssueNumber(issue_number),
     ) {
-        Ok(prs) => prs.iter().any(|pr| pr.state.eq_ignore_ascii_case("merged")),
+        // codex #3226 review: only a PR that actually CLOSES the issue counts
+        // — a merged PR that merely references it (Refs #N / partial work)
+        // must not mark the issue done.
+        Ok(prs) => prs
+            .iter()
+            .any(|pr| pr.will_close_target && pr.state.eq_ignore_ascii_case("merged")),
         Err(error) => {
             tracing::debug!(
                 issue = issue_number,

--- a/crates/gwt/tests/cli_test.rs
+++ b/crates/gwt/tests/cli_test.rs
@@ -1221,6 +1221,7 @@ fn red_102_dispatch_issue_linked_prs_is_cache_first() {
             title: "Cached linked PR".to_string(),
             state: "OPEN".to_string(),
             url: "https://example.com/pr/10".to_string(),
+            will_close_target: true,
         }],
     );
 
@@ -1240,6 +1241,7 @@ fn red_102_dispatch_issue_linked_prs_is_cache_first() {
             title: "Fresh linked PR".to_string(),
             state: "OPEN".to_string(),
             url: "https://example.com/pr/11".to_string(),
+            will_close_target: true,
         }],
     );
 


### PR DESCRIPTION
## Summary

merged 済み PR #3226 への codex / coderabbit review 指摘の follow-up。完了 probe を「issue を実際に close する merged PR」に限定する。

## Changes

- timeline GraphQL に `CrossReferencedEvent.willCloseTarget` を追加し、`LinkedPrSummary.will_close_target` を導入（serde default で cache 互換）。`ConnectedEvent`（手動リンク）は closing 扱い。同一 PR の複数 event は closing flag を OR-merge。
- probe 条件を `will_close_target && MERGED` に限定 — 単なる cross-reference（Refs #N / 部分対応 PR）の merge では issue を完了扱いにしない（誤 record_merged による自動 launch 永久停止を防止）。
- parse を `parse_linked_pr_nodes` として純関数化し unit test 4 観点を追加。

## Testing

- unit: closing / 参照のみ / 手動リンク / duplicate OR-merge + 既存 probe 契約
- fmt / clippy(--workspace -D warnings) / rustdoc: clean
- lib 1306 / bin 692 ほか全 suites PASS

## PR Readiness

State: Ready

- releaseable slice: probe の判定精度強化のみ（保守側へ）。fail-open は不変。
- 既知 blocker: なし。
- User Verification Result: n/a（backend のみ）。

## Closing Issues

None

## Related Issues

#3225 / #3165

## Checklist

- [x] テスト追加
- [x] fmt / clippy / rustdoc / test 全通過
- [x] commitlint 通過
- [x] User Verification: n/a（backend のみ）
