### PR TITLE
fix(intake): hook 設定の削除と読取エラーを keep 側に倒す (codex #3238)

### DIFF
--- a/crates/gwt-skills/src/settings_local.rs
+++ b/crates/gwt-skills/src/settings_local.rs
@@ -226,10 +226,16 @@ fn find_ancestor_git_entry(base_dir: &Path) -> Option<(PathBuf, PathBuf)> {
 /// `hooks`, containing only managed entries. This lets an ephemeral intake
 /// worktree reap even though its launch materialized the hook config, while a
 /// user edit (an extra key or a non-managed hook) keeps it. Fails closed
-/// (returns `true`) on any read/parse ambiguity so nothing is destroyed.
+/// (returns `true`) on any non-absent read/parse ambiguity so nothing is
+/// destroyed; only a genuinely absent file returns `false` (nothing to lose).
 pub fn managed_hook_config_has_user_content(path: &Path) -> bool {
-    let Ok(content) = fs::read_to_string(path) else {
-        return false; // absent/unreadable: nothing to preserve here.
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        // Absent: nothing to preserve here.
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return false,
+        // Present but unreadable (invalid UTF-8 from a manual edit, a transient
+        // permission error, …): fail closed — keep it.
+        Err(_) => return true,
     };
     if content.trim().is_empty() {
         return false;
@@ -794,6 +800,13 @@ mod tests {
         // Absent → nothing to preserve.
         std::fs::remove_file(&settings).unwrap();
         assert!(!managed_hook_config_has_user_content(&settings));
+
+        // Present but unreadable (a directory at the path) → fail closed (keep).
+        std::fs::create_dir_all(&settings).unwrap();
+        assert!(
+            managed_hook_config_has_user_content(&settings),
+            "a present-but-unreadable config fails closed (kept), unlike an absent one"
+        );
     }
 
     fn commands_for_event<'a>(value: &'a Value, event: &str) -> Vec<&'a str> {

--- a/crates/gwt/src/runtime_support.rs
+++ b/crates/gwt/src/runtime_support.rs
@@ -404,7 +404,14 @@ pub fn intake_hook_config_is_disposable(worktree: &Path, entry: &str) -> bool {
     if entry != ".claude/settings.local.json" && entry != ".codex/hooks.json" {
         return false;
     }
-    !gwt_skills::managed_hook_config_has_user_content(&worktree.join(entry))
+    let path = worktree.join(entry);
+    // A status line for a path that no longer exists is a tracked DELETION —
+    // a real change (codex #3238). Keep it: only a present, purely-generated
+    // config is disposable.
+    if !path.exists() {
+        return false;
+    }
+    !gwt_skills::managed_hook_config_has_user_content(&path)
 }
 
 pub fn first_available_worktree_path(
@@ -826,10 +833,45 @@ pub fn parse_github_remote_url(url: &str) -> Option<(String, String)> {
 mod tests {
     use std::path::PathBuf;
 
-    use super::{front_door_route, FrontDoorRoute};
+    use super::{front_door_route, intake_hook_config_is_disposable, FrontDoorRoute};
 
     fn argv(parts: &[&str]) -> Vec<String> {
         parts.iter().map(std::string::ToString::to_string).collect()
+    }
+
+    #[test]
+    fn intake_hook_config_disposable_only_for_present_generated_configs() {
+        let dir = tempfile::tempdir().unwrap();
+        let worktree = dir.path();
+
+        // Unrelated path → never handled here.
+        assert!(!intake_hook_config_is_disposable(worktree, "tasks/todo.md"));
+
+        // A reported hook path that does not exist = a tracked deletion → keep
+        // (codex #3238), never treat as disposable.
+        assert!(!intake_hook_config_is_disposable(
+            worktree,
+            ".claude/settings.local.json"
+        ));
+
+        // A present, purely gwt-generated hook config → disposable.
+        std::fs::create_dir_all(worktree.join(".claude")).unwrap();
+        gwt_skills::generate_settings_local(worktree).unwrap();
+        assert!(intake_hook_config_is_disposable(
+            worktree,
+            ".claude/settings.local.json"
+        ));
+
+        // A user edit to it → keep.
+        std::fs::write(
+            worktree.join(".claude/settings.local.json"),
+            "{\"permissions\":{\"allow\":[\"*\"]}}",
+        )
+        .unwrap();
+        assert!(!intake_hook_config_is_disposable(
+            worktree,
+            ".claude/settings.local.json"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

merged 済み PR #3238 への codex review 指摘 2 件（P2）の follow-up。

## Changes

1. **tracked deletion の誤 dispose**: `intake_hook_config_is_disposable` が `.claude/settings.local.json` / `.codex/hooks.json` のパスを受けたとき、status が削除（`D`）で実ファイルが存在しなくても disposable 判定し得た。削除は実変更のため、対象パスが存在しない場合は keep（disposable=false）に修正。
2. **fail-closed 契約違反**: `managed_hook_config_has_user_content` が absent と unreadable を区別せず read 失敗時に一律 false を返していた。`ErrorKind::NotFound` のみ false、その他の read エラー（invalid UTF-8 の手動編集・transient permission 等）は true（keep）に修正。doc の「non-absent の read/parse 曖昧は fail closed」契約に整合。

## Testing

- 存在しない hook パス→disposable=false（削除保護）/ 生成物→true / user 編集→false
- present-but-unreadable（path にディレクトリ）→ fail closed で has_user_content=true
- fmt / clippy / rustdoc / **81 suites / 0 failed**

## PR Readiness

State: Ready（correctness・user-visible 挙動なし）

- User Verification Result: **n/a**（backend のみ）。

## Related SPEC

SPEC #3214（Phase 1 hardening）

## Checklist

- [x] codex #3238 P2×2 反映 + テスト
- [x] fmt / clippy / rustdoc / test 全通過
- [x] commitlint 通過
- [x] User Verification: n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of edited versus generated hook settings so user changes are preserved more reliably.
  * Missing hook config files are now handled as tracked deletions instead of being treated as disposable.
  * Present-but-unreadable config paths are treated as user content, reducing the risk of accidentally overwriting local changes.
  * Added a regression test covering deleted, generated, and user-modified hook config scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->