### PR TITLE
fix(intake): ephemeral 判定の誤検出を修正 — user の .claude/.codex 内容と .intake 名 branch worktree を保護 (codex #3235)

### DIFF
--- a/crates/gwt-git/src/worktree.rs
+++ b/crates/gwt-git/src/worktree.rs
@@ -941,23 +941,28 @@ fn path_arg_for_git(path: &Path) -> String {
 
 /// Parse `git worktree list --porcelain` output into `WorktreeInfo` entries.
 /// SPEC-3214: paths that a `git status --ignored` line may report which are
-/// safe to destroy when reaping an ephemeral intake worktree — gwt-materialized
-/// managed assets (written into every worktree at launch) and OS cruft.
-/// Everything else (a gitignored `tasks/todo.md`, `.env`, `.gwt/draft/…`, any
-/// tracked change) is treated as the user's local work and keeps the worktree.
+/// safe to destroy when reaping an ephemeral intake worktree. These are ONLY
+/// gwt's own materialized managed assets — the exact patterns gwt writes into
+/// every worktree's `.git/info/exclude` (see `gwt-skills` `git_exclude.rs`:
+/// `.claude/skills/gwt-*`, `.claude/commands/gwt-*`, `.claude/settings.local.json`,
+/// `.codex/skills/gwt-*`) — plus OS cruft. Everything else is the user's local
+/// work and keeps the worktree: a gitignored `tasks/todo.md` / `.env`, anything
+/// under `.gwt/`, a user-authored `.claude/skills/<custom>` or a
+/// `.claude/settings.json` edit (codex #3235 review), and any tracked change.
 fn is_disposable_worktree_entry(entry: &str) -> bool {
     let entry = entry.trim().trim_matches('"');
     let entry = entry.strip_prefix("./").unwrap_or(entry);
-    const MANAGED_PREFIXES: &[&str] = &[".claude/", ".codex/"];
-    if entry == ".claude" || entry == ".codex" {
-        return true;
-    }
-    if MANAGED_PREFIXES
-        .iter()
-        .any(|prefix| entry.starts_with(prefix))
+
+    // gwt-managed skill / command dirs are prefixed `gwt-`; git may report the
+    // collapsed dir (`.claude/skills/gwt-coordination/`) or individual files.
+    if entry.starts_with(".claude/skills/gwt-")
+        || entry.starts_with(".claude/commands/gwt-")
+        || entry.starts_with(".codex/skills/gwt-")
+        || entry == ".claude/settings.local.json"
     {
         return true;
     }
+
     entry == ".DS_Store" || entry.ends_with("/.DS_Store")
 }
 
@@ -1478,9 +1483,10 @@ prunable gitdir file points to non-existent location
         let repo_path = tmp.path().join("repo");
         std::fs::create_dir_all(&repo_path).unwrap();
         init_git_repo(&repo_path);
+        // Mirror gwt's managed-asset exclude patterns (git_exclude.rs).
         std::fs::write(
             repo_path.join(".gitignore"),
-            "tasks/\n.env\n.claude/settings.local.json\n",
+            "tasks/\n.env\n.claude/skills/gwt-*\n.claude/commands/gwt-*\n.claude/settings.local.json\n.codex/skills/gwt-*\n",
         )
         .unwrap();
         gwt_core::process::run_git_logged(&["add", "-A"], Some(&repo_path)).unwrap();
@@ -1497,14 +1503,55 @@ prunable gitdir file points to non-existent location
             "a pristine intake worktree has no local work"
         );
 
-        // 2. Only gwt-managed materialized assets present → still discardable.
-        std::fs::create_dir_all(fresh.join(".claude")).unwrap();
+        // 2. Only gwt-materialized managed assets present → still discardable.
+        std::fs::create_dir_all(fresh.join(".claude/skills/gwt-coordination")).unwrap();
+        std::fs::write(
+            fresh.join(".claude/skills/gwt-coordination/SKILL.md"),
+            "managed",
+        )
+        .unwrap();
+        std::fs::create_dir_all(fresh.join(".claude/commands")).unwrap();
+        std::fs::write(fresh.join(".claude/commands/gwt-x.md"), "managed").unwrap();
         std::fs::write(fresh.join(".claude/settings.local.json"), "{}").unwrap();
-        std::fs::create_dir_all(fresh.join(".codex/skills")).unwrap();
-        std::fs::write(fresh.join(".codex/skills/x.md"), "managed").unwrap();
+        std::fs::create_dir_all(fresh.join(".codex/skills/gwt-coordination")).unwrap();
+        std::fs::write(
+            fresh.join(".codex/skills/gwt-coordination/SKILL.md"),
+            "managed",
+        )
+        .unwrap();
         assert!(
             !manager.ephemeral_worktree_has_local_work(&fresh).unwrap(),
-            "gwt-materialized .claude/.codex assets are not user work"
+            "gwt-materialized managed assets are not user work"
+        );
+
+        // 2b. USER content under .claude/.codex (codex #3235 P1) → keep.
+        let user_claude = tmp.path().join(".intake-userclaude");
+        manager.create_detached("develop", &user_claude).unwrap();
+        std::fs::create_dir_all(user_claude.join(".claude/skills/my-custom")).unwrap();
+        std::fs::write(
+            user_claude.join(".claude/skills/my-custom/SKILL.md"),
+            "the user's own skill",
+        )
+        .unwrap();
+        assert!(
+            manager
+                .ephemeral_worktree_has_local_work(&user_claude)
+                .unwrap(),
+            "a user-authored skill under .claude is local work, not a gwt-managed asset"
+        );
+        let user_settings = tmp.path().join(".intake-usersettings");
+        manager.create_detached("develop", &user_settings).unwrap();
+        std::fs::create_dir_all(user_settings.join(".claude")).unwrap();
+        std::fs::write(
+            user_settings.join(".claude/settings.json"),
+            "{\"edited\":true}",
+        )
+        .unwrap();
+        assert!(
+            manager
+                .ephemeral_worktree_has_local_work(&user_settings)
+                .unwrap(),
+            "a user .claude/settings.json edit must not be treated as disposable"
         );
 
         // 3. A gitignored agent-authored file (tasks/todo.md) → keep.

--- a/crates/gwt/src/app_runtime/launch.rs
+++ b/crates/gwt/src/app_runtime/launch.rs
@@ -36,10 +36,10 @@ use super::{
     is_ephemeral_intake_worktree, launch_output_mirror, mark_auto_resume_source_completed,
     normalize_branch_name, refresh_managed_gwt_assets_for_agent_with_codex_hook_discovery_mode,
     resolve_docker_launch_plan, resolve_launch_spec_with_fallback, resolve_launch_worktree,
-    save_resumed_workspace_projection, save_start_work_workspace_projection, ActiveAgentSession,
-    AgentKanbanLaunchTarget, AppEventProxy, AppRuntime, BackendEvent, HookForwardTarget,
-    LaunchFeedbackContext, LiveSessionEntry, OutboundEvent, Pane, UserEvent, WindowGeometry,
-    WindowPreset, WindowProcessStatus, WindowRuntime, WorkspaceResumeContext,
+    same_worktree_path, save_resumed_workspace_projection, save_start_work_workspace_projection,
+    ActiveAgentSession, AgentKanbanLaunchTarget, AppEventProxy, AppRuntime, BackendEvent,
+    HookForwardTarget, LaunchFeedbackContext, LiveSessionEntry, OutboundEvent, Pane, UserEvent,
+    WindowGeometry, WindowPreset, WindowProcessStatus, WindowRuntime, WorkspaceResumeContext,
 };
 
 #[derive(Debug, Clone)]
@@ -1847,7 +1847,7 @@ impl AppRuntime {
         // identity. On session end, remove the worktree when clean; keep it
         // when dirty so uncommitted work is never lost. Skip the Paused-Work /
         // projection persistence entirely.
-        if is_ephemeral_intake_worktree(&session.worktree_path) {
+        if self.is_ephemeral_intake_session(&session) {
             self.finalize_ephemeral_intake_worktree(&session);
             let _ = gwt_agent::persist_session_status(
                 &self.sessions_dir,
@@ -1885,6 +1885,34 @@ impl AppRuntime {
             gwt_agent::AgentStatus::Stopped,
         );
         self.launch_wizard_cache.mark_stopped(&session.session_id);
+    }
+
+    /// SPEC-3214 (codex #3235 review): whether a stopped session is an
+    /// ephemeral intake session. The `.intake-*` basename alone is not enough —
+    /// a normal branch worktree a user happens to name `.intake-*` must keep its
+    /// Paused-Work / resume behavior. The definitive signal is that the intake
+    /// worktree is DETACHED (branchless), which only `create_detached` produces.
+    /// A worktree that is already gone is treated as ephemeral (it was reaped).
+    fn is_ephemeral_intake_session(&self, session: &ActiveAgentSession) -> bool {
+        if !is_ephemeral_intake_worktree(&session.worktree_path) {
+            return false;
+        }
+        let Some(main_repo_path) = self
+            .tab(&session.tab_id)
+            .map(|tab| tab.project_root.clone())
+            .and_then(|root| gwt_git::worktree::main_worktree_root(&root).ok())
+        else {
+            return !session.worktree_path.exists();
+        };
+        match gwt_git::WorktreeManager::new(&main_repo_path).list() {
+            Ok(worktrees) => worktrees
+                .iter()
+                .find(|info| same_worktree_path(&info.path, &session.worktree_path))
+                // On a branch → a real worktree, not intake. Detached → intake.
+                .is_none_or(|info| info.branch.is_none()),
+            // Cannot enumerate: fall back to "gone means it was ephemeral".
+            Err(_) => !session.worktree_path.exists(),
+        }
     }
 
     /// SPEC-3214 (FR-002): tear down an ephemeral intake worktree when its

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -7029,6 +7029,58 @@ fn ephemeral_intake_session_stop_keeps_dirty_worktree() {
     );
 }
 
+// SPEC-3214 (codex #3235 review): a NORMAL branch worktree that a user happens
+// to name `.intake-*` must NOT be misclassified as an ephemeral intake session
+// — it keeps its worktree and its Paused-Work behavior. Classification requires
+// the worktree to be branchless (detached), not just `.intake-*`-named.
+#[test]
+fn branch_worktree_named_intake_is_not_treated_as_ephemeral() {
+    let _env_lock = env_test_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let temp = tempdir().expect("tempdir");
+    let _home = ScopedEnvVar::set("HOME", temp.path());
+    let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+    let repo = temp.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    init_repo(&repo);
+    run_git(&repo, &["config", "user.email", "test@example.com"]);
+    run_git(&repo, &["config", "user.name", "Test User"]);
+    run_git(&repo, &["commit", "--allow-empty", "-m", "init"]);
+
+    // A real BRANCH worktree that merely happens to be named `.intake-real`.
+    let branch_wt = temp.path().join(".intake-real");
+    gwt_git::WorktreeManager::new(&repo)
+        .create_from_base("HEAD", "feature/real", &branch_wt)
+        .expect("branch worktree");
+    assert!(branch_wt.exists());
+
+    let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+    let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+    let mut session = sample_active_agent_session("tab-1", "tab-1::real");
+    session.session_id = "session-real".to_string();
+    session.branch_name = "feature/real".to_string();
+    session.worktree_path = branch_wt.clone();
+    session.window_id = "tab-1::real".to_string();
+    runtime
+        .active_agent_sessions
+        .insert("tab-1::real".to_string(), session);
+
+    runtime.mark_agent_session_stopped("tab-1::real");
+
+    assert!(
+        branch_wt.exists(),
+        "a real branch worktree named .intake-* must not be removed as ephemeral"
+    );
+    let works = gwt_core::workspace_projection::load_workspace_work_items(&repo)
+        .ok()
+        .flatten();
+    assert!(
+        works.is_some_and(|projection| !projection.work_items.is_empty()),
+        "a real branch session still records a Paused Work"
+    );
+}
+
 // #3065: a stopped session's Pause record must not inherit the repo-shared
 // projection's owner/title — those belong to whatever Work last wrote the
 // projection. Owner/summary come from the session's own Work item (matched


### PR DESCRIPTION
## Summary

merged 済み PR #3235（SPEC-3214 Phase 1）への codex review 指摘 2 件（P1 データ喪失 / P2 誤分類）の follow-up fix。

## Changes

**P1（データ喪失）**: teardown の破棄安全判定 `ephemeral_worktree_has_local_work` が `.claude/`/`.codex/` を**丸ごと** disposable 扱いしていたため、ユーザーが intake 中に書いた `.claude/skills/<custom>` や `.claude/settings.json` 編集まで削除され得た。
→ gwt が実際に materialize する正確なパターン（`gwt-skills` `git_exclude.rs` 準拠: `.claude/skills/gwt-*` / `.claude/commands/gwt-*` / `.claude/settings.local.json` / `.codex/skills/gwt-*`）と `.DS_Store` のみ disposable とし、それ以外の `.claude`/`.codex` 内容・`.gwt/` 配下はすべて user work として保持。

**P2（誤分類）**: ephemeral 判定が `.intake-*` basename のみだったため、ユーザーが偶然 `.intake-*` と名付けた通常 branch worktree が ephemeral 扱いされ Paused Work / resume を失う恐れ。
→ `is_ephemeral_intake_session` が定義的 signal（intake worktree は `create_detached` による detached=branchless）を `list()` で確認。branch を持つ worktree は通常セッション扱い（worktree が既に消えている場合のみ reap 済みとして ephemeral 扱い）。`branch_name` は None 時 "work" にフォールバックするため空判定は使えず git-level の branchless 確認を採用。

## Testing

- `ephemeral_worktree_has_local_work`: user 作成 `.claude/skills/<custom>` / `.claude/settings.json` 編集の**保持**ケースを追加（gwt-managed のみ disposable）
- `branch_worktree_named_intake_is_not_treated_as_ephemeral`: `.intake-*` 名の branch worktree が削除されず Paused Work を維持する contract
- fmt / clippy(--workspace -D warnings) / rustdoc / `cargo test -p gwt-core -p gwt -p gwt-git -p gwt-agent --all-features`: **78 suites / 0 failed**

## PR Readiness

State: Ready（correctness 保守側修正・user-visible 挙動なし）

- User Verification Result: **n/a**（backend のみ）。

## Related SPEC

SPEC #3214（Phase 1 hardening）

## Checklist

- [x] codex #3235 P1/P2 反映 + テスト追加
- [x] fmt / clippy / rustdoc / test 全通過
- [x] commitlint 通過
- [x] User Verification: n/a
