### PR TITLE
fix(intake): merged hook 設定を保持し prune も branchless に限定 (codex #3236)

### DIFF
--- a/crates/gwt-git/src/worktree.rs
+++ b/crates/gwt-git/src/worktree.rs
@@ -942,13 +942,23 @@ fn path_arg_for_git(path: &Path) -> String {
 /// Parse `git worktree list --porcelain` output into `WorktreeInfo` entries.
 /// SPEC-3214: paths that a `git status --ignored` line may report which are
 /// safe to destroy when reaping an ephemeral intake worktree. These are ONLY
-/// gwt's own materialized managed assets — the exact patterns gwt writes into
-/// every worktree's `.git/info/exclude` (see `gwt-skills` `git_exclude.rs`:
-/// `.claude/skills/gwt-*`, `.claude/commands/gwt-*`, `.claude/settings.local.json`,
-/// `.codex/skills/gwt-*`) — plus OS cruft. Everything else is the user's local
-/// work and keeps the worktree: a gitignored `tasks/todo.md` / `.env`, anything
-/// under `.gwt/`, a user-authored `.claude/skills/<custom>` or a
-/// `.claude/settings.json` edit (codex #3235 review), and any tracked change.
+/// gwt's own PURE materialized managed assets — the regenerated, user-free
+/// skill/command dirs gwt writes into every worktree (`.claude/skills/gwt-*`,
+/// `.claude/commands/gwt-*`, `.codex/skills/gwt-*`) — plus OS cruft.
+///
+/// Deliberately NOT disposable: `.claude/settings.local.json` and
+/// `.codex/hooks.json` are MERGED files — gwt preserves user hooks and unrelated
+/// top-level settings in them (see `gwt-skills` `settings_local.rs`), so a user
+/// edit could live there and must never be destroyed (codex #3236). Everything
+/// else is the user's local work and keeps the worktree: a gitignored
+/// `tasks/todo.md` / `.env`, anything under `.gwt/`, a user-authored
+/// `.claude/skills/<custom>` or `.claude/settings.json`, and any tracked change.
+///
+/// NB: because launched intake worktrees legitimately receive these merged
+/// files (the intake agent needs gwt's managed hooks), such worktrees are kept
+/// rather than reaped. Reaping launched intakes precisely (regenerate-and-diff
+/// the managed portion) is handled with the Phase 3 intake-launch lifecycle;
+/// keeping is the data-safe interim.
 fn is_disposable_worktree_entry(entry: &str) -> bool {
     let entry = entry.trim().trim_matches('"');
     let entry = entry.strip_prefix("./").unwrap_or(entry);
@@ -958,7 +968,6 @@ fn is_disposable_worktree_entry(entry: &str) -> bool {
     if entry.starts_with(".claude/skills/gwt-")
         || entry.starts_with(".claude/commands/gwt-")
         || entry.starts_with(".codex/skills/gwt-")
-        || entry == ".claude/settings.local.json"
     {
         return true;
     }
@@ -1503,7 +1512,8 @@ prunable gitdir file points to non-existent location
             "a pristine intake worktree has no local work"
         );
 
-        // 2. Only gwt-materialized managed assets present → still discardable.
+        // 2. Only gwt-materialized PURE managed skill/command dirs present →
+        //    still discardable (these hold no user content).
         std::fs::create_dir_all(fresh.join(".claude/skills/gwt-coordination")).unwrap();
         std::fs::write(
             fresh.join(".claude/skills/gwt-coordination/SKILL.md"),
@@ -1512,7 +1522,6 @@ prunable gitdir file points to non-existent location
         .unwrap();
         std::fs::create_dir_all(fresh.join(".claude/commands")).unwrap();
         std::fs::write(fresh.join(".claude/commands/gwt-x.md"), "managed").unwrap();
-        std::fs::write(fresh.join(".claude/settings.local.json"), "{}").unwrap();
         std::fs::create_dir_all(fresh.join(".codex/skills/gwt-coordination")).unwrap();
         std::fs::write(
             fresh.join(".codex/skills/gwt-coordination/SKILL.md"),
@@ -1521,7 +1530,23 @@ prunable gitdir file points to non-existent location
         .unwrap();
         assert!(
             !manager.ephemeral_worktree_has_local_work(&fresh).unwrap(),
-            "gwt-materialized managed assets are not user work"
+            "gwt-materialized pure managed skill/command dirs are not user work"
+        );
+
+        // 2a. `.claude/settings.local.json` is a MERGED file (gwt preserves user
+        // hooks and unrelated settings), so it must be kept — a user edit there
+        // must never be destroyed (codex #3236 P1).
+        let merged_settings = tmp.path().join(".intake-settings");
+        manager
+            .create_detached("develop", &merged_settings)
+            .unwrap();
+        std::fs::create_dir_all(merged_settings.join(".claude")).unwrap();
+        std::fs::write(merged_settings.join(".claude/settings.local.json"), "{}").unwrap();
+        assert!(
+            manager
+                .ephemeral_worktree_has_local_work(&merged_settings)
+                .unwrap(),
+            ".claude/settings.local.json is a merged file that may hold user hooks; keep it"
         );
 
         // 2b. USER content under .claude/.codex (codex #3235 P1) → keep.

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -240,6 +240,12 @@ pub fn prune_orphan_intake_worktrees(repo_path: &Path, max_removals: usize) -> u
         if !is_ephemeral_intake_worktree(&worktree.path) {
             continue;
         }
+        // codex #3236 P2: only reap the branchless intake worktrees this feature
+        // creates — a real branch worktree a user happens to name `.intake-*`
+        // has a branch and must be left alone (mirrors is_ephemeral_intake_session).
+        if worktree.branch.is_some() {
+            continue;
+        }
         match manager.ephemeral_worktree_has_local_work(&worktree.path) {
             Ok(false) => {
                 if manager.remove_force(&worktree.path).is_ok() {

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -5777,8 +5777,15 @@ mod tests {
         }
         fs::write(dirty.join("wip.txt"), "unsaved").expect("dirty file");
 
+        // A real BRANCH worktree that happens to be named `.intake-*` must be
+        // left alone by the reaper (codex #3236 P2).
+        let branch_named = temp.path().join(".intake-branch");
+        manager
+            .create_from_base("HEAD", "feature/keep", &branch_named)
+            .expect("branch worktree");
+
         let removed = super::prune_orphan_intake_worktrees(&repo, 10);
-        assert_eq!(removed, 2, "both clean intake worktrees pruned");
+        assert_eq!(removed, 2, "both clean detached intake worktrees pruned");
         assert!(
             !clean_a.exists() && !clean_b.exists(),
             "clean intake pruned"
@@ -5786,6 +5793,10 @@ mod tests {
         assert!(
             dirty.exists() && dirty.join("wip.txt").exists(),
             "dirty intake kept — never destroy uncommitted work"
+        );
+        assert!(
+            branch_named.exists(),
+            "a real branch worktree named .intake-* is never reaped"
         );
 
         // Bounded: a second batch of clean intakes is capped at the limit.


### PR DESCRIPTION
## Summary

merged 済み PR #3236 への codex review 指摘 3 件（P1 データ喪失 / P2 誤分類 / P2 pinning）の follow-up fix。

## Changes

**P1（データ喪失）**: `.claude/settings.local.json` を disposable 扱いしていたが、gwt はこれを **merge 生成**し user hooks / unrelated top-level settings を保持する（`gwt-skills` `settings_local.rs`）。ユーザー編集が force-remove で失われ得た。
→ disposable 集合から除外。`.codex/hooks.json` も同様に merge されるため含めない。disposable は **PURE managed skill/command dir**（`.claude/skills/gwt-*` / `.claude/commands/gwt-*` / `.codex/skills/gwt-*`）と `.DS_Store` のみ。

**P2（prune 経路の誤分類）**: `mark_agent_session_stopped` は branchless 確認で保護済みだったが、startup の `prune_orphan_intake_worktrees` は basename のみで判定していた。
→ prune も `worktree.branch.is_some()` をスキップ（`list()` の `WorktreeInfo` 再利用で追加コストなし）。

**P2（.codex/hooks.json pinning）**: 上記 P1 対応で merged hook ファイルは keep。intake agent は gwt managed hooks を必要とするため launched intake worktree はこれらを持つ＝現状 keep（reap されない）。これは**データ安全側の interim**で、launched intake の精密な reap（managed 部分を regenerate して diff し user 由来のみ keep）は intake-launch が実在する **Phase 3** のライフサイクルで実装する。Phase 1 時点では production で intake 起動が未配線のため機能退行はない。

## Testing

- `.claude/settings.local.json` present → **keep**（merged file）
- PURE managed dir のみ → discardable のまま
- branch worktree 名 `.intake-*` が prune されない contract
- fmt / clippy / rustdoc / **78 suites / 0 failed**

## PR Readiness

State: Ready（data-safety 補強・user-visible 挙動なし）

- User Verification Result: **n/a**（backend のみ）。

## Related SPEC

SPEC #3214（Phase 1 hardening）

## Checklist

- [x] codex #3236 P1/P2 反映 + テスト
- [x] fmt / clippy / rustdoc / test 全通過
- [x] commitlint 通過
- [x] User Verification: n/a
