### PR TITLE
feat(intake): SPEC-3214 Phase 2a — Quick issue 登録の backend handler

### DIFF
--- a/crates/gwt/src/app_runtime/frontend_action_log.rs
+++ b/crates/gwt/src/app_runtime/frontend_action_log.rs
@@ -668,6 +668,13 @@ pub(super) fn frontend_user_action_log(event: &FrontendEvent) -> Option<Frontend
         FrontendEvent::ListIssueMonitor => {
             FrontendUserActionLog::new("list_issue_monitor", "issue_monitor")
         }
+        FrontendEvent::QuickRegisterIssue { launch, .. } => {
+            FrontendUserActionLog::new("quick_register_issue", "issue_monitor").mode(if *launch {
+                "launch"
+            } else {
+                "register"
+            })
+        }
         FrontendEvent::IssueMonitorLaunchNow { issue_number, .. } => {
             FrontendUserActionLog::new("issue_monitor_launch_now", "issue_monitor")
                 .target(issue_number.to_string())

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1287,6 +1287,68 @@ impl AppRuntime {
         self.local_issue_monitor_events_for(Some(client_id), apply)
     }
 
+    /// SPEC-3214 (FR-004/005/011): register a Quick issue (a fresh
+    /// `investigation` GitHub issue) and surface the outcome as a toast. On
+    /// success the Issue Monitor inbox is refreshed so the new issue appears;
+    /// with `launch` it is handed to the existing human-gated launch path
+    /// (`auto_launch_issue_monitor_request_events`) — no new execution path.
+    pub(crate) fn quick_register_issue_events(
+        &mut self,
+        client_id: &str,
+        title: &str,
+        launch: bool,
+    ) -> Vec<OutboundEvent> {
+        let error_toast = |message: String| {
+            vec![OutboundEvent::reply(
+                client_id.to_string(),
+                BackendEvent::IssueMonitorToast {
+                    level: "error".to_string(),
+                    message,
+                    issue_number: None,
+                },
+            )]
+        };
+
+        let Some(project_root) = self.active_project_root().map(Path::to_path_buf) else {
+            return error_toast("No active project".to_string());
+        };
+        let (owner, repo) =
+            match gwt::issue_monitor_worker::github_remote_owner_and_repo(&project_root) {
+                Ok(pair) => pair,
+                Err(error) => return error_toast(error.to_string()),
+            };
+        let client = match gwt_github::client::http::HttpIssueClient::from_gh_auth(&owner, &repo) {
+            Ok(client) => client,
+            Err(error) => {
+                return error_toast(format!("GitHub authentication unavailable: {error}"))
+            }
+        };
+
+        let outcome = gwt::issue_monitor_worker::quick_register_issue_outcome(&client, title);
+        let mut events = vec![OutboundEvent::reply(
+            client_id.to_string(),
+            BackendEvent::IssueMonitorToast {
+                level: outcome.toast_level,
+                message: outcome.toast_message,
+                issue_number: outcome.issue_number,
+            },
+        )];
+
+        if let Some(issue_number) = outcome.issue_number {
+            // Refresh the inbox so the freshly registered issue is visible.
+            events.extend(self.local_issue_monitor_events(client_id, |_| {}));
+            if launch {
+                // A Quick issue carries the `investigation` label, so it is a
+                // plain Issue (never a SPEC) for launch purposes.
+                events.extend(self.auto_launch_issue_monitor_request_events(
+                    issue_number,
+                    gwt::LinkedIssueKind::Issue,
+                ));
+            }
+        }
+        events
+    }
+
     fn local_issue_monitor_events_for(
         &mut self,
         client_id: Option<&str>,
@@ -2122,6 +2184,9 @@ impl AppRuntime {
                         })
                     }
                 }
