### PR TITLE
feat(intake): SPEC-3214 Phase 1 — ephemeral detached intake worktree の基盤

### DIFF
--- a/.gwt/work/memory.md
+++ b/.gwt/work/memory.md
@@ -7568,3 +7568,10 @@ Type: failure-pattern
 Context: SPEC #3206 PR 作成時、.gwt/work/memory.md の merge conflict を Edit tool で解消した際、old_string に開始マーカーと '=======' だけ含め、develop 側ブロック末尾の閉じマーカー '>>>>>>> origin/develop' を含め忘れた。stray marker が commit/push され、次の merge で HEAD 側がマーカー 1 行だけという見かけ上おかしな conflict として表面化した。
 Learning: conflict 解消を Edit tool で行う場合、<<<<<<< / ======= / >>>>>>> の 3 マーカーが 1 hunk 分すべて old_string に含まれているかを確認する。解消後は必ず grep -n '^<<<<<<<\|^=======$\|^>>>>>>>' <file> で全マーカー不在を検証してから git add する。今回は次 merge の conflict で偶然発覚したが、conflict しなければ stray marker が PR diff に残ったまま merge されていた。
 Future Action: merge conflict 解消の直後に、対象ファイル全体への conflict-marker grep を必ず 1 回実行する（部分表示の Read だけで判断しない）。
+
+## 2026-07-02 — Issue Monitor 多重起動: per-call 再構築 + ACK 再入 + 未永続 claim の合成罠
+
+Type: bug-fix
+Context: Issue #3222: Max=5 で同一 issue が 2〜3 回 spawn（window 10/追跡 5）。fresh 実機ログで再現機序を確定し PR #3223/#3224 で修正。
+Learning: (1)状態機械を handler ごとに disk から再構築する設計では、in-flight（claim 済み・ACK 前）を persist しない限り並行 handler に不可視になり、同一 owner の claim が renewal 扱いで再取得され side effect（spawn）が重複する。(2)非同期 ACK が同じ scan+claim フローに再入する構造は、ACK 連鎖が事実上の driver になり重複を増幅する。ACK/close は Observe（scan 可・claim/launch 禁止）に分離する。(3)refill の駆動源は単一 owner（daemon）に置き、他 process の in-flight は scan 冒頭で disk から union-merge して会計を統合する。(4)persist する in-flight claim には必ず TTL anchor（claimed_at + claim_ttl_secs 失効）を付け、crash 由来の slot 永久リークを防ぐ。(5)schema 進化時は untagged 互換 deserializer を用意（parse 失敗→unwrap_or_default は全 prefs 消失）。(6)テスト注意: crates/gwt/src/app_runtime/tests.rs は bin ターゲット（cargo test -p gwt --bin gwt）であり --lib では走らない。HOME 依存テストは process-global env でなく gwt_core::test_support::ScopedGwtHome（thread-local）を使う。
+Future Action: Issue Monitor に新しい launch/ACK 経路を足すときは (a) claim の即 persist、(b) ACK 経路の Observe 維持、(c) daemon 単一 driver、(d) TTL anchor の4点を必ず守る。app_runtime のテストは --bin gwt で回し、HOME は ScopedGwtHome を使う。

--- a/crates/gwt-agent/src/launch.rs
+++ b/crates/gwt-agent/src/launch.rs
@@ -405,6 +405,14 @@ pub struct LaunchConfig {
     pub docker_lifecycle_intent: DockerLifecycleIntent,
     pub linked_issue_number: Option<u64>,
     pub windows_shell: Option<crate::WindowsShellKind>,
+    /// SPEC-3214: this launch runs in an ephemeral, detached intake worktree
+    /// that is removed when the session ends. `true` routes worktree
+    /// resolution through the detached-worktree path instead of creating a
+    /// branch.
+    pub is_ephemeral: bool,
+    /// Base committish for the ephemeral intake worktree (e.g. `origin/develop`).
+    /// `None` defaults to `HEAD`. Only meaningful when `is_ephemeral` is set.
+    pub ephemeral_base_ref: Option<String>,
 }
 
 /// Permission mode for agent launch.
@@ -461,6 +469,8 @@ pub struct AgentLaunchBuilder {
     docker_lifecycle_intent: DockerLifecycleIntent,
     linked_issue_number: Option<u64>,
     windows_shell: Option<crate::WindowsShellKind>,
+    is_ephemeral: bool,
+    ephemeral_base_ref: Option<String>,
 }
 
 impl AgentLaunchBuilder {
@@ -494,7 +504,17 @@ impl AgentLaunchBuilder {
             docker_lifecycle_intent: DockerLifecycleIntent::Connect,
             linked_issue_number: None,
             windows_shell: None,
+            is_ephemeral: false,
+            ephemeral_base_ref: None,
         }
+    }
+
+    /// SPEC-3214: mark this launch as an ephemeral intake session that runs in
+    /// a detached, throwaway worktree based on `base_ref` (`None` → `HEAD`).
+    pub fn ephemeral(mut self, base_ref: Option<String>) -> Self {
+        self.is_ephemeral = true;
+        self.ephemeral_base_ref = base_ref;
+        self
     }
 
     pub fn custom_agent(mut self, agent: CustomCodingAgent) -> Self {
@@ -790,6 +810,8 @@ impl AgentLaunchBuilder {
             docker_lifecycle_intent: self.docker_lifecycle_intent,
             linked_issue_number: self.linked_issue_number,
             windows_shell: self.windows_shell,
+            is_ephemeral: self.is_ephemeral,
+            ephemeral_base_ref: self.ephemeral_base_ref,
         }
     }
 

