### PR TITLE
fix(github): oversized SPEC sectionを分割保存するsupported multipart writerを実装

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,6 +1437,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 2.0.18",
 ]

--- a/crates/gwt-core/src/work_events_intake.rs
+++ b/crates/gwt-core/src/work_events_intake.rs
@@ -160,12 +160,12 @@ fn ingest_work_events_contents_locked<'a>(
         .into_iter()
         .filter(|(event, _)| {
             seen_event_ids.contains(&event.id)
-                || !previous
+                || previous
                     .work_items
                     .iter()
                     .find(|item| item.id == event.work_item_id)
                     .and_then(terminal_close_time)
-                    .is_some_and(|closed_at| event.updated_at <= closed_at)
+                    .is_none_or(|closed_at| event.updated_at > closed_at)
         })
         .collect();
     let mut projection = refold_work_events_projection_with_keys(&previous, replayable)?;

--- a/crates/gwt-github/Cargo.toml
+++ b/crates/gwt-github/Cargo.toml
@@ -11,6 +11,7 @@ serde_json = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 gwt-core = { workspace = true }
+sha2 = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/gwt-github/src/body.rs
+++ b/crates/gwt-github/src/body.rs
@@ -103,7 +103,8 @@ impl SpecBody {
                 }
                 SectionLocation::Comments(ids) => {
                     // Concatenate content from each referenced comment in order.
-                    let mut chunks: Vec<(u32, String)> = Vec::new();
+                    let mut chunks: Vec<(Option<crate::sections::SectionPart>, String)> =
+                        Vec::new();
                     for &cid in ids {
                         let comment =
                             comment_map
@@ -123,9 +124,13 @@ impl SpecBody {
                                         cid, name.0
                                     ))
                                 })?;
-                        let index = matching.part.as_ref().map(|p| p.index).unwrap_or(1);
-                        chunks.push((index, matching.content));
+                        chunks.push((matching.part, matching.content));
                     }
+                    validate_split_chunks(name, &chunks)?;
+                    let mut chunks: Vec<(u32, String)> = chunks
+                        .into_iter()
+                        .map(|(part, content)| (part.map(|p| p.index).unwrap_or(1), content))
+                        .collect();
                     chunks.sort_by_key(|(i, _)| *i);
                     let joined = chunks
                         .into_iter()
