### PR TITLE
feat(hooks): lane-first hooks v2 (SPEC-3248)

### DIFF
--- a/crates/gwt-skills/src/distribute.rs
+++ b/crates/gwt-skills/src/distribute.rs
@@ -121,6 +121,43 @@ pub fn distribute_to_worktree_for_targets(
     Ok(report)
 }
 
+/// Implementation-skill basenames a reduced (curation) skill set omits. An
+/// intake lane registers Issues/SPECs and does not implement, so it should not
+/// surface the build / verify / PR skills. Curation skills (register-issue,
+/// discussion, plan-spec, search, arch-review, register-spec, …) and the
+/// always-present gwt-coordination guidance stay.
+pub const CURATION_EXCLUDED_SKILLS: &[&str] = &[
+    "gwt-build-spec",
+    "gwt-verify",
+    "gwt-manage-pr",
+    "gwt-fix-issue",
+];
+
+/// Apply a reduced (curation) skill set to a worktree by removing the
+/// implementation skills/commands (SPEC-3248 P4, FR-011). Runs after
+/// distribution as a post-pass, so the write/prune materialization core is
+/// untouched. Idempotent: missing paths are ignored. Only gwt-managed
+/// (gitignored) assets are removed; a re-materialize restores the full set for
+/// a non-reduced lane.
+pub fn apply_reduced_skill_set(worktree: &Path) -> io::Result<usize> {
+    let mut removed = 0usize;
+    for name in CURATION_EXCLUDED_SKILLS {
+        for skills_root in [".claude/skills", ".codex/skills", ".gwt/hermes/skills"] {
+            let dir = worktree.join(skills_root).join(name);
+            if dir.is_dir() {
+                fs::remove_dir_all(&dir)?;
+                removed += 1;
+            }
+        }
+        let command = worktree.join(".claude/commands").join(format!("{name}.md"));
+        if command.is_file() {
+            fs::remove_file(&command)?;
+            removed += 1;
+        }
+    }
+    Ok(removed)
+}
+
 /// Remove stale gwt-managed asset paths from the target worktree without
 /// materializing the current bundle.
 pub fn prune_stale_gwt_assets(worktree: &Path) -> io::Result<usize> {
@@ -541,6 +578,52 @@ mod tests {
                 .exists(),
             "gwt-* skill must still be materialized for ClaudeCode target"
         );
+    }
+
+    #[test]
+    fn apply_reduced_skill_set_removes_implementation_skills_keeps_curation() {
+        let dir = tempfile::tempdir().unwrap();
+        distribute_to_worktree_for_targets(
+            dir.path(),
+            &[ManagedAssetTarget::ClaudeCode, ManagedAssetTarget::Codex],
+        )
+        .unwrap();
+
+        // Sanity: implementation + curation skills both present after full
+        // distribution.
+        assert!(dir
+            .path()
+            .join(".claude/skills/gwt-build-spec/SKILL.md")
+            .exists());
+        assert!(dir
+            .path()
+            .join(".claude/skills/gwt-register-issue/SKILL.md")
+            .exists());
+
+        let removed = apply_reduced_skill_set(dir.path()).unwrap();
+        assert!(removed > 0, "reduced skill set must remove something");
+
+        // Implementation skills + their commands are gone (Claude + Codex).
+        for excluded in CURATION_EXCLUDED_SKILLS {
+            assert!(
+                !dir.path().join(".claude/skills").join(excluded).exists(),
+                "intake must drop implementation skill {excluded} (claude)"
+            );
+            assert!(
+                !dir.path().join(".codex/skills").join(excluded).exists(),
+                "intake must drop implementation skill {excluded} (codex)"
+            );
+        }
+        // Curation skills survive.
+        assert!(
+            dir.path()
+                .join(".claude/skills/gwt-register-issue/SKILL.md")
+                .exists(),
+            "intake must keep curation skills"
+        );
+
+        // Idempotent: a second application removes nothing.
+        assert_eq!(apply_reduced_skill_set(dir.path()).unwrap(), 0);
     }
 
     #[test]

