### PR TITLE
fix(intake): Quick issue の空タイトルを auth 前に検証し登録後 refresh を Observe に (codex #3240)

### DIFF
--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -1309,6 +1309,11 @@ impl AppRuntime {
             )]
         };
 
+        // codex #3240: reject a blank title before any project / GitHub-auth
+        // resolution so a mistap never triggers a network round-trip.
+        if title.trim().is_empty() {
+            return error_toast("Issue title is required".to_string());
+        }
         let Some(project_root) = self.active_project_root().map(Path::to_path_buf) else {
             return error_toast("No active project".to_string());
         };
@@ -1335,8 +1340,14 @@ impl AppRuntime {
         )];
 
         if let Some(issue_number) = outcome.issue_number {
-            // Refresh the inbox so the freshly registered issue is visible.
-            events.extend(self.local_issue_monitor_events(client_id, |_| {}));
+            // Refresh the inbox so the freshly registered issue is visible, but
+            // OBSERVE-only: registering must never itself claim/launch (codex
+            // #3240). A launch happens solely through the explicit handoff below.
+            events.extend(self.local_issue_monitor_events_with_policy(
+                Some(client_id),
+                IssueMonitorScanPolicy::Observe,
+                |_| {},
+            ));
             if launch {
                 // A Quick issue carries the `investigation` label, so it is a
                 // plain Issue (never a SPEC) for launch purposes.

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -7061,6 +7061,40 @@ fn quick_register_issue_without_active_project_replies_with_error_toast() {
     );
 }
 
+// SPEC-3214 (codex #3240): a blank Quick issue title is rejected BEFORE any
+// project / GitHub-auth resolution, so a mistap never hits the network.
+#[test]
+fn quick_register_issue_rejects_blank_title_before_touching_github() {
+    let temp = tempdir().expect("tempdir");
+    let repo = temp.path().join("repo");
+    fs::create_dir_all(&repo).expect("create repo");
+    init_repo(&repo);
+    let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
+    let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
+
+    let events = runtime.handle_frontend_event(
+        "client-1".to_string(),
+        FrontendEvent::QuickRegisterIssue {
+            title: "   ".to_string(),
+            launch: false,
+        },
+    );
+
+    let toast = events
+        .iter()
+        .find_map(|event| match &event.event {
+            BackendEvent::IssueMonitorToast { level, message, .. } => Some((level, message)),
+            _ => None,
+        })
+        .expect("blank title emits a toast");
+    assert_eq!(toast.0, "error");
+    assert!(
+        toast.1.contains("title is required"),
+        "the blank-title reason precedes any auth error: {}",
+        toast.1
+    );
+}
+
 // SPEC-3214 (codex #3235 review): a NORMAL branch worktree that a user happens
 // to name `.intake-*` must NOT be misclassified as an ephemeral intake session
 // — it keeps its worktree and its Paused-Work behavior. Classification requires


### PR DESCRIPTION
## Summary

merged 済み PR #3240 への codex review 指摘 2 件（P2）の follow-up。

## Changes

1. **空タイトルの network round-trip**: handler が owner/repo 解決と `HttpIssueClient::from_gh_auth` の後に空タイトルを弾いていたため、mistap でも gh auth を叩いていた。handler 冒頭で `title.trim().is_empty()` を検証し、project / auth 解決より前に error toast を返す。
2. **登録後 refresh の副作用**: 登録成功後の inbox refresh に `local_issue_monitor_events`（ClaimAndLaunch policy）を使っていたため register-only でも scan が claim/launch を誘発し得た。`IssueMonitorScanPolicy::Observe`（snapshot 用 scan・claim/launch 禁止）に切替。launch は `launch=true` 時の明示 handoff だけが行う。

## Testing

- active project + 空タイトル → "title is required" が auth error より先に返る
- fmt / clippy / **bin 700 / 0 failed**

## PR Readiness

State: Ready（correctness・user-visible 挙動なし）

- User Verification Result: **n/a**（backend のみ）。

## Related SPEC

SPEC #3214（Phase 2a hardening）

## Checklist

- [x] codex #3240 P2×2 反映 + テスト
- [x] fmt / clippy / test 全通過
- [x] commitlint 通過
- [x] User Verification: n/a