@@ -163,6 +168,65 @@ impl fmt::Display for SpecMeta {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Fail-closed validation for sections split across comments (SPEC-3248 P7C
+/// / #3284). A section whose chunks carry `part=N/M` markers must be
+/// structurally complete: every chunk marked, one consistent total, exactly
+/// the indices `1..=total` present once each, and exactly `total` referenced
+/// comments. Unmarked multi-comment sections (the legacy layout) are joined
+/// without part validation, preserving backward compatibility.
+fn validate_split_chunks(
+    name: &SectionName,
+    chunks: &[(Option<crate::sections::SectionPart>, String)],
+) -> Result<(), ParseError> {
+    let marked = chunks.iter().filter(|(p, _)| p.is_some()).count();
+    if marked == 0 {
+        return Ok(());
+    }
+    if marked != chunks.len() {
+        return Err(ParseError::BrokenIndex(format!(
+            "section '{}' mixes part-marked and unmarked comments",
+            name.0
+        )));
+    }
+    let total = chunks[0].0.as_ref().map(|p| p.total).unwrap_or(0);
+    if total == 0 {
+        return Err(ParseError::BrokenIndex(format!(
+            "section '{}' declares a zero part total",
+            name.0
+        )));
+    }
+    for (part, _) in chunks {
+        let part = part.as_ref().expect("all chunks marked");
+        if part.total != total {
+            return Err(ParseError::BrokenIndex(format!(
+                "section '{}' has inconsistent part totals ({} vs {})",
+                name.0, part.total, total
+            )));
+        }
+    }
+    if chunks.len() != total as usize {
+        return Err(ParseError::IncompleteParts {
+            section: name.0.clone(),
+            expected: total,
+            found: chunks.len() as u32,
+        });
+    }
+    let mut seen: Vec<u32> = chunks
+        .iter()
+        .map(|(p, _)| p.as_ref().expect("all chunks marked").index)
+        .collect();
+    seen.sort_unstable();
+    let expected: Vec<u32> = (1..=total).collect();
+    if seen != expected {
+        return Err(ParseError::IncompleteParts {
+            section: name.0.clone(),
+            expected: total,
+            found: seen.iter().collect::<std::collections::BTreeSet<_>>().len() as u32,
+        });
+    }
+    Ok(())
+}
 
 fn parse_header(body: &str) -> Result<SpecMeta, ParseError> {
     let re = Regex::new(r"<!--\s*gwt-spec\s+id=(?P<id>\S+)\s+version=(?P<version>\d+)\s*-->")

--- a/crates/gwt-github/src/client.rs
+++ b/crates/gwt-github/src/client.rs
@@ -156,6 +156,11 @@ pub trait IssueClient: Send + Sync {
 
     fn create_comment(&self, number: IssueNumber, body: &str) -> Result<CommentSnapshot, ApiError>;
 
+    /// Delete an Issue comment. Used by the multipart section writer
+    /// (SPEC-3248 P7C / #3284) to clean up stale part comments after a
+    /// successful index swap.
+    fn delete_comment(&self, comment_id: CommentId) -> Result<(), ApiError>;
+
     fn create_issue(
         &self,
         title: &str,

--- a/crates/gwt-github/src/client/fake.rs
+++ b/crates/gwt-github/src/client/fake.rs
@@ -25,6 +25,12 @@ pub struct FakeIssueClient {
     next_issue_number: AtomicU64,
     next_comment_id: AtomicU64,
     clock: AtomicU64,
+    /// Failure-injection countdown for `create_comment`: `-1` disables the
+    /// knob; `n >= 0` allows `n` more successful creates, then fails.
+    fail_create_comment_after: std::sync::atomic::AtomicI64,
+    /// When set, the next `create_comment` stores a corrupted body so tests
+    /// can prove that post-write readback fails closed.
+    corrupt_next_create_comment: std::sync::atomic::AtomicBool,
 }
 
 struct FakeState {
@@ -43,7 +49,23 @@ impl FakeIssueClient {
             next_issue_number: AtomicU64::new(1),
             next_comment_id: AtomicU64::new(1),
             clock: AtomicU64::new(1),
+            fail_create_comment_after: std::sync::atomic::AtomicI64::new(-1),
+            corrupt_next_create_comment: std::sync::atomic::AtomicBool::new(false),
         }
+    }
+
+    /// Failure injection: allow `n` more successful `create_comment` calls,
+    /// then fail every subsequent call with [`ApiError::Unexpected`].
+    pub fn fail_create_comment_after(&self, n: u64) {
+        self.fail_create_comment_after
+            .store(n as i64, Ordering::SeqCst);
+    }
+
+    /// Corruption injection: the next `create_comment` stores a body whose
+    /// section content differs from what the caller sent.
+    pub fn corrupt_next_create_comment(&self) {
+        self.corrupt_next_create_comment
+            .store(true, Ordering::SeqCst);
     }
 
     /// Preload an Issue snapshot. Used by tests to set up fixtures.
@@ -193,6 +215,26 @@ impl IssueClient for FakeIssueClient {
         if body.len() > 65_536 {
             return Err(ApiError::BodyTooLarge);
         }
+        let countdown = self.fail_create_comment_after.load(Ordering::SeqCst);
+        if countdown >= 0 {
+            if countdown == 0 {
+                return Err(ApiError::Unexpected(
+                    "injected create_comment failure".to_string(),
+                ));
+            }
+            self.fail_create_comment_after
+                .store(countdown - 1, Ordering::SeqCst);
+        }
+        let stored_body = if self
+            .corrupt_next_create_comment
+            .swap(false, Ordering::SeqCst)
+        {
+            // Inject garbage right after the first marker line so the stored
+            // section content no longer matches what the caller sent.
+            body.replacen("-->\n", "-->\nGARBAGE-INJECTED\n", 1)
+        } else {
+            body.to_string()
+        };
         let new_id = CommentId(self.next_comment_id.fetch_add(1, Ordering::SeqCst));
         let mut state = self
             .inner
@@ -205,12 +247,28 @@ impl IssueClient for FakeIssueClient {
             .ok_or(ApiError::NotFound(number))?;
         let snapshot = CommentSnapshot {
             id: new_id,
-            body: body.to_string(),
+            body: stored_body,
             updated_at: self.tick(),
         };
         issue.comments.push(snapshot.clone());
         issue.updated_at = snapshot.updated_at.clone();
         Ok(snapshot)
+    }
+
+    fn delete_comment(&self, comment_id: CommentId) -> Result<(), ApiError> {
+        let mut state = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        self.record(&mut state, "delete_comment", &comment_id.to_string());
+        for issue in state.issues.values_mut() {
+            if let Some(pos) = issue.comments.iter().position(|c| c.id == comment_id) {
+                issue.comments.remove(pos);
+                issue.updated_at = self.tick();
+                return Ok(());
+            }
+        }
+        Err(ApiError::CommentNotFound(comment_id))
     }
 
     fn create_issue(

--- a/crates/gwt-github/src/client/http.rs
+++ b/crates/gwt-github/src/client/http.rs
@@ -31,6 +31,7 @@ pub enum HttpMethod {
     Get,
     Post,
     Patch,
+    Delete,
 }
 
 impl HttpMethod {
@@ -39,6 +40,7 @@ impl HttpMethod {
             HttpMethod::Get => "GET",
             HttpMethod::Post => "POST",
             HttpMethod::Patch => "PATCH",
+            HttpMethod::Delete => "DELETE",
         }
     }
 }
@@ -169,6 +171,7 @@ impl HttpTransport for ReqwestTransport {
             HttpMethod::Get => reqwest::Method::GET,
             HttpMethod::Post => reqwest::Method::POST,
             HttpMethod::Patch => reqwest::Method::PATCH,
+            HttpMethod::Delete => reqwest::Method::DELETE,
         };
         let mut builder = self.client.request(method, &request.url);
         for (k, v) in &request.headers {
@@ -282,6 +285,20 @@ impl<T: HttpTransport> HttpIssueClient<T> {
                 url: format!("{}{}", self.rest_base, path),
                 headers,
                 body: Some(body.to_string()),
+            })
+            .map_err(|e| ApiError::Network(e.to_string()))?;
+        check_status(&resp)?;
+        Ok(resp)
+    }
+
+    fn rest_delete(&self, path: &str) -> Result<HttpResponse, ApiError> {
+        let resp = self
+            .transport
+            .execute(HttpRequest {
+                method: HttpMethod::Delete,
+                url: format!("{}{}", self.rest_base, path),
+                headers: self.auth_headers(),
+                body: None,
             })
             .map_err(|e| ApiError::Network(e.to_string()))?;
         check_status(&resp)?;
@@ -624,6 +641,17 @@ impl<T: HttpTransport> IssueClient for HttpIssueClient<T> {
         let value: Value = serde_json::from_str(&resp.body)
             .map_err(|e| ApiError::Unexpected(format!("create_comment json: {e}")))?;
         parse_rest_comment(&value)
+    }
+
+    fn delete_comment(&self, comment_id: CommentId) -> Result<(), ApiError> {
+        let path = format!(
+            "/repos/{}/{}/issues/comments/{}",
+            self.owner, self.repo, comment_id.0
+        );
+        // GitHub answers 204 No Content on success; 404 maps through
+        // check_status like every other comment operation.
+        let _resp = self.rest_delete(&path)?;
+        Ok(())
     }
 
     fn create_issue(

--- a/crates/gwt-github/src/lib.rs
+++ b/crates/gwt-github/src/lib.rs
@@ -32,8 +32,11 @@ pub use client::{
     fake::FakeIssueClient, ApiError, CommentId, CommentSnapshot, FetchResult, IssueClient,
     IssueNumber, IssueSnapshot, IssueState, SpecListFilter, SpecSummary, UpdatedAt,
 };
-pub use routing::{decide_routing, Routing, ROUTING_PROMOTE_THRESHOLD_BYTES};
+pub use routing::{
+    decide_routing, split_section_into_parts, Routing, SplitError, COMMENT_PART_BUDGET_BYTES,
+    ROUTING_PROMOTE_THRESHOLD_BYTES,
+};
 pub use sections::{
     extract_sections, ExtractedSection, SectionName, SectionParseError, SectionPart,
 };
-pub use spec_ops::{SpecOps, SpecOpsError};
+pub use spec_ops::{SpecOps, SpecOpsError, WriteReceipt};

--- a/crates/gwt-github/src/routing.rs
+++ b/crates/gwt-github/src/routing.rs
@@ -17,6 +17,12 @@ pub const ROUTING_PROMOTE_THRESHOLD_BYTES: usize = 16 * 1024;
 /// The total body budget — beyond this, sections are demoted to comments.
 pub const ROUTING_BODY_BUDGET_BYTES: usize = 60 * 1024;
 
+/// Per-part content budget for comment-resident sections (SPEC-3248 P7C /
+/// #3284). GitHub rejects comments beyond 65,536 characters; keeping each
+/// part's *content* at 60 KiB leaves headroom for the part markers while
+/// staying conservative for both byte- and character-counted limits.
+pub const COMMENT_PART_BUDGET_BYTES: usize = 60 * 1024;
+
 /// Default body-resident sections. Everything else defaults to comment.
 pub const DEFAULT_BODY_SECTIONS: &[&str] = &["spec", "tasks"];
 
@@ -80,4 +86,61 @@ pub fn decide_routing(sections: &BTreeMap<SectionName, String>) -> Routing {
     }
 
     Routing(map)
+}
+
+/// Errors reported by [`split_section_into_parts`].
+#[derive(Debug, thiserror::Error)]
+pub enum SplitError {
+    /// A single line is larger than the per-part budget, so no line-boundary
+    /// cut can fit it. The writer must fail closed instead of truncating.
+    #[error(
+        "section line {line} exceeds the {budget}-byte part budget and \
+         cannot be split at a line boundary"
+    )]
+    UnsplittableChunk { line: usize, budget: usize },
+}
+
+/// Split section content into comment-sized parts (SPEC-3248 P7C / #3284).
+///
+/// Cuts are made only at line boundaries. Losslessness relies on the marker
+/// parser's exact-trim contract for part-marked sections: the writer wraps
+/// each part as `BEGIN part=i/K` + `\n` + part + `\n` + `END part=i/K`, the
+/// parser strips exactly that one newline per side, and
+/// [`crate::body::SpecBody::parse`] rejoins parts with a single `\n` — the
+/// same newline the cut consumed. Parts may therefore begin or end with
+/// blank lines and still roundtrip byte-for-byte.
+///
+/// Content within [`COMMENT_PART_BUDGET_BYTES`] is returned as a single part
+/// byte-for-byte. A single line larger than the budget fails closed with
+/// [`SplitError::UnsplittableChunk`].
+pub fn split_section_into_parts(content: &str) -> Result<Vec<String>, SplitError> {
+    if content.len() <= COMMENT_PART_BUDGET_BYTES {
+        return Ok(vec![content.to_string()]);
+    }
+
+    let lines: Vec<&str> = content.split('\n').collect();
+    let mut parts: Vec<String> = Vec::new();
+    let mut start = 0usize;
+    while start < lines.len() {
+        if lines[start].len() > COMMENT_PART_BUDGET_BYTES {
+            return Err(SplitError::UnsplittableChunk {
+                line: start + 1,
+                budget: COMMENT_PART_BUDGET_BYTES,
+            });
+        }
+        // Grow the window greedily while the joined size fits the budget.
+        let mut end = start;
+        let mut size = lines[start].len();
+        while end + 1 < lines.len() {
+            let next = size + 1 + lines[end + 1].len();
+            if next > COMMENT_PART_BUDGET_BYTES {
+                break;
+            }
+            end += 1;
+            size = next;
+        }
+        parts.push(lines[start..=end].join("\n"));
+        start = end + 1;
+    }
+    Ok(parts)
 }

--- a/crates/gwt-github/src/sections.rs
+++ b/crates/gwt-github/src/sections.rs
@@ -191,7 +191,16 @@ pub fn extract_sections(text: &str) -> Result<Vec<ExtractedSection>, SectionPars
                 };
                 let body_end = end_marker.marker_start;
                 let raw = &text[body_start..body_end];
-                let content = trim_surrounding_newlines(raw).to_string();
+                // Unmarked sections keep the legacy strip-all-edge-newlines
+                // behavior. Part-marked sections (SPEC-3248 P7C / #3284)
+                // strip exactly the one newline the writer places on each
+                // side of the content, so a part may itself begin or end
+                // with newlines and multipart content rejoins losslessly.
+                let content = if begin_part.is_some() {
+                    trim_exactly_one_newline(raw).to_string()
+                } else {
+                    trim_surrounding_newlines(raw).to_string()
+                };
                 // Duplicate detection: same name AND same part.
                 let is_duplicate = out
                     .iter()
@@ -210,9 +219,28 @@ pub fn extract_sections(text: &str) -> Result<Vec<ExtractedSection>, SectionPars
     Ok(out)
 }
 
+/// Strip exactly one leading and one trailing newline (`\n` or `\r\n`) —
+/// the ones the multipart writer places around each part's content. Interior
+/// and any additional edge newlines are content and must survive.
+fn trim_exactly_one_newline(raw: &str) -> &str {
+    let mut s = raw;
+    if let Some(rest) = s.strip_prefix("\r\n") {
+        s = rest;
+    } else if let Some(rest) = s.strip_prefix('\n') {
+        s = rest;
+    }
+    if let Some(rest) = s.strip_suffix("\r\n") {
+        s = rest;
+    } else if let Some(rest) = s.strip_suffix('\n') {
+        s = rest;
+    }
+    s
+}
+
 /// Strip at most the leading/trailing newline characters from the section
-/// body without touching interior whitespace.
-fn trim_surrounding_newlines(raw: &str) -> &str {
+/// body without touching interior whitespace. Shared with the writer side
+/// (`spec_ops`) so canonical content matches what a later parse returns.
+pub(crate) fn trim_surrounding_newlines(raw: &str) -> &str {
     let bytes = raw.as_bytes();
     let mut start = 0usize;
     let mut end = bytes.len();

--- a/crates/gwt-github/src/spec_ops.rs
+++ b/crates/gwt-github/src/spec_ops.rs
@@ -7,14 +7,16 @@
 
 use std::collections::BTreeMap;
 
+use sha2::{Digest, Sha256};
+
 use crate::{
     body::{Comment as BodyComment, SectionLocation, SectionsIndex, SpecMeta},
     cache::{Cache, CacheError},
     client::{
-        ApiError, CommentSnapshot, FetchResult, IssueClient, IssueNumber, IssueSnapshot,
+        ApiError, CommentId, CommentSnapshot, FetchResult, IssueClient, IssueNumber, IssueSnapshot,
         IssueState, UpdatedAt,
     },
-    routing::decide_routing,
+    routing::{decide_routing, split_section_into_parts},
     sections::SectionName,
 };
 
@@ -27,8 +29,29 @@ pub enum SpecOpsError {
     Cache(#[from] CacheError),
     #[error(transparent)]
     Parse(#[from] crate::body::ParseError),
+    #[error(transparent)]
+    Split(#[from] crate::routing::SplitError),
     #[error("section '{0}' not found")]
     SectionNotFound(String),
+    /// Post-write readback found remote content that differs from what was
+    /// written (SPEC-3248 P7C / #3284). The write was rolled back where
+    /// possible and must not be treated as committed.
+    #[error(
+        "post-write readback mismatch for section '{section}' — remote content \
+         does not match the written content; do not trust this write"
+    )]
+    ReadbackMismatch { section: String },
+}
+
+/// Receipt for a committed [`SpecOps::write_section`] call (SPEC-3248 P7C /
+/// #3284): canonical content size, comment part count (`0` when the section
+/// is body-resident), and the SHA-256 of the canonical content that the
+/// post-write readback verified against the remote copy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WriteReceipt {
+    pub bytes: usize,
+    pub parts: usize,
+    pub sha256: String,
 }
 
 /// High-level SPEC operations backed by an [`IssueClient`] and a [`Cache`].
@@ -78,26 +101,34 @@ impl<C: IssueClient> SpecOps<C> {
 
     /// Replace the content of a section.
     ///
-    /// The updated content is routed via [`decide_routing`]. When the target
-    /// ends up in the body, a single `patch_body` call updates the Issue.
-    /// When the target is routed to a comment, the appropriate
-    /// `create_comment` / `patch_comment` is emitted followed by one final
-    /// `patch_body` that persists the new section index map. Cache is updated
-    /// only on success; failures leave the cache untouched.
+    /// The updated content is canonicalized (surrounding newlines trimmed,
+    /// matching what a later parse returns) and routed via
+    /// [`decide_routing`]. Comment-resident content is split into
+    /// comment-sized parts by [`split_section_into_parts`] (SPEC-3248 P7C /
+    /// #3284) and written with `part=N/M` markers.
+    ///
+    /// Write protocol for part-count-changing comment writes is
+    /// create-then-swap-then-delete: new part comments are created first, a
+    /// single `patch_body` atomically swaps the section index to the new
+    /// comment ids, and stale comments are deleted only after the post-write
+    /// readback verifies the remote content. A failure before the index swap
+    /// leaves readers on the previous content (zero partial overwrite); a
+    /// readback mismatch rolls the body back and fails closed.
     pub fn write_section(
         &self,
         number: IssueNumber,
         name: &SectionName,
         content: &str,
-    ) -> Result<(), SpecOpsError> {
+    ) -> Result<WriteReceipt, SpecOpsError> {
         // Refresh cache to the latest snapshot before editing.
         self.refresh_cache(number)?;
         let entry = self
             .cache
             .load_entry(number)
             .ok_or_else(|| SpecOpsError::SectionNotFound(format!("issue {}", number.0)))?;
+        let canonical = crate::sections::trim_surrounding_newlines(content).to_string();
         let mut spec_body = entry.spec_body.clone();
-        spec_body.splice(name.clone(), content.to_string());
+        spec_body.splice(name.clone(), canonical.clone());
 
         // Recompute routing from the new section map.
         let new_routing = decide_routing(&spec_body.sections);
@@ -112,66 +143,120 @@ impl<C: IssueClient> SpecOps<C> {
             .cloned()
             .unwrap_or(SectionLocation::Body);
 
-        // Start from the latest full body text and patch it in place.
+        // Start from the latest full body text and patch it in place. Keep
+        // the original for rollback after a readback mismatch.
+        let original_body = entry.snapshot.body.clone();
         let mut issue_body = entry.snapshot.body;
         let mut new_sections_index = spec_body.sections_index.clone();
+
+        let prev_ids: Vec<u64> = match &prev_location {
+            Some(SectionLocation::Comments(ids)) => ids.clone(),
+            _ => Vec::new(),
+        };
+
+        // Comments created by this write (rolled back on readback mismatch)
+        // and stale comments to delete after a verified swap.
+        let mut created_ids: Vec<u64> = Vec::new();
+        let mut stale_ids: Vec<u64> = Vec::new();
+        // Whether rolling back means restoring the original body text.
+        let mut rollback_body = false;
+        let parts_written: usize;
 
         match (&prev_location, &new_location) {
             // Stay in body: rewrite the section between the markers, then patch.
             (Some(SectionLocation::Body) | None, SectionLocation::Body) => {
-                issue_body = rewrite_body_section(&issue_body, name, content);
+                issue_body = rewrite_body_section(&issue_body, name, &canonical);
                 new_sections_index
                     .0
                     .insert(name.clone(), SectionLocation::Body);
                 issue_body = rewrite_index_map(&issue_body, &new_sections_index);
                 let _snap = self.client.patch_body(number, &issue_body)?;
+                rollback_body = true;
+                parts_written = 0;
             }
-            // Body -> Comment promotion: create a new comment, drop the
-            // body-inline markers, then patch the body with the new index map.
-            (Some(SectionLocation::Body) | None, SectionLocation::Comments(_)) => {
-                let comment_body = wrap_comment_body(name, content);
-                let comment: CommentSnapshot = self.client.create_comment(number, &comment_body)?;
+            // Comment -> Comment, single part staying single: patch the
+            // existing comment in place (stable comment id, single atomic
+            // mutation).
+            (Some(SectionLocation::Comments(ids)), SectionLocation::Comments(_))
+                if ids.len() == 1
+                    && canonical.len() <= crate::routing::COMMENT_PART_BUDGET_BYTES =>
+            {
+                let comment_body = wrap_comment_part_body(name, &canonical, 1, 1);
+                let _patched = self
+                    .client
+                    .patch_comment(CommentId(ids[0]), &comment_body)?;
+                parts_written = 1;
+            }
+            // Every other comment-resident shape (promotion from body, part
+            // count changes, or an index entry with no recorded id):
+            // create-then-swap-then-delete.
+            (_, SectionLocation::Comments(_)) => {
+                let parts = split_section_into_parts(&canonical)?;
+                let total = parts.len();
+                for (i, part) in parts.iter().enumerate() {
+                    let comment_body = wrap_comment_part_body(name, part, i + 1, total);
+                    let comment: CommentSnapshot =
+                        self.client.create_comment(number, &comment_body)?;
+                    created_ids.push(comment.id.0);
+                }
                 new_sections_index
                     .0
-                    .insert(name.clone(), SectionLocation::Comments(vec![comment.id.0]));
-                issue_body = strip_body_section(&issue_body, name);
+                    .insert(name.clone(), SectionLocation::Comments(created_ids.clone()));
+                if matches!(&prev_location, Some(SectionLocation::Body)) {
+                    issue_body = strip_body_section(&issue_body, name);
+                }
                 issue_body = rewrite_index_map(&issue_body, &new_sections_index);
                 let _snap = self.client.patch_body(number, &issue_body)?;
-            }
-            // Comment -> Comment: patch the first referenced comment in place.
-            (Some(SectionLocation::Comments(ids)), SectionLocation::Comments(_)) => {
-                if let Some(first) = ids.first().copied() {
-                    let comment_body = wrap_comment_body(name, content);
-                    let _patched = self
-                        .client
-                        .patch_comment(crate::client::CommentId(first), &comment_body)?;
-                    // Routing (and existing id list) is unchanged.
-                } else {
-                    // Index claimed comment but no id recorded — treat as new.
-                    let comment_body = wrap_comment_body(name, content);
-                    let comment = self.client.create_comment(number, &comment_body)?;
-                    new_sections_index
-                        .0
-                        .insert(name.clone(), SectionLocation::Comments(vec![comment.id.0]));
-                    issue_body = rewrite_index_map(&issue_body, &new_sections_index);
-                    let _snap = self.client.patch_body(number, &issue_body)?;
-                }
+                rollback_body = true;
+                stale_ids = prev_ids;
+                parts_written = total;
             }
             // Comment -> Body: (rare) inline the content back into the body.
             (Some(SectionLocation::Comments(_)), SectionLocation::Body) => {
-                issue_body = insert_body_section(&issue_body, name, content);
+                issue_body = insert_body_section(&issue_body, name, &canonical);
                 new_sections_index
                     .0
                     .insert(name.clone(), SectionLocation::Body);
                 issue_body = rewrite_index_map(&issue_body, &new_sections_index);
                 let _snap = self.client.patch_body(number, &issue_body)?;
+                rollback_body = true;
+                stale_ids = prev_ids;
+                parts_written = 0;
             }
         }
 
-        // After a successful write, refresh the cache from the server so the
-        // locally-assembled body and any side-effect changes remain consistent.
-        self.refresh_cache(number)?;
-        Ok(())
+        // Post-write readback: refetch the issue unconditionally and verify
+        // the section now parses back to exactly the canonical content.
+        let readback_ok = self.readback_section(number, name, &canonical)?;
+        if !readback_ok {
+            // Roll back: restore the original body (and with it the original
+            // section index), then drop any comments this write created.
+            if rollback_body {
+                let _ = self.client.patch_body(number, &original_body);
+            }
+            for id in created_ids {
+                let _ = self.client.delete_comment(CommentId(id));
+            }
+            // Leave the cache on the (restored) remote state.
+            let _ = self.force_refresh_cache(number);
+            return Err(SpecOpsError::ReadbackMismatch {
+                section: name.0.clone(),
+            });
+        }
+
+        // Verified: clean up stale comments that are no longer referenced by
+        // the swapped index. Deletion failures leave harmless orphans (the
+        // index no longer references them), so they are best-effort.
+        for id in stale_ids {
+            let _ = self.client.delete_comment(CommentId(id));
+        }
+        self.force_refresh_cache(number)?;
+
+        Ok(WriteReceipt {
+            bytes: canonical.len(),
+            parts: parts_written,
+            sha256: format!("{:x}", Sha256::digest(canonical.as_bytes())),
+        })
     }
 
     /// Create a brand-new SPEC.
@@ -211,16 +296,24 @@ impl<C: IssueClient> SpecOps<C> {
         let created = self.client.create_issue(title, &initial_body, &labels)?;
         let number = created.number;
 
-        // 2. For each comment-resident section, create a comment and record the id.
+        // 2. For each comment-resident section, create one comment per part
+        //    (SPEC-3248 P7C / #3284) and record the ids in part order.
         let mut comment_id_map: BTreeMap<SectionName, Vec<u64>> = BTreeMap::new();
         let mut ordered: Vec<(&SectionName, &SectionLocation)> = routing.0.iter().collect();
         ordered.sort_by(|a, b| a.0.cmp(b.0));
         for (name, location) in ordered {
             if matches!(location, SectionLocation::Comments(_)) {
                 let content = sections.get(name).cloned().unwrap_or_default();
-                let comment_body = wrap_comment_body(name, &content);
-                let snapshot = self.client.create_comment(number, &comment_body)?;
-                comment_id_map.insert(name.clone(), vec![snapshot.id.0]);
+                let canonical = crate::sections::trim_surrounding_newlines(&content).to_string();
+                let parts = split_section_into_parts(&canonical)?;
+                let total = parts.len();
+                let mut ids: Vec<u64> = Vec::new();
+                for (i, part) in parts.iter().enumerate() {
+                    let comment_body = wrap_comment_part_body(name, part, i + 1, total);
+                    let snapshot = self.client.create_comment(number, &comment_body)?;
+                    ids.push(snapshot.id.0);
+                }
+                comment_id_map.insert(name.clone(), ids);
             }
         }
 
@@ -261,6 +354,31 @@ impl<C: IssueClient> SpecOps<C> {
                 Ok(())
             }
         }
+    }
+
+    /// Unconditional refresh: refetch the issue without a conditional key so
+    /// same-timestamp mutations (GitHub `updatedAt` has second granularity)
+    /// cannot leave the cache stale during post-write readback.
+    fn force_refresh_cache(&self, number: IssueNumber) -> Result<(), SpecOpsError> {
+        match self.client.fetch(number, None)? {
+            FetchResult::Updated(snapshot) => {
+                self.cache.write_snapshot(&snapshot)?;
+                Ok(())
+            }
+            FetchResult::NotModified => Ok(()),
+        }
+    }
+
+    /// Post-write readback (SPEC-3248 P7C / #3284): refetch the remote issue
+    /// and confirm the section parses back to exactly `expected`.
+    fn readback_section(
+        &self,
+        number: IssueNumber,
+        name: &SectionName,
+        expected: &str,
+    ) -> Result<bool, SpecOpsError> {
+        self.force_refresh_cache(number)?;
+        Ok(self.cache.read_section(number, name)?.as_deref() == Some(expected))
     }
 }
 
@@ -347,6 +465,22 @@ fn wrap_comment_body(name: &SectionName, content: &str) -> String {
     let trimmed = content.trim_end_matches('\n');
     format!(
         "<!-- artifact:{name} BEGIN -->\n{trimmed}\n<!-- artifact:{name} END -->",
+        name = name.0
+    )
+}
+
+/// Wrap one part of a (possibly multipart) comment-resident section. A
+/// single-part section keeps the unmarked legacy format so older readers stay
+/// compatible; multipart sections carry `part=N/M` markers under the parser's
+/// exact-trim contract, so the part content must not be re-trimmed here — a
+/// part may legitimately begin or end with blank lines that belong to the
+/// section content.
+fn wrap_comment_part_body(name: &SectionName, content: &str, index: usize, total: usize) -> String {
+    if total <= 1 {
+        return wrap_comment_body(name, content);
+    }
+    format!(
+        "<!-- artifact:{name} BEGIN part={index}/{total} -->\n{content}\n<!-- artifact:{name} END part={index}/{total} -->",
         name = name.0
     )
 }

--- a/crates/gwt-github/tests/body_test.rs
+++ b/crates/gwt-github/tests/body_test.rs
@@ -216,3 +216,138 @@ fn red_18_splice_adds_new_section() {
 fn _touch(idx: &SectionsIndex) -> usize {
     idx.0.len()
 }
+
+// ---------------------------------------------------------------------------
+// SPEC-3248 P7C bootstrap (#3284): fail-closed split-section validation
+// ---------------------------------------------------------------------------
+
+fn mk_split_body(section: &str, comment_ids: &[u64]) -> String {
+    let refs = comment_ids
+        .iter()
+        .map(|id| format!("comment:{id}"))
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        "<!-- gwt-spec id=2003 version=1 -->\n\
+<!-- sections:\n\
+{section}={refs}\n\
+spec=body\n\
+-->\n\
+\n\
+<!-- artifact:spec BEGIN -->\n\
+s\n\
+<!-- artifact:spec END -->\n"
+    )
+}
+
+fn mk_part_comment(id: u64, name: &str, index: u32, total: u32, content: &str) -> Comment {
+    Comment {
+        id,
+        body: format!(
+            "<!-- artifact:{name} BEGIN part={index}/{total} -->\n{content}\n<!-- artifact:{name} END part={index}/{total} -->"
+        ),
+    }
+}
+
+// RED-80: a part is missing (totals say 3, only parts 1 and 2 referenced) —
+// parse must fail closed instead of silently joining a truncated section.
+#[test]
+fn red_80_incomplete_parts_rejected() {
+    let body = mk_split_body("plan", &[111, 222]);
+    let comments = [
+        mk_part_comment(111, "plan", 1, 3, "alpha"),
+        mk_part_comment(222, "plan", 2, 3, "beta"),
+    ];
+    let err = SpecBody::parse(&body, &comments).unwrap_err();
+    assert!(
+        matches!(
+            &err,
+            ParseError::IncompleteParts { section, expected: 3, found: 2 } if section == "plan"
+        ),
+        "expected IncompleteParts, got {err:?}"
+    );
+}
+
+// RED-81: duplicate part index must be rejected, not double-joined.
+#[test]
+fn red_81_duplicate_part_index_rejected() {
+    let body = mk_split_body("plan", &[111, 222]);
+    let comments = [
+        mk_part_comment(111, "plan", 1, 2, "alpha"),
+        mk_part_comment(222, "plan", 1, 2, "alpha again"),
+    ];
+    let err = SpecBody::parse(&body, &comments).unwrap_err();
+    assert!(
+        matches!(&err, ParseError::IncompleteParts { section, .. } if section == "plan")
+            || matches!(&err, ParseError::BrokenIndex(_)),
+        "expected fail-closed error, got {err:?}"
+    );
+}
+
+// RED-82: inconsistent totals across parts must be rejected.
+#[test]
+fn red_82_inconsistent_totals_rejected() {
+    let body = mk_split_body("plan", &[111, 222]);
+    let comments = [
+        mk_part_comment(111, "plan", 1, 2, "alpha"),
+        mk_part_comment(222, "plan", 2, 3, "beta"),
+    ];
+    let err = SpecBody::parse(&body, &comments).unwrap_err();
+    assert!(
+        matches!(&err, ParseError::IncompleteParts { section, .. } if section == "plan")
+            || matches!(&err, ParseError::BrokenIndex(_)),
+        "expected fail-closed error, got {err:?}"
+    );
+}
+
+// RED-83: mixing a part-marked comment and an unmarked comment for the same
+// section is structurally ambiguous — fail closed.
+#[test]
+fn red_83_mixed_part_and_unmarked_rejected() {
+    let body = mk_split_body("plan", &[111, 222]);
+    let comments = [
+        mk_comment(111, "plan", "alpha"),
+        mk_part_comment(222, "plan", 2, 2, "beta"),
+    ];
+    let err = SpecBody::parse(&body, &comments).unwrap_err();
+    assert!(
+        matches!(&err, ParseError::IncompleteParts { section, .. } if section == "plan")
+            || matches!(&err, ParseError::BrokenIndex(_)),
+        "expected fail-closed error, got {err:?}"
+    );
+}
+
+// RED-84: complete parts listed out of id order still join by part index.
+#[test]
+fn red_84_out_of_order_ids_join_by_part_index() {
+    let body = mk_split_body("plan", &[222, 111]);
+    let comments = [
+        mk_part_comment(111, "plan", 1, 2, "alpha"),
+        mk_part_comment(222, "plan", 2, 2, "beta"),
+    ];
+    let spec_body = SpecBody::parse(&body, &comments).unwrap();
+    assert_eq!(
+        spec_body
+            .sections
+            .get(&n("plan"))
+            .map(std::string::String::as_str),
+        Some("alpha\nbeta")
+    );
+}
+
+// RED-85: part count must also match the number of referenced comments —
+// referencing the same complete pair twice is rejected.
+#[test]
+fn red_85_reference_count_mismatch_rejected() {
+    let body = mk_split_body("plan", &[111, 222, 111]);
+    let comments = [
+        mk_part_comment(111, "plan", 1, 2, "alpha"),
+        mk_part_comment(222, "plan", 2, 2, "beta"),
+    ];
+    let err = SpecBody::parse(&body, &comments).unwrap_err();
+    assert!(
+        matches!(&err, ParseError::IncompleteParts { section, .. } if section == "plan")
+            || matches!(&err, ParseError::BrokenIndex(_)),
+        "expected fail-closed error, got {err:?}"
+    );
+}

--- a/crates/gwt-github/tests/client_test.rs
+++ b/crates/gwt-github/tests/client_test.rs
@@ -247,3 +247,42 @@ fn seed_spec(client: &FakeIssueClient, number: u64, title: &str, phase_label: &s
         comments: Vec::new(),
     });
 }
+
+// ---------------------------------------------------------------------------
+// SPEC-3248 P7C bootstrap (#3284): delete_comment contract
+// ---------------------------------------------------------------------------
+
+// RED-46: delete_comment removes the comment and bumps the issue updated_at.
+#[test]
+fn red_46_delete_comment_removes_comment() {
+    let c = FakeIssueClient::new();
+    seed_simple(&c, 3001, "SPEC", "body");
+    let created = c.create_comment(IssueNumber(3001), "comment body").unwrap();
+    let before = c.fetch(IssueNumber(3001), None).unwrap();
+    let before_updated = match before {
+        FetchResult::Updated(s) => s.updated_at,
+        FetchResult::NotModified => panic!("expected Updated"),
+    };
+
+    c.delete_comment(created.id).unwrap();
+
+    let after = c.fetch(IssueNumber(3001), None).unwrap();
+    let snap = match after {
+        FetchResult::Updated(s) => s,
+        FetchResult::NotModified => panic!("expected Updated after delete"),
+    };
+    assert!(
+        snap.comments.iter().all(|cm| cm.id != created.id),
+        "deleted comment must be gone"
+    );
+    assert_ne!(snap.updated_at, before_updated);
+}
+
+// RED-47: deleting an unknown comment returns CommentNotFound.
+#[test]
+fn red_47_delete_unknown_comment_errors() {
+    let c = FakeIssueClient::new();
+    seed_simple(&c, 3002, "SPEC", "body");
+    let err = c.delete_comment(CommentId(99_999)).unwrap_err();
+    assert!(matches!(err, ApiError::CommentNotFound(CommentId(99_999))));
+}

--- a/crates/gwt-github/tests/routing_test.rs
+++ b/crates/gwt-github/tests/routing_test.rs
@@ -1,11 +1,19 @@
 //! Contract tests for the `routing` module (SPEC-12 tdd.md Layer 3).
+//!
+//! The `split_*` tests cover the SPEC-3248 P7C bootstrap (#3284): oversized
+//! section content must split into comment-sized parts that rejoin losslessly
+//! under the parser's surrounding-newline trimming, and impossible splits must
+//! fail closed instead of truncating.
 
 use std::collections::BTreeMap;
 
 use gwt_github::{
     body::SectionLocation,
-    routing::{decide_routing, ROUTING_PROMOTE_THRESHOLD_BYTES},
-    sections::SectionName,
+    routing::{
+        decide_routing, split_section_into_parts, SplitError, COMMENT_PART_BUDGET_BYTES,
+        ROUTING_PROMOTE_THRESHOLD_BYTES,
+    },
+    sections::{extract_sections, SectionName},
 };
 
 fn n(s: &str) -> SectionName {
@@ -100,4 +108,105 @@ fn red_25_decide_routing_is_pure() {
     let r1 = decide_routing(&s);
     let r2 = decide_routing(&s);
     assert_eq!(r1, r2);
+}
+
+// ---------------------------------------------------------------------------
+// SPEC-3248 P7C bootstrap (#3284): comment part splitting
+// ---------------------------------------------------------------------------
+
+/// Rejoin parts through the real storage pipeline: wrap each part the way the
+/// writer does (`part=i/K` markers around `\n`-delimited content), run the
+/// production marker parser over the wrapped body, then join the extracted
+/// contents with a single `\n` exactly like `SpecBody::parse`. The splitter
+/// contract is that this full pipeline is lossless.
+fn rejoin(parts: &[String]) -> String {
+    let total = parts.len();
+    parts
+        .iter()
+        .enumerate()
+        .map(|(i, part)| {
+            let wrapped = format!(
+                "<!-- artifact:plan BEGIN part={idx}/{total} -->\n{part}\n<!-- artifact:plan END part={idx}/{total} -->",
+                idx = i + 1
+            );
+            let extracted = extract_sections(&wrapped).expect("wrapped part must parse");
+            assert_eq!(extracted.len(), 1);
+            extracted[0].content.clone()
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+// RED-70: content within the budget stays a single part, byte-for-byte.
+#[test]
+fn red_70_split_under_budget_single_part() {
+    let content = "line one\nline two\nline three";
+    let parts = split_section_into_parts(content).unwrap();
+    assert_eq!(parts, vec![content.to_string()]);
+}
+
+// RED-71: oversized content splits into multiple parts, each within the
+// per-part budget, and rejoins losslessly under parser trimming semantics.
+#[test]
+fn red_71_split_over_budget_lossless() {
+    // ~3 budgets worth of realistic multi-line markdown.
+    let line = "- [ ] T-999 some task line with a bit of text to fill space\n";
+    let repeat = (COMMENT_PART_BUDGET_BYTES * 3) / line.len();
+    let content = line.repeat(repeat).trim_end_matches('\n').to_string();
+
+    let parts = split_section_into_parts(&content).unwrap();
+    assert!(
+        parts.len() >= 3,
+        "expected at least 3 parts, got {}",
+        parts.len()
+    );
+    for (i, part) in parts.iter().enumerate() {
+        assert!(
+            part.len() <= COMMENT_PART_BUDGET_BYTES,
+            "part {} exceeds budget: {} bytes",
+            i + 1,
+            part.len()
+        );
+    }
+    assert_eq!(rejoin(&parts), content, "parts must rejoin losslessly");
+}
+
+// RED-72: paragraph-per-line markdown (every second line blank, so cut
+// points inevitably touch blank lines) must still roundtrip exactly through
+// the exact-trim part contract.
+#[test]
+fn red_72_split_preserves_interior_blank_lines() {
+    let paragraph = "## Heading\n\nBody text line that is reasonably long for a paragraph.\n\n";
+    let repeat = (COMMENT_PART_BUDGET_BYTES * 2) / paragraph.len() + 1;
+    let content = paragraph.repeat(repeat).trim_end_matches('\n').to_string();
+
+    let parts = split_section_into_parts(&content).unwrap();
+    assert!(parts.len() >= 2, "expected a multi-part split");
+    assert_eq!(
+        rejoin(&parts),
+        content,
+        "blank lines must survive the split"
+    );
+}
+
+// RED-73: a single line larger than the budget cannot be split safely —
+// fail closed, never truncate.
+#[test]
+fn red_73_split_single_oversized_line_fails_closed() {
+    let content = "x".repeat(COMMENT_PART_BUDGET_BYTES + 1);
+    let err = split_section_into_parts(&content).unwrap_err();
+    assert!(matches!(err, SplitError::UnsplittableChunk { .. }));
+}
+
+// RED-74: splitting is deterministic.
+#[test]
+fn red_74_split_is_pure() {
+    let line = "content line for determinism check\n";
+    let content = line
+        .repeat(COMMENT_PART_BUDGET_BYTES / line.len() * 2)
+        .trim_end_matches('\n')
+        .to_string();
+    let p1 = split_section_into_parts(&content).unwrap();
+    let p2 = split_section_into_parts(&content).unwrap();
+    assert_eq!(p1, p2);
 }

--- a/crates/gwt-github/tests/spec_ops_test.rs
+++ b/crates/gwt-github/tests/spec_ops_test.rs
@@ -152,24 +152,24 @@ fn red_63_write_section_new_section_creates_comment() {
     assert_eq!(got, "plan body");
 }
 
-// RED-64: write_section failure leaves cache unchanged
+// RED-64 (reshaped by SPEC-3248 P7C / #3284): oversized section content is no
+// longer a hard failure — the supported multipart writer splits it across
+// comments. A write that cannot be performed safely still leaves the cache
+// unchanged (see red_92_multipart_failure_zero_partial_overwrite).
 #[test]
-fn red_64_write_section_failure_preserves_cache() {
+fn red_64_write_section_oversized_succeeds_via_multipart() {
     let tmp = TempDir::new().unwrap();
     let cache = Cache::new(tmp.path().to_path_buf());
     let client = FakeIssueClient::new();
     seed_spec(&client, &cache, 1, "v1", "t1");
 
     let ops = SpecOps::new(client, cache);
-    // Force a BodyTooLarge failure by writing content that, after assembly,
-    // explodes the body size beyond 65,536 bytes.
-    let huge = "x".repeat(70_000);
-    let res = ops.write_section(IssueNumber(1), &n("tasks"), &huge);
-    assert!(res.is_err(), "expected write to fail, got Ok");
+    let huge = oversized_content(70_000);
+    ops.write_section(IssueNumber(1), &n("tasks"), &huge)
+        .unwrap();
 
-    // Cache should still show the original content.
     let got = ops.read_section(IssueNumber(1), &n("tasks")).unwrap();
-    assert_eq!(got, "t1");
+    assert_eq!(got, huge);
 }
 
 // RED-65: create_spec call order: create_issue -> create_comment* -> patch_body
@@ -222,4 +222,240 @@ fn red_66_read_missing_section_errors() {
     let ops = SpecOps::new(client, cache);
     let err = ops.read_section(IssueNumber(1), &n("plan")).unwrap_err();
     assert!(matches!(err, SpecOpsError::SectionNotFound(_)));
+}
+
+// ---------------------------------------------------------------------------
+// SPEC-3248 P7C bootstrap (#3284): supported multipart section writer
+// ---------------------------------------------------------------------------
+
+/// Multi-line content of roughly `target` bytes so the splitter has safe cut
+/// points at line boundaries.
+fn oversized_content(target: usize) -> String {
+    let line = "- [ ] T-xxx multipart writer fixture line with enough text to be realistic\n";
+    line.repeat(target / line.len() + 1)
+        .trim_end_matches('\n')
+        .to_string()
+}
+
+// RED-90: oversized write splits into part-marked comments, records every
+// comment id in the sections index in part order, and round-trips exactly.
+#[test]
+fn red_90_multipart_write_creates_part_comments() {
+    let tmp = TempDir::new().unwrap();
+    let cache = Cache::new(tmp.path().to_path_buf());
+    let client = FakeIssueClient::new();
+    seed_spec(&client, &cache, 1, "v1", "t1");
+
+    let ops = SpecOps::new(client, cache);
+    let huge = oversized_content(70_000);
+    ops.write_section(IssueNumber(1), &n("tasks"), &huge)
+        .unwrap();
+
+    let comments = ops.client().comments(IssueNumber(1));
+    let part_comments: Vec<_> = comments
+        .iter()
+        .filter(|c| c.body.contains("<!-- artifact:tasks BEGIN part="))
+        .collect();
+    assert!(
+        part_comments.len() >= 2,
+        "expected >= 2 part comments, got {}",
+        part_comments.len()
+    );
+    for c in &comments {
+        assert!(
+            c.body.len() <= 65_536,
+            "comment body exceeds GitHub limit: {} bytes",
+            c.body.len()
+        );
+    }
+    assert!(
+        part_comments[0].body.contains("part=1/"),
+        "first part comment must carry part=1 marker"
+    );
+
+    // Round-trip through a fresh read.
+    let got = ops.read_section(IssueNumber(1), &n("tasks")).unwrap();
+    assert_eq!(got, huge);
+}
+
+// RED-91: shrinking a multipart section back to a small single-comment
+// section swaps to one fresh comment and deletes the stale part comments.
+#[test]
+fn red_91_multipart_shrink_deletes_stale_parts() {
+    let tmp = TempDir::new().unwrap();
+    let cache = Cache::new(tmp.path().to_path_buf());
+    let client = FakeIssueClient::new();
+    seed_spec(&client, &cache, 1, "v1", "t1");
+
+    let ops = SpecOps::new(client, cache);
+    let huge = oversized_content(70_000);
+    ops.write_section(IssueNumber(1), &n("tasks"), &huge)
+        .unwrap();
+    let before = ops.client().comments(IssueNumber(1));
+    assert!(before.len() >= 2);
+
+    ops.write_section(IssueNumber(1), &n("tasks"), &oversized_content(20_000))
+        .unwrap();
+
+    let log = ops.client().call_log();
+    assert!(
+        log.iter().any(|l| l.starts_with("delete_comment:")),
+        "stale part comments must be deleted: {log:?}"
+    );
+    let after = ops.client().comments(IssueNumber(1));
+    let tasks_comments: Vec<_> = after
+        .iter()
+        .filter(|c| c.body.contains("<!-- artifact:tasks BEGIN"))
+        .collect();
+    assert_eq!(
+        tasks_comments.len(),
+        1,
+        "expected exactly one tasks comment after shrink"
+    );
+    let got = ops.read_section(IssueNumber(1), &n("tasks")).unwrap();
+    assert_eq!(got, oversized_content(20_000));
+}
+
+// RED-92: a failure while creating part comments must not touch the section
+// index — readers keep seeing the previous content (zero partial overwrite).
+#[test]
+fn red_92_multipart_failure_zero_partial_overwrite() {
+    let tmp = TempDir::new().unwrap();
+    let cache = Cache::new(tmp.path().to_path_buf());
+    let client = FakeIssueClient::new();
+    seed_spec(&client, &cache, 1, "v1", "t1");
+
+    let ops = SpecOps::new(client, cache);
+    // Establish tasks as a comment-resident section first.
+    ops.write_section(IssueNumber(1), &n("tasks"), &oversized_content(20_000))
+        .unwrap();
+
+    // Now inject a failure on the second part creation of the next write.
+    ops.client().fail_create_comment_after(1);
+    let huge = oversized_content(70_000);
+    let err = ops.write_section(IssueNumber(1), &n("tasks"), &huge);
+    assert!(err.is_err(), "expected injected create failure to surface");
+
+    // The section must still read back as the previous content.
+    let got = ops.read_section(IssueNumber(1), &n("tasks")).unwrap();
+    assert_eq!(got, oversized_content(20_000));
+}
+
+// RED-93: post-write readback verifies the remote content actually matches
+// what was written; server-side corruption fails closed and rolls back.
+#[test]
+fn red_93_readback_mismatch_fails_closed() {
+    let tmp = TempDir::new().unwrap();
+    let cache = Cache::new(tmp.path().to_path_buf());
+    let client = FakeIssueClient::new();
+    seed_spec(&client, &cache, 1, "v1", "t1");
+
+    let ops = SpecOps::new(client, cache);
+    ops.write_section(IssueNumber(1), &n("tasks"), &oversized_content(20_000))
+        .unwrap();
+
+    ops.client().corrupt_next_create_comment();
+    let huge = oversized_content(70_000);
+    let err = ops
+        .write_section(IssueNumber(1), &n("tasks"), &huge)
+        .unwrap_err();
+    assert!(
+        matches!(err, SpecOpsError::ReadbackMismatch { .. }),
+        "expected ReadbackMismatch, got other error"
+    );
+
+    // Rollback: the previous content must still be readable.
+    let got = ops.read_section(IssueNumber(1), &n("tasks")).unwrap();
+    assert_eq!(got, oversized_content(20_000));
+}
+
+// RED-94: small single-comment sections keep the in-place patch behavior
+// (stable comment id, no create/delete churn).
+#[test]
+fn red_94_small_section_keeps_in_place_patch() {
+    let tmp = TempDir::new().unwrap();
+    let cache = Cache::new(tmp.path().to_path_buf());
+    let client = FakeIssueClient::new();
+    seed_spec(&client, &cache, 1, "v1", "t1");
+
+    let ops = SpecOps::new(client, cache);
+    ops.write_section(IssueNumber(1), &n("plan"), "plan v1")
+        .unwrap();
+    let first_id = ops.client().comments(IssueNumber(1))[0].id;
+
+    ops.write_section(IssueNumber(1), &n("plan"), "plan v2")
+        .unwrap();
+
+    let log = ops.client().call_log();
+    assert!(
+        log.iter()
+            .any(|l| l.starts_with(&format!("patch_comment:comment:{}", first_id.0))),
+        "expected in-place patch of the existing comment: {log:?}"
+    );
+    assert!(
+        !log.iter().any(|l| l.starts_with("delete_comment:")),
+        "no delete expected for single->single rewrite: {log:?}"
+    );
+    let comments = ops.client().comments(IssueNumber(1));
+    assert_eq!(comments.len(), 1);
+    assert_eq!(comments[0].id, first_id, "comment id must stay stable");
+    let got = ops.read_section(IssueNumber(1), &n("plan")).unwrap();
+    assert_eq!(got, "plan v2");
+}
+
+// RED-95: create_spec with an oversized section materializes it as multipart
+// comments and round-trips exactly.
+#[test]
+fn red_95_create_spec_with_oversized_section() {
+    let tmp = TempDir::new().unwrap();
+    let cache = Cache::new(tmp.path().to_path_buf());
+    let client = FakeIssueClient::new();
+
+    let ops = SpecOps::new(client, cache);
+    let huge = oversized_content(70_000);
+    let mut sections = std::collections::BTreeMap::new();
+    sections.insert(n("spec"), "spec content".to_string());
+    sections.insert(n("plan"), huge.clone());
+
+    let snap = ops.create_spec("Oversized SPEC", sections, &[]).unwrap();
+
+    let comments = ops.client().comments(snap.number);
+    for c in &comments {
+        assert!(c.body.len() <= 65_536);
+    }
+    let got = ops.read_section(snap.number, &n("plan")).unwrap();
+    assert_eq!(got, huge);
+}
+
+// RED-96: #3248-scale roundtrip — ~130 KiB of mixed-width markdown survives
+// write -> remote storage -> readback byte-for-byte across >= 3 parts.
+#[test]
+fn red_96_spec_3248_scale_roundtrip() {
+    let tmp = TempDir::new().unwrap();
+    let cache = Cache::new(tmp.path().to_path_buf());
+    let client = FakeIssueClient::new();
+    seed_spec(&client, &cache, 1, "v1", "t1");
+
+    let block = "## 2026-07-07 Tasks: 統合ゲート強化\n\n- [ ] **T-100** 検証コマンドと結果を記録する。日本語の説明文を含む現実的なタスク行。\n- [ ] **T-101** stale evidence を拒否し、fail-closed で報告する。\n\n";
+    let mut content = String::new();
+    while content.len() < 130 * 1024 {
+        content.push_str(block);
+    }
+    let content = content.trim_end_matches('\n').to_string();
+
+    let ops = SpecOps::new(client, cache);
+    ops.write_section(IssueNumber(1), &n("tasks"), &content)
+        .unwrap();
+
+    let comments = ops.client().comments(IssueNumber(1));
+    let parts: Vec<_> = comments
+        .iter()
+        .filter(|c| c.body.contains("<!-- artifact:tasks BEGIN part="))
+        .collect();
+    assert!(parts.len() >= 3, "expected >= 3 parts, got {}", parts.len());
+    for c in &comments {
+        assert!(c.body.len() <= 65_536);
+    }
+    let got = ops.read_section(IssueNumber(1), &n("tasks")).unwrap();
+    assert_eq!(got, content);
 }

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -16204,6 +16204,10 @@ impl IssueClient for PermissionDeniedCreateIssueClient {
         unreachable!("quick register only creates issues")
     }
 
+    fn delete_comment(&self, _comment_id: CommentId) -> Result<(), ApiError> {
+        unreachable!("quick register only creates issues")
+    }
+
     fn create_issue(
         &self,
         _title: &str,

--- a/crates/gwt/src/cli/env/default.rs
+++ b/crates/gwt/src/cli/env/default.rs
@@ -101,6 +101,13 @@ impl IssueClient for LazyIssueClient {
         self.resolve()?.create_comment(number, body)
     }
 
+    fn delete_comment(
+        &self,
+        comment_id: gwt_github::client::CommentId,
+    ) -> Result<(), gwt_github::client::ApiError> {
+        self.resolve()?.delete_comment(comment_id)
+    }
+
     fn create_issue(
         &self,
         title: &str,

--- a/crates/gwt/src/cli/env/mod.rs
+++ b/crates/gwt/src/cli/env/mod.rs
@@ -148,6 +148,12 @@ impl<'a, C: IssueClient> IssueClient for ClientRef<'a, C> {
     ) -> Result<gwt_github::client::CommentSnapshot, gwt_github::client::ApiError> {
         self.inner.create_comment(number, body)
     }
+    fn delete_comment(
+        &self,
+        comment_id: gwt_github::client::CommentId,
+    ) -> Result<(), gwt_github::client::ApiError> {
+        self.inner.delete_comment(comment_id)
+    }
     fn create_issue(
         &self,
         title: &str,

--- a/crates/gwt/src/cli/issue_spec/mod.rs
+++ b/crates/gwt/src/cli/issue_spec/mod.rs
@@ -475,12 +475,24 @@ fn write_spec_section<E: CliEnv>(
         },
         cache,
     );
-    ops.write_section(IssueNumber(number), &SectionName(section.clone()), &content)?;
-    out.push_str(&format!(
-        "wrote {} bytes to section '{section}'\n",
-        content.len()
-    ));
+    let receipt =
+        ops.write_section(IssueNumber(number), &SectionName(section.clone()), &content)?;
+    out.push_str(&render_write_receipt(&section, &receipt));
     Ok(0)
+}
+
+/// Render the committed-write evidence line (SPEC-3248 P7C / #3284): byte
+/// count, storage shape, content hash, and the readback confirmation.
+fn render_write_receipt(section: &str, receipt: &gwt_github::WriteReceipt) -> String {
+    let shape = match receipt.parts {
+        0 => "body".to_string(),
+        1 => "1 comment part".to_string(),
+        n => format!("{n} comment parts"),
+    };
+    format!(
+        "wrote {} bytes to section '{section}' ({shape}, sha256:{}, readback verified)\n",
+        receipt.bytes, receipt.sha256
+    )
 }
 
 fn write_structured_spec_section<E: CliEnv>(
@@ -511,11 +523,9 @@ fn write_structured_spec_section<E: CliEnv>(
     } else {
         merge_structured_spec(&existing, &structured)
     };
-    ops.write_section(IssueNumber(number), &SectionName(section.clone()), &content)?;
-    out.push_str(&format!(
-        "wrote {} bytes to section '{section}'\n",
-        content.len()
-    ));
+    let receipt =
+        ops.write_section(IssueNumber(number), &SectionName(section.clone()), &content)?;
+    out.push_str(&render_write_receipt(&section, &receipt));
     Ok(0)
 }
 


### PR DESCRIPTION
## Summary

SPEC #3248 P7C bootstrap (#3284 IMPLEMENTATION-GAP): oversized な SPEC section を canonical 経路（`issue.spec.edit` / `issue.spec.create`）のまま安全に分割保存・読み戻しできる supported multipart writer を実装する。これにより comment 4955008882 の gate chain（#3284 修正 -> supported writer で task/launch contract 修正 -> remote roundtrip）が完了し、#3248 P7A launch が unblock される。

## Root cause

`SpecOps::write_section` は comment-resident section を先頭 comment 1 個への `patch_comment` でしか書けず、size preflight・分割・post-write readback が無かった。読み側も `part=N/M` の構造検証が無く（`ParseError::IncompleteParts` は未配線）、part 欠落を silent に truncated join していた。#3248 の spec/plan/tasks は単一 comment writer の安全上限を超えており、正本を安全に更新できない状態だった。

## Changes

- `crates/gwt-github/src/routing.rs`: `COMMENT_PART_BUDGET_BYTES` (60KiB/part) + `split_section_into_parts`（行境界カットのみ・単一行超過は `SplitError` で fail-closed・truncation なし）
- `crates/gwt-github/src/sections.rs`: part 付き section の exact-trim contract（writer 付加の改行 1 個のみ除去、任意の行境界カットが byte-for-byte 可逆）
- `crates/gwt-github/src/body.rs`: `SpecBody::parse` の fail-closed split validation（part 欠落/重複/総数不一致/marked-unmarked 混在/参照数不一致を拒否）
- `crates/gwt-github/src/spec_ops.rs`: multipart write = create-then-swap-then-delete（単一 `patch_body` で index 原子交換）、無条件 refetch の post-write readback、mismatch 時 rollback + `ReadbackMismatch`、`WriteReceipt {bytes, parts, sha256}`
- `crates/gwt-github/src/client.rs` + `fake.rs` + `http.rs`: `delete_comment`（REST DELETE）追加、fake に failure/corruption 注入 knob
- `crates/gwt/src/cli/...`: delegation 追加 + `issue.spec.edit` 出力に evidence line（bytes/parts/sha256/readback verified）
- `crates/gwt-core/src/work_events_intake.rs`: clippy `nonminimal_bool` 解消（等価変形、別コミット）

## Verification

- `cargo fmt --check` PASS / `cargo clippy --all-targets --all-features -- -D warnings` PASS / `RUSTDOCFLAGS=-D warnings cargo doc --no-deps -p gwt-github` PASS
- `cargo test -p gwt-github -p gwt-core -p gwt-skills -p gwt-agent -p gwt --all-features`: gwt-github 全 GREEN（新規 RED-46〜47 / 70〜74 / 80〜85 / 90〜96、~130KB #3248-scale roundtrip E2E 含む）。gwt bin の app_runtime 10 件のみ失敗するが、**base commit でも同一 10 件が失敗する**マシンローカル干渉（live agent/process 検出系、A/B stash 検証済み）で本変更と無関係。CI を正式ゲートとする。
- 実地検証: この writer で #3248 tasks section（74,672 bytes）を更新し、2 comment parts への分割・sha256 receipt・readback verified・独立再読み取りの byte 一致・spec/plan の parse 健全性を確認済み（tasks=comment:4989266696,comment:4989266809）。

## User Verification Result

n/a — CLI/library の挙動変更のみで直接の UI surface は無い。

## Draft note / Remaining scope

- CI（Build/Lint/Test）green 確認後に Ready 化可能。既知 blocker なし。
- 本 PR は #3248 P7C の bootstrap slice（T-277/T-278 の writer/parser/readback 基盤）のみ。P7C の残り（Artifact Operability Record 本体、Phase Launch Packet 等 T-274〜T-282 の未実装分）と P7A（T-070〜T-097）は後続タスク。
- Rollback 境界: gwt-github クレートの writer 挙動のみ。multipart 化済み section（#3248 tasks）の編集は本 writer を含むビルドが必要（旧 writer は multipart section を破損させ、新 reader が fail-closed 検出する）。

Refs #3284, #3248

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Large sections can now be stored across multiple comments while preserving content exactly.
  * Write results include committed size, part count, SHA-256 hash, and readback verification status.
  * Stale comment parts are automatically removed when content is updated or reduced.
* **Bug Fixes**
  * Invalid, incomplete, duplicated, or inconsistent multipart content is rejected safely.
  * Failed writes and verification mismatches roll back without exposing partial updates.
  * Terminal items no longer replay events after their closing time.
* **Tests**
  * Expanded coverage for multipart splitting, round-trip fidelity, rollback, cleanup, and comment deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->