--- a/crates/gwt-skills/src/lane.rs
+++ b/crates/gwt-skills/src/lane.rs
@@ -88,7 +88,8 @@ pub const INTAKE_PROFILE: LaneProfile = LaneProfile {
     policy_flags: LanePolicyFlags {
         emit_work_state_reminders: false,
         self_improvement_stop: false,
-        block_production_code_edits: false,
+        // SPEC-3248 P4: intake registers Issues/SPECs, it does not edit code.
+        block_production_code_edits: true,
         // SPEC-3248 P4: nudge to register curated work before Stop.
         completion_gate: true,
         // SPEC-3248 P4: intake opens with a curation SessionStart 导线.
@@ -274,7 +275,7 @@ mod tests {
                 policy_flags: LanePolicyFlags {
                     emit_work_state_reminders: false,
                     self_improvement_stop: false,
-                    block_production_code_edits: false,
+                    block_production_code_edits: true,
                     completion_gate: true,
                     sessionstart_onboarding: true,
                     reduced_skill_set: false,

--- a/crates/gwt-skills/src/lane.rs
+++ b/crates/gwt-skills/src/lane.rs
@@ -1,0 +1,288 @@
+//! Lane registry and lane profiles (SPEC-3248 hooks v2, P0 Foundational).
+//!
+//! A **lane** is the role a launched agent session plays. SPEC-3247 introduced
+//! two ([`SessionKind::Intake`] / [`SessionKind::Execution`]) and branched
+//! individual hooks on the `GWT_SESSION_KIND` env at runtime. hooks v2 makes
+//! the lane a first-class, N-extensible dimension: each lane declares a
+//! [`LaneProfile`] (guidance variant + policy flags + — later — skill set), and
+//! hooks/guidance/skills consult the profile instead of re-deriving behavior
+//! per hook. Adding a lane becomes "add a profile", not "wire every hook".
+//!
+//! P0 introduces the registry, the profiles for the two existing lanes, and the
+//! worktree lane file that is the deterministic source of truth (env stays a
+//! fast-path). It intentionally does not yet rewire the hooks — that is P1–P4,
+//! migrated one handler at a time (strangler-fig). The `intake`/`execution`
+//! profiles here encode exactly the behavior SPEC-3247 already ships, so P0 is
+//! behavior-neutral.
+
+use std::path::{Path, PathBuf};
+
+use crate::session_kind::SessionKind;
+
+/// Which coordination-guidance body a lane materializes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuidanceVariant {
+    /// Curate lane: no Work-state (`workspace.update`) instructions.
+    Curation,
+    /// Execute lane: full producing-work guidance.
+    ProducingWork,
+}
+
+/// Boolean switches a [`LaneProfile`] toggles for hooks/guidance/skills.
+///
+/// P0 wires none of these into hooks yet; they exist so P1–P4 can consult the
+/// profile instead of the ad-hoc `SessionKind::from_env()` branches SPEC-3247
+/// left behind. The `execution` and `intake` defaults below reproduce the
+/// current shipped behavior exactly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LanePolicyFlags {
+    /// Emit the producing-work Work-state reminders (title/progress) in
+    /// board_reminder. `false` for intake (it owns no Work).
+    pub emit_work_state_reminders: bool,
+    /// Let the gwt self-improvement Stop gate fire. `false` for intake.
+    pub self_improvement_stop: bool,
+    /// Block Edit/Write to production source at PreToolUse (P4). `false` today.
+    pub block_production_code_edits: bool,
+    /// Nudge to register the curated Issue/SPEC before Stop (P4). `false` today.
+    pub completion_gate: bool,
+    /// Emit a lane-specific SessionStart onboarding导线 (P4). `false` today.
+    pub sessionstart_onboarding: bool,
+    /// Distribute only the curation skill subset (P4). `false` today (all
+    /// skills go to every lane).
+    pub reduced_skill_set: bool,
+}
+
+/// A declarative profile for one lane. Adding a lane = adding a profile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LaneProfile {
+    /// Stable lane id materialized into the lane file (`intake` / `execution` /
+    /// future `review` …).
+    pub id: &'static str,
+    /// Coordination-guidance body this lane uses.
+    pub guidance_variant: GuidanceVariant,
+    /// Hook/guidance/skill policy switches.
+    pub policy_flags: LanePolicyFlags,
+}
+
+/// The Execute lane: full producing-work behavior (the default, and the
+/// behavior every non-intake launch has today).
+pub const EXECUTION_PROFILE: LaneProfile = LaneProfile {
+    id: "execution",
+    guidance_variant: GuidanceVariant::ProducingWork,
+    policy_flags: LanePolicyFlags {
+        emit_work_state_reminders: true,
+        self_improvement_stop: true,
+        block_production_code_edits: false,
+        completion_gate: false,
+        sessionstart_onboarding: false,
+        reduced_skill_set: false,
+    },
+};
+
+/// The Curate lane: branchless intake. Encodes exactly what SPEC-3247 already
+/// ships (no Work-state reminders, no self-improvement Stop, curation
+/// guidance). The P4 flags stay `false` here until their phases land.
+pub const INTAKE_PROFILE: LaneProfile = LaneProfile {
+    id: "intake",
+    guidance_variant: GuidanceVariant::Curation,
+    policy_flags: LanePolicyFlags {
+        emit_work_state_reminders: false,
+        self_improvement_stop: false,
+        block_production_code_edits: false,
+        completion_gate: false,
+        sessionstart_onboarding: false,
+        reduced_skill_set: false,
+    },
+};
+
+/// Registry of lane profiles. N-extensible: adding a lane means adding a
+/// profile constant and a `resolve` arm.
+pub struct LaneRegistry;
+
+impl LaneRegistry {
+    /// The default lane when nothing else is known. Execution preserves the
+    /// current producing-work behavior for old launches / existing worktrees.
+    #[must_use]
+    pub fn default_profile() -> &'static LaneProfile {
+        &EXECUTION_PROFILE
+    }
+
+    /// Resolve a lane id to its profile. Unknown / empty ids fall back to the
+    /// default (execution) — the same fail-safe as the lane file and env.
+    #[must_use]
+    pub fn resolve(id: &str) -> &'static LaneProfile {
+        match id.trim() {
+            "intake" => &INTAKE_PROFILE,
+            "execution" => &EXECUTION_PROFILE,
+            _ => Self::default_profile(),
+        }
+    }
+
+    /// Bridge from the SPEC-3247 [`SessionKind`] enum to a lane profile, so the
+    /// two representations cannot drift while hooks migrate.
+    #[must_use]
+    pub fn for_session_kind(kind: SessionKind) -> &'static LaneProfile {
+        match kind {
+            SessionKind::Intake => &INTAKE_PROFILE,
+            SessionKind::Execution => &EXECUTION_PROFILE,
+        }
+    }
+}
+
+/// Worktree-relative path of the lane file (the deterministic source of truth).
+pub const LANE_FILE_RELATIVE: &str = ".gwt/session-kind.json";
+
+/// Current lane-file schema version.
+pub const LANE_FILE_VERSION: u32 = 1;
+
+/// Absolute lane-file path for a worktree.
+#[must_use]
+pub fn lane_file_path(worktree: &Path) -> PathBuf {
+    worktree.join(LANE_FILE_RELATIVE)
+}
+
+/// Materialize the lane file for `worktree` from a resolved [`LaneProfile`].
+///
+/// Called at launch with the authoritative lane (from `is_ephemeral`), this
+/// writes `.gwt/session-kind.json` atomically so hooks read the lane
+/// deterministically regardless of env propagation (SPEC-3247 hit a
+/// production env dead-path; the lane file avoids that class of bug).
+pub fn write_lane_file(worktree: &Path, profile: &LaneProfile) -> std::io::Result<()> {
+    let path = lane_file_path(worktree);
+    let body = format!(
+        "{{\n  \"lane\": \"{lane}\",\n  \"profile_version\": {version}\n}}\n",
+        lane = profile.id,
+        version = LANE_FILE_VERSION,
+    );
+    crate::settings_local::write_text_atomically(&path, &body)
+}
+
+/// Read the lane profile from a worktree's lane file. A missing, unreadable, or
+/// unparseable file — and any unknown lane id — resolves to the default
+/// (execution), preserving backward compatibility for worktrees materialized
+/// before hooks v2.
+#[must_use]
+pub fn read_lane_profile(worktree: &Path) -> &'static LaneProfile {
+    let path = lane_file_path(worktree);
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return LaneRegistry::default_profile();
+    };
+    match parse_lane_id(&text) {
+        Some(id) => LaneRegistry::resolve(&id),
+        None => LaneRegistry::default_profile(),
+    }
+}
+
+/// Extract the `"lane"` string from the lane file body without pulling in a
+/// JSON dependency for such a tiny schema. Returns `None` on any shape it does
+/// not recognize (→ caller falls back to the default profile).
+fn parse_lane_id(text: &str) -> Option<String> {
+    let after = text.split("\"lane\"").nth(1)?;
+    let after = after.trim_start();
+    let after = after.strip_prefix(':')?.trim_start();
+    let rest = after.strip_prefix('"')?;
+    let end = rest.find('"')?;
+    let id = rest[..end].trim().to_string();
+    (!id.is_empty()).then_some(id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn resolve_maps_known_lanes_and_defaults_execution() {
+        assert_eq!(LaneRegistry::resolve("intake"), &INTAKE_PROFILE);
+        assert_eq!(LaneRegistry::resolve("execution"), &EXECUTION_PROFILE);
+        // Unknown / empty / whitespace → execution default (fail-safe).
+        assert_eq!(LaneRegistry::resolve("review"), &EXECUTION_PROFILE);
+        assert_eq!(LaneRegistry::resolve(""), &EXECUTION_PROFILE);
+        assert_eq!(LaneRegistry::resolve("  "), &EXECUTION_PROFILE);
+        assert_eq!(LaneRegistry::resolve(" intake "), &INTAKE_PROFILE);
+        assert_eq!(LaneRegistry::default_profile(), &EXECUTION_PROFILE);
+    }
+
+    #[test]
+    fn session_kind_bridge_matches_registry() {
+        assert_eq!(
+            LaneRegistry::for_session_kind(SessionKind::Intake),
+            &INTAKE_PROFILE
+        );
+        assert_eq!(
+            LaneRegistry::for_session_kind(SessionKind::Execution),
+            &EXECUTION_PROFILE
+        );
+    }
+
+    #[test]
+    fn profiles_reproduce_spec_3247_behavior() {
+        // Lock the whole profiles against explicit expected values (a
+        // regression guard, and not a constant `assert!`). execution = full
+        // producing-work baseline; intake = exactly what SPEC-3247 ships (no
+        // Work-state nag, no self-improvement Stop, curation guidance) with all
+        // P4 flags still off until their phase lands.
+        assert_eq!(
+            EXECUTION_PROFILE,
+            LaneProfile {
+                id: "execution",
+                guidance_variant: GuidanceVariant::ProducingWork,
+                policy_flags: LanePolicyFlags {
+                    emit_work_state_reminders: true,
+                    self_improvement_stop: true,
+                    block_production_code_edits: false,
+                    completion_gate: false,
+                    sessionstart_onboarding: false,
+                    reduced_skill_set: false,
+                },
+            }
+        );
+        assert_eq!(
+            INTAKE_PROFILE,
+            LaneProfile {
+                id: "intake",
+                guidance_variant: GuidanceVariant::Curation,
+                policy_flags: LanePolicyFlags {
+                    emit_work_state_reminders: false,
+                    self_improvement_stop: false,
+                    block_production_code_edits: false,
+                    completion_gate: false,
+                    sessionstart_onboarding: false,
+                    reduced_skill_set: false,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn lane_file_roundtrips_through_write_and_read() {
+        let dir = TempDir::new().expect("tempdir");
+        std::fs::create_dir_all(dir.path().join(".gwt")).expect("mk .gwt");
+
+        write_lane_file(dir.path(), &INTAKE_PROFILE).expect("write intake lane file");
+        assert_eq!(read_lane_profile(dir.path()), &INTAKE_PROFILE);
+
+        write_lane_file(dir.path(), &EXECUTION_PROFILE).expect("write execution lane file");
+        assert_eq!(read_lane_profile(dir.path()), &EXECUTION_PROFILE);
+    }
+
+    #[test]
+    fn read_lane_profile_defaults_execution_when_absent_or_malformed() {
+        let dir = TempDir::new().expect("tempdir");
+        // Absent file → execution.
+        assert_eq!(read_lane_profile(dir.path()), &EXECUTION_PROFILE);
+
+        // Malformed / unknown lane → execution.
+        std::fs::create_dir_all(dir.path().join(".gwt")).expect("mk .gwt");
+        std::fs::write(lane_file_path(dir.path()), "not json").expect("write junk");
+        assert_eq!(read_lane_profile(dir.path()), &EXECUTION_PROFILE);
+        std::fs::write(lane_file_path(dir.path()), "{\"lane\":\"review\"}").expect("write unknown");
+        assert_eq!(read_lane_profile(dir.path()), &EXECUTION_PROFILE);
+    }
+
+    #[test]
+    fn lane_file_path_is_worktree_relative() {
+        let p = lane_file_path(Path::new("/tmp/wt"));
+        assert!(p.ends_with(".gwt/session-kind.json"));
+    }
+}

--- a/crates/gwt-skills/src/lane.rs
+++ b/crates/gwt-skills/src/lane.rs
@@ -89,7 +89,8 @@ pub const INTAKE_PROFILE: LaneProfile = LaneProfile {
         emit_work_state_reminders: false,
         self_improvement_stop: false,
         block_production_code_edits: false,
-        completion_gate: false,
+        // SPEC-3248 P4: nudge to register curated work before Stop.
+        completion_gate: true,
         // SPEC-3248 P4: intake opens with a curation SessionStart 导线.
         sessionstart_onboarding: true,
         reduced_skill_set: false,
@@ -274,7 +275,7 @@ mod tests {
                     emit_work_state_reminders: false,
                     self_improvement_stop: false,
                     block_production_code_edits: false,
-                    completion_gate: false,
+                    completion_gate: true,
                     sessionstart_onboarding: true,
                     reduced_skill_set: false,
                 },

--- a/crates/gwt-skills/src/lane.rs
+++ b/crates/gwt-skills/src/lane.rs
@@ -94,7 +94,8 @@ pub const INTAKE_PROFILE: LaneProfile = LaneProfile {
         completion_gate: true,
         // SPEC-3248 P4: intake opens with a curation SessionStart 导线.
         sessionstart_onboarding: true,
-        reduced_skill_set: false,
+        // SPEC-3248 P4: intake surfaces only curation skills.
+        reduced_skill_set: true,
     },
 };
 
@@ -278,7 +279,7 @@ mod tests {
                     block_production_code_edits: true,
                     completion_gate: true,
                     sessionstart_onboarding: true,
-                    reduced_skill_set: false,
+                    reduced_skill_set: true,
                 },
             }
         );

--- a/crates/gwt-skills/src/lane.rs
+++ b/crates/gwt-skills/src/lane.rs
@@ -90,7 +90,8 @@ pub const INTAKE_PROFILE: LaneProfile = LaneProfile {
         self_improvement_stop: false,
         block_production_code_edits: false,
         completion_gate: false,
-        sessionstart_onboarding: false,
+        // SPEC-3248 P4: intake opens with a curation SessionStart 导线.
+        sessionstart_onboarding: true,
         reduced_skill_set: false,
     },
 };
@@ -274,7 +275,7 @@ mod tests {
                     self_improvement_stop: false,
                     block_production_code_edits: false,
                     completion_gate: false,
-                    sessionstart_onboarding: false,
+                    sessionstart_onboarding: true,
                     reduced_skill_set: false,
                 },
             }

--- a/crates/gwt-skills/src/lane.rs
+++ b/crates/gwt-skills/src/lane.rs
@@ -173,6 +173,23 @@ pub fn read_lane_profile(worktree: &Path) -> &'static LaneProfile {
     }
 }
 
