### PR TITLE
fix(intake): 生成のみの merged hook 設定は reap し user 編集は保持 (codex #3237)

### DIFF
--- a/crates/gwt-git/src/worktree.rs
+++ b/crates/gwt-git/src/worktree.rs
@@ -266,6 +266,20 @@ impl WorktreeManager {
     /// cruft (`.DS_Store`) are treated as disposable, so a normal intake
     /// worktree still reaps. Fail-closed callers keep the worktree on `Err`.
     pub fn ephemeral_worktree_has_local_work(&self, path: &Path) -> Result<bool> {
+        self.ephemeral_worktree_has_local_work_with(path, |_| false)
+    }
+
+    /// [`Self::ephemeral_worktree_has_local_work`] with a caller-supplied
+    /// `extra_disposable` predicate over worktree-relative status entries.
+    /// Higher layers use it to also discard gwt's MERGED hook configs
+    /// (`.claude/settings.local.json`, `.codex/hooks.json`) when they contain
+    /// only gwt-generated content — a decision that needs `gwt-skills`, which
+    /// this crate cannot depend on (codex #3237).
+    pub fn ephemeral_worktree_has_local_work_with<F: Fn(&str) -> bool>(
+        &self,
+        path: &Path,
+        extra_disposable: F,
+    ) -> Result<bool> {
         // Tracked changes, untracked files, and ignored files in one pass.
         let output = gwt_core::process::run_git_logged(
             &[
@@ -290,7 +304,7 @@ impl WorktreeManager {
             // is `old -> new`; the new path after the arrow is what matters).
             let entry = &line[3..];
             let entry = entry.rsplit(" -> ").next().unwrap_or(entry);
-            if !is_disposable_worktree_entry(entry) {
+            if !is_disposable_worktree_entry(entry) && !extra_disposable(entry) {
                 return Ok(true);
             }
         }

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -43,7 +43,7 @@ pub use provider_hooks::{
 pub use registry::{EmbeddedSkill, RegistryError, SkillRegistry};
 pub use settings_local::{
     generate_codex_hooks, generate_codex_hooks_for_mode, generate_settings_local,
-    CodexHookDiscoveryMode,
+    managed_hook_config_has_user_content, CodexHookDiscoveryMode,
 };
 
 #[cfg(test)]

--- a/crates/gwt-skills/src/settings_local.rs
+++ b/crates/gwt-skills/src/settings_local.rs
@@ -216,6 +216,38 @@ fn find_ancestor_git_entry(base_dir: &Path) -> Option<(PathBuf, PathBuf)> {
     None
 }
 
+/// SPEC-3214 (codex #3237): whether a gwt-managed merged hook config
+/// (`.claude/settings.local.json` or `.codex/hooks.json`) at `path` holds any
+/// USER content, as opposed to being a pristine gwt-generated file.
+///
+/// gwt regenerates these files by merging its own hooks (tagged with the
+/// `GWT_MANAGED_HOOK` runtime marker) with any user hooks and preserving unrelated
+/// top-level keys. A freshly generated file therefore has exactly one key,
+/// `hooks`, containing only managed entries. This lets an ephemeral intake
+/// worktree reap even though its launch materialized the hook config, while a
+/// user edit (an extra key or a non-managed hook) keeps it. Fails closed
+/// (returns `true`) on any read/parse ambiguity so nothing is destroyed.
+pub fn managed_hook_config_has_user_content(path: &Path) -> bool {
+    let Ok(content) = fs::read_to_string(path) else {
+        return false; // absent/unreadable: nothing to preserve here.
+    };
+    if content.trim().is_empty() {
+        return false;
+    }
+    let root = match serde_json::from_str::<Value>(&content) {
+        Ok(Value::Object(map)) => map,
+        // Non-object or malformed JSON is not something gwt writes — treat as
+        // a user edit and keep it.
+        _ => return true,
+    };
+    // Any top-level key other than the managed `hooks` key is user content.
+    if root.keys().any(|key| key != "hooks") {
+        return true;
+    }
+    // Any non-managed hook within `hooks` is user content.
+    !existing_user_hooks(root.get("hooks")).is_empty()
+}
+
 fn read_existing_settings(path: &Path) -> io::Result<Map<String, Value>> {
     if !path.exists() {
         return Ok(Map::new());
@@ -709,6 +741,60 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn managed_hook_config_has_user_content_distinguishes_generated_from_edited() {
+        let dir = tempfile::tempdir().unwrap();
+        let settings = dir.path().join(".claude/settings.local.json");
+
+        // A pristine gwt-generated file has only managed hooks → no user content.
+        generate_settings_local(dir.path()).unwrap();
+        assert!(
+            !managed_hook_config_has_user_content(&settings),
+            "a freshly gwt-generated hook config holds no user content"
+        );
+
+        // A user hook added under `hooks` → user content.
+        let mut root = read_existing_settings(&settings).unwrap();
+        let hooks = root
+            .entry("hooks".to_string())
+            .or_insert_with(|| Value::Object(Map::new()));
+        if let Value::Object(events) = hooks {
+            events.insert(
+                "PreToolUse".to_string(),
+                serde_json::json!([{ "hooks": [{ "type": "command", "command": "echo user" }] }]),
+            );
+        }
+        write_settings_atomically(&settings, &Value::Object(root)).unwrap();
+        assert!(
+            managed_hook_config_has_user_content(&settings),
+            "a user-authored hook is user content"
+        );
+
+        // An unrelated top-level key gwt does not manage → user content.
+        generate_settings_local(dir.path()).unwrap();
+        let mut root = read_existing_settings(&settings).unwrap();
+        root.insert(
+            "permissions".to_string(),
+            serde_json::json!({"allow": ["*"]}),
+        );
+        write_settings_atomically(&settings, &Value::Object(root)).unwrap();
+        assert!(
+            managed_hook_config_has_user_content(&settings),
+            "an unrelated top-level user setting is user content"
+        );
+
+        // Malformed JSON → fail closed (keep).
+        std::fs::write(&settings, "{ not json").unwrap();
+        assert!(
+            managed_hook_config_has_user_content(&settings),
+            "malformed config fails closed (treated as user content)"
+        );
+
+        // Absent → nothing to preserve.
+        std::fs::remove_file(&settings).unwrap();
+        assert!(!managed_hook_config_has_user_content(&settings));
+    }
 
     fn commands_for_event<'a>(value: &'a Value, event: &str) -> Vec<&'a str> {
         value["hooks"][event]

--- a/crates/gwt/src/app_runtime/launch.rs
+++ b/crates/gwt/src/app_runtime/launch.rs
@@ -33,8 +33,9 @@ use super::{
     apply_docker_runtime_to_launch_config, apply_host_package_runner_fallback_checked,
     apply_windows_host_shell_wrapper, combined_window_id, detect_shell_program,
     finalize_docker_agent_launch_config, geometry_to_pty_size, install_launch_gwt_bin_env,
-    is_ephemeral_intake_worktree, launch_output_mirror, mark_auto_resume_source_completed,
-    normalize_branch_name, refresh_managed_gwt_assets_for_agent_with_codex_hook_discovery_mode,
+    intake_hook_config_is_disposable, is_ephemeral_intake_worktree, launch_output_mirror,
+    mark_auto_resume_source_completed, normalize_branch_name,
+    refresh_managed_gwt_assets_for_agent_with_codex_hook_discovery_mode,
     resolve_docker_launch_plan, resolve_launch_spec_with_fallback, resolve_launch_worktree,
     same_worktree_path, save_resumed_workspace_projection, save_start_work_workspace_projection,
     ActiveAgentSession, AgentKanbanLaunchTarget, AppEventProxy, AppRuntime, BackendEvent,
@@ -1928,7 +1929,9 @@ impl AppRuntime {
             .unwrap_or_else(|| worktree_path.to_path_buf());
         let manager = gwt_git::WorktreeManager::new(&main_repo_path);
 
-        match manager.ephemeral_worktree_has_local_work(worktree_path) {
+        match manager.ephemeral_worktree_has_local_work_with(worktree_path, |entry| {
+            intake_hook_config_is_disposable(worktree_path, entry)
+        }) {
             Ok(true) => {
                 tracing::warn!(
                     worktree_path = %worktree_path.display(),

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -246,7 +246,10 @@ pub fn prune_orphan_intake_worktrees(repo_path: &Path, max_removals: usize) -> u
         if worktree.branch.is_some() {
             continue;
         }
-        match manager.ephemeral_worktree_has_local_work(&worktree.path) {
+        let worktree_path = worktree.path.clone();
+        match manager.ephemeral_worktree_has_local_work_with(&worktree.path, |entry| {
+            intake_hook_config_is_disposable(&worktree_path, entry)
+        }) {
             Ok(false) => {
                 if manager.remove_force(&worktree.path).is_ok() {
                     removed += 1;

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -109,12 +109,13 @@ pub(crate) use runtime_support::{
     attach_parent_console_for_cli, close_window_from_workspace, combined_window_id,
     current_git_branch, dedupe_recent_projects, fallback_project_target,
     first_available_worktree_path, front_door_route, geometry_to_pty_size,
-    is_ephemeral_intake_worktree, knowledge_kind_for_preset, local_branch_exists,
-    normalize_active_tab_id, normalize_branch_name, normalize_recent_project_path,
-    normalize_recent_projects, origin_remote_ref, prune_missing_recent_projects,
-    resolve_launch_spec_with_fallback, resolve_project_target, run_cli, same_worktree_path,
-    should_auto_close_agent_window, should_auto_start_restored_window, synthetic_branch_entry,
-    usable_worktree_path_for_branch, worktrees_have_stale_branch_entry, INTAKE_WORKTREE_PREFIX,
+    intake_hook_config_is_disposable, is_ephemeral_intake_worktree, knowledge_kind_for_preset,
+    local_branch_exists, normalize_active_tab_id, normalize_branch_name,
+    normalize_recent_project_path, normalize_recent_projects, origin_remote_ref,
+    prune_missing_recent_projects, resolve_launch_spec_with_fallback, resolve_project_target,
+    run_cli, same_worktree_path, should_auto_close_agent_window, should_auto_start_restored_window,
+    synthetic_branch_entry, usable_worktree_path_for_branch, worktrees_have_stale_branch_entry,
+    INTAKE_WORKTREE_PREFIX,
 };
 pub(crate) use update_front_door::{apply_update_state_and_exit, spawn_startup_update_check};
 #[cfg(test)]
@@ -5784,8 +5785,23 @@ mod tests {
             .create_from_base("HEAD", "feature/keep", &branch_named)
             .expect("branch worktree");
 
+        // A clean intake whose ONLY content is a gwt-generated hook config must
+        // still reap (codex #3237): launched intakes materialize managed hooks.
+        let generated_hook = temp.path().join(".intake-hook");
+        manager
+            .create_detached("HEAD", &generated_hook)
+            .expect("intake worktree");
+        gwt_skills::generate_settings_local(&generated_hook).expect("generate hook config");
+
         let removed = super::prune_orphan_intake_worktrees(&repo, 10);
-        assert_eq!(removed, 2, "both clean detached intake worktrees pruned");
+        assert_eq!(
+            removed, 3,
+            "clean detached intakes reap, including one with only a generated hook config"
+        );
+        assert!(
+            !generated_hook.exists(),
+            "an intake with only a gwt-generated hook config is reaped (codex #3237)"
+        );
         assert!(
             !clean_a.exists() && !clean_b.exists(),
             "clean intake pruned"

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -394,6 +394,19 @@ pub fn is_ephemeral_intake_worktree(path: &Path) -> bool {
         })
 }
 
+/// SPEC-3214 (codex #3237): whether a worktree-relative status `entry` is a
+/// gwt MERGED hook config (`.claude/settings.local.json` / `.codex/hooks.json`)
+/// that currently holds ONLY gwt-generated content, and so is safe to reap
+/// along with an ephemeral intake worktree. A user edit (an extra key or a
+/// non-managed hook) makes it non-disposable. Bridges `gwt-git`'s teardown
+/// probe (which cannot depend on `gwt-skills`) to the managed-hook semantics.
+pub fn intake_hook_config_is_disposable(worktree: &Path, entry: &str) -> bool {
+    if entry != ".claude/settings.local.json" && entry != ".codex/hooks.json" {
+        return false;
+    }
+    !gwt_skills::managed_hook_config_has_user_content(&worktree.join(entry))
+}
+
 pub fn first_available_worktree_path(
     preferred_path: &Path,
     worktrees: &[gwt_git::WorktreeInfo],


### PR DESCRIPTION
## Summary

merged 済み PR #3237 への codex review 指摘（launched intake の pinning）の follow-up。#3237 で `.claude/settings.local.json` / `.codex/hooks.json` を無条件 keep にしたため、intake agent が必要とする gwt managed hooks を materialize した launched intake worktree が clean でも reap されず、SPEC の中核（intake worktree は session 終了で消える）が壊れていた。**Phase 3 送りにせず精密判定で解決**。

## Changes

- **gwt-skills**: `managed_hook_config_has_user_content(path)` を公開。gwt が merge 生成する hook 設定に USER 内容（gwt 管理外の top-level key、または `GWT_MANAGED_HOOK` マーカーを持たない user hook）があるかを判定。純生成物なら false（reap 可）、user 編集ありなら true（keep）。parse 不能は fail closed で true。
- **gwt-git**: `ephemeral_worktree_has_local_work_with(path, extra_disposable)` を追加。caller が status entry を追加 disposable 判定する predicate を注入できる（gwt-git は gwt-skills に依存不可のため層を分離）。
- **gwt**: `runtime_support::intake_hook_config_is_disposable(worktree, entry)` を追加し、`.claude/settings.local.json` / `.codex/hooks.json` を「user 内容なし」のときだけ disposable 判定。finalize（session 終了）と prune（起動時）の両経路を predicate 付き版に配線。

結果: **純生成の hook 設定だけを持つ clean intake は reap され、user が編集した intake は保持**。data safety と ephemeral 設計を両立。

## Testing

- gwt-skills detector: 生成物→false / user hook・追加 key→true / malformed→fail closed / 不在→false
- prune 統合: 生成 hook のみの intake を reap（removed=3）し、user 編集・branch worktree は保持
- fmt / clippy / rustdoc / **81 suites / 0 failed**

## PR Readiness

State: Ready（correctness + data-safety、user-visible 挙動なし）

- User Verification Result: **n/a**（backend のみ）。

## Related SPEC

SPEC #3214（Phase 1 hardening 完了）

## Checklist

- [x] codex #3237 P2 を Phase 3 送りにせず解決 + テスト
- [x] fmt / clippy / rustdoc / test 全通過
- [x] commitlint 通過
- [x] User Verification: n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved cleanup of ephemeral and orphaned worktrees by recognizing generated hook/config files as disposable when they contain no user edits.
  * Added a safer check for hook configuration files that treats malformed or unreadable content conservatively.

* **Bug Fixes**
  * Worktrees with only managed hook settings are now more likely to be removed during pruning.
  * Existing local changes still prevent cleanup, preserving user work more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->