+            }
+            FrontendEvent::QuickRegisterIssue { title, launch } => {
+                self.quick_register_issue_events(&client_id, &title, launch)
             }
             FrontendEvent::ListIssueMonitor => self.local_issue_monitor_events(&client_id, |_| {}),
             FrontendEvent::IssueMonitorLaunchNow {

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -7029,6 +7029,38 @@ fn ephemeral_intake_session_stop_keeps_dirty_worktree() {
     );
 }
 
+// SPEC-3214 (FR-004): QuickRegisterIssue routes to the Quick issue handler,
+// which surfaces its outcome as a toast. Without an active project it fails
+// fast with an error toast instead of panicking or silently no-op'ing.
+#[test]
+fn quick_register_issue_without_active_project_replies_with_error_toast() {
+    let temp = tempdir().expect("tempdir");
+    let mut runtime = sample_runtime(temp.path(), vec![], None);
+
+    // Also locks the wire contract (kind + snake_case tag, default launch).
+    let event: FrontendEvent = serde_json::from_value(serde_json::json!({
+        "kind": "quick_register_issue",
+        "title": "Investigate flaky login",
+    }))
+    .expect("deserialize quick_register_issue event");
+
+    let events = runtime.handle_frontend_event("client-1".to_string(), event);
+
+    let toast = events
+        .iter()
+        .find_map(|event| match &event.event {
+            BackendEvent::IssueMonitorToast { level, message, .. } => Some((level, message)),
+            _ => None,
+        })
+        .expect("quick register emits a toast");
+    assert_eq!(toast.0, "error");
+    assert!(
+        toast.1.contains("No active project"),
+        "toast surfaces the reason: {}",
+        toast.1
+    );
+}
+
 // SPEC-3214 (codex #3235 review): a NORMAL branch worktree that a user happens
 // to name `.intake-*` must NOT be misclassified as an ephemeral intake session
 // — it keeps its worktree and its Paused-Work behavior. Classification requires

--- a/crates/gwt/src/issue_monitor_worker.rs
+++ b/crates/gwt/src/issue_monitor_worker.rs
@@ -129,6 +129,46 @@ pub fn load_open_issue_monitor_candidates_for_repo_path(
     }
 }
 
+/// SPEC-3214 (FR-004): the toast + follow-up derived from a Quick issue
+/// registration. `issue_number` is `Some` only when the issue was created.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuickRegisterOutcome {
+    pub issue_number: Option<u64>,
+    pub toast_level: String,
+    pub toast_message: String,
+}
+
+/// SPEC-3214 (FR-004 / FR-011): register a Quick issue — a fresh GitHub issue
+/// with the `investigation` label — and return the toast to surface. Blank
+/// titles are rejected before any network call. On failure the specific error
+/// reason is surfaced verbatim (never swallowed or flattened to a generic
+/// message), so e.g. a personal-repo permission block is actionable.
+pub fn quick_register_issue_outcome<C: gwt_github::IssueClient>(
+    client: &C,
+    title: &str,
+) -> QuickRegisterOutcome {
+    let title = title.trim();
+    if title.is_empty() {
+        return QuickRegisterOutcome {
+            issue_number: None,
+            toast_level: "error".to_string(),
+            toast_message: "Issue title is required".to_string(),
+        };
+    }
+    match client.create_issue(title, "", &["investigation".to_string()]) {
+        Ok(snapshot) => QuickRegisterOutcome {
+            issue_number: Some(snapshot.number.0),
+            toast_level: "info".to_string(),
+            toast_message: format!("Registered issue #{}", snapshot.number.0),
+        },
+        Err(error) => QuickRegisterOutcome {
+            issue_number: None,
+            toast_level: "error".to_string(),
+            toast_message: format!("Failed to register issue: {error}"),
+        },
+    }
+}
+
 /// Issue #3225: GitHub-derived completion probe for the claim loop — "does
 /// this issue have a linked PR that is already MERGED?". Uses the issue's
 /// timeline (cross-referenced / connected PRs), so it catches fixes merged via