+/// Resolve the lane profile for a worktree at hook time.
+///
+/// The lane file is the source of truth; when it is present it wins
+/// (deterministic, env-independent). For worktrees materialized before hooks v2
+/// (no lane file yet) this falls back to the `GWT_SESSION_KIND` env fast-path,
+/// so the transition period keeps SPEC-3247 behavior. Both paths default to
+/// execution, so an unknown or absent signal never changes producing-work
+/// behavior (FR-009 backward compatibility).
+#[must_use]
+pub fn resolve_lane_for_worktree(worktree: &Path) -> &'static LaneProfile {
+    if lane_file_path(worktree).exists() {
+        read_lane_profile(worktree)
+    } else {
+        LaneRegistry::for_session_kind(SessionKind::from_env())
+    }
+}
+
 /// Extract the `"lane"` string from the lane file body without pulling in a
 /// JSON dependency for such a tiny schema. Returns `None` on any shape it does
 /// not recognize (→ caller falls back to the default profile).
@@ -189,7 +206,17 @@ fn parse_lane_id(text: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
     use tempfile::TempDir;
+
+    /// Serialize the one test that mutates the process-global
+    /// `GWT_SESSION_KIND` env so parallel test threads cannot race on it.
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
 
     #[test]
     fn resolve_maps_known_lanes_and_defaults_execution() {
@@ -278,6 +305,23 @@ mod tests {
         assert_eq!(read_lane_profile(dir.path()), &EXECUTION_PROFILE);
         std::fs::write(lane_file_path(dir.path()), "{\"lane\":\"review\"}").expect("write unknown");
         assert_eq!(read_lane_profile(dir.path()), &EXECUTION_PROFILE);
+    }
+
+    #[test]
+    fn resolve_lane_prefers_lane_file_then_env_then_execution() {
+        let _guard = env_lock();
+        let dir = TempDir::new().expect("tempdir");
+        // No lane file, no env → execution.
+        std::env::remove_var(crate::GWT_SESSION_KIND_ENV);
+        assert_eq!(resolve_lane_for_worktree(dir.path()), &EXECUTION_PROFILE);
+        // No lane file, env=intake → env fast-path (transition worktrees).
+        std::env::set_var(crate::GWT_SESSION_KIND_ENV, "intake");
+        assert_eq!(resolve_lane_for_worktree(dir.path()), &INTAKE_PROFILE);
+        // Lane file present wins over env (source of truth): file=execution
+        // beats env=intake.
+        write_lane_file(dir.path(), &EXECUTION_PROFILE).expect("write lane file");
+        assert_eq!(resolve_lane_for_worktree(dir.path()), &EXECUTION_PROFILE);
+        std::env::remove_var(crate::GWT_SESSION_KIND_ENV);
     }
 
     #[test]

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -29,8 +29,9 @@ pub use coordination_guidance::{
     generate_coordination_guidance_for_codex,
 };
 pub use distribute::{
-    distribute_to_worktree, distribute_to_worktree_for_targets, prune_stale_gwt_assets,
-    prune_stale_gwt_assets_for_targets, DistributeReport, ManagedAssetTarget,
+    apply_reduced_skill_set, distribute_to_worktree, distribute_to_worktree_for_targets,
+    prune_stale_gwt_assets, prune_stale_gwt_assets_for_targets, DistributeReport,
+    ManagedAssetTarget, CURATION_EXCLUDED_SKILLS,
 };
 pub use git_exclude::{update_git_exclude, update_git_exclude_for_targets};
 pub use hooks::{

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -7,6 +7,7 @@ pub mod coordination_guidance;
 pub mod distribute;
 pub mod git_exclude;
 pub mod hooks;
+pub mod lane;
 pub mod provider_hooks;
 pub mod registry;
 pub mod session_kind;
@@ -35,6 +36,11 @@ pub use git_exclude::{update_git_exclude, update_git_exclude_for_targets};
 pub use hooks::{
     backup_hooks, detect_corruption, is_gwt_managed, merge_hooks, merge_hooks_safe,
     restore_from_backup, Hook, HooksConfig, HooksError,
+};
+pub use lane::{
+    lane_file_path, read_lane_profile, write_lane_file, GuidanceVariant, LanePolicyFlags,
+    LaneProfile, LaneRegistry, EXECUTION_PROFILE, INTAKE_PROFILE, LANE_FILE_RELATIVE,
+    LANE_FILE_VERSION,
 };
 pub use provider_hooks::{
     generate_hermes_hooks, generate_openclaw_hooks, generate_opencode_hooks, hermes_is_configured,

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -38,9 +38,9 @@ pub use hooks::{
     restore_from_backup, Hook, HooksConfig, HooksError,
 };
 pub use lane::{
-    lane_file_path, read_lane_profile, write_lane_file, GuidanceVariant, LanePolicyFlags,
-    LaneProfile, LaneRegistry, EXECUTION_PROFILE, INTAKE_PROFILE, LANE_FILE_RELATIVE,
-    LANE_FILE_VERSION,
+    lane_file_path, read_lane_profile, resolve_lane_for_worktree, write_lane_file, GuidanceVariant,
+    LanePolicyFlags, LaneProfile, LaneRegistry, EXECUTION_PROFILE, INTAKE_PROFILE,
+    LANE_FILE_RELATIVE, LANE_FILE_VERSION,
 };
 pub use provider_hooks::{
     generate_hermes_hooks, generate_openclaw_hooks, generate_opencode_hooks, hermes_is_configured,

--- a/crates/gwt/src/app_runtime/launch.rs
+++ b/crates/gwt/src/app_runtime/launch.rs
@@ -1499,6 +1499,15 @@ impl AppRuntime {
             // materializes curation-framed guidance without Work-state
             // instructions.
             let session_kind = gwt_skills::SessionKind::from_is_ephemeral(config.is_ephemeral);
+            // SPEC-3248 (hooks v2 P0): materialize the lane file — the
+            // deterministic source of truth hooks read via the lane registry —
+            // from the authoritative launch-time lane (is_ephemeral). Best
+            // effort: a write failure must not block the launch, and hooks fall
+            // back to the execution default when the file is absent.
+            let _ = gwt_skills::write_lane_file(
+                &worktree_path,
+                gwt_skills::LaneRegistry::for_session_kind(session_kind),
+            );
             refresh_managed_gwt_assets_for_agent_with_codex_hook_discovery_mode(
                 &worktree_path,
                 &config.agent_id,

--- a/crates/gwt/src/cli/hook/board_reminder/mod.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/mod.rs
@@ -622,7 +622,28 @@ pub fn compute_plan(
         plan.output = prepend_lane_onboarding(plan.output, lane, &language);
     }
 
+    // SPEC-3248 (hooks v2 P4): a lane with the completion gate gets a soft,
+    // non-blocking Stop nudge to register the work it curated. It never blocks
+    // Stop — an intake session may legitimately end in no-action.
+    if intent_event == IntentBoundaryEvent::Stop && lane.policy_flags.completion_gate {
+        plan.output = append_intake_completion_reminder(plan.output, &language);
+    }
+
     Ok(Some(plan))
+}
+
+/// Append the intake completion nudge to a Stop output (SPEC-3248 P4). Stop
+/// emits `SystemMessage` (Claude Code rejects `hookSpecificOutput` on Stop), so
+/// this stays a user-facing reminder and never a `StopBlock`.
+fn append_intake_completion_reminder(output: HookOutput, language: &str) -> HookOutput {
+    let reminder = texts::intake_completion_reminder(language);
+    match output {
+        HookOutput::SystemMessage(text) => {
+            HookOutput::system_message(format!("{text}\n\n{reminder}"))
+        }
+        HookOutput::Silent => HookOutput::system_message(reminder.to_string()),
+        other => other,
+    }
 }
 
 /// Prepend a lane-specific SessionStart onboarding block (SPEC-3248 FR-011).
@@ -1431,6 +1452,49 @@ mod tests {
         assert!(
             !exec_text.contains("gwt-register-issue"),
             "execution SessionStart must not carry the intake onboarding: {exec_text}"
+        );
+    }
+
+    /// SPEC-3248 P4 (FR-011): an intake lane gets a soft, non-blocking Stop
+    /// nudge to register curated work; execution does not. Must be a
+    /// SystemMessage (not a StopBlock) so it never forces continuation.
+    #[test]
+    fn intake_stop_appends_completion_reminder_without_blocking() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let home = tempfile::tempdir().expect("home");
+        let _home = ScopedEnvVar::set("HOME", home.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
+        let repo = home.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let session = make_session(&repo, "work/intake", "Codex");
+
+        let _intake = ScopedEnvVar::set(gwt_skills::GWT_SESSION_KIND_ENV, "intake");
+        let intake = compute_plan("Stop", &session, Utc::now())
+            .expect("compute plan")
+            .expect("plan");
+        // Non-blocking: a SystemMessage, never a StopBlock.
+        let HookOutput::SystemMessage(text) = &intake.output else {
+            panic!("intake Stop completion nudge must be a SystemMessage: {intake:?}");
+        };
+        assert!(
+            text.contains("gwt-register-issue") || text.contains("gwt-register-spec"),
+            "intake Stop must nudge registration: {text}"
+        );
+
+        let _exec = ScopedEnvVar::set(gwt_skills::GWT_SESSION_KIND_ENV, "execution");
+        let exec = compute_plan("Stop", &session, Utc::now())
+            .expect("compute plan")
+            .expect("plan");
+        let exec_text = match &exec.output {
+            HookOutput::SystemMessage(text) => text.as_str(),
+            HookOutput::Silent => "",
+            other => panic!("unexpected execution Stop output: {other:?}"),
+        };
+        assert!(
+            !exec_text.contains("Intake 完了") && !exec_text.contains("Intake completion"),
+            "execution Stop must not carry the intake completion nudge: {exec_text}"
         );
     }
 

--- a/crates/gwt/src/cli/hook/board_reminder/mod.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/mod.rs
@@ -539,11 +539,8 @@ pub fn compute_plan(
     // from the worktree lane file (source of truth), falling back to the env
     // fast-path and then execution (FR-009). Replaces the SPEC-3247 ad-hoc
     // `SessionKind::from_env()` branch.
-    let emit_work_state_reminders =
-        super::context::HookContext::for_worktree(&session.worktree_path)
-            .lane
-            .policy_flags
-            .emit_work_state_reminders;
+    let lane = super::context::HookContext::for_worktree(&session.worktree_path).lane;
+    let emit_work_state_reminders = lane.policy_flags.emit_work_state_reminders;
 
     let mut plan = plan_reminder(ReminderInputs {
         event: intent_event,
@@ -615,7 +612,40 @@ pub fn compute_plan(
         &language,
     );
 
+    // SPEC-3248 (hooks v2 P4): a lane whose profile enables SessionStart
+    // onboarding gets a lane-framed 导线 prepended on SessionStart, so an
+    // intake session opens with the curation workflow (register / discuss /
+    // plan) instead of the producing-work default.
+    if intent_event == IntentBoundaryEvent::SessionStart
+        && lane.policy_flags.sessionstart_onboarding
+    {
+        plan.output = prepend_lane_onboarding(plan.output, lane, &language);
+    }
+
     Ok(Some(plan))
+}
+
+/// Prepend a lane-specific SessionStart onboarding block (SPEC-3248 FR-011).
+/// Only lanes whose `guidance_variant` is `Curation` currently carry a distinct
+/// 导线; other lanes return the output unchanged.
+fn prepend_lane_onboarding(
+    output: HookOutput,
+    lane: &gwt_skills::LaneProfile,
+    language: &str,
+) -> HookOutput {
+    let Some(onboarding) = texts::lane_onboarding(lane, language) else {
+        return output;
+    };
+    match output {
+        HookOutput::HookSpecificAdditionalContext { event, text } => {
+            HookOutput::hook_specific_additional_context(event, format!("{onboarding}\n\n{text}"))
+        }
+        HookOutput::Silent => HookOutput::hook_specific_additional_context(
+            IntentBoundaryEvent::SessionStart,
+            onboarding.to_string(),
+        ),
+        other => other,
+    }
 }
 
 /// Resolve the narrative-output language from the global gwt config
@@ -1363,6 +1393,47 @@ mod tests {
     /// owns no Work. The same setup in an execution session (default signal)
     /// still injects both. The shared Board-coordination reminder and the
     /// memory reminder survive in intake, so intake is not silenced wholesale.
+    /// SPEC-3248 P4 (FR-011): an intake lane opens SessionStart with the
+    /// curation 导线; execution does not.
+    #[test]
+    fn intake_sessionstart_prepends_curation_onboarding() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let home = tempfile::tempdir().expect("home");
+        let _home = ScopedEnvVar::set("HOME", home.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
+        let repo = home.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("repo");
+        let session = make_session(&repo, "work/intake", "Codex");
+
+        // Intake (env fast-path, no lane file in the temp repo).
+        let _intake = ScopedEnvVar::set(gwt_skills::GWT_SESSION_KIND_ENV, "intake");
+        let intake = compute_plan("SessionStart", &session, Utc::now())
+            .expect("compute plan")
+            .expect("plan");
+        let intake_text = additional_context(&intake.output);
+        assert!(
+            intake_text.contains("Intake") && intake_text.contains("gwt-register-issue"),
+            "intake SessionStart must prepend the curation onboarding: {intake_text}"
+        );
+
+        // Execution: no onboarding.
+        let _exec = ScopedEnvVar::set(gwt_skills::GWT_SESSION_KIND_ENV, "execution");
+        let exec = compute_plan("SessionStart", &session, Utc::now())
+            .expect("compute plan")
+            .expect("plan");
+        let exec_text = match &exec.output {
+            HookOutput::HookSpecificAdditionalContext { text, .. } => text.as_str(),
+            HookOutput::Silent => "",
+            other => panic!("unexpected execution output: {other:?}"),
+        };
+        assert!(
+            !exec_text.contains("gwt-register-issue"),
+            "execution SessionStart must not carry the intake onboarding: {exec_text}"
+        );
+    }
+
     #[test]
     fn intake_session_suppresses_title_summary_work_reminder() {
         let _env_lock = crate::env_test_lock()

--- a/crates/gwt/src/cli/hook/board_reminder/mod.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/mod.rs
@@ -532,12 +532,18 @@ pub fn compute_plan(
 
     let self_match_keys = build_self_match_keys(session);
     let language = resolve_narrative_language();
-    // SPEC-3247 FR-003 / AS-4: intake (Curate) sessions own no Work, so the
-    // Work-state reminders (title purpose, progress summary) must not fire.
-    // Board-read injection and the memory reminder still apply — an intake
-    // session still coordinates and records lessons. Absent/unknown signal
-    // defaults to Execution, preserving the current behavior (FR-004).
-    let session_is_intake = gwt_skills::SessionKind::from_env().is_intake();
+    // SPEC-3248 (hooks v2 P3): the Work-state reminders (title purpose,
+    // progress summary) fire only when the resolved lane profile asks for them.
+    // Board-read injection and the memory reminder still apply — a lane that
+    // owns no Work (intake) still coordinates and records lessons. Resolved
+    // from the worktree lane file (source of truth), falling back to the env
+    // fast-path and then execution (FR-009). Replaces the SPEC-3247 ad-hoc
+    // `SessionKind::from_env()` branch.
+    let emit_work_state_reminders =
+        super::context::HookContext::for_worktree(&session.worktree_path)
+            .lane
+            .policy_flags
+            .emit_work_state_reminders;
 
     let mut plan = plan_reminder(ReminderInputs {
         event: intent_event,
@@ -552,7 +558,7 @@ pub fn compute_plan(
         self_workspace_id,
     });
 
-    if !session_is_intake {
+    if emit_work_state_reminders {
         plan.output = append_title_summary_required_context(
             plan.output,
             intent_event,
@@ -577,7 +583,7 @@ pub fn compute_plan(
         &plan.next_reminders,
     );
     plan.next_reminders = updated_state;
-    if !session_is_intake {
+    if emit_work_state_reminders {
         plan.output =
             append_title_summary_stale_context(plan.output, intent_event, stale, &language);
     }
@@ -588,7 +594,7 @@ pub fn compute_plan(
         &plan.next_reminders,
     );
     plan.next_reminders = progress_state;
-    if !session_is_intake {
+    if emit_work_state_reminders {
         plan.output = append_progress_summary_context(
             plan.output,
             intent_event,

--- a/crates/gwt/src/cli/hook/board_reminder/texts.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/texts.rs
@@ -327,6 +327,28 @@ pub(super) fn lane_onboarding(
     }
 }
 
+/// Intake completion nudge shown on Stop (SPEC-3248 P4, FR-011). A soft,
+/// non-blocking reminder — an intake session may legitimately end in no-action,
+/// so this promotes registration without forcing it.
+pub(super) fn intake_completion_reminder(language: &str) -> &'static str {
+    match reminder_language(language) {
+        ReminderLanguage::Ja => INTAKE_COMPLETION_REMINDER_JA,
+        ReminderLanguage::En => INTAKE_COMPLETION_REMINDER,
+    }
+}
+
+pub(super) const INTAKE_COMPLETION_REMINDER: &str = "# Intake completion\n\n\
+Before stopping this intake session: register the work you curated \
+(`gwt-register-issue` for a plain Issue, or `gwt-discussion` → `gwt-register-spec` \
+for a SPEC), or state explicitly that no action is needed. Intake produces \
+Issues/SPECs — do not stop with curated-but-unregistered work.";
+
+pub(super) const INTAKE_COMPLETION_REMINDER_JA: &str = "# Intake 完了\n\n\
+この intake セッションを停止する前に、curate した作業を登録してください\
+（plain Issue は `gwt-register-issue`、SPEC は `gwt-discussion` → `gwt-register-spec`）。\
+不要なら「対応不要」と明示してください。intake は Issue/SPEC を生成する役割です — \
+curate したのに未登録のまま停止しないでください。";
+
 pub(super) const INTAKE_ONBOARDING: &str = "# Intake (Curate) session\n\n\
 This is a branchless, ephemeral **intake** session: you curate and register \
 work, you do not implement it. Produce GitHub Issues / SPECs, not code.\n\n\

--- a/crates/gwt/src/cli/hook/board_reminder/texts.rs
+++ b/crates/gwt/src/cli/hook/board_reminder/texts.rs
@@ -311,6 +311,39 @@ pub(super) fn user_prompt_reminder(lang: ReminderLanguage, short: bool) -> &'sta
     }
 }
 
+/// Lane-specific SessionStart onboarding (SPEC-3248 FR-011). Curation lanes
+/// (intake) open with the register / discuss / plan 导线; producing-work lanes
+/// have no distinct onboarding (they keep the default reminder flow).
+pub(super) fn lane_onboarding(
+    lane: &gwt_skills::LaneProfile,
+    language: &str,
+) -> Option<&'static str> {
+    match lane.guidance_variant {
+        gwt_skills::GuidanceVariant::Curation => Some(match reminder_language(language) {
+            ReminderLanguage::Ja => INTAKE_ONBOARDING_JA,
+            ReminderLanguage::En => INTAKE_ONBOARDING,
+        }),
+        gwt_skills::GuidanceVariant::ProducingWork => None,
+    }
+}
+
+pub(super) const INTAKE_ONBOARDING: &str = "# Intake (Curate) session\n\n\
+This is a branchless, ephemeral **intake** session: you curate and register \
+work, you do not implement it. Produce GitHub Issues / SPECs, not code.\n\n\
+- Search first, then register: `gwt-search` → `gwt-register-issue` (plain Issue \
+vs SPEC) or `gwt-discussion` (shape a SPEC) → `gwt-plan-spec`.\n\
+- Coordinate through the Board; you own no Work state (no `workspace.update`).\n\
+- Leave implementation, verification, and PRs to Execute-lane sessions (opened \
+from a Workspace or the Issue Monitor).\n";
+
+pub(super) const INTAKE_ONBOARDING_JA: &str = "# Intake (Curate) セッション\n\n\
+これは branchless で使い捨ての **intake** セッションです。作業を curate・登録し、\
+実装はしません。コードではなく GitHub Issue / SPEC を生成します。\n\n\
+- まず検索、次に登録: `gwt-search` → `gwt-register-issue`（plain Issue か SPEC か）\
+または `gwt-discussion`（SPEC を形にする）→ `gwt-plan-spec`。\n\
+- 協調は Board 経由。Work state は持ちません（`workspace.update` 不要）。\n\
+- 実装・検証・PR は Execute レーンのセッション（Workspace か Issue Monitor 起動）に任せます。\n";
+
 pub(super) fn stop_reminder(lang: ReminderLanguage, short: bool) -> &'static str {
     match (lang, short) {
         (ReminderLanguage::Ja, true) => STOP_REMINDER_SHORT_JA,

--- a/crates/gwt/src/cli/hook/context.rs
+++ b/crates/gwt/src/cli/hook/context.rs
@@ -1,0 +1,35 @@
+//! Shared per-invocation hook context (SPEC-3248 hooks v2, P1).
+//!
+//! Hooks currently re-derive the session lane (and, elsewhere, the session /
+//! workspace projection / Board scope) independently in each handler. hooks v2
+//! consolidates that into a single [`HookContext`] resolved once per hook event
+//! and passed to handlers, so behavior branches on a shared, deterministic
+//! lane profile instead of ad-hoc `SessionKind::from_env()` calls.
+//!
+//! P1 seeds the context with the lane resolution (consuming the P0 lane file as
+//! the source of truth, with an env fast-path fallback for pre-hooks-v2
+//! worktrees). Later phases fold the duplicated session / projection / Board
+//! loading into this same struct.
+
+use std::path::Path;
+
+use gwt_skills::LaneProfile;
+
+/// Context shared across the handlers of a single hook invocation.
+pub struct HookContext {
+    /// The resolved lane profile for the worktree (deterministic; defaults to
+    /// execution when no lane file / signal is present — FR-009).
+    pub lane: &'static LaneProfile,
+}
+
+impl HookContext {
+    /// Resolve the context for a worktree. The lane comes from the worktree's
+    /// lane file (source of truth), falling back to the `GWT_SESSION_KIND` env
+    /// fast-path and then to execution.
+    #[must_use]
+    pub fn for_worktree(worktree: &Path) -> Self {
+        Self {
+            lane: gwt_skills::resolve_lane_for_worktree(worktree),
+        }
+    }
+}

--- a/crates/gwt/src/cli/hook/gwt_self_improvement_stop.rs
+++ b/crates/gwt/src/cli/hook/gwt_self_improvement_stop.rs
@@ -9,26 +9,31 @@ use std::{path::Path, process::Command};
 use super::{envelope::stop_hook_active_from, HookOutput};
 
 pub fn handle_with_input(worktree_root: &Path, input: &str) -> HookOutput {
-    evaluate(
-        worktree_root,
-        stop_hook_active_from(input),
-        gwt_skills::SessionKind::from_env().is_intake(),
-    )
+    // SPEC-3248 (hooks v2 P3): whether this Stop gate fires is a lane policy,
+    // resolved from the worktree lane file (source of truth) via the shared
+    // HookContext. A lane whose profile disables `self_improvement_stop`
+    // (intake today) suppresses the gate. Replaces the SPEC-3247 ad-hoc
+    // `SessionKind::from_env().is_intake()` branch.
+    let suppress = !super::context::HookContext::for_worktree(worktree_root)
+        .lane
+        .policy_flags
+        .self_improvement_stop;
+    evaluate(worktree_root, stop_hook_active_from(input), suppress)
 }
 
 /// Decide the self-improvement Stop block.
 ///
-/// SPEC-3247 FR-003 / AS-4: this is a producing-work Stop gate. An intake
-/// (Curate) session owns no Work and must never be forced to handle
-/// improvement candidates before stopping, so `session_is_intake` short-
-/// circuits to [`HookOutput::Silent`] alongside the existing `stop_hook_active`
-/// / non-gwt-repo guards.
+/// SPEC-3247 FR-003 / AS-4 → SPEC-3248 (hooks v2): this is a producing-work Stop
+/// gate. A lane whose profile disables `self_improvement_stop` (intake today)
+/// must never be forced to handle improvement candidates before stopping, so
+/// `suppressed_by_lane` short-circuits to [`HookOutput::Silent`] alongside the
+/// existing `stop_hook_active` / non-gwt-repo guards.
 pub fn evaluate(
     worktree_root: &Path,
     stop_hook_active: bool,
-    session_is_intake: bool,
+    suppressed_by_lane: bool,
 ) -> HookOutput {
-    if stop_hook_active || session_is_intake || !is_gwt_repository(worktree_root) {
+    if stop_hook_active || suppressed_by_lane || !is_gwt_repository(worktree_root) {
         return HookOutput::Silent;
     }
 

--- a/crates/gwt/src/cli/hook/mod.rs
+++ b/crates/gwt/src/cli/hook/mod.rs
@@ -17,6 +17,7 @@ pub mod block_file_ops;
 pub mod block_git_branch_ops;
 pub mod block_git_dir_override;
 pub mod board_reminder;
+pub mod context;
 pub mod coordination_event;
 pub mod diagnostics;
 pub mod envelope;

--- a/crates/gwt/src/cli/hook/mod.rs
+++ b/crates/gwt/src/cli/hook/mod.rs
@@ -33,6 +33,7 @@ pub mod skill_build_spec_stop_check;
 pub mod skill_discussion_stop_check;
 pub mod skill_plan_spec_stop_check;
 pub mod skill_register_spec_stop_check;
+pub mod state_file_stop_check;
 pub mod workflow_policy;
 mod workspace_identity;
 pub mod worktree;

--- a/crates/gwt/src/cli/hook/skill_build_spec_stop_check.rs
+++ b/crates/gwt/src/cli/hook/skill_build_spec_stop_check.rs
@@ -32,7 +32,7 @@ pub fn handle_with_input(
     input: &str,
     current_session_id: Option<&str>,
 ) -> HookOutput {
-    super::skill_plan_spec_stop_check::decide(
+    super::state_file_stop_check::decide(
         worktree,
         input,
         current_session_id,

--- a/crates/gwt/src/cli/hook/skill_plan_spec_stop_check.rs
+++ b/crates/gwt/src/cli/hook/skill_plan_spec_stop_check.rs
@@ -20,9 +20,8 @@ use std::{
 };
 
 use gwt_agent::GWT_SESSION_ID_ENV;
-use gwt_core::skill_state;
 
-use super::{envelope::stop_hook_active_from, HookError, HookOutput};
+use super::{HookError, HookOutput};
 
 pub const SKILL_NAME: &str = "plan-spec";
 pub const SKILL_DISPLAY: &str = "gwt-plan-spec";
@@ -40,62 +39,16 @@ pub fn handle_with_input(
     input: &str,
     current_session_id: Option<&str>,
 ) -> HookOutput {
-    decide(
+    // SPEC-3248 hooks v2 P2: the shared decision now lives in the neutral
+    // `state_file_stop_check` module (build-spec / register-spec delegate to
+    // the same body by design, not by reaching into this module's internals).
+    super::state_file_stop_check::decide(
         worktree,
         input,
         current_session_id,
         SKILL_NAME,
         SKILL_DISPLAY,
     )
-}
-
-/// Shared decision logic between plan-spec and build-spec handlers.
-pub(crate) fn decide(
-    worktree: &Path,
-    input: &str,
-    current_session_id: Option<&str>,
-    skill_name: &str,
-    skill_display: &str,
-) -> HookOutput {
-    if stop_hook_active_from(input) {
-        return HookOutput::Silent;
-    }
-    let Ok(Some(state)) = skill_state::load(worktree, skill_name) else {
-        return HookOutput::Silent;
-    };
-    if !state.active {
-        return HookOutput::Silent;
-    }
-    if let Some(current) = current_session_id {
-        if current != state.session_id {
-            return HookOutput::Silent;
-        }
-    }
-
-    let phase_clause = state
-        .phase
-        .as_deref()
-        .map(|p| format!(" (phase: {p})"))
-        .unwrap_or_default();
-    let spec_clause = state
-        .owner_spec
-        .map(|n| format!("SPEC-{n}"))
-        .unwrap_or_else(|| "the current owner".to_string());
-    let action_prefix = action_prefix_for(skill_name);
-
-    HookOutput::stop_block(format!(
-        "{skill_display} for {spec_clause} is still active{phase_clause}.\n\
-         Continue the {skill_display} workflow, or run JSON operation `{action_prefix}.complete` with `params.spec:<n>` when the artifacts are ready, \
-         or JSON operation `{action_prefix}.abort` with `params.spec:<n>` and `params.reason` to abandon.",
-    ))
-}
-
-fn action_prefix_for(skill_name: &str) -> &'static str {
-    match skill_name {
-        "plan-spec" => "plan",
-        "build-spec" => "build",
-        _ => "<skill>",
-    }
 }
 
 #[cfg(test)]
@@ -197,7 +150,7 @@ mod tests {
     #[test]
     fn silent_when_state_file_json_is_malformed() {
         let dir = tempfile::tempdir().unwrap();
-        let path = skill_state::state_path(dir.path(), SKILL_NAME);
+        let path = gwt_core::skill_state::state_path(dir.path(), SKILL_NAME);
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(&path, "{broken").unwrap();
         assert_eq!(

--- a/crates/gwt/src/cli/hook/skill_register_spec_stop_check.rs
+++ b/crates/gwt/src/cli/hook/skill_register_spec_stop_check.rs
@@ -32,7 +32,7 @@ pub fn handle_with_input(
     input: &str,
     current_session_id: Option<&str>,
 ) -> HookOutput {
-    super::skill_plan_spec_stop_check::decide(
+    super::state_file_stop_check::decide(
         worktree,
         input,
         current_session_id,

--- a/crates/gwt/src/cli/hook/state_file_stop_check.rs
+++ b/crates/gwt/src/cli/hook/state_file_stop_check.rs
@@ -1,0 +1,151 @@
+//! Generic Stop-block decision for skills backed by a
+//! `.gwt/skill-state/<skill>.json` file (SPEC-3248 hooks v2 P2).
+//!
+//! `gwt-plan-spec`, `gwt-build-spec`, and `gwt-register-spec` all share the
+//! same Stop-block semantics: while the skill state is `active: true` for the
+//! current agent session, block Stop so the skill keeps running; honour
+//! `stop_hook_active: true` to cap forced continuation at one per cycle
+//! (FR-014o); fail open on any I/O or JSON error (FR-014u); and stay silent
+//! when the recorded `session_id` differs from the current session (FR-014t).
+//!
+//! Before P2 this body lived inside `skill_plan_spec_stop_check` and the other
+//! two handlers reached into it, so they stayed in lock-step by accident rather
+//! than design. This module makes the shared decision a first-class, per-skill
+//! parameterized function; each `skill_*_stop_check` handler is now a thin
+//! wrapper that supplies only its skill name / display / action prefix.
+
+use std::path::Path;
+
+use gwt_core::skill_state;
+
+use super::{envelope::stop_hook_active_from, HookOutput};
+
+/// Shared Stop-block decision for a skill-state-backed skill.
+pub(crate) fn decide(
+    worktree: &Path,
+    input: &str,
+    current_session_id: Option<&str>,
+    skill_name: &str,
+    skill_display: &str,
+) -> HookOutput {
+    if stop_hook_active_from(input) {
+        return HookOutput::Silent;
+    }
+    let Ok(Some(state)) = skill_state::load(worktree, skill_name) else {
+        return HookOutput::Silent;
+    };
+    if !state.active {
+        return HookOutput::Silent;
+    }
+    if let Some(current) = current_session_id {
+        if current != state.session_id {
+            return HookOutput::Silent;
+        }
+    }
+
+    let phase_clause = state
+        .phase
+        .as_deref()
+        .map(|p| format!(" (phase: {p})"))
+        .unwrap_or_default();
+    let spec_clause = state
+        .owner_spec
+        .map(|n| format!("SPEC-{n}"))
+        .unwrap_or_else(|| "the current owner".to_string());
+    let action_prefix = action_prefix_for(skill_name);
+
+    HookOutput::stop_block(format!(
+        "{skill_display} for {spec_clause} is still active{phase_clause}.\n\
+         Continue the {skill_display} workflow, or run JSON operation `{action_prefix}.complete` with `params.spec:<n>` when the artifacts are ready, \
+         or JSON operation `{action_prefix}.abort` with `params.spec:<n>` and `params.reason` to abandon.",
+    ))
+}
+
+/// Map a skill name to its `gwtd` JSON operation prefix (`<prefix>.complete` /
+/// `<prefix>.abort`).
+fn action_prefix_for(skill_name: &str) -> &'static str {
+    match skill_name {
+        "plan-spec" => "plan",
+        "build-spec" => "build",
+        "register-spec" => "register",
+        _ => "<skill>",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use gwt_core::skill_state::{save, SkillState};
+
+    fn active_state(session: &str, phase: &str) -> SkillState {
+        SkillState {
+            active: true,
+            owner_spec: Some(3248),
+            started_at: Utc.with_ymd_and_hms(2026, 7, 5, 9, 0, 0).unwrap(),
+            phase: Some(phase.to_string()),
+            session_id: session.to_string(),
+        }
+    }
+
+    #[test]
+    fn decide_is_generic_across_skills_with_correct_action_prefix() {
+        for (skill, display, prefix) in [
+            ("plan-spec", "gwt-plan-spec", "plan.complete"),
+            ("build-spec", "gwt-build-spec", "build.complete"),
+            ("register-spec", "gwt-register-spec", "register.complete"),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            save(dir.path(), skill, &active_state("sess-1", "phase-x")).unwrap();
+            let HookOutput::StopBlock { reason } =
+                decide(dir.path(), "{}", Some("sess-1"), skill, display)
+            else {
+                panic!("expected StopBlock for {skill}");
+            };
+            assert!(reason.contains(display), "{reason}");
+            assert!(
+                reason.contains(prefix),
+                "{skill} must use {prefix}: {reason}"
+            );
+        }
+    }
+
+    #[test]
+    fn decide_honours_stop_hook_active_session_isolation_and_fail_open() {
+        let dir = tempfile::tempdir().unwrap();
+        // Fail-open: no state file → Silent.
+        assert_eq!(
+            decide(
+                dir.path(),
+                "{}",
+                Some("sess-1"),
+                "plan-spec",
+                "gwt-plan-spec"
+            ),
+            HookOutput::Silent
+        );
+        save(dir.path(), "plan-spec", &active_state("sess-1", "p")).unwrap();
+        // stop_hook_active → Silent.
+        assert_eq!(
+            decide(
+                dir.path(),
+                r#"{"stop_hook_active":true}"#,
+                Some("sess-1"),
+                "plan-spec",
+                "gwt-plan-spec"
+            ),
+            HookOutput::Silent
+        );
+        // Session mismatch → Silent.
+        assert_eq!(
+            decide(
+                dir.path(),
+                "{}",
+                Some("other"),
+                "plan-spec",
+                "gwt-plan-spec"
+            ),
+            HookOutput::Silent
+        );
+    }
+}

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -115,6 +115,10 @@ pub fn evaluate_with_context(
     if safety != HookOutput::Silent {
         return Ok(safety);
     }
+    let lane_code_edit = evaluate_lane_code_edit_guard(event, worktree_root)?;
+    if lane_code_edit != HookOutput::Silent {
+        return Ok(lane_code_edit);
+    }
     let title_summary = evaluate_title_summary_guard(event, context.title_summary_missing)?;
     if title_summary != HookOutput::Silent {
         return Ok(title_summary);
@@ -341,6 +345,57 @@ Start or link the work first through `gwt-register-issue`, `gwt-fix-issue`, or a
             ))
         }
     }
+}
+
+/// SPEC-3248 P4 (FR-011): a lane whose profile sets `block_production_code_edits`
+/// (intake today) may not edit production source. It registers Issues/SPECs and
+/// leaves implementation to Execute-lane sessions. Bookkeeping under `.gwt/` and
+/// `tasks/`, and documentation/guidance edits, stay allowed. Fail-open: if the
+/// target path cannot be determined, the edit is not blocked.
+fn evaluate_lane_code_edit_guard(
+    event: &HookEvent,
+    worktree_root: &Path,
+) -> Result<HookOutput, HookError> {
+    let lane = crate::cli::hook::context::HookContext::for_worktree(worktree_root).lane;
+    if !lane.policy_flags.block_production_code_edits || !is_mutating_work_event(event) {
+        return Ok(HookOutput::Silent);
+    }
+    let paths = event_target_paths(event);
+    if paths.is_empty()
+        || paths
+            .iter()
+            .all(|path| is_intake_editable_path(path, worktree_root))
+    {
+        return Ok(HookOutput::Silent);
+    }
+    Ok(HookOutput::pre_tool_use_permission(
+        "Intake (Curate) sessions do not edit production code",
+        "This is a Curate (intake) session: it registers Issues/SPECs and does not implement. \
+Editing production source is blocked here. Register the work \
+(`gwt-register-issue` for a plain Issue, or `gwt-discussion` → `gwt-register-spec` for a SPEC) \
+and let an Execute-lane session (Workspace / Issue Monitor) implement it. \
+Bookkeeping under `.gwt/` and `tasks/`, and documentation edits, are allowed.",
+    ))
+}
+
+/// Paths an intake session may still edit: gwt bookkeeping (`.gwt/`, `tasks/`)
+/// and documentation/guidance. Everything else inside the worktree is treated
+/// as production source and blocked.
+fn is_intake_editable_path(path: &str, worktree_root: &Path) -> bool {
+    if is_documentation_or_guidance_path(path, worktree_root) {
+        return true;
+    }
+    let candidate = Path::new(path);
+    let relative = candidate
+        .strip_prefix(worktree_root)
+        .unwrap_or(candidate)
+        .components()
+        .filter_map(|component| match component {
+            std::path::Component::Normal(part) => part.to_str(),
+            _ => None,
+        })
+        .next();
+    matches!(relative, Some(".gwt") | Some("tasks"))
 }
 
 fn requires_owner_for_mutating_work(event: &HookEvent, worktree_root: &Path) -> bool {
@@ -1173,6 +1228,44 @@ Coverage requirements.
         assert!(detail.contains(r#""purpose""#));
         assert!(detail.contains("work name"), "{detail}");
         assert!(detail.contains("which window is doing what"), "{detail}");
+    }
+
+    #[test]
+    fn lane_code_edit_guard_blocks_intake_production_edits_allows_bookkeeping() {
+        let repo = tempfile::tempdir().expect("repo");
+        let edit_event = |path: &std::path::Path| HookEvent {
+            tool_name: Some("Edit".to_string()),
+            tool_input: Some(serde_json::json!({ "file_path": path.to_str().unwrap() })),
+            transcript_path: None,
+            cwd: None,
+        };
+        let src = repo.path().join("crates/gwt/src/main.rs");
+        let bookkeeping = repo.path().join(".gwt/work/events.jsonl");
+
+        // Intake lane (from the lane file): block production source, allow the
+        // .gwt/ bookkeeping path.
+        gwt_skills::write_lane_file(repo.path(), &gwt_skills::INTAKE_PROFILE).expect("intake lane");
+        assert!(
+            matches!(
+                evaluate_lane_code_edit_guard(&edit_event(&src), repo.path()).expect("guard"),
+                HookOutput::PreToolUsePermission { .. }
+            ),
+            "intake must not edit production source"
+        );
+        assert_eq!(
+            evaluate_lane_code_edit_guard(&edit_event(&bookkeeping), repo.path()).expect("guard"),
+            HookOutput::Silent,
+            "intake may edit .gwt bookkeeping"
+        );
+
+        // Execution lane: no code-edit block.
+        gwt_skills::write_lane_file(repo.path(), &gwt_skills::EXECUTION_PROFILE)
+            .expect("execution lane");
+        assert_eq!(
+            evaluate_lane_code_edit_guard(&edit_event(&src), repo.path()).expect("guard"),
+            HookOutput::Silent,
+            "execution may edit production code"
+        );
     }
 
     #[test]

--- a/crates/gwt/src/managed_assets.rs
+++ b/crates/gwt/src/managed_assets.rs
@@ -120,6 +120,17 @@ fn materialize_managed_gwt_assets_for_targets(
     distribute_to_worktree_for_targets(worktree, targets).map_err(|error| {
         io::Error::other(format!("failed to distribute gwt managed assets: {error}"))
     })?;
+    // SPEC-3248 P4 (FR-011): a lane with a reduced skill set (intake) omits the
+    // implementation skills/commands. Applied as a post-pass so the
+    // distribution core is untouched; a non-reduced lane keeps the full set.
+    if gwt_skills::LaneRegistry::for_session_kind(session_kind)
+        .policy_flags
+        .reduced_skill_set
+    {
+        gwt_skills::apply_reduced_skill_set(worktree).map_err(|error| {
+            io::Error::other(format!("failed to apply reduced skill set: {error}"))
+        })?;
+    }
     if targets.is_empty() {
         return Ok(());
     }

--- a/crates/gwt/tests/managed_assets_test.rs
+++ b/crates/gwt/tests/managed_assets_test.rs
@@ -58,6 +58,52 @@ fn session_kind_selects_intake_or_execution_coordination_guidance() {
     );
 }
 
+/// SPEC-3248 P4 (FR-011): materializing with `SessionKind::Intake` applies the
+/// reduced (curation) skill set — implementation skills are dropped, curation
+/// skills stay; execution keeps the full set.
+#[test]
+fn intake_materialize_applies_reduced_skill_set() {
+    fn materialize(kind: SessionKind) -> tempfile::TempDir {
+        let dir = tempdir().expect("tempdir");
+        run_git(dir.path(), &["init", "-q"]);
+        let _env_guard = env_lock();
+        let cli_bin = dir.path().join("bin/gwtd");
+        std::fs::create_dir_all(cli_bin.parent().expect("bin parent")).expect("create bin dir");
+        std::fs::write(&cli_bin, "#!/bin/sh\n").expect("write cli bin");
+        let _cli_bin_guard = ScopedEnvVar::set("GWT_HOOK_BIN", &cli_bin);
+        refresh_managed_gwt_assets_for_agent_with_codex_hook_discovery_mode(
+            dir.path(),
+            &AgentId::ClaudeCode,
+            CodexHookDiscoveryMode::WorkspaceHome,
+            kind,
+        )
+        .expect("materialize managed assets");
+        dir
+    }
+
+    let intake = materialize(SessionKind::Intake);
+    assert!(
+        !intake.path().join(".claude/skills/gwt-build-spec").exists(),
+        "intake must drop the implementation skill gwt-build-spec"
+    );
+    assert!(
+        intake
+            .path()
+            .join(".claude/skills/gwt-register-issue/SKILL.md")
+            .exists(),
+        "intake must keep curation skills"
+    );
+
+    let execution = materialize(SessionKind::Execution);
+    assert!(
+        execution
+            .path()
+            .join(".claude/skills/gwt-build-spec/SKILL.md")
+            .exists(),
+        "execution must keep the full skill set"
+    );
+}
+
 #[test]
 fn refresh_managed_gwt_assets_materializes_skills_commands_hooks_and_excludes() {
     let dir = tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

gwt managed-hooks の lane-first re-architecture（SPEC #3248 hooks v2）。lane を first-class 次元にし、session-kind 別の差別化を LaneProfile で宣言的に表現、consolidation も行う。strangler-fig で段階実装し、各 phase で全テスト GREEN を維持。

## Changes

- **P0 lane 基盤**: `LaneProfile{id,guidance_variant,policy_flags}` + `LaneRegistry`（N 拡張前提・unknown→execution 既定）+ **lane file `.gwt/session-kind.json`**（決定的 source of truth・欠落/破損→execution）+ launch materialize。SPEC-3247 の env 未配線 BLOCKER を構造的に回避。
- **P1/P3 HookContext + lane-aware**: 共有 `HookContext` で lane を決定的解決。board_reminder / gwt_self_improvement_stop の ad-hoc `SessionKind::from_env()` を lane profile 経由へ（active な残存 0）。
- **P4 差別化 4 面（LaneProfile.policy_flags）**:
  - `sessionstart_onboarding`: intake の SessionStart に curation 导线。
  - `completion_gate`: intake Stop に登録促し（非ブロッキング SystemMessage）。
  - `block_production_code_edits`: intake の production source 編集を PreToolUse で block（.gwt/・tasks/・docs は許可、fail-open）。
  - `reduced_skill_set`: intake に curation skill のみ配布（実装 skill/command 除去・冪等 post-pass）。
- **P2 stop-check 統合**: plan/build/register-spec の Stop-block を neutral `state_file_stop_check` module へ集約 + register の action_prefix bug 修正。
- **P5 provider consolidation**: 調査により binary-path/marker/shell/is_gwt_repository は既に settings_local に一元化済みと確定（provider_hooks が再利用）。ProviderTransport trait は divergent provider への過剰抽象として不採用。

## Behavior impact

- **execution（Issue Monitor / Workspace 起動）**: 従来どおり（変更なし）。
- **intake（Curate）**: 上記 4 面の差別化が有効。すべて lane file / LaneProfile 駆動。

## Testing

- gwt-skills + gwt-agent + gwt **3043 tests GREEN**（lane roundtrip / HookContext / 各差別化面の intake/execution 分岐 / stop-check 統合 / materialize 統合を含む）。
- `cargo fmt --all -- --check` / `cargo clippy --workspace --all-targets --all-features -- -D warnings` / `RUSTDOCFLAGS=-D warnings cargo doc` すべて PASS。

## PR Readiness

- State: **Ready**
- User Verification Result: **n/a**（backend hooks / materialization のみ・UI 変更なし。挙動はテストで検証）。
- Releaseable slice: lane-first hooks v2 の完結した一式。execution は behavior-preserving、intake は additive な差別化。

## Related Issues

Closes #3248

## Checklist

- [x] 全 phase テスト追加・3043 GREEN
- [x] fmt / clippy -D warnings / rustdoc -D warnings クリーン
- [x] execution behavior-preserving / intake は additive
- [x] User Verification Result = n/a（UI 変更なし）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lane-aware behavior for sessions, including different guidance for intake vs. execution.
  * Intake sessions now show onboarding and completion reminders, and can use a reduced set of available skills.
  * Launches now record the active lane so behavior stays consistent across hooks.

* **Bug Fixes**
  * Improved stop-check handling so reminders and blocks behave more consistently per session type.
  * Intake sessions now avoid production code edits while still allowing bookkeeping and curation tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->