### PR TITLE
fix(issue-monitor): closing keyword 判定に word boundary を要求 (codex/coderabbit #3228)

### DIFF
--- a/crates/gwt/src/cli/issue.rs
+++ b/crates/gwt/src/cli/issue.rs
@@ -583,24 +583,40 @@ pub(crate) fn parse_linked_pr_nodes(
 pub(crate) fn body_closes_issue(body: &str, issue_number: u64) -> bool {
     let needle = format!("#{issue_number}");
     let lower = body.to_lowercase();
+    let bytes = lower.as_bytes();
     for keyword in [
         "close", "closes", "closed", "fix", "fixes", "fixed", "resolve", "resolves", "resolved",
     ] {
         let mut start = 0;
         while let Some(pos) = lower[start..].find(keyword) {
-            let after = start + pos + keyword.len();
+            let begin = start + pos;
+            let after = begin + keyword.len();
+            start = after;
+            // #3228 review: the keyword must stand alone. Without a leading
+            // word boundary, `prefix #42` / `hotfix #42` (fix) and
+            // `disclosed #42` / `enclosed #42` (closed) would count as
+            // closing intent. A trailing boundary is required too so `close`
+            // does not fire inside `closedown #42`-style words (the exact
+            // keywords `closes`/`closed` match via their own entries).
+            let leading_ok = begin == 0 || !bytes[begin - 1].is_ascii_alphanumeric();
+            let trailing_ok = !bytes
+                .get(after)
+                .copied()
+                .is_some_and(|next| next.is_ascii_alphanumeric());
+            if !leading_ok || !trailing_ok {
+                continue;
+            }
             let rest = lower[after..].trim_start_matches([':', ' ', '\t']);
             if rest.starts_with(&needle) {
                 let tail = &rest[needle.len()..];
-                if tail
+                let digit_follows = tail
                     .chars()
                     .next()
-                    .is_none_or(|next| !next.is_ascii_digit())
-                {
+                    .is_some_and(|next| next.is_ascii_digit());
+                if !digit_follows {
                     return true;
                 }
             }
-            start = after;
         }
     }
     false
@@ -655,6 +671,39 @@ mod tests {
             !get(14).will_close_target,
             "closing keyword for a DIFFERENT issue does not count"
         );
+    }
+
+    #[test]
+    fn body_closes_issue_requires_word_boundaries() {
+        // codex/coderabbit #3228 review: `find(keyword)` matched substrings
+        // inside longer words, so `prefix #42` (fix), `disclosed #42` /
+        // `enclosed #42` (closed), `hotfix #42` (fix) all counted as closing.
+        for negative in [
+            "prefix #42",
+            "hotfix #42",
+            "disclosed #42",
+            "enclosed #42",
+            "unfixed #42",
+        ] {
+            assert!(
+                !body_closes_issue(negative, 42),
+                "substring keyword must not close: {negative}"
+            );
+        }
+        for positive in [
+            "Closes #42",
+            "fixes #42",
+            "Fixed: #42",
+            "resolve #42",
+            "- Fix #42 in the parser",
+        ] {
+            assert!(
+                body_closes_issue(positive, 42),
+                "standalone keyword closes: {positive}"
+            );
+        }
+        // Trailing-digit boundary is preserved.
+        assert!(!body_closes_issue("Closes #421", 42));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

merged 済み PR #3228 への codex / coderabbit review 指摘 3 件（word boundary ×2 / MSRV ×1）の follow-up fix。

## Changes

- **word boundary**: `body_closes_issue` の keyword 一致に前後の word boundary を要求。`prefix #42` / `hotfix #42`（fix の部分一致）、`disclosed #42` / `enclosed #42`（closed の部分一致）が完了扱いになる誤検出を排除。
- **MSRV/clippy**: `Option::is_none_or` を `is_some_and` ベースへ書き換え。

## Testing

- unit: 負例 5 種（prefix/hotfix/disclosed/enclosed/unfixed）+ 桁境界（#421）と正例 5 種（Closes/fixes/Fixed:/resolve/文中 Fix）
- fmt / clippy(--workspace -D warnings) / lib 1307: 全 PASS

## PR Readiness

State: Ready

- releaseable slice: 判定精度の保守側修正のみ。
- 既知 blocker: なし。
- User Verification Result: n/a（backend のみ）。

## Closing Issues

None

## Related Issues

#3225 / #3165

## Checklist

- [x] テスト追加
- [x] fmt / clippy / test 全通過
- [x] commitlint 通過
- [x] User Verification: n/a（backend のみ）
