### PR TITLE
feat(workspace): 操作対象とライフサイクルを分離

### DIFF
--- a/crates/gwt-core/src/workspace_projection/lifecycle.rs
+++ b/crates/gwt-core/src/workspace_projection/lifecycle.rs
@@ -193,11 +193,8 @@ pub enum WorkCloseDecision {
     /// A live agent session still owns this Work — block the close and do not
     /// touch the worktree (FR-352). The owning session must be stopped first.
     BlockedLiveAgent,
-    /// No live agent and a worktree path is known — remove the worktree only
-    /// (branch / PR are retained) and record the terminal close.
-    CleanupWorktree { worktree_path: PathBuf },
-    /// No live agent and no resolvable worktree path — record the terminal
-    /// close in the work history but perform no filesystem cleanup.
+    /// No live agent: record the terminal close without filesystem cleanup.
+    /// Worktree deletion belongs to the vetted cleanup transport.
     RecordOnly,
 }
 
@@ -206,21 +203,15 @@ pub enum WorkCloseDecision {
 /// Decision order:
 /// 1. If a live agent session owns this Work (`live_agent` is `true`), block the
 ///    close — the worktree must never be removed while an agent is running.
-/// 2. Otherwise, if a worktree path is known, request worktree-only cleanup.
-/// 3. Otherwise, record the close without any filesystem side effect.
+/// 2. Otherwise, record the close without any filesystem side effect.
 ///
-/// Pure: takes only resolved inputs and returns a value, so it is exercised
-/// directly by unit tests while the git removal itself is verified separately.
-pub fn decide_work_close(live_agent: bool, worktree_path: Option<PathBuf>) -> WorkCloseDecision {
+/// `worktree_path` remains in the signature for source compatibility but is
+/// intentionally ignored: close and cleanup are separate operations.
+pub fn decide_work_close(live_agent: bool, _worktree_path: Option<PathBuf>) -> WorkCloseDecision {
     if live_agent {
         return WorkCloseDecision::BlockedLiveAgent;
     }
-    match worktree_path {
-        Some(path) if !path.as_os_str().is_empty() => WorkCloseDecision::CleanupWorktree {
-            worktree_path: path,
-        },
-        _ => WorkCloseDecision::RecordOnly,
-    }
+    WorkCloseDecision::RecordOnly
 }
 
 #[cfg(test)]
@@ -244,12 +235,11 @@ mod tests {
     }
 
     #[test]
-    fn decide_work_close_cleans_worktree_when_paused_with_path() {
+    fn decide_work_close_records_only_when_paused_with_path() {
         assert_eq!(
             decide_work_close(false, Some(PathBuf::from("/repo/work/paused"))),
-            WorkCloseDecision::CleanupWorktree {
-                worktree_path: PathBuf::from("/repo/work/paused")
-            }
+            WorkCloseDecision::RecordOnly,
+            "Work close must not perform worktree cleanup"
         );
     }
 

--- a/crates/gwt/playwright/tests/workspace-remote-branch-rows.spec.ts
+++ b/crates/gwt/playwright/tests/workspace-remote-branch-rows.spec.ts
@@ -36,7 +36,8 @@ test("remote branches fold into the unified Workspace list as Remote-tagged rows
   // Bare name (origin/ stripped) + the shared Remote tag, styled like any row.
   await expect(firstRemote.locator(".workspace-overview-row-title")).toHaveText("feature-foo");
   await expect(firstRemote.locator(".workspace-overview-remote")).toHaveText("Remote");
-  await expect(firstRemote).toHaveAttribute("data-attention", "paused");
+  await expect(firstRemote).toHaveAttribute("data-attention", "remote");
+  await expect(firstRemote.locator(".workspace-overview-lifecycle")).toHaveCount(0);
 
   // ▶ continues on the branch via open_launch_wizard; the backend normalizes
   // the (already stripped) name to continue-on-branch.

--- a/crates/gwt/src/app_runtime/launch.rs
+++ b/crates/gwt/src/app_runtime/launch.rs
@@ -1719,11 +1719,11 @@ impl AppRuntime {
     /// - If the owning agent session (derived from `work_id`) is still live, the
     ///   close is blocked and the worktree is left untouched (FR-352). The
     ///   owning agent must be stopped first.
-    /// - Otherwise (a Paused Work with no running agent), the worktree is removed
-    ///   (worktree only — branch / PR are retained) and the terminal close is
-    ///   recorded in the work history. A `done` close records a Done event; a
-    ///   `discarded` close records a Discard event. Both remove the Work from the
-    ///   active Work surface. Re-closing an already-closed Work is a noop.
+    /// - Otherwise (a Paused Work with no running agent), only the terminal close
+    ///   is recorded in Work history. Worktree, branch, and PR are unchanged;
+    ///   worktree deletion remains an independent vetted cleanup operation. A
+    ///   `done` close records a Done event and `discarded` records a Discard
+    ///   event. Re-closing an already-closed Work is a noop.
     pub(crate) fn close_work(&mut self, work_id: &str, close_kind: &str) -> Vec<OutboundEvent> {
         let work_id = work_id.trim();
         if work_id.is_empty() {
@@ -1760,12 +1760,7 @@ impl AppRuntime {
                 .any(|session| session.session_id == session_id)
         });
 
-        // Resolve the worktree path from the retained work history so a Paused
-        // Work can have its worktree removed without a live session.
-        let worktree_path = self.resolve_work_worktree_path(&project_root, work_id);
-
-        let decision =
-            gwt_core::workspace_projection::decide_work_close(has_live_agent, worktree_path);
+        let decision = gwt_core::workspace_projection::decide_work_close(has_live_agent, None);
 
         match decision {
             gwt_core::workspace_projection::WorkCloseDecision::BlockedLiveAgent => {
@@ -1777,14 +1772,9 @@ impl AppRuntime {
                 );
                 return Vec::new();
             }
-            gwt_core::workspace_projection::WorkCloseDecision::CleanupWorktree {
-                worktree_path,
-            } => {
-                self.remove_work_worktree_only(&project_root, &worktree_path);
-            }
             gwt_core::workspace_projection::WorkCloseDecision::RecordOnly => {
-                // No resolvable worktree path: record the close without any
-                // filesystem side effect.
+                // Work close records lifecycle only. Worktree deletion is an
+                // independent cleanup operation with its own safety gates.
             }
         }
 
@@ -1820,53 +1810,6 @@ impl AppRuntime {
         self.active_work_projection_broadcast_for_active_tab()
             .into_iter()
             .collect()
-    }
-
-    /// SPEC-2359 Phase W-12 Slice 4 (FR-352): resolve the worktree path for
-    /// `work_id` from the retained work history's execution containers. Returns
-    /// `None` when the Work has no recorded worktree, in which case the close is
-    /// recorded without filesystem cleanup.
-    fn resolve_work_worktree_path(&self, project_root: &Path, work_id: &str) -> Option<PathBuf> {
-        let projection = self
-            .work_items_cache
-            .borrow_mut()
-            .load_or_synthesize(project_root)
-            .ok()?;
-        let item = projection
-            .work_items
-            .iter()
-            .find(|item| item.id == work_id)?;
-        item.execution_containers
-            .iter()
-            .find_map(|container| container.worktree_path.clone())
-    }
-
-    /// SPEC-2359 Phase W-12 Slice 4 (FR-352): remove the worktree at
-    /// `worktree_path` (worktree only — the branch and any PR are retained). A
-    /// missing or already-removed worktree is treated as success so the close
-    /// stays robust; other failures are logged but do not abort recording the
-    /// close.
-    fn remove_work_worktree_only(&self, project_root: &Path, worktree_path: &Path) {
-        let main_repo_path = match gwt_git::worktree::main_worktree_root(project_root) {
-            Ok(path) => path,
-            Err(error) => {
-                tracing::warn!(
-                    project_root = %project_root.display(),
-                    worktree_path = %worktree_path.display(),
-                    error = %error,
-                    "Work close could not resolve main worktree root; skipping worktree removal"
-                );
-                return;
-            }
-        };
-        let manager = gwt_git::WorktreeManager::new(&main_repo_path);
-        if let Err(error) = manager.remove_force(worktree_path) {
-            tracing::warn!(
-                worktree_path = %worktree_path.display(),
-                error = %error,
-                "Work close worktree removal failed; recording the close anyway"
-            );
-        }
     }
 
     pub(crate) fn mark_agent_session_stopped(&mut self, window_id: &str) {

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -6672,6 +6672,19 @@ fn app_runtime_active_work_projection_separates_sessions_on_same_branch() {
         row.session_agent_total, 2,
         "hidden same-agent candidates stay counted for the session summary"
     );
+    assert_eq!(
+        row.works.len(),
+        2,
+        "both launch-scoped Works remain addressable"
+    );
+    assert!(row
+        .works
+        .iter()
+        .any(|work| work.id == "work-session-session-a"));
+    assert!(row
+        .works
+        .iter()
+        .any(|work| work.id == "work-session-session-b"));
     assert!(row.workspace_key.is_some());
 }
 
@@ -7321,12 +7334,11 @@ fn app_runtime_close_work_blocks_when_owning_agent_is_live() {
     );
 }
 
-/// SPEC-2359 Phase W-12 Slice 4 (FR-352): the worktree-only cleanup removes
-/// the actual worktree directory but retains the branch (branch / PR are
-/// preserved). Uses a real temp git repo + worktree to verify the
-/// `remove_force` side effect.
+/// SPEC-2359 W-21 (FR-463): Work close records lifecycle history only. The
+/// actual worktree and branch remain until the independent cleanup transport
+/// removes them.
 #[test]
-fn app_runtime_close_work_removes_worktree_only_and_retains_branch() {
+fn app_runtime_close_work_retains_worktree_and_branch() {
     let _env_lock = env_test_lock()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -7400,18 +7412,26 @@ fn app_runtime_close_work_removes_worktree_only_and_retains_branch() {
     let tab = sample_project_tab("tab-1", "Repo", repo.clone(), ProjectKind::Git, &[]);
     let mut runtime = sample_runtime(temp.path(), vec![tab], Some("tab-1"));
 
-    // No live agent session → cleanup path. Close (Done).
+    // No live agent session: close the Work without cleaning its materialization.
     let events = runtime.close_work("work-session-session-cleanup", "done");
     assert!(!events.is_empty());
 
     assert!(
-        !worktree_path.exists(),
-        "worktree-only cleanup must remove the worktree directory"
+        worktree_path.exists(),
+        "Work close must retain the worktree directory"
     );
     assert!(
         crate::runtime_support::local_branch_exists(&repo, "work/cleanup").unwrap_or(false),
         "worktree-only cleanup must retain the branch (branch / PR are preserved)"
     );
+    let works = gwt_core::workspace_projection::load_or_synthesize_workspace_work_items(&repo)
+        .expect("load Work history");
+    let closed = works
+        .work_items
+        .iter()
+        .find(|item| item.id == "work-session-session-cleanup")
+        .expect("closed Work remains in history");
+    assert!(closed.is_terminal());
 }
 
 /// SPEC-2359 Phase W-12 Slice 5a (FR-350): resuming a paused Work (a live
@@ -19621,6 +19641,7 @@ fn attach_registry_sessions_caps_total_agents_on_the_wire() {
         pr_state: None,
         board_refs: Vec::new(),
         agents,
+        works: Vec::new(),
         lifecycle_state: "paused".to_string(),
         closed_at: None,
         session_agent_total: 0,
@@ -19741,6 +19762,7 @@ fn attach_registry_sessions_keeps_latest_entry_per_agent_identity() {
                 "conv-l",
             ),
         ],
+        works: Vec::new(),
         lifecycle_state: "paused".to_string(),
         closed_at: None,
         session_agent_total: 0,
@@ -19850,6 +19872,7 @@ fn attach_registry_sessions_recomputes_agent_counters_after_identity_collapse() 
             ),
             agent_view("codex-blocked", "Codex", "blocked", "2026-06-09T00:00:00Z"),
         ],
+        works: Vec::new(),
         lifecycle_state: "active".to_string(),
         closed_at: None,
         session_agent_total: 0,
@@ -19933,6 +19956,7 @@ fn attach_registry_sessions_drops_ghost_agents_without_identity_or_sessions() {
             bare_agent("gwt-ghost", ""),
             bare_agent("gwt-named", "Claude Code"),
         ],
+        works: Vec::new(),
         lifecycle_state: "paused".to_string(),
         closed_at: None,
         session_agent_total: 0,
@@ -20065,6 +20089,7 @@ fn attach_registry_sessions_dedupes_agents_sharing_a_conversation() {
             // A different conversation must survive untouched.
             agent_view("gwt-other", "Codex", "2026-06-11T00:00:00Z", "conv-other"),
         ],
+        works: Vec::new(),
         lifecycle_state: "paused".to_string(),
         closed_at: None,
         session_agent_total: 0,
@@ -20198,6 +20223,7 @@ fn attach_registry_sessions_filters_agents_from_other_workspace_rows() {
                 "019ed018-c208-7183-bb6e-b08ba2ef4981",
             ),
         ],
+        works: Vec::new(),
         lifecycle_state: "paused".to_string(),
         closed_at: None,
         session_agent_total: 0,
@@ -20362,6 +20388,7 @@ fn active_works_are_sorted_by_latest_update_descending() {
         pr_state: None,
         board_refs: Vec::new(),
         agents: Vec::new(),
+        works: Vec::new(),
         lifecycle_state: "paused".to_string(),
         closed_at: None,
         session_agent_total: 0,
@@ -20438,6 +20465,7 @@ fn mark_merged_active_works_flags_cache_and_pr_state() {
         pr_state: pr_state.map(str::to_string),
         board_refs: Vec::new(),
         agents: Vec::new(),
+        works: Vec::new(),
         lifecycle_state: "paused".to_string(),
         closed_at: None,
         session_agent_total: 0,
@@ -20505,6 +20533,7 @@ fn dirty_worktree_pr_state_merged_does_not_flag_or_cleanup() {
         pr_state: Some("MERGED".to_string()),
         board_refs: Vec::new(),
         agents: Vec::new(),
+        works: Vec::new(),
         lifecycle_state: "paused".to_string(),
         closed_at: None,
         session_agent_total: 0,
@@ -21088,6 +21117,7 @@ fn assign_and_merge_workspace_groups_unifies_same_branch_rows() {
         branch: Option<&str>,
         updated_at: &str,
         agents: usize,
+        lifecycle: &str,
     ) -> gwt::ActiveWorkItemView {
         gwt::ActiveWorkItemView {
             id: id.to_string(),
@@ -21108,7 +21138,8 @@ fn assign_and_merge_workspace_groups_unifies_same_branch_rows() {
             pr_state: None,
             board_refs: Vec::new(),
             agents: Vec::new(),
-            lifecycle_state: "paused".to_string(),
+            works: Vec::new(),
+            lifecycle_state: lifecycle.to_string(),
             closed_at: None,
             session_agent_total: 1,
             merged_into_base: false,
@@ -21128,15 +21159,23 @@ fn assign_and_merge_workspace_groups_unifies_same_branch_rows() {
             "work-session-aaaa",
             Some("work/x"),
             "2026-06-11T10:00:00Z",
-            1,
+            0,
+            "paused",
         ),
         row(
             "work-session-bbbb",
             Some("origin/work/x"),
             "2026-06-12T10:00:00Z",
             2,
+            "active",
         ),
-        row("workspace-1748822400000", None, "2026-06-10T10:00:00Z", 0),
+        row(
+            "workspace-1748822400000",
+            None,
+            "2026-06-10T10:00:00Z",
+            0,
+            "paused",
+        ),
     ];
 
     super::assign_and_merge_workspace_groups(&mut works, &root);
@@ -21157,9 +21196,38 @@ fn assign_and_merge_workspace_groups_unifies_same_branch_rows() {
         group.id, "work-session-bbbb",
         "newest row is the representative"
     );
-    assert_eq!(group.active_agents, 3, "agent counts sum");
+    assert_eq!(group.active_agents, 2, "agent counts sum");
     assert_eq!(group.session_agent_total, 2, "session totals sum");
     assert!(group.workspace_key.is_some());
+    assert_eq!(
+        group.works.len(),
+        2,
+        "Workspace grouping must preserve both child Works"
+    );
+    assert_eq!(
+        group
+            .works
+            .iter()
+            .map(|work| work.id.as_str())
+            .collect::<std::collections::BTreeSet<_>>(),
+        std::collections::BTreeSet::from(["work-session-aaaa", "work-session-bbbb"]),
+        "each child Work keeps its stable identity"
+    );
+    let paused = group
+        .works
+        .iter()
+        .find(|work| work.id == "work-session-aaaa")
+        .expect("paused child Work");
+    assert_eq!(paused.lifecycle_state, "paused");
+    assert!(paused.manual_close_allowed);
+    assert_eq!(paused.close_blocked_reason, None);
+    let active = group
+        .works
+        .iter()
+        .find(|work| work.id == "work-session-bbbb")
+        .expect("active child Work");
+    assert!(!active.manual_close_allowed);
+    assert_eq!(active.close_blocked_reason.as_deref(), Some("live_agent"));
     let legacy = works
         .iter()
         .find(|work| work.id == "workspace-1748822400000")
@@ -21167,6 +21235,37 @@ fn assign_and_merge_workspace_groups_unifies_same_branch_rows() {
     assert_eq!(
         legacy.workspace_key.as_deref(),
         Some("workspace-1748822400000")
+    );
+}
+
+#[test]
+fn legacy_workspace_lifecycle_does_not_create_an_implicit_close_target() {
+    let legacy = serde_json::json!({
+        "id": "work-legacy-parent",
+        "title": "Legacy Workspace",
+        "status_category": "idle",
+        "status_text": "Paused",
+        "summary": null,
+        "owner": null,
+        "next_action": null,
+        "active_agents": 0,
+        "blocked_agents": 0,
+        "branch": "work/legacy",
+        "worktree_path": null,
+        "pr_number": null,
+        "pr_url": null,
+        "pr_state": null,
+        "board_refs": [],
+        "agents": [],
+        "lifecycle_state": "paused"
+    });
+
+    let workspace: gwt::ActiveWorkItemView =
+        serde_json::from_value(legacy).expect("deserialize legacy Workspace row");
+
+    assert!(
+        workspace.works.is_empty(),
+        "legacy parent lifecycle is display compatibility only and must not invent a child Work"
     );
 }
 
@@ -21196,6 +21295,7 @@ fn mark_remote_only_flags_fetched_branches_without_local_worktree() {
             pr_state: None,
             board_refs: Vec::new(),
             agents: Vec::new(),
+            works: Vec::new(),
             lifecycle_state: "paused".to_string(),
             closed_at: None,
             session_agent_total: 0,
@@ -21218,12 +21318,19 @@ fn mark_remote_only_flags_fetched_branches_without_local_worktree() {
         row("w-branchless", None, None),
     ];
 
+    super::assign_and_merge_workspace_groups(&mut works, Path::new("/repo"));
     super::mark_remote_only_active_works(&mut works, Some(&local));
 
     assert!(works[0].remote_only, "fetched-only branch is Remote");
     assert!(!works[1].remote_only, "locally checked-out branch is not");
     assert!(!works[2].remote_only, "rows with a worktree are not");
     assert!(!works[3].remote_only, "branchless rows are not");
+    assert_eq!(works[0].works.len(), 1);
+    assert!(!works[0].works[0].manual_close_allowed);
+    assert_eq!(
+        works[0].works[0].close_blocked_reason.as_deref(),
+        Some("remote_environment_unknown")
+    );
 }
 
 /// SPEC-2359 W16-4 (FR-391): merged ∧ stale rows classify as derived Done;
@@ -21258,6 +21365,7 @@ fn mark_merged_classifies_done_equivalent_for_stale_merged_rows() {
             pr_state: pr_state.map(str::to_string),
             board_refs: Vec::new(),
             agents: Vec::new(),
+            works: Vec::new(),
             lifecycle_state: lifecycle.to_string(),
             closed_at: None,
             session_agent_total: 0,
@@ -21333,6 +21441,7 @@ fn mark_cleanup_candidates_exposes_no_changes_reason_without_merged_badge() {
         pr_state: None,
         board_refs: Vec::new(),
         agents: Vec::new(),
+        works: Vec::new(),
         lifecycle_state: "paused".to_string(),
         closed_at: None,
         session_agent_total: 0,
@@ -21394,6 +21503,7 @@ fn mark_cleanup_candidates_sets_blocked_reason_for_live_agent_and_process() {
             pr_state: Some("MERGED".to_string()),
             board_refs: Vec::new(),
             agents: Vec::new(),
+            works: Vec::new(),
             lifecycle_state: "active".to_string(),
             closed_at: None,
             session_agent_total: 0,
@@ -21424,6 +21534,7 @@ fn mark_cleanup_candidates_sets_blocked_reason_for_live_agent_and_process() {
             pr_state: None,
             board_refs: Vec::new(),
             agents: Vec::new(),
+            works: Vec::new(),
             lifecycle_state: "paused".to_string(),
             closed_at: None,
             session_agent_total: 0,
@@ -21602,6 +21713,7 @@ fn apply_work_summary_external_sources_prefers_pr_then_ai_then_commit_subject() 
         pr_state: None,
         board_refs: vec![],
         agents: vec![],
+        works: Vec::new(),
         lifecycle_state: "paused".to_string(),
         closed_at: None,
         session_agent_total: 0,

--- a/crates/gwt/src/app_runtime/workspace_views.rs
+++ b/crates/gwt/src/app_runtime/workspace_views.rs
@@ -743,6 +743,7 @@ fn active_work_items_from_projection(
                 // SPEC-2359 Phase W-12 (FR-349): active_work_items groups live
                 // assigned agents, so the owning agent session is Running and
                 // not user-closed → Active.
+                works: Vec::new(),
                 lifecycle_state: work_active_lifecycle_state_wire(
                     gwt_core::workspace_projection::recompute_work_active_lifecycle(
                         gwt_core::workspace_projection::WorkAgentRuntime::Running,
@@ -848,6 +849,7 @@ fn append_paused_work_items(
                 .collect(),
             // No live agent session owns this Work and it is not user-closed →
             // WorkAgentRuntime::None resolves to Paused (FR-350).
+            works: Vec::new(),
             lifecycle_state: work_active_lifecycle_state_wire(
                 gwt_core::workspace_projection::recompute_work_active_lifecycle(
                     gwt_core::workspace_projection::WorkAgentRuntime::None,
@@ -1696,6 +1698,10 @@ pub(super) fn assign_and_merge_workspace_groups(
     project_root: &Path,
 ) {
     for work in active_works.iter_mut() {
+        if work.works.is_empty() {
+            let child = active_workspace_child_work(work);
+            work.works.push(child);
+        }
         let branch = work
             .branch
             .as_deref()
@@ -1723,6 +1729,11 @@ pub(super) fn assign_and_merge_workspace_groups(
                 let newer = work.updated_at > target.updated_at;
                 let mut agents = std::mem::take(&mut target.agents);
                 agents.extend(work.agents.iter().cloned());
+                let mut child_works = std::mem::take(&mut target.works);
+                child_works.extend(work.works.iter().cloned());
+                child_works.sort_by(|left, right| right.updated_at.cmp(&left.updated_at));
+                let mut seen_work_ids = HashSet::new();
+                child_works.retain(|child| seen_work_ids.insert(child.id.clone()));
                 let active_agents = target.active_agents + work.active_agents;
                 let blocked_agents = target.blocked_agents + work.blocked_agents;
                 let session_agent_total = target.session_agent_total + work.session_agent_total;
@@ -1749,6 +1760,7 @@ pub(super) fn assign_and_merge_workspace_groups(
                     }
                 }
                 target.agents = agents;
+                target.works = child_works;
                 target.active_agents = active_agents;
                 target.blocked_agents = blocked_agents;
                 target.session_agent_total = session_agent_total;
@@ -1765,6 +1777,28 @@ pub(super) fn assign_and_merge_workspace_groups(
         }
     }
     *active_works = merged;
+}
+
+fn active_workspace_child_work(work: &gwt::ActiveWorkItemView) -> gwt::ActiveWorkspaceWorkView {
+    let lifecycle_state = work.lifecycle_state.clone();
+    let manual_close_allowed = lifecycle_state == "paused" && work.active_agents == 0;
+    let close_blocked_reason = (!manual_close_allowed
+        && !matches!(lifecycle_state.as_str(), "done" | "discarded"))
+    .then(|| "live_agent".to_string());
+    gwt::ActiveWorkspaceWorkView {
+        id: work.id.clone(),
+        title: work.title.clone(),
+        work_summary: work.work_summary.clone(),
+        status_category: work.status_category.clone(),
+        status_text: work.status_text.clone(),
+        owner: work.owner.clone(),
+        lifecycle_state,
+        closed_at: work.closed_at.clone(),
+        manual_close_allowed,
+        close_blocked_reason,
+        agents: work.agents.clone(),
+        updated_at: work.updated_at.clone(),
+    }
 }
 
 fn merged_branch_fallback(agents: &[gwt::ActiveWorkAgentView]) -> Option<String> {
@@ -1797,6 +1831,12 @@ pub(super) fn mark_remote_only_active_works(
             .map(|branch| local_branches.is_some_and(|set| set.contains(&branch)));
         // Branchless rows are never "remote": there is nothing to fetch.
         work.remote_only = matches!(branch_local, Some(false));
+        if work.remote_only {
+            for child in &mut work.works {
+                child.manual_close_allowed = false;
+                child.close_blocked_reason = Some("remote_environment_unknown".to_string());
+            }
+        }
     }
 }
 
@@ -2488,6 +2528,7 @@ impl AppRuntime {
             agents: agents.clone(),
             // SPEC-2359 Phase W-12 (FR-349): synthesized from live sessions, so
             // the owning agent is Running and not user-closed → Active.
+            works: Vec::new(),
             lifecycle_state: work_active_lifecycle_state_wire(
                 gwt_core::workspace_projection::recompute_work_active_lifecycle(
                     gwt_core::workspace_projection::WorkAgentRuntime::Running,

--- a/crates/gwt/src/cli/build.rs
+++ b/crates/gwt/src/cli/build.rs
@@ -17,5 +17,68 @@ pub(super) fn run<E: CliEnv>(
     action: SkillStateAction,
     out: &mut String,
 ) -> Result<i32, SpecOpsError> {
+    if let Err(error) = record_current_work_terminal_before_finalize(env, &action) {
+        out.push_str(&format!("{VERB}: Work lifecycle update failed: {error}\n"));
+        return Ok(1);
+    }
     skill_state_runtime::run(env, action, SKILL_NAME, SKILL_DISPLAY, VERB, out)
+}
+
+fn record_current_work_terminal_before_finalize<E: CliEnv>(
+    env: &E,
+    action: &SkillStateAction,
+) -> Result<(), String> {
+    let (spec, close_kind) = match action {
+        SkillStateAction::Complete { spec } => (*spec, WorkTerminalKind::Done),
+        SkillStateAction::Abort { spec, .. } => (*spec, WorkTerminalKind::Discarded),
+        SkillStateAction::Start { .. } | SkillStateAction::Phase { .. } => return Ok(()),
+    };
+    let repo = env.repo_path();
+    let state = gwt_core::skill_state::load(repo, SKILL_NAME).map_err(|error| error.to_string())?;
+    let Some(state) = state else {
+        return Ok(());
+    };
+    if state.owner_spec.is_some() && state.owner_spec != Some(spec) {
+        return Ok(());
+    }
+
+    let session_id = std::env::var(gwt_agent::GWT_SESSION_ID_ENV)
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if session_id.is_empty() {
+        return Ok(());
+    }
+    let work_id = format!("work-session-{session_id}");
+    let Some(projection) = gwt_core::workspace_projection::load_workspace_work_items(repo)
+        .map_err(|error| error.to_string())?
+    else {
+        return Ok(());
+    };
+    let Some(work) = projection.work_items.iter().find(|work| work.id == work_id) else {
+        return Ok(());
+    };
+    if work.is_terminal() {
+        return Ok(());
+    }
+
+    let now = chrono::Utc::now();
+    match close_kind {
+        WorkTerminalKind::Done => {
+            gwt_core::workspace_projection::emit_workspace_done_event_if_absent(repo, &work_id, now)
+        }
+        WorkTerminalKind::Discarded => {
+            gwt_core::workspace_projection::emit_workspace_discard_event_if_absent(
+                repo, &work_id, now,
+            )
+        }
+    }
+    .map(|_| ())
+    .map_err(|error| error.to_string())
+}
+
+#[derive(Debug, Clone, Copy)]
+enum WorkTerminalKind {
+    Done,
+    Discarded,
 }

--- a/crates/gwt/src/lib.rs
+++ b/crates/gwt/src/lib.rs
@@ -141,15 +141,16 @@ pub use preset::{
 };
 pub use protocol::{
     ActiveWorkAgentView, ActiveWorkCleanupCandidateView, ActiveWorkItemView,
-    ActiveWorkProjectionView, AppStateView, ArrangeMode, AttachmentProgressPhase, BackendEvent,
-    BranchEntriesPhase, CustomAgentErrorCode, FileAttachment, FileContentErrorKind,
-    FileContentMode, FileContentSaveErrorKind, FocusCycleDirection, FrontendEvent,
-    GitHubRepositorySearchResultView, IndexSearchMatchMode, IndexSearchResult, IndexSearchScope,
-    IndexSearchTarget, ManagedHookHealthView, ManagedHookPendingDiscussionView,
-    ManagedHookPendingGoalView, ManagedHookSlowHandlerView, ProfileEntryView, ProfileEnvEntryView,
-    ProfileSnapshotView, ProjectTabView, RecentProjectView, RunningAgentSummary, UiTraceEntry,
-    UiTracePayload, WorkAgentView, WorkEventView, WorkItemView, WorkspaceExecutionContainerView,
-    WorkspaceHistoryAgentView, WorkspaceHistoryEventView, WorkspaceHistorySessionView,
-    WorkspaceHistoryView, WorkspaceJournalEntryView, WorkspaceResumeSource, WorkspaceView,
+    ActiveWorkProjectionView, ActiveWorkspaceWorkView, AppStateView, ArrangeMode,
+    AttachmentProgressPhase, BackendEvent, BranchEntriesPhase, CustomAgentErrorCode,
+    FileAttachment, FileContentErrorKind, FileContentMode, FileContentSaveErrorKind,
+    FocusCycleDirection, FrontendEvent, GitHubRepositorySearchResultView, IndexSearchMatchMode,
+    IndexSearchResult, IndexSearchScope, IndexSearchTarget, ManagedHookHealthView,
+    ManagedHookPendingDiscussionView, ManagedHookPendingGoalView, ManagedHookSlowHandlerView,
+    ProfileEntryView, ProfileEnvEntryView, ProfileSnapshotView, ProjectTabView, RecentProjectView,
+    RunningAgentSummary, UiTraceEntry, UiTracePayload, WorkAgentView, WorkEventView, WorkItemView,
+    WorkspaceExecutionContainerView, WorkspaceHistoryAgentView, WorkspaceHistoryEventView,
+    WorkspaceHistorySessionView, WorkspaceHistoryView, WorkspaceJournalEntryView,
+    WorkspaceResumeSource, WorkspaceView,
 };
 pub use window_canvas::WindowCanvasState;

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -1246,6 +1246,35 @@ fn default_work_lifecycle_state() -> String {
     "active".to_string()
 }
 
+/// One launch-scoped Work contained by a canonical-branch Workspace row.
+///
+/// Workspace is a read projection; lifecycle operations target this stable
+/// Work identity. The parent row keeps its legacy lifecycle fields only for
+/// older consumers and never supplies an implicit close target.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ActiveWorkspaceWorkView {
+    pub id: String,
+    pub title: String,
+    #[serde(default)]
+    pub work_summary: Option<String>,
+    pub status_category: String,
+    pub status_text: String,
+    #[serde(default)]
+    pub owner: Option<String>,
+    #[serde(default = "default_work_lifecycle_state")]
+    pub lifecycle_state: String,
+    #[serde(default)]
+    pub closed_at: Option<String>,
+    #[serde(default)]
+    pub manual_close_allowed: bool,
+    #[serde(default)]
+    pub close_blocked_reason: Option<String>,
+    #[serde(default)]
+    pub agents: Vec<ActiveWorkAgentView>,
+    #[serde(default)]
+    pub updated_at: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ActiveWorkItemView {
     pub id: String,
@@ -1274,6 +1303,11 @@ pub struct ActiveWorkItemView {
     pub pr_state: Option<String>,
     pub board_refs: Vec<String>,
     pub agents: Vec<ActiveWorkAgentView>,
+    /// Launch-scoped Works grouped under this canonical-branch Workspace.
+    /// Empty for legacy payloads; consumers must not infer an operation target
+    /// from the parent row when no child Work is present.
+    #[serde(default)]
+    pub works: Vec<ActiveWorkspaceWorkView>,
     /// SPEC-2359 Phase W-12 (FR-349): agent-session Work lifecycle state
     /// (active / paused / done / discarded). Distinct from `status_category`
     /// which tracks runtime agent activity. Back-compat default is `"active"`.
@@ -3201,6 +3235,7 @@ mod tests {
                     pr_state: Some("OPEN".to_string()),
                     board_refs: vec!["board-1".to_string()],
                     agents: Vec::new(),
+                    works: Vec::new(),
                     lifecycle_state: "active".to_string(),
                     closed_at: None,
                     session_agent_total: 0,

--- a/crates/gwt/tests/skill_exit_cli_test.rs
+++ b/crates/gwt/tests/skill_exit_cli_test.rs
@@ -8,6 +8,7 @@
 
 use gwt::cli::{dispatch, TestEnv};
 use gwt_core::skill_state::{self, SkillState};
+use gwt_core::test_support::{env_lock, ScopedEnvVar, ScopedGwtHome};
 use tempfile::TempDir;
 
 fn argv(parts: &[&str]) -> Vec<String> {
@@ -281,6 +282,136 @@ fn build_abort_records_reason_in_phase_field() {
         .as_deref()
         .unwrap_or("")
         .starts_with("aborted: "));
+}
+
+fn seed_session_work(repo: &std::path::Path, session_id: &str) {
+    gwt_core::workspace_projection::record_workspace_work_paused_event(
+        repo,
+        &format!("work-session-{session_id}"),
+        Some("Build lifecycle Work"),
+        None,
+        Some("SPEC-2359"),
+        &[],
+        None,
+        Some(session_id),
+        chrono::Utc::now(),
+    )
+    .expect("seed session Work");
+}
+
+#[test]
+fn build_complete_marks_current_session_work_done_idempotently() {
+    let _lock = env_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let (mut env, dir) = new_env();
+    let _home = ScopedGwtHome::set(dir.path().join("home"));
+    let _session = ScopedEnvVar::set(gwt_agent::GWT_SESSION_ID_ENV, "session-build-done");
+    seed_session_work(dir.path(), "session-build-done");
+
+    dispatch_json(&mut env, "build.start", serde_json::json!({"spec": 2359}));
+    assert_eq!(
+        dispatch_json(
+            &mut env,
+            "build.complete",
+            serde_json::json!({"spec": 2359})
+        ),
+        0
+    );
+    assert_eq!(
+        dispatch_json(
+            &mut env,
+            "build.complete",
+            serde_json::json!({"spec": 2359})
+        ),
+        0,
+        "retry remains successful"
+    );
+
+    let projection = gwt_core::workspace_projection::load_workspace_work_items(dir.path())
+        .expect("load Work items")
+        .expect("Work items");
+    let work = projection
+        .work_items
+        .iter()
+        .find(|item| item.id == "work-session-session-build-done")
+        .expect("current session Work");
+    assert_eq!(
+        work.status_category,
+        gwt_core::workspace_projection::WorkspaceStatusCategory::Done
+    );
+    assert_eq!(
+        work.events
+            .iter()
+            .filter(|event| { event.kind == gwt_core::workspace_projection::WorkEventKind::Done })
+            .count(),
+        1,
+        "build.complete retry must not duplicate Done"
+    );
+}
+
+#[test]
+fn build_abort_discards_only_current_session_work() {
+    let _lock = env_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let (mut env, dir) = new_env();
+    let _home = ScopedGwtHome::set(dir.path().join("home"));
+    let _session = ScopedEnvVar::set(gwt_agent::GWT_SESSION_ID_ENV, "session-build-abort");
+    seed_session_work(dir.path(), "session-build-abort");
+    seed_session_work(dir.path(), "session-other");
+
+    dispatch_json(&mut env, "build.start", serde_json::json!({"spec": 2359}));
+    assert_eq!(
+        dispatch_json(
+            &mut env,
+            "build.abort",
+            serde_json::json!({"spec": 2359, "reason": "cancelled"})
+        ),
+        0
+    );
+
+    let projection = gwt_core::workspace_projection::load_workspace_work_items(dir.path())
+        .expect("load Work items")
+        .expect("Work items");
+    let current = projection
+        .work_items
+        .iter()
+        .find(|item| item.id == "work-session-session-build-abort")
+        .expect("current Work");
+    assert!(current.discarded);
+    let other = projection
+        .work_items
+        .iter()
+        .find(|item| item.id == "work-session-session-other")
+        .expect("other Work");
+    assert!(!other.is_terminal(), "other Work must remain untouched");
+}
+
+#[test]
+fn build_complete_without_registered_work_is_successful_noop() {
+    let _lock = env_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let (mut env, dir) = new_env();
+    let _home = ScopedGwtHome::set(dir.path().join("home"));
+    let _session = ScopedEnvVar::set(gwt_agent::GWT_SESSION_ID_ENV, "standalone-session");
+
+    dispatch_json(&mut env, "build.start", serde_json::json!({"spec": 2359}));
+    assert_eq!(
+        dispatch_json(
+            &mut env,
+            "build.complete",
+            serde_json::json!({"spec": 2359})
+        ),
+        0
+    );
+    assert!(
+        gwt_core::workspace_projection::load_workspace_work_items(dir.path())
+            .expect("load Work items")
+            .is_none(),
+        "standalone completion must not invent a Work"
+    );
 }
 
 #[test]

--- a/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
+++ b/crates/gwt/web/__tests__/workspace-kanban-surface.test.mjs
@@ -461,6 +461,8 @@ test("Workspace detail renders structured body sections without preformatted dum
   assert.deepEqual(sectionTitles, [
     "Progress Summary",
     "Current State",
+    "Branch",
+    "Worktree",
     "Agents & Sessions",
     "Linked Work",
     "Lifecycle",
@@ -932,7 +934,7 @@ test("Work surface renders a lifecycle_state badge on each Work row (SPEC-2359 W
   assert.equal(pausedBadge.dataset.lifecycle, "paused");
 });
 
-test("Work surface Done action sends close_work with close_kind done (SPEC-2359 W-12 FR-351)", () => {
+test("Paused child Work Done sends close_work for the child identity", () => {
   const fixture = createFixture();
   const sent = [];
   const surface = createSurface(fixture, {
@@ -942,11 +944,20 @@ test("Work surface Done action sends close_work with close_kind done (SPEC-2359 
     active_work_count: 1,
     active_works: [
       {
-        id: "work-active",
-        title: "Active Work",
-        status_category: "active",
-        lifecycle_state: "active",
+        id: "workspace-work-shared",
+        title: "Shared branch",
+        status_category: "idle",
+        lifecycle_state: "paused",
         agents: [],
+        works: [{
+          id: "work-paused",
+          title: "Paused Work",
+          status_category: "idle",
+          status_text: "Paused",
+          lifecycle_state: "paused",
+          manual_close_allowed: true,
+          agents: [],
+        }],
       },
     ],
   }, { send: (message) => sent.push(message) });
@@ -960,11 +971,11 @@ test("Work surface Done action sends close_work with close_kind done (SPEC-2359 
   assert.ok(doneButton, "expected a Done action on the selected Work detail");
   doneButton.click();
   assert.deepEqual(sent, [
-    { kind: "close_work", work_id: "work-active", close_kind: "done" },
+    { kind: "close_work", work_id: "work-paused", close_kind: "done" },
   ]);
 });
 
-test("Work surface Discard action sends close_work with close_kind discarded (SPEC-2359 W-12 FR-351)", () => {
+test("Paused child Work Discard sends close_work for the child identity", () => {
   const fixture = createFixture();
   const sent = [];
   const surface = createSurface(fixture, {
@@ -974,11 +985,20 @@ test("Work surface Discard action sends close_work with close_kind discarded (SP
     active_work_count: 1,
     active_works: [
       {
-        id: "work-active",
-        title: "Active Work",
-        status_category: "active",
-        lifecycle_state: "active",
+        id: "workspace-work-shared",
+        title: "Shared branch",
+        status_category: "idle",
+        lifecycle_state: "paused",
         agents: [],
+        works: [{
+          id: "work-paused",
+          title: "Paused Work",
+          status_category: "idle",
+          status_text: "Paused",
+          lifecycle_state: "paused",
+          manual_close_allowed: true,
+          agents: [],
+        }],
       },
     ],
   }, { send: (message) => sent.push(message) });
@@ -992,8 +1012,98 @@ test("Work surface Discard action sends close_work with close_kind discarded (SP
   assert.ok(discardButton, "expected a Discard action on the selected Work detail");
   discardButton.click();
   assert.deepEqual(sent, [
-    { kind: "close_work", work_id: "work-active", close_kind: "discarded" },
+    { kind: "close_work", work_id: "work-paused", close_kind: "discarded" },
   ]);
+});
+
+test("Workspace header is read-only and operations belong to target contexts", () => {
+  const fixture = createFixture();
+  const sent = [];
+  const cleanupCalls = [];
+  const surface = createSurface(
+    fixture,
+    {
+      id: "projection",
+      title: "projection",
+      status_category: "idle",
+      active_works: [{
+        id: "workspace-work-shared",
+        title: "Shared branch",
+        branch: "work/shared",
+        worktree_path: "/repo/work/shared",
+        status_category: "active",
+        lifecycle_state: "active",
+        cleanup_candidate: {
+          branch: "work/shared",
+          worktree_path: "/repo/work/shared",
+          reason: "no_changes",
+        },
+        agents: [],
+        works: [
+          {
+            id: "work-paused",
+            title: "Paused Work",
+            status_category: "idle",
+            status_text: "Paused",
+            lifecycle_state: "paused",
+            manual_close_allowed: true,
+            agents: [],
+          },
+          {
+            id: "work-live",
+            title: "Live Work",
+            status_category: "active",
+            status_text: "Running",
+            lifecycle_state: "active",
+            manual_close_allowed: false,
+            close_blocked_reason: "live_agent",
+            agents: [],
+          },
+        ],
+      }],
+      agents: [],
+    },
+    {
+      send: (message) => sent.push(message),
+      openWorkspaceCleanup: (candidate) => cleanupCalls.push(candidate),
+    },
+  );
+
+  surface.mount(fixture.body, fixture.windowData, {
+    focusWindowLocally() {},
+    sendFocus() {},
+  });
+
+  assert.equal(
+    fixture.body.querySelectorAll(".workspace-detail-header button").length,
+    0,
+    "Workspace header is read-only",
+  );
+  assert.ok(
+    fixture.body.querySelector('[data-section="branch-context"] [data-action="launch-workspace"]'),
+    "Launch belongs to branch context",
+  );
+  assert.ok(
+    fixture.body.querySelector('[data-section="worktree-context"] [data-action="cleanup-merged-workspace"]'),
+    "Clean Up belongs to worktree context",
+  );
+  const paused = fixture.body.querySelector('[data-work-id="work-paused"]');
+  assert.ok(paused.querySelector('[data-action="close-work-done"]'));
+  assert.ok(paused.querySelector('[data-action="close-work-discard"]'));
+  const live = fixture.body.querySelector('[data-work-id="work-live"]');
+  assert.equal(live.querySelector('[data-action="close-work-done"]').disabled, true);
+  assert.equal(live.querySelector('[data-action="close-work-discard"]').disabled, true);
+
+  paused.querySelector('[data-action="close-work-done"]').click();
+  assert.deepEqual(sent.at(-1), {
+    kind: "close_work",
+    work_id: "work-paused",
+    close_kind: "done",
+  });
+  fixture.body
+    .querySelector('[data-section="worktree-context"] [data-action="cleanup-merged-workspace"]')
+    .click();
+  assert.equal(cleanupCalls.length, 1);
 });
 
 function sampleProjection() {
@@ -1202,11 +1312,9 @@ test("sessionless Workspace offers a Launch control that opens the launch wizard
   assert.equal(sent[0].branch_name, "work/foo");
 });
 
-// Placement feedback (2026-06-11 user verification): the Launch Agent control
-// has one canonical home — the detail header actions — never an arbitrary
-// position after a variable-length Work list. A backfilled row whose title IS
-// the branch name must not repeat the same string as subtitle meta.
-test("Launch control lives in the detail header actions and duplicate branch meta is suppressed", () => {
+// W-21: Launch is a branch operation. A backfilled row whose title IS the
+// branch name must not repeat the same string as subtitle meta.
+test("Launch control lives in branch context and duplicate branch meta is suppressed", () => {
   const fixture = createFixture();
   const surface = createSurface(
     fixture,
@@ -1240,8 +1348,8 @@ test("Launch control lives in the detail header actions and duplicate branch met
   const launch = fixture.body.querySelector('[data-action="launch-workspace"]');
   assert.ok(launch, "Launch Agent control must exist");
   assert.ok(
-    launch.parentElement.classList.contains("workspace-detail-actions"),
-    "Launch Agent belongs to the detail header actions",
+    launch.closest('[data-section="branch-context"]'),
+    "Launch Agent belongs to branch context",
   );
 
   const row = fixture.body.querySelector(".workspace-overview-row[data-workspace-id]");
@@ -1671,14 +1779,12 @@ test("Workspace with existing Works still offers a Launch control", () => {
   assert.equal(sent.at(-1)?.kind, "open_launch_wizard");
   assert.equal(sent.at(-1)?.branch_name, "develop");
 
-  // Placement feedback (2026-06-11): one fixed home in the header actions —
-  // first action, before Done / Discard — and no floating row after the list.
-  const actions = fixture.body.querySelector(".workspace-detail-actions");
-  assert.ok(actions, "detail header actions container must exist");
+  const actions = fixture.body.querySelector('[data-section="branch-context"]');
+  assert.ok(actions, "branch context must exist");
   assert.equal(
-    actions.firstElementChild?.dataset?.action,
+    actions.querySelector('[data-action="launch-workspace"]')?.dataset?.action,
     "launch-workspace",
-    "Launch Agent is the first (primary) header action",
+    "Launch Agent is owned by branch context",
   );
   assert.equal(
     fixture.body.querySelectorAll('[data-action="launch-workspace"]').length,
@@ -1737,8 +1843,9 @@ test("merged Workspace detail offers Clean Up only from a backend cleanup candid
     sendFocus() {},
   });
 
-  const cleanup = [...fixture.body.querySelectorAll(".workspace-detail-actions button")]
-    .find((button) => button.textContent.trim() === "Clean Up");
+  const cleanup = fixture.body.querySelector(
+    '[data-section="worktree-context"] [data-action="cleanup-merged-workspace"]',
+  );
   assert.ok(cleanup, "merged Workspace must offer a Clean Up action");
   cleanup.click();
   assert.equal(cleanupCalls.length, 1);
@@ -2136,6 +2243,15 @@ test("remote-only Workspace shows the Remote badge and keeps the prefilled Launc
   const badge = fixture.body.querySelector(".workspace-overview-remote");
   assert.ok(badge, "Remote badge renders for remote-only rows");
   assert.equal(badge.textContent, "Remote");
+  assert.equal(
+    fixture.body.querySelectorAll(".workspace-overview-lifecycle").length,
+    0,
+    "remote environment absence must not be shown as a local Paused/Closed lifecycle",
+  );
+  assert.equal(
+    fixture.body.querySelector(".workspace-overview-row").dataset.attention,
+    "remote",
+  );
   assert.equal(sent.length, 0, "rendering generates no events (FR-381/FR-390)");
 
   const launch = fixture.body.querySelector('[data-action="launch-workspace"]');
@@ -2203,7 +2319,7 @@ test("eligible remote branches render as unified Workspace rows tagged Remote", 
 
   assert.deepEqual(
     rowIdsInList(fixture),
-    ["work-local", "remote-start:feature-foo", "remote-start:feature/bar"],
+    ["remote-start:feature-foo", "remote-start:feature/bar", "work-local"],
     "eligible remote branches join the list as rows; a duplicate of a real work is dropped",
   );
 
@@ -2219,8 +2335,8 @@ test("eligible remote branches render as unified Workspace rows tagged Remote", 
   );
   assert.equal(
     remoteRow.dataset.attention,
-    "paused",
-    "a startable remote branch sits in the Paused lane",
+    "remote",
+    "a startable remote branch stays Remote instead of guessing a local Paused state",
   );
   const tag = remoteRow.querySelector(".workspace-overview-remote");
   assert.ok(tag, "the row carries the shared Remote tag");

--- a/crates/gwt/web/workspace-kanban-surface.js
+++ b/crates/gwt/web/workspace-kanban-surface.js
@@ -38,8 +38,9 @@ export function createWorkspaceKanbanSurface({
   const ATTENTION_PRIORITY = Object.freeze({
     needs_attention: 0,
     running: 1,
-    paused: 2,
-    closed: 3,
+    remote: 2,
+    paused: 3,
+    closed: 4,
   });
 
   function compactText(value, fallback = "") {
@@ -161,6 +162,9 @@ export function createWorkspaceKanbanSurface({
         label: "Closed",
         reason: item?.done_equivalent ? "Merged with no updates" : formatLifecycleStateLabel(lifecycle),
       };
+    }
+    if (item?.remote_only) {
+      return { lane: "remote", label: "Remote", reason: "" };
     }
     const reason = explicitAttentionReason(item);
     if (reason) {
@@ -295,6 +299,17 @@ export function createWorkspaceKanbanSurface({
         : Array.isArray(fallback.agents)
           ? fallback.agents
           : [],
+      // W-21: launch-scoped Works are explicit children of the canonical
+      // branch Workspace. Empty means legacy display compatibility only; it
+      // must never create an implicit close target from the parent row.
+      works: Array.isArray(item?.works)
+        ? item.works.map((work) => ({
+            ...work,
+            agents: Array.isArray(work?.agents) ? work.agents : [],
+            manual_close_allowed: Boolean(work?.manual_close_allowed),
+            close_blocked_reason: compactText(work?.close_blocked_reason),
+          }))
+        : [],
       // SPEC-2359 W16-2 (FR-389): Workspace grouping key (backend merges
       // same-key rows before the wire; carried for tooling/tests).
       workspace_key: item?.workspace_key || null,
@@ -538,7 +553,7 @@ export function createWorkspaceKanbanSurface({
     // SPEC-2359 US-83 (UX revision 2026-06-24): a startable remote branch has
     // no Work yet, so a lifecycle state ("Paused") would misread as a stalled
     // Work. The Remote tag is its only state marker.
-    if (!item.startable_remote) {
+    if (!item.remote_only) {
       const doneEquivalent = Boolean(item.done_equivalent);
       const lifecycleBadge = createNode(
         "span",
@@ -880,17 +895,9 @@ export function createWorkspaceKanbanSurface({
     return section;
   }
 
-  // SPEC-2359 Workspace → Work → Session: the detail is Session-centric. Each
-  // `work` (a launch, carried in `workspace.agents`) holds its conversation
-  // Sessions in `work.sessions`. Sessions render as the primary rows; a Work
-  // heading only appears when the Workspace has more than one Work. Persistent
-  // Works always render (no live-only filtering), so Paused Workspaces are not
-  // mislabelled "No assigned agents".
-  // SPEC-2359 W-15 (FR-379 follow-up): Launch opens the launch wizard
-  // prefilled with the Workspace's branch; the new launch becomes a new Work
-  // joining this Workspace. Lives in the detail header actions as the primary
-  // action — one fixed home, never after the variable-length Work list
-  // (placement feedback, user verification 2026-06-11).
+  // Workspace -> Work -> Session: Workspace is a read projection. Launch is a
+  // branch operation, lifecycle close targets a child Work, and Resume targets
+  // a Session owned by that Work.
   function renderLaunchWorkspaceButton(workspace, windowId) {
     const branch = workspace && workspace.branch ? String(workspace.branch) : "";
     if (!branch) return null;
@@ -922,23 +929,31 @@ export function createWorkspaceKanbanSurface({
     const wrap = createNode("div", "workspace-detail-work-list");
     for (const work of list) {
       const group = createNode("div", "workspace-detail-work-group");
-      group.dataset.agentColor = agentColorKeyword(work);
-      // Each Work is one Agent (a launch). The Agent header names the agent
-      // (tool); the Work's Sessions (its conversation history) are listed under
-      // it as sub-rows, and Resume lives on each Session row (a single list
-      // element) so any conversation can be resumed directly. The header is
-      // always shown so two Sessions of one Work never look like two Agents.
+      if (work?.id) group.dataset.workId = work.id;
+      const agents = Array.isArray(work?.agents) ? work.agents : [];
+      const agent = agents[0] || work;
+      group.dataset.agentColor = agentColorKeyword(agent);
       const head = createNode("div", "workspace-detail-work-head");
       head.appendChild(
         createNode(
           "div",
           "workspace-detail-work-heading",
-          work.display_name || work.agent_id || "Agent",
+          work.work_summary || work.title || agent.display_name || agent.agent_id || "Work",
         ),
       );
+      if (!workspace?.remote_only) {
+        const lifecycle = createNode(
+          "span",
+          "workspace-overview-lifecycle",
+          formatLifecycleStateLabel(work.lifecycle_state),
+        );
+        lifecycle.dataset.lifecycle = String(work.lifecycle_state || "active").toLowerCase();
+        head.appendChild(lifecycle);
+      }
+      appendWorkCloseActions(head, work);
       group.appendChild(head);
 
-      const sessions = Array.isArray(work.sessions) ? work.sessions : [];
+      const sessions = Array.isArray(agent.sessions) ? agent.sessions : [];
       if (sessions.length === 0) {
         // No conversation recorded yet — still expose a Resume control on the
         // placeholder row so a session-less Work stays launchable.
@@ -947,7 +962,7 @@ export function createWorkspaceKanbanSurface({
           "workspace-overview-empty workspace-detail-session-empty",
           "No session yet",
         );
-        const resumeBtn = renderWorkResumeButton(work);
+        const resumeBtn = renderWorkResumeButton(agent);
         if (resumeBtn) {
           empty.appendChild(resumeBtn);
         }
@@ -959,12 +974,12 @@ export function createWorkspaceKanbanSurface({
         const latest =
           sessions.find((session) => session && session.is_active) ||
           sessions[sessions.length - 1];
-        group.appendChild(renderSessionRow(work, latest));
+        group.appendChild(renderSessionRow(agent, latest));
         // E1: when the visible Session is history-only (not resumable) on a
         // non-running Work, no Resume appears — offer a "Start Fresh" control
         // so the Work stays launchable. Distinct label so the user knows it
         // starts a new conversation, not a resumed one.
-        const startFresh = renderStartFreshButton(work, [latest]);
+        const startFresh = renderStartFreshButton(agent, [latest]);
         if (startFresh) {
           group.appendChild(startFresh);
         }
@@ -985,6 +1000,49 @@ export function createWorkspaceKanbanSurface({
         ),
       );
     }
+  }
+
+  function appendWorkCloseActions(container, work) {
+    if (!work?.id) return;
+    const lifecycle = String(work.lifecycle_state || "active").toLowerCase();
+    if (lifecycle === "done" || lifecycle === "discarded") return;
+    if (!work.manual_close_allowed && !work.close_blocked_reason) return;
+
+    const actions = createNode("div", "workspace-detail-work-actions");
+    for (const [action, label, closeKind] of [
+      ["close-work-done", "Done", "done"],
+      ["close-work-discard", "Discard", "discarded"],
+    ]) {
+      const button = createNode("button", "wizard-button is-compact", label);
+      button.type = "button";
+      button.dataset.action = action;
+      if (!work.manual_close_allowed) {
+        button.disabled = true;
+        button.title = work.close_blocked_reason;
+        button.setAttribute("aria-label", `${label} unavailable: ${work.close_blocked_reason}`);
+      } else {
+        button.addEventListener("click", () =>
+          send({ kind: "close_work", work_id: work.id, close_kind: closeKind }),
+        );
+      }
+      actions.appendChild(button);
+    }
+    container.appendChild(actions);
+  }
+
+  function displayedWorkspaceWorks(workspace) {
+    if (Array.isArray(workspace?.works) && workspace.works.length > 0) {
+      return workspace.works;
+    }
+    // Legacy payloads carried launch/session summaries directly in `agents`.
+    // Preserve Resume/display compatibility without inventing close targets.
+    return (Array.isArray(workspace?.agents) ? workspace.agents : []).map((agent) => ({
+      title: agent.display_name || agent.agent_id || "Work",
+      lifecycle_state: workspace?.lifecycle_state || "active",
+      agents: [agent],
+      manual_close_allowed: false,
+      close_blocked_reason: "",
+    }));
   }
 
   function renderWorkResumeButton(work) {
@@ -1347,64 +1405,6 @@ export function createWorkspaceKanbanSurface({
     titleWrap.appendChild(subtitle);
     header.appendChild(titleWrap);
 
-    const actions = createNode("div", "workspace-detail-actions");
-    // SPEC-2359: Resume is a per-Work (launch) operation, so the Resume control
-    // lives on each Work row (see appendWorks / renderWorkResumeButton). The
-    // Workspace header carries Launch Agent (the primary Workspace action —
-    // a new Work joining this Workspace) plus the lifecycle closes
-    // (Done / Discard / Clean Up).
-    const launchAction = renderLaunchWorkspaceButton(workspace, windowId);
-    if (launchAction) {
-      actions.appendChild(launchAction);
-    }
-    // SPEC-2359 Phase W-12 (FR-351): the Work surface owns Work lifecycle
-    // closing. Done / Discard are explicit user closes (FR-350 — agent stop
-    // alone never closes a Work). The actual cleanup is a follow-up slice, so
-    // these buttons only emit the `close_work` message for now.
-    const lifecycleState = String(workspace.lifecycle_state || "active").toLowerCase();
-    // SPEC-2359 US-83: a startable remote branch has no Work yet, so the detail
-    // offers only Launch — Done / Discard would close a Work that does not exist.
-    if (
-      !workspace.startable_remote &&
-      lifecycleState !== "done" &&
-      lifecycleState !== "discarded"
-    ) {
-      const doneButton = createNode("button", "wizard-button", "Done");
-      doneButton.type = "button";
-      doneButton.dataset.action = "close-work-done";
-      doneButton.addEventListener("click", () =>
-        send({ kind: "close_work", work_id: workspace.id, close_kind: "done" }),
-      );
-      actions.appendChild(doneButton);
-
-      const discardButton = createNode("button", "wizard-button", "Discard");
-      discardButton.type = "button";
-      discardButton.dataset.action = "close-work-discard";
-      discardButton.addEventListener("click", () =>
-        send({ kind: "close_work", work_id: workspace.id, close_kind: "discarded" }),
-      );
-      actions.appendChild(discardButton);
-    }
-    // SPEC-2359 US-78: cleanup eligibility is backend-owned per row after the
-    // live-agent guard. `merged_into_base` is only a display badge.
-    if (workspace.cleanup_candidate) {
-      const cleanupButton = createNode("button", "wizard-button", "Clean Up");
-      cleanupButton.type = "button";
-      cleanupButton.dataset.action = "cleanup-merged-workspace";
-      cleanupButton.addEventListener("click", () =>
-        openWorkspaceCleanup?.(workspace.cleanup_candidate, windowId),
-      );
-      actions.appendChild(cleanupButton);
-    } else if (workspace.cleanup_blocked_reason) {
-      const cleanupButton = createNode("button", "wizard-button", "Clean Up");
-      cleanupButton.type = "button";
-      cleanupButton.disabled = true;
-      cleanupButton.dataset.action = "cleanup-blocked-workspace";
-      cleanupButton.title = cleanupBlockedTitle(workspace.cleanup_blocked_reason);
-      cleanupButton.setAttribute("aria-label", cleanupButton.title);
-      actions.appendChild(cleanupButton);
-    }
-    header.appendChild(actions);
     container.appendChild(header);
 
     // SPEC-3075: the Work *purpose* ("what work was running") is the detail
@@ -1446,8 +1446,45 @@ export function createWorkspaceKanbanSurface({
       }),
     );
     container.appendChild(
+      (() => {
+        const section = detailSection("Branch", (body) => {
+          appendDefinitionList(body, [["Branch", workspace.branch]]);
+          const launchAction = renderLaunchWorkspaceButton(workspace, windowId);
+          if (launchAction) body.appendChild(launchAction);
+        });
+        section.dataset.section = "branch-context";
+        return section;
+      })(),
+    );
+    if (workspace.worktree_path || workspace.cleanup_candidate || workspace.cleanup_blocked_reason) {
+      const worktreeSection = detailSection("Worktree", (body) => {
+        appendDefinitionList(body, [
+          ["Path", compactPath(workspace.worktree_path) || workspace.worktree_path],
+        ]);
+        if (workspace.cleanup_candidate) {
+          const cleanupButton = createNode("button", "wizard-button", "Clean Up");
+          cleanupButton.type = "button";
+          cleanupButton.dataset.action = "cleanup-merged-workspace";
+          cleanupButton.addEventListener("click", () =>
+            openWorkspaceCleanup?.(workspace.cleanup_candidate, windowId),
+          );
+          body.appendChild(cleanupButton);
+        } else if (workspace.cleanup_blocked_reason) {
+          const cleanupButton = createNode("button", "wizard-button", "Clean Up");
+          cleanupButton.type = "button";
+          cleanupButton.disabled = true;
+          cleanupButton.dataset.action = "cleanup-blocked-workspace";
+          cleanupButton.title = cleanupBlockedTitle(workspace.cleanup_blocked_reason);
+          cleanupButton.setAttribute("aria-label", cleanupButton.title);
+          body.appendChild(cleanupButton);
+        }
+      });
+      worktreeSection.dataset.section = "worktree-context";
+      container.appendChild(worktreeSection);
+    }
+    container.appendChild(
       detailSection("Agents & Sessions", (body) => {
-        appendWorks(body, workspace.agents, workspace);
+        appendWorks(body, displayedWorkspaceWorks(workspace), workspace);
       }),
     );
     container.appendChild(
@@ -1475,11 +1512,7 @@ export function createWorkspaceKanbanSurface({
     );
     container.appendChild(
       detailSection("Context", (body) => {
-        appendDefinitionList(body, [
-          ["Purpose", purposeText],
-          ["Branch", workspace.branch],
-          ["Worktree", compactPath(workspace.worktree_path) || workspace.worktree_path],
-        ]);
+        appendDefinitionList(body, [["Purpose", purposeText]]);
       }),
     );
   }


### PR DESCRIPTION
## Summary

- Workspaceをcanonical branch単位のsystem-managed projectionとして維持し、操作対象をWork、Session、branch、worktreeへ分離します。
- WorkのDone/Discardを履歴更新だけに限定し、Issue、SPEC、remote branch、worktreeを保持します。
- build lifecycleからcurrent sessionのWorkだけを冪等にDone/Discardedへ遷移させます。

## Changes

- `crates/gwt/src/protocol.rs` / `app_runtime/workspace_views.rs`: Workspace配下に後方互換なchild Work viewを追加し、同一canonical branchの複数Workを独立identityで投影します。
- `crates/gwt-core/src/workspace_projection/lifecycle.rs` / `app_runtime/launch.rs`: Work closeからworktree削除side effectを撤去し、live agent時のbackend blockを維持します。
- `crates/gwt/src/cli/build.rs`: `build.complete` / `build.abort`をcurrent gwt sessionのWork eventへ接続し、standaloneとretryを成功no-opにします。
- `crates/gwt/web/workspace-kanban-surface.js`: Workspace headerをread-onlyにし、Resume、Done/Discard、Launch、Clean Upを各target sectionへ配置します。
- Rust、frontend unit、Playwright fixtureを更新し、remote-only、legacy payload、child Work、close保持契約を固定します。

## Testing

- [x] `cargo fmt -- --check && git diff --check` - PASS。
- [x] `cargo test -p gwt-core -p gwt --all-features --quiet` - PASS（gwt lib 1363 passed / 1 ignored、gwt bin 726 passed、gwt-core 587 passed、全integration failure 0）。
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - PASS。
- [x] `cargo build -p gwt --bin gwt --bin gwtd` - PASS。
- [x] `bash scripts/run-frontend-unit-tests.sh` - PASS（1018 passed）。
- [x] `bash scripts/run-frontend-smoke-tests.sh` - PASS（30 passed）。
- [x] `bash scripts/run-visual-tests.sh` - PASS（170 passed、76 environment-dependent skipped）。
- [x] `cargo llvm-cov -p gwt-core -p gwt --all-features --json --summary-only --output-path target/coverage-summary.json` + threshold check - PASS（90.60%）。
- [x] markdownlint / commitlint - PASS。
- [x] Fresh browser-check - User Verification Result: confirmed（Remote Workspace保持、read-only header、target別操作配置、Issue/SPEC/branch/worktree保持）。

## PR Readiness

- State: Ready for review
- Releaseable slice: yes - backward-compatible DTO追加と操作ownership分離を一体で提供し、既存Workspace表示とcleanup経路を壊しません。
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

None

## Related Issues / Links

- #2359
- #3278（`workspace.update` completion sequencing / event-root validationは別scope）
- #3273

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated: N/A - public操作名と導線は維持し、仕様はSPEC #2359へ反映済み
- [x] Migration/backfill plan included: N/A - `serde(default)`による後方互換追加で破壊的migrationなし
- [x] CHANGELOG impact considered: `feat` commitとしてリリースノート対象

## Context

- Workspaceはユーザーが削除するrecordではなく、canonical branchから再構築される環境横断projectionです。以前の親Workspace単位操作では、Issue/SPECや他環境で利用中のremote branchまで削除対象と誤解される余地がありました。
- 本PRはoperation ownershipを明確化し、Work closeとworktree cleanupを別のbackend-vetted経路へ分離します。

## Risk / Impact

- **Affected areas**: Workspace Overview、Work lifecycle events、build lifecycle JSON operations、worktree cleanup境界。
- **Rollback plan**: 本PRをrevertすると旧Workspace-level操作へ戻ります。データmigrationは無いため追加rollback手順は不要です。

## Screenshots

- Fresh browser-checkでユーザー確認済みです。Remote rowsが`Remote`のまま残り、`feature/spec-3273`のWorkspace、Issue/SPEC、branch、worktreeが保持され、Branch sectionにのみ`Launch Agent`が表示されることを確認しました。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workspace details now show launch-scoped child Works with clearer agent and session information.
  - Added dedicated Branch and Worktree action areas for launching and cleanup.
  - Build completion and abortion now record the current Work’s terminal status.

- **Bug Fixes**
  - Paused Works are retained for separate cleanup instead of being removed immediately.
  - Remote-only Workspaces are clearly labeled and no longer display local lifecycle badges.
  - Close actions now target the selected child Work accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->