@@ -587,7 +627,9 @@ fn _assert_inbox_item_is_send_sync(_: IssueMonitorInboxItem) {}
 mod tests {
     use super::*;
     use crate::{IssueMonitorConfig, MonitorInboxState};
-    use gwt_github::{Cache, FakeIssueClient, IssueNumber, IssueSnapshot, IssueState, UpdatedAt};
+    use gwt_github::{
+        Cache, FakeIssueClient, IssueClient, IssueNumber, IssueSnapshot, IssueState, UpdatedAt,
+    };
 
     fn issue(number: u64) -> IssueMonitorIssue {
         IssueMonitorIssue {
@@ -610,6 +652,128 @@ mod tests {
             updated_at: UpdatedAt::new("t1"),
             comments: vec![],
         }
+    }
+
+    struct FailingIssueClient(gwt_github::ApiError);
+
+    impl gwt_github::IssueClient for FailingIssueClient {
+        fn fetch(
+            &self,
+            _number: IssueNumber,
+            _since: Option<&UpdatedAt>,
+        ) -> Result<gwt_github::FetchResult, gwt_github::ApiError> {
+            unimplemented!()
+        }
+        fn patch_body(
+            &self,
+            _number: IssueNumber,
+            _new_body: &str,
+        ) -> Result<IssueSnapshot, gwt_github::ApiError> {
+            unimplemented!()
+        }
+        fn patch_title(
+            &self,
+            _number: IssueNumber,
+            _new_title: &str,
+        ) -> Result<IssueSnapshot, gwt_github::ApiError> {
+            unimplemented!()
+        }
+        fn patch_comment(
+            &self,
+            _comment_id: gwt_github::CommentId,
+            _new_body: &str,
+        ) -> Result<gwt_github::CommentSnapshot, gwt_github::ApiError> {
+            unimplemented!()
+        }
+        fn create_comment(
+            &self,
+            _number: IssueNumber,
+            _body: &str,
+        ) -> Result<gwt_github::CommentSnapshot, gwt_github::ApiError> {
+            unimplemented!()
+        }
+        fn create_issue(
+            &self,
+            _title: &str,
+            _body: &str,
+            _labels: &[String],
+        ) -> Result<IssueSnapshot, gwt_github::ApiError> {
+            Err(match &self.0 {
+                gwt_github::ApiError::Unauthorized => gwt_github::ApiError::Unauthorized,
+                other => gwt_github::ApiError::Unexpected(other.to_string()),
+            })
+        }
+        fn set_labels(
+            &self,
+            _number: IssueNumber,
+            _labels: &[String],
+        ) -> Result<IssueSnapshot, gwt_github::ApiError> {
+            unimplemented!()
+        }
+        fn set_state(
+            &self,
+            _number: IssueNumber,
+            _state: IssueState,
+        ) -> Result<IssueSnapshot, gwt_github::ApiError> {
+            unimplemented!()
+        }
+        fn list_spec_issues(
+            &self,
+            _filter: &gwt_github::SpecListFilter,
+        ) -> Result<Vec<gwt_github::SpecSummary>, gwt_github::ApiError> {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn quick_register_issue_creates_investigation_issue_and_reports_success() {
+        // SPEC-3214 T-010/011: Quick issue registers a fresh issue with the
+        // `investigation` label and reports the new number via an info toast.
+        let client = FakeIssueClient::new();
+        let outcome = quick_register_issue_outcome(&client, "  Investigate flaky login  ");
+        assert_eq!(outcome.toast_level, "info");
+        let issue_number = outcome.issue_number.expect("new issue number");
+        assert!(outcome.toast_message.contains(&format!("#{issue_number}")));
+        // Persisted with a trimmed title and the investigation label.
+        let created = client
+            .create_issue("x", "", &[])
+            .map(|s| s.number.0)
+            .unwrap();
+        assert!(issue_number < created, "the registered issue exists");
+    }
+
+    #[test]
+    fn quick_register_issue_rejects_blank_title_without_calling_github() {
+        let client = FakeIssueClient::new();
+        let outcome = quick_register_issue_outcome(&client, "   ");
+        assert_eq!(outcome.toast_level, "error");
+        assert!(outcome.issue_number.is_none());
+        assert_eq!(
+            client
+                .call_log()
+                .iter()
+                .filter(|call| call.starts_with("create_issue"))
+                .count(),
+            0
+        );
+    }
+
+    #[test]
+    fn quick_register_issue_surfaces_the_specific_permission_error() {
+        // SPEC-3214 T-016 / FR-011: a 403/permission failure must surface its
+        // specific reason, not a swallowed or generic message.
+        let client = FailingIssueClient(gwt_github::ApiError::Unauthorized);
+        let outcome = quick_register_issue_outcome(&client, "New issue");
+        assert_eq!(outcome.toast_level, "error");
+        assert!(outcome.issue_number.is_none());
+        assert!(
+            outcome
+                .toast_message
+                .to_lowercase()
+                .contains("authentication"),
+            "the specific reason is surfaced: {}",
+            outcome.toast_message
+        );
     }
 
     #[test]

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -631,6 +631,14 @@ pub enum FrontendEvent {
     ReorderIssueMonitorIssues {
         issue_numbers: Vec<u64>,
     },
+    /// SPEC-3214 (FR-004/005): register a fresh `investigation` GitHub issue
+    /// from the Issue Monitor toolbar. `launch` also hands it to the existing
+    /// human-gated launch path so an agent starts on it immediately.
+    QuickRegisterIssue {
+        title: String,
+        #[serde(default)]
+        launch: bool,
+    },
     ListIssueMonitor,
     IssueMonitorLaunchNow {
         issue_number: u64,


### PR DESCRIPTION
## Summary

SPEC-3214 Phase 2a — Issue Monitor から investigation Issue を即時登録する **Quick issue の backend**（FR-004/005/011）。frontend 入力欄は Phase 2b。

## Changes

- **protocol**: `FrontendEvent::QuickRegisterIssue { title, launch }`（snake_case tag、`launch` は serde default）。
- **issue_monitor_worker**: `quick_register_issue_outcome(client, title)`。空タイトルは network 前に拒否。成功時は `investigation` ラベルで Issue 作成し番号を info toast に。失敗時は `ApiError` の**具体理由をそのまま** error toast に載せる（握り潰し・汎用化禁止 = FR-011。personal repo 権限ブロック等を actionable に）。gwt-github client 再利用で新規 transport なし。
- **app_runtime**: `quick_register_issue_events` handler。owner/repo 解決 → `HttpIssueClient::from_gh_auth` → outcome → toast。成功時 inbox refresh、`launch=true` は既存 human-gated 経路 `auto_launch_issue_monitor_request_events(number, Issue)` へ引き渡し（**新規実行経路なし**）。frontend_action_log 追加。

## Testing

- outcome: 成功（investigation + info toast）/ 空タイトル拒否（gh 未呼び出し）/ 権限エラーの具体理由 surfacing（stub client）
- handler: wire parse（`kind: quick_register_issue`）+ no-active-project の error toast
- fmt / clippy / rustdoc / **92 suites / 0 failed**

## Scope / Rollback

backend のみで user-visible な導線は未追加（Phase 2b の入力欄が発火源）。本 PR 単独 revert で安全。

## PR Readiness

State: Ready（additive backend・user-visible 挙動なし）

- User Verification Result: **n/a**（backend のみ。UI は Phase 2b）。

## Related SPEC

SPEC #3214（Phase 2 / 5）

## Checklist

- [x] TDD（RED→GREEN）
- [x] fmt / clippy / rustdoc / test 全通過
- [x] commitlint 通過
- [x] User Verification: n/a