--- a/crates/gwt-agent/tests/launch_pipeline_test.rs
+++ b/crates/gwt-agent/tests/launch_pipeline_test.rs
@@ -225,6 +225,8 @@ fn prepare_agent_launch_composes_session_env_without_spawning() {
         docker_lifecycle_intent: DockerLifecycleIntent::Connect,
         linked_issue_number: None,
         windows_shell: None,
+        is_ephemeral: false,
+        ephemeral_base_ref: None,
     };
 
     let mut refreshed_paths = Vec::new();

--- a/crates/gwt-git/src/worktree.rs
+++ b/crates/gwt-git/src/worktree.rs
@@ -216,6 +216,119 @@ impl WorktreeManager {
         Ok(())
     }
 
+    /// Create an ephemeral worktree at `path` with a detached HEAD at
+    /// `base_ref` (SPEC-3214 T-002).
+    ///
+    /// Unlike [`create`](Self::create) / [`create_from_base`](Self::create_from_base)
+    /// this does not create or check out a branch: the intake worktree exists
+    /// only to host a short-lived agent session and is removed when that
+    /// session ends, so it must not leave a branch ref behind.
+    pub fn create_detached(&self, base_ref: &str, path: &Path) -> Result<()> {
+        if path.exists() {
+            return Err(GwtError::Git(format!(
+                "worktree path already exists: {}",
+                path.display()
+            )));
+        }
+
+        let path_arg = path_arg_for_git(path);
+        let output = gwt_core::process::run_git_logged(
+            &["worktree", "add", "--detach", path_arg.as_str(), base_ref],
+            Some(&self.repo_path),
+        )
+        .map_err(|e| GwtError::Git(format!("worktree add --detach: {e}")))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            return Err(GwtError::Git(stderr));
+        }
+
+        Ok(())
+    }
+
+    /// Whether the worktree at `path` has uncommitted changes (tracked or
+    /// untracked, excluding ignored files). SPEC-3214.
+    pub fn is_worktree_dirty(&self, path: &Path) -> Result<bool> {
+        Ok(!crate::diff::get_status(path)?.is_empty())
+    }
+
+    /// Whether an ephemeral intake worktree at `path` holds anything the user
+    /// could lose, so it must NOT be force-removed (SPEC-3214, hardened after
+    /// adversarial review). Stricter than [`Self::is_worktree_dirty`] — a bare
+    /// working-tree check would silently destroy:
+    ///
+    /// * gitignored files the agent wrote (e.g. `tasks/todo.md`, which
+    ///   AGENTS.md mandates, or a scratch `.env`), and
+    /// * commits made on the detached HEAD (they dangle and are gc'd once the
+    ///   worktree — and its HEAD reflog — is removed).
+    ///
+    /// Only gwt-materialized managed assets (`.claude` / `.codex`) and OS
+    /// cruft (`.DS_Store`) are treated as disposable, so a normal intake
+    /// worktree still reaps. Fail-closed callers keep the worktree on `Err`.
+    pub fn ephemeral_worktree_has_local_work(&self, path: &Path) -> Result<bool> {
+        // Tracked changes, untracked files, and ignored files in one pass.
+        let output = gwt_core::process::run_git_logged(
+            &[
+                "status",
+                "--porcelain=v1",
+                "--ignored",
+                "--untracked-files=all",
+            ],
+            Some(path),
+        )
+        .map_err(|e| GwtError::Git(format!("status --ignored: {e}")))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            return Err(GwtError::Git(format!("status --ignored: {stderr}")));
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for line in stdout.lines() {
+            if line.len() < 4 {
+                continue;
+            }
+            // Porcelain v1: two status columns, a space, then the path (a rename
+            // is `old -> new`; the new path after the arrow is what matters).
+            let entry = &line[3..];
+            let entry = entry.rsplit(" -> ").next().unwrap_or(entry);
+            if !is_disposable_worktree_entry(entry) {
+                return Ok(true);
+            }
+        }
+
+        // Commits made on the detached HEAD that no ref reaches would dangle if
+        // the worktree were removed. A pristine intake worktree's HEAD equals
+        // its base ref (reachable from a branch/remote/tag), so this is empty.
+        // NB: `--all` would include this worktree's own detached HEAD (git
+        // exposes per-worktree HEADs to `--all`), hiding the very commits we
+        // must detect — enumerate real refs explicitly instead.
+        let unreachable = gwt_core::process::run_git_logged(
+            &[
+                "rev-list",
+                "--max-count=1",
+                "HEAD",
+                "--not",
+                "--branches",
+                "--tags",
+                "--remotes",
+            ],
+            Some(path),
+        )
+        .map_err(|e| GwtError::Git(format!("rev-list HEAD --not refs: {e}")))?;
+        if unreachable.status.success() {
+            if !String::from_utf8_lossy(&unreachable.stdout)
+                .trim()
+                .is_empty()
+            {
+                return Ok(true);
+            }
+        } else {
+            // Cannot prove the HEAD is reachable — fail closed (keep).
+            return Ok(true);
+        }
+
+        Ok(false)
+    }
+
     /// Create a new worktree at `path`, creating `new_branch` from `base_branch`.
     pub fn create_from_base(&self, base_branch: &str, new_branch: &str, path: &Path) -> Result<()> {
         if path.exists() {
@@ -827,6 +940,27 @@ fn path_arg_for_git(path: &Path) -> String {
 }
 
 /// Parse `git worktree list --porcelain` output into `WorktreeInfo` entries.
+/// SPEC-3214: paths that a `git status --ignored` line may report which are
+/// safe to destroy when reaping an ephemeral intake worktree — gwt-materialized
+/// managed assets (written into every worktree at launch) and OS cruft.
+/// Everything else (a gitignored `tasks/todo.md`, `.env`, `.gwt/draft/…`, any
+/// tracked change) is treated as the user's local work and keeps the worktree.
+fn is_disposable_worktree_entry(entry: &str) -> bool {
+    let entry = entry.trim().trim_matches('"');
+    let entry = entry.strip_prefix("./").unwrap_or(entry);
+    const MANAGED_PREFIXES: &[&str] = &[".claude/", ".codex/"];
+    if entry == ".claude" || entry == ".codex" {
+        return true;
+    }
+    if MANAGED_PREFIXES
+        .iter()
+        .any(|prefix| entry.starts_with(prefix))
+    {
+        return true;
+    }
+    entry == ".DS_Store" || entry.ends_with("/.DS_Store")
+}
+
 fn parse_porcelain_output(output: &str) -> Vec<WorktreeInfo> {
     let mut worktrees = Vec::new();
     let mut path: Option<PathBuf> = None;
@@ -1277,6 +1411,149 @@ prunable gitdir file points to non-existent location
         assert_eq!(
             String::from_utf8_lossy(&branch_output.stdout).trim(),
             "feature/materialized"
+        );
+    }
+
+    #[test]
+    fn create_detached_makes_branchless_worktree_without_new_branch() {
+        // SPEC-3214 T-001: an intake worktree checks out a base ref at a
+        // detached HEAD — no new branch is created (so `git branch` is
+        // unchanged) and `list()` reports the entry with `branch: None`.
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo_path).unwrap();
+        init_git_repo(&repo_path);
+        git_commit_allow_empty(&repo_path, "initial commit");
+        git_checkout_new_branch(&repo_path, "develop");
+
+        let manager = WorktreeManager::new(&repo_path);
+        let branches_before = gwt_core::process::run_git_logged(
+            &["branch", "--format=%(refname:short)"],
+            Some(&repo_path),
+        )
+        .expect("git branch");
+        let before = String::from_utf8_lossy(&branches_before.stdout).to_string();
+
+        let worktree_path = tmp.path().join(".intake-abc123");
+        manager.create_detached("develop", &worktree_path).unwrap();
+
+        assert!(worktree_path.exists(), "intake worktree materialized");
+        // HEAD is detached: `git branch --show-current` prints nothing.
+        let current =
+            gwt_core::process::run_git_logged(&["branch", "--show-current"], Some(&worktree_path))
+                .expect("git branch --show-current");
+        assert!(
+            String::from_utf8_lossy(&current.stdout).trim().is_empty(),
+            "detached worktree has no current branch"
+        );
+        // No new branch ref was created in the repo.
+        let branches_after = gwt_core::process::run_git_logged(
+            &["branch", "--format=%(refname:short)"],
+            Some(&repo_path),
+        )
+        .expect("git branch");
+        assert_eq!(
+            String::from_utf8_lossy(&branches_after.stdout),
+            before,
+            "no new branch is created by an intake worktree"
+        );
+        // list() reports the entry as branchless.
+        let listed = manager.list().expect("worktree list");
+        let entry = listed
+            .iter()
+            .find(|w| w.path.ends_with(".intake-abc123"))
+            .expect("intake worktree present in list");
+        assert!(entry.branch.is_none(), "intake worktree is branchless");
+    }
+
+    #[test]
+    fn ephemeral_worktree_has_local_work_guards_ignored_files_and_detached_commits() {
+        // SPEC-3214 (adversarial review): the teardown safety probe must keep a
+        // worktree that holds ANYTHING the user could lose — not just tracked
+        // working-tree changes. Specifically: gitignored files the agent wrote
+        // (e.g. tasks/todo.md, which AGENTS.md mandates) and commits made on the
+        // detached HEAD. Only gwt-materialized managed assets (.claude/.codex)
+        // are treated as disposable.
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo_path).unwrap();
+        init_git_repo(&repo_path);
+        std::fs::write(
+            repo_path.join(".gitignore"),
+            "tasks/\n.env\n.claude/settings.local.json\n",
+        )
+        .unwrap();
+        gwt_core::process::run_git_logged(&["add", "-A"], Some(&repo_path)).unwrap();
+        git_commit_allow_empty(&repo_path, "seed with gitignore");
+        git_checkout_new_branch(&repo_path, "develop");
+
+        let manager = WorktreeManager::new(&repo_path);
+
+        // 1. Fresh detached intake worktree: nothing to lose → discardable.
+        let fresh = tmp.path().join(".intake-fresh");
+        manager.create_detached("develop", &fresh).unwrap();
+        assert!(
+            !manager.ephemeral_worktree_has_local_work(&fresh).unwrap(),
+            "a pristine intake worktree has no local work"
+        );
+
+        // 2. Only gwt-managed materialized assets present → still discardable.
+        std::fs::create_dir_all(fresh.join(".claude")).unwrap();
+        std::fs::write(fresh.join(".claude/settings.local.json"), "{}").unwrap();
+        std::fs::create_dir_all(fresh.join(".codex/skills")).unwrap();
+        std::fs::write(fresh.join(".codex/skills/x.md"), "managed").unwrap();
+        assert!(
+            !manager.ephemeral_worktree_has_local_work(&fresh).unwrap(),
+            "gwt-materialized .claude/.codex assets are not user work"
+        );
+
+        // 3. A gitignored agent-authored file (tasks/todo.md) → keep.
+        let ignored = tmp.path().join(".intake-ignored");
+        manager.create_detached("develop", &ignored).unwrap();
+        std::fs::create_dir_all(ignored.join("tasks")).unwrap();
+        std::fs::write(ignored.join("tasks/todo.md"), "the agent's working log").unwrap();
+        assert!(
+            manager.ephemeral_worktree_has_local_work(&ignored).unwrap(),
+            "a gitignored agent working log is local work that must not be destroyed"
+        );
+
+        // 4. A commit on the detached HEAD → keep (dangling-commit data loss).
+        let committed = tmp.path().join(".intake-committed");
+        manager.create_detached("develop", &committed).unwrap();
+        std::fs::write(committed.join("finding.txt"), "investigation result").unwrap();
+        gwt_core::process::run_git_logged(&["add", "-A"], Some(&committed)).unwrap();
+        gwt_core::process::run_git_logged(&["commit", "-m", "save"], Some(&committed)).unwrap();
+        assert!(
+            manager
+                .ephemeral_worktree_has_local_work(&committed)
+                .unwrap(),
+            "a commit on the detached intake HEAD must not become a dangling loss"
+        );
+    }
+
+    #[test]
+    fn is_worktree_dirty_reports_uncommitted_changes() {
+        // SPEC-3214 T-005: session-end cleanup keeps a dirty intake worktree
+        // and removes a clean one, so it needs an accurate dirty probe.
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_path = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo_path).unwrap();
+        init_git_repo(&repo_path);
+        git_commit_allow_empty(&repo_path, "initial commit");
+        git_checkout_new_branch(&repo_path, "develop");
+
+        let manager = WorktreeManager::new(&repo_path);
+        let worktree_path = tmp.path().join(".intake-dirty");
+        manager.create_detached("develop", &worktree_path).unwrap();
+
+        assert!(
+            !manager.is_worktree_dirty(&worktree_path).unwrap(),
+            "a freshly created intake worktree is clean"
+        );
+        std::fs::write(worktree_path.join("scratch.txt"), "wip").unwrap();
+        assert!(
+            manager.is_worktree_dirty(&worktree_path).unwrap(),
+            "an untracked file makes the worktree dirty"
         );
     }
 

--- a/crates/gwt/src/app_runtime/launch.rs
+++ b/crates/gwt/src/app_runtime/launch.rs
@@ -33,8 +33,8 @@ use super::{
     apply_docker_runtime_to_launch_config, apply_host_package_runner_fallback_checked,
     apply_windows_host_shell_wrapper, combined_window_id, detect_shell_program,
     finalize_docker_agent_launch_config, geometry_to_pty_size, install_launch_gwt_bin_env,
-    launch_output_mirror, mark_auto_resume_source_completed, normalize_branch_name,
-    refresh_managed_gwt_assets_for_agent_with_codex_hook_discovery_mode,
+    is_ephemeral_intake_worktree, launch_output_mirror, mark_auto_resume_source_completed,
+    normalize_branch_name, refresh_managed_gwt_assets_for_agent_with_codex_hook_discovery_mode,
     resolve_docker_launch_plan, resolve_launch_spec_with_fallback, resolve_launch_worktree,
     save_resumed_workspace_projection, save_start_work_workspace_projection, ActiveAgentSession,
     AgentKanbanLaunchTarget, AppEventProxy, AppRuntime, BackendEvent, HookForwardTarget,
@@ -1842,6 +1842,21 @@ impl AppRuntime {
         let Some(session) = self.active_agent_sessions.remove(window_id) else {
             return;
         };
+        // SPEC-3214 (FR-002 / T-005 / T-007): an ephemeral intake session runs
+        // in a throwaway detached `.intake-*` worktree and produces NO Work
+        // identity. On session end, remove the worktree when clean; keep it
+        // when dirty so uncommitted work is never lost. Skip the Paused-Work /
+        // projection persistence entirely.
+        if is_ephemeral_intake_worktree(&session.worktree_path) {
+            self.finalize_ephemeral_intake_worktree(&session);
+            let _ = gwt_agent::persist_session_status(
+                &self.sessions_dir,
+                &session.session_id,
+                gwt_agent::AgentStatus::Stopped,
+            );
+            self.launch_wizard_cache.mark_stopped(&session.session_id);
+            return;
+        }
         if let Some(project_root) = self
             .tab(&session.tab_id)
             .map(|tab| tab.project_root.clone())
@@ -1870,6 +1885,48 @@ impl AppRuntime {
             gwt_agent::AgentStatus::Stopped,
         );
         self.launch_wizard_cache.mark_stopped(&session.session_id);
+    }
+
+    /// SPEC-3214 (FR-002): tear down an ephemeral intake worktree when its
+    /// session ends. A clean worktree is force-removed; a dirty one is kept and
+    /// logged so uncommitted work is never destroyed (the user-facing retention
+    /// notice ships with the intake UI in a later phase).
+    fn finalize_ephemeral_intake_worktree(&self, session: &ActiveAgentSession) {
+        let worktree_path = session.worktree_path.as_path();
+        let main_repo_path = self
+            .tab(&session.tab_id)
+            .map(|tab| tab.project_root.clone())
+            .and_then(|root| gwt_git::worktree::main_worktree_root(&root).ok())
+            .unwrap_or_else(|| worktree_path.to_path_buf());
+        let manager = gwt_git::WorktreeManager::new(&main_repo_path);
+
+        match manager.ephemeral_worktree_has_local_work(worktree_path) {
+            Ok(true) => {
+                tracing::warn!(
+                    worktree_path = %worktree_path.display(),
+                    "ephemeral intake worktree has local work (changes, ignored files, or commits); keeping it so nothing is lost"
+                );
+                return;
+            }
+            Ok(false) => {}
+            Err(error) => {
+                // Fail closed: if we cannot prove the worktree is empty, keep it.
+                tracing::warn!(
+                    worktree_path = %worktree_path.display(),
+                    error = %error,
+                    "could not determine intake worktree cleanliness; keeping it"
+                );
+                return;
+            }
+        }
+
+        if let Err(error) = manager.remove_force(worktree_path) {
+            tracing::warn!(
+                worktree_path = %worktree_path.display(),
+                error = %error,
+                "failed to remove clean ephemeral intake worktree"
+            );
+        }
     }
 
     /// SPEC-2359 Phase W-12 Slice 5a (FR-350): record a Pause work event for a

--- a/crates/gwt/src/app_runtime/startup.rs
+++ b/crates/gwt/src/app_runtime/startup.rs
@@ -21,12 +21,15 @@
 use std::path::Path;
 
 use super::{
-    combined_window_id, launch_config_from_persisted_session, same_worktree_path,
-    should_auto_start_restored_window, workspace_resume_context_for_work_item, AppRuntime,
-    HookForwardTarget, OutboundEvent, PendingStartupAutoResumeSession, WindowGeometry,
+    combined_window_id, launch_config_from_persisted_session, prune_orphan_intake_worktrees,
+    same_worktree_path, should_auto_start_restored_window, workspace_resume_context_for_work_item,
+    AppRuntime, HookForwardTarget, OutboundEvent, PendingStartupAutoResumeSession, WindowGeometry,
     WindowPreset, WindowProcessStatus, WorkspaceResumeContext,
 };
 
+/// SPEC-3214 T-006: per-repo cap on orphaned intake worktrees reaped per
+/// startup so a pathological pile-up cannot stall boot.
+const MAX_STARTUP_INTAKE_PRUNE: usize = 32;
 const STARTUP_AUTO_RESUME_STALE_AFTER_SECS: i64 = 24 * 60 * 60;
 const STARTUP_AUTO_RESUME_STACK_OFFSET_X: f64 = 28.0;
 const STARTUP_AUTO_RESUME_STACK_OFFSET_Y: f64 = 24.0;
@@ -139,6 +142,18 @@ impl AppRuntime {
             let _ = gwt_core::workspace_projection::reset_legacy_agent_identity_for_repo(
                 &tab.project_root,
             );
+            // SPEC-3214 T-006: reap ephemeral `.intake-*` worktrees orphaned by
+            // a crash (no intake session is live at startup). Clean ones are
+            // removed; dirty ones are kept. Bounded so a pile-up cannot stall
+            // startup.
+            let pruned = prune_orphan_intake_worktrees(&tab.project_root, MAX_STARTUP_INTAKE_PRUNE);
+            if pruned > 0 {
+                tracing::info!(
+                    project_root = %tab.project_root.display(),
+                    pruned,
+                    "reaped orphaned ephemeral intake worktrees on startup"
+                );
+            }
         }
 
         self.queue_startup_auto_resume_sessions();

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -6929,6 +6929,106 @@ fn app_runtime_active_work_projection_retains_stopped_agent_work_as_paused() {
     assert_eq!(paused.branch.as_deref(), Some("work/paused"));
 }
 
+// SPEC-3214 T-005/T-007: an ephemeral intake session leaves NO Work identity
+// and its throwaway `.intake-*` worktree is removed when it ends (clean), while
+// a dirty intake worktree is kept so no in-progress work is lost.
+#[test]
+fn ephemeral_intake_session_stop_removes_clean_worktree_and_emits_no_paused_work() {
+    let _env_lock = env_test_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let temp = tempdir().expect("tempdir");
+    let _home = ScopedEnvVar::set("HOME", temp.path());
+    let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+    let repo = temp.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    init_repo(&repo);
+    run_git(&repo, &["config", "user.email", "test@example.com"]);
+    run_git(&repo, &["config", "user.name", "Test User"]);
+    run_git(&repo, &["commit", "--allow-empty", "-m", "init"]);
+
+    let intake = temp.path().join(".intake-clean");
+    gwt_git::WorktreeManager::new(&repo)
+        .create_detached("HEAD", &intake)
+        .expect("intake worktree");
+    assert!(intake.exists());
+
+    let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+    let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+    let mut session = sample_active_agent_session("tab-1", "tab-1::intake");
+    session.session_id = "session-intake".to_string();
+    session.branch_name = String::new();
+    session.worktree_path = intake.clone();
+    session.window_id = "tab-1::intake".to_string();
+    runtime
+        .active_agent_sessions
+        .insert("tab-1::intake".to_string(), session);
+
+    runtime.mark_agent_session_stopped("tab-1::intake");
+
+    assert!(!runtime.active_agent_sessions.contains_key("tab-1::intake"));
+    assert!(
+        !intake.exists(),
+        "clean intake worktree is removed when the session ends"
+    );
+    let active_work_count = runtime
+        .active_work_projection_for_tab("tab-1", &runtime.tabs[0])
+        .map(|view| view.active_works.len())
+        .unwrap_or(0);
+    assert_eq!(
+        active_work_count, 0,
+        "an ephemeral intake session emits no Work identity (paused or otherwise)"
+    );
+    let recorded = gwt_core::workspace_projection::load_workspace_work_items(&repo)
+        .ok()
+        .flatten();
+    assert!(
+        recorded.is_none_or(|projection| projection.work_items.is_empty()),
+        "no Work event is recorded for an ephemeral intake session"
+    );
+}
+
+#[test]
+fn ephemeral_intake_session_stop_keeps_dirty_worktree() {
+    let _env_lock = env_test_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let temp = tempdir().expect("tempdir");
+    let _home = ScopedEnvVar::set("HOME", temp.path());
+    let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+    let repo = temp.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    init_repo(&repo);
+    run_git(&repo, &["config", "user.email", "test@example.com"]);
+    run_git(&repo, &["config", "user.name", "Test User"]);
+    run_git(&repo, &["commit", "--allow-empty", "-m", "init"]);
+
+    let intake = temp.path().join(".intake-dirty");
+    gwt_git::WorktreeManager::new(&repo)
+        .create_detached("HEAD", &intake)
+        .expect("intake worktree");
+    // Uncommitted work must not be destroyed.
+    fs::write(intake.join("wip.txt"), "unsaved intake work").expect("write wip");
+
+    let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+    let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+    let mut session = sample_active_agent_session("tab-1", "tab-1::intake");
+    session.session_id = "session-intake-dirty".to_string();
+    session.branch_name = String::new();
+    session.worktree_path = intake.clone();
+    session.window_id = "tab-1::intake".to_string();
+    runtime
+        .active_agent_sessions
+        .insert("tab-1::intake".to_string(), session);
+
+    runtime.mark_agent_session_stopped("tab-1::intake");
+
+    assert!(
+        intake.exists() && intake.join("wip.txt").exists(),
+        "a dirty intake worktree is kept so uncommitted work is never lost"
+    );
+}
+
 // #3065: a stopped session's Pause record must not inherit the repo-shared
 // projection's owner/title — those belong to whatever Work last wrote the
 // projection. Owner/summary come from the session's own Work item (matched

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -171,16 +171,112 @@ pub fn resolve_launch_worktree_request(
     Ok(())
 }
 
+/// Resolve a working directory for an ephemeral intake launch (SPEC-3214
+/// T-004): materialize a detached `.intake-*` worktree at `base_ref` and set
+/// `working_dir`. Unlike [`resolve_launch_worktree_request`] this never creates
+/// a branch — the intake worktree hosts a short-lived session and is removed
+/// when the session ends. `working_dir` already set is a no-op (idempotent /
+/// reuse). Collisions with existing worktrees are avoided by suffixing.
+pub fn resolve_ephemeral_launch_worktree(
+    repo_path: &Path,
+    base_ref: Option<&str>,
+    working_dir: &mut Option<PathBuf>,
+    env_vars: &mut HashMap<String, String>,
+) -> Result<(), String> {
+    if working_dir.is_some() {
+        return Ok(());
+    }
+
+    let main_repo_path =
+        gwt_git::worktree::main_worktree_root(repo_path).map_err(|err| err.to_string())?;
+    let manager = gwt_git::WorktreeManager::new(&main_repo_path);
+    let worktrees = manager.list().map_err(|err| err.to_string())?;
+
+    let layout_root = main_repo_path.parent().unwrap_or(main_repo_path.as_path());
+    let preferred_path = layout_root.join(INTAKE_WORKTREE_PREFIX);
+    let worktree_path = first_available_worktree_path(&preferred_path, &worktrees)
+        .ok_or_else(|| "failed to resolve available intake worktree path".to_string())?;
+
+    // Default to HEAD: `git worktree add --detach <path> HEAD` always resolves
+    // in a repo with commits. Callers (Phase 3 intake launch) pass an explicit
+    // base ref such as `origin/develop` when they need a specific base.
+    let base_ref = base_ref.unwrap_or("HEAD");
+    manager
+        .create_detached(base_ref, &worktree_path)
+        .map_err(|err| err.to_string())?;
+
+    set_worktree_launch_path(working_dir, env_vars, &worktree_path);
+    Ok(())
+}
+
 fn is_start_work_branch_name(branch_name: &str) -> bool {
     branch_name
         .strip_prefix("work/")
         .is_some_and(|name| !name.is_empty())
 }
 
+/// Reap orphaned ephemeral intake worktrees at startup (SPEC-3214 T-006).
+///
+/// A crash between an intake launch and its session-end cleanup leaves a
+/// detached `.intake-*` worktree behind. On startup no intake session is live,
+/// so every `.intake-*` worktree is an orphan: remove the clean ones and keep
+/// the dirty ones (uncommitted work is never destroyed). Bounded by
+/// `max_removals` so a pathological pile-up cannot stall startup. Returns the
+/// number removed. Never errors — best-effort recovery.
+pub fn prune_orphan_intake_worktrees(repo_path: &Path, max_removals: usize) -> usize {
+    let Ok(main_repo_path) = gwt_git::worktree::main_worktree_root(repo_path) else {
+        return 0;
+    };
+    let manager = gwt_git::WorktreeManager::new(&main_repo_path);
+    let Ok(worktrees) = manager.list() else {
+        return 0;
+    };
+
+    let mut removed = 0;
+    for worktree in worktrees {
+        if removed >= max_removals {
+            break;
+        }
+        if !is_ephemeral_intake_worktree(&worktree.path) {
+            continue;
+        }
+        match manager.ephemeral_worktree_has_local_work(&worktree.path) {
+            Ok(false) => {
+                if manager.remove_force(&worktree.path).is_ok() {
+                    removed += 1;
+                }
+            }
+            // Has local work or unknown → keep it (fail closed).
+            _ => {
+                tracing::warn!(
+                    worktree_path = %worktree.path.display(),
+                    "keeping orphaned intake worktree with local work (changes, ignored files, or commits)"
+                );
+            }
+        }
+    }
+    if removed > 0 {
+        let _ = manager.prune();
+    }
+    removed
+}
+
 pub fn resolve_launch_worktree(
     repo_path: &Path,
     config: &mut gwt_agent::LaunchConfig,
 ) -> Result<(), String> {
+    // SPEC-3214: an ephemeral intake launch resolves a detached throwaway
+    // worktree instead of creating/reusing a branch worktree.
+    if config.is_ephemeral {
+        resolve_ephemeral_launch_worktree(
+            repo_path,
+            config.ephemeral_base_ref.as_deref(),
+            &mut config.working_dir,
+            &mut config.env_vars,
+        )?;
+        normalize_launch_config_working_dir(config);
+        return Ok(());
+    }
     let mut base_branch = config.base_branch.clone();
     resolve_launch_worktree_request(
         repo_path,

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -92,13 +92,13 @@ use embedded_server::{ClientHub, EmbeddedServer};
 pub(crate) use launch_runtime::{
     apply_host_package_runner_fallback_checked, apply_windows_host_shell_wrapper,
     build_shell_process_launch, ensure_docker_launch_runtime_ready, install_launch_gwt_bin_env,
-    resolve_launch_worktree, resolve_shell_launch_worktree,
+    prune_orphan_intake_worktrees, resolve_launch_worktree, resolve_shell_launch_worktree,
 };
 #[cfg(test)]
 pub(crate) use launch_runtime::{
     apply_host_package_runner_fallback_with_probe, command_matches_runner,
     install_launch_gwt_bin_env_with_lookup, probe_host_package_runner_with_timeout,
-    resolve_launch_worktree_request,
+    resolve_ephemeral_launch_worktree, resolve_launch_worktree_request,
 };
 #[cfg(test)]
 pub(crate) use runtime_support::{
@@ -109,11 +109,12 @@ pub(crate) use runtime_support::{
     attach_parent_console_for_cli, close_window_from_workspace, combined_window_id,
     current_git_branch, dedupe_recent_projects, fallback_project_target,
     first_available_worktree_path, front_door_route, geometry_to_pty_size,
-    knowledge_kind_for_preset, local_branch_exists, normalize_active_tab_id, normalize_branch_name,
-    normalize_recent_project_path, normalize_recent_projects, origin_remote_ref,
-    prune_missing_recent_projects, resolve_launch_spec_with_fallback, resolve_project_target,
-    run_cli, same_worktree_path, should_auto_close_agent_window, should_auto_start_restored_window,
-    synthetic_branch_entry, usable_worktree_path_for_branch, worktrees_have_stale_branch_entry,
+    is_ephemeral_intake_worktree, knowledge_kind_for_preset, local_branch_exists,
+    normalize_active_tab_id, normalize_branch_name, normalize_recent_project_path,
+    normalize_recent_projects, origin_remote_ref, prune_missing_recent_projects,
+    resolve_launch_spec_with_fallback, resolve_project_target, run_cli, same_worktree_path,
+    should_auto_close_agent_window, should_auto_start_restored_window, synthetic_branch_entry,
+    usable_worktree_path_for_branch, worktrees_have_stale_branch_entry, INTAKE_WORKTREE_PREFIX,
 };
 pub(crate) use update_front_door::{apply_update_state_and_exit, spawn_startup_update_check};
 #[cfg(test)]
@@ -5755,6 +5756,107 @@ mod tests {
             .expect("tokio runtime")
             .block_on(super::health_handler());
         assert_eq!(health, "ok");
+    }
+
+    #[test]
+    fn prune_orphan_intake_worktrees_removes_clean_keeps_dirty_and_is_bounded() {
+        // SPEC-3214 T-006: on startup, `.intake-*` worktrees left by a crash
+        // are reaped — clean ones removed, dirty ones kept, capped per run.
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        init_git_clone_with_origin(&repo);
+        let manager = gwt_git::WorktreeManager::new(&repo);
+
+        let clean_a = temp.path().join(".intake-a");
+        let clean_b = temp.path().join(".intake-b");
+        let dirty = temp.path().join(".intake-dirty");
+        for path in [&clean_a, &clean_b, &dirty] {
+            manager
+                .create_detached("HEAD", path)
+                .expect("intake worktree");
+        }
+        fs::write(dirty.join("wip.txt"), "unsaved").expect("dirty file");
+
+        let removed = super::prune_orphan_intake_worktrees(&repo, 10);
+        assert_eq!(removed, 2, "both clean intake worktrees pruned");
+        assert!(
+            !clean_a.exists() && !clean_b.exists(),
+            "clean intake pruned"
+        );
+        assert!(
+            dirty.exists() && dirty.join("wip.txt").exists(),
+            "dirty intake kept — never destroy uncommitted work"
+        );
+
+        // Bounded: a second batch of clean intakes is capped at the limit.
+        let clean_c = temp.path().join(".intake-c");
+        let clean_d = temp.path().join(".intake-d");
+        for path in [&clean_c, &clean_d] {
+            manager
+                .create_detached("HEAD", path)
+                .expect("intake worktree");
+        }
+        let removed_bounded = super::prune_orphan_intake_worktrees(&repo, 1);
+        assert_eq!(removed_bounded, 1, "prune is bounded per run");
+    }
+
+    #[test]
+    fn resolve_ephemeral_launch_worktree_creates_detached_intake_worktree() {
+        // SPEC-3214 T-003: an ephemeral intake launch materializes a detached
+        // `.intake-*` worktree (no branch) and sets working_dir; the existing
+        // branch-based launch path is untouched.
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        init_git_clone_with_origin(&repo);
+
+        let mut working_dir = None;
+        let mut env_vars = HashMap::new();
+        super::resolve_ephemeral_launch_worktree(
+            &repo,
+            Some("develop"),
+            &mut working_dir,
+            &mut env_vars,
+        )
+        .expect("ephemeral intake worktree resolves");
+
+        let intake_dir = working_dir.expect("intake working_dir set");
+        assert!(intake_dir.exists(), "intake worktree materialized");
+        assert!(
+            intake_dir
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with(".intake")),
+            "intake worktree uses the .intake-* layout: {}",
+            intake_dir.display()
+        );
+        assert!(env_vars
+            .get("GWT_PROJECT_ROOT")
+            .is_some_and(|value| super::same_worktree_path(Path::new(value), &intake_dir)));
+
+        // Detached HEAD: no current branch.
+        let current =
+            gwt_core::process::run_git_logged(&["branch", "--show-current"], Some(&intake_dir))
+                .expect("git branch --show-current");
+        assert!(
+            String::from_utf8_lossy(&current.stdout).trim().is_empty(),
+            "intake worktree is detached (branchless)"
+        );
+
+        // A second concurrent intake launch avoids the occupied path.
+        let mut second_dir = None;
+        let mut second_env = HashMap::new();
+        super::resolve_ephemeral_launch_worktree(
+            &repo,
+            Some("develop"),
+            &mut second_dir,
+            &mut second_env,
+        )
+        .expect("second ephemeral intake worktree resolves");
+        let second_dir = second_dir.expect("second intake working_dir");
+        assert_ne!(
+            second_dir, intake_dir,
+            "collision avoided for concurrent intake"
+        );
     }
 
     #[test]

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -376,6 +376,24 @@ pub fn usable_worktree_entry(worktree: &gwt_git::WorktreeInfo) -> bool {
     !worktree.prunable && worktree.path.exists()
 }
 
+/// SPEC-3214: filename stem for ephemeral intake worktrees. Placed as a
+/// sibling of the main worktree (`<layout_root>/.intake`, suffixed on
+/// collision) so it is easy to recognize and prune.
+pub const INTAKE_WORKTREE_PREFIX: &str = ".intake";
+
+/// Whether `path` is an ephemeral intake worktree created by
+/// [`crate::launch_runtime::resolve_ephemeral_launch_worktree`] — i.e. its
+/// file name is `.intake` or `.intake-<n>`. Session-end cleanup and orphan
+/// pruning key off this so they never touch a real branch worktree.
+pub fn is_ephemeral_intake_worktree(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| {
+            name == INTAKE_WORKTREE_PREFIX
+                || name.starts_with(&format!("{INTAKE_WORKTREE_PREFIX}-"))
+        })
+}
+
 pub fn first_available_worktree_path(
     preferred_path: &Path,
     worktrees: &[gwt_git::WorktreeInfo],


### PR DESCRIPTION
## Summary

SPEC-3214 Phase 1 — intake（Issue 登録・調査）を throwaway な **detached intake worktree** で完結させる基盤（FR-001/002/003/012）。Issue Monitor が起動時のみブランチを materialize する運用になり、intake 用の永続ブランチが不要になったことに対応。

## Changes

- **gwt-git worktree.rs**: `create_detached(base_ref, path)`（`git worktree add --detach`、ブランチ ref を残さない）+ teardown 安全判定 `ephemeral_worktree_has_local_work`。
- **gwt-agent LaunchConfig**: `is_ephemeral` / `ephemeral_base_ref` + `builder.ephemeral()`。
- **gwt launch_runtime.rs**: `resolve_ephemeral_launch_worktree`（`.intake-*` detached worktree 作成 + working_dir 設定、衝突は first_available で回避）、`resolve_launch_worktree` が `config.is_ephemeral` で dispatch（**既存 branch 経路は不変**）、`prune_orphan_intake_worktrees`（起動時に孤児 `.intake-*` を bounded 回収）。
- **app_runtime**: `mark_agent_session_stopped` が ephemeral session を検出 → `finalize_ephemeral_intake_worktree`（安全なら削除・危険なら保持）、Paused Work / projection 非生成（Work identity 非発生）。bootstrap で per-tab orphan prune。

## データ喪失防止（敵対的 review workflow で確定した 3 件を反映）

PR 前に多レンズ + 敵対検証の review workflow（21 agents）を実施し、**実データ喪失バグ 3 件（critical 1・high 2）を検出→修正**:
1. **CRITICAL**: `git status --porcelain` は gitignore 対象を clean 扱いするため、AGENTS.md が書けと指示する `tasks/todo.md` や `.env` が `remove_force` で消える。
2. **HIGH**: detached HEAD 上の commit は working tree clean のため削除で dangling commit 化・gc 消失。

→ teardown の「破棄安全」判定を `ephemeral_worktree_has_local_work` に集約し、(a) gitignore 対象の agent 生成物と (b) detached HEAD の到達不能 commit も「保持」に含める。gwt が全 worktree に materialize する `.claude`/`.codex` の managed asset と `.DS_Store` のみ disposable 扱いとして never-reaping を回避。到達性判定は `--all`（worktree の detached HEAD を含む罠）を避け `--branches --tags --remotes` を列挙。

## Scope / Rollback

- Phase 1 は**基盤のみで user-visible な挙動を追加しない**。ephemeral 起動を production で発火させる導線（intake palette）は **Phase 3** で配線。orphan prune は起動毎に走るが `.intake-*` が存在しなければ no-op。
- dirty 保持時の user-facing toast は intake UI と共に Phase 3 で追加。
- rollback は本 PR 単独 revert で安全（後続 phase は未マージ）。

## Testing

- `create_detached`（branchless・no new branch・list branch:None）
- `ephemeral_worktree_has_local_work`（fresh / managed-only / gitignored 生成物 / detached commit の 4 分岐）
- `resolve_ephemeral_launch_worktree`（.intake-* 作成・working_dir・衝突回避）
- session-end（clean 削除・dirty 保持・Work 非生成）+ orphan prune（clean 回収・dirty 保持・bounded）
- fmt / clippy(--workspace -D warnings) / rustdoc(-D warnings) / `cargo test -p gwt-core -p gwt -p gwt-git -p gwt-agent --all-features`: **78 suites / 0 failed**

## PR Readiness

State: Ready（additive foundation・user-visible 挙動なし）

- User Verification Result: **n/a**（backend のみ。UI 導線は Phase 3）。

## Related SPEC

SPEC #3214（Phase 1 / 5）

## Checklist

- [x] TDD（RED→GREEN）
- [x] 敵対的 review の confirmed findings 反映
- [x] fmt / clippy / rustdoc / test 全通過
- [x] commitlint 通過
- [x] User Verification: n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for short-lived “intake” worktrees for sessions that start in a detached state.
  * Launches can now create isolated intake worktrees without reusing a branch-based workspace.

* **Bug Fixes**
  * Prevents accidental loss of in-progress changes by keeping intake worktrees when local work is detected.
  * Cleans up empty orphaned intake worktrees on startup, while preserving dirty or uncertain ones.
  * Improves handling of repeated intake launches by avoiding path collisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->