### PR TITLE
feat(hooks): SPEC-3248 P9 remainder（T-124 integrity違反診断 + T-125 resume E2E）

### DIFF
--- a/crates/gwt/src/cli/execution_state.rs
+++ b/crates/gwt/src/cli/execution_state.rs
@@ -25,7 +25,7 @@
 //!   record; a resume preserves an existing settled record for the same
 //!   owner.
 //! - Saves are atomic file replacements but the read-modify-write cycle is
-//!   not serialized across processes; P9's write lease (T-124/T-125) owns
+//!   not serialized across processes; the owner write lease (T-149) owns
 //!   real serialization.
 
 use std::{
@@ -549,15 +549,49 @@ pub(super) fn run<E: CliEnv>(
             Ok(0)
         }
         SettleResult::SessionMismatch { record_session_id } => {
+            // T-124: an unauthorized settlement attempt against an ACTIVE
+            // record is bookkept as a deduped self-improvement candidate
+            // (owner + violation kind). A mismatch against an already
+            // settled record is a harmless retry — refused, not captured.
+            let note = match load(&worktree) {
+                Ok(Some(record)) if record.status == ExecutionControlStatus::Active => {
+                    crate::cli::improvement::execution_integrity_capture_note(
+                        &worktree,
+                        "Execution settlement attempted by a session that does not own the record (unauthorized takeover path)",
+                        &format!(
+                            "{kind} #{number}: settlement session mismatch (T-124)",
+                            kind = record.owner_kind.as_str(),
+                            number = record.owner_number,
+                        ),
+                    )
+                }
+                _ => String::new(),
+            };
             out.push_str(&format!(
-                "execution: settlement refused — record belongs to session {record_session_id}, not the current session. Take it over explicitly with JSON operation `execution.adopt` and a non-empty `params.reason` (T-117)\n",
+                "execution: settlement refused — record belongs to session {record_session_id}, not the current session. Take it over explicitly with JSON operation `execution.adopt` and a non-empty `params.reason` (T-117){note}\n",
             ));
             Ok(2)
         }
         SettleResult::Tampered => {
-            out.push_str(
-                "execution: settlement refused — the record failed integrity validation (edited outside the canonical operations). Repair with JSON operation `execution.adopt` and a non-empty `params.reason`, then re-verify\n",
+            let owner = load(&worktree)
+                .ok()
+                .flatten()
+                .map(|record| {
+                    format!(
+                        "{kind} #{number}",
+                        kind = record.owner_kind.as_str(),
+                        number = record.owner_number,
+                    )
+                })
+                .unwrap_or_else(|| "unknown owner".to_string());
+            let note = crate::cli::improvement::execution_integrity_capture_note(
+                &worktree,
+                "Execution control record failed integrity validation at settlement (edited outside the canonical operations)",
+                &format!("{owner}: settlement tamper refusal (T-124)"),
             );
+            out.push_str(&format!(
+                "execution: settlement refused — the record failed integrity validation (edited outside the canonical operations). Repair with JSON operation `execution.adopt` and a non-empty `params.reason`, then re-verify{note}\n",
+            ));
             Ok(2)
         }
     }
@@ -1035,6 +1069,154 @@ mod tests {
         ) -> Result<(i32, String), gwt_github::SpecOpsError> {
             let mut env = TestEnv::new(repo.to_path_buf());
             run_collect(&mut env, CliCommand::Execution(command))
+        }
+
+        // T-124: unauthorized settlement attempts (session mismatch) and
+        // tampered-record refusals auto-capture one deduped
+        // issue-spec-workflow improvement candidate.
+        #[test]
+        fn settlement_refusals_capture_improvement_candidate() {
+            let _env_lock = crate::env_test_lock()
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let _session = ScopedEnvVar::set(gwt_agent::GWT_SESSION_ID_ENV, "sess-intruder");
+            let dir = tempfile::tempdir().unwrap();
+            save(dir.path(), &active_record("sess-owner")).unwrap();
+
+            // Unauthorized settle from a non-owner session.
+            let (code, out) = run_cmd(dir.path(), ExecutionCommand::Complete).unwrap();
+            assert_eq!(code, 2, "{out}");
+            assert!(out.contains("execution.adopt"), "{out}");
+            assert!(out.contains("Self-improvement candidate"), "{out}");
+
+            // Tampered record refusal (blocked settle has no evidence gate,
+            // so it reaches the integrity check directly).
+            let path = state_path(dir.path());
+            let tampered = fs::read_to_string(&path)
+                .unwrap()
+                .replace("$gwt-execute", "$gwt-forged");
+            fs::write(&path, tampered).unwrap();
+            let (code, out) = run_cmd(
+                dir.path(),
+                ExecutionCommand::Blocked {
+                    reason: "verification runner unavailable".to_string(),
+                    missing_verification: None,
+                },
+            )
+            .unwrap();
+            assert_eq!(code, 2, "{out}");
+            assert!(out.contains("integrity validation"), "{out}");
+            assert!(out.contains("Self-improvement candidate"), "{out}");
+
+            let candidates = crate::cli::improvement::candidate_public_values(dir.path());
+            assert_eq!(candidates.len(), 1, "one deduped candidate expected");
+            assert_eq!(
+                candidates[0]
+                    .get("legacy_occurrence_count")
+                    .and_then(|v| v.as_u64()),
+                Some(2)
+            );
+            // Owner attribution survives in the deduped candidate details.
+            let store_raw = fs::read_to_string(
+                crate::cli::improvement_store::candidate_store_path(dir.path()),
+            )
+            .unwrap();
+            assert!(store_raw.contains("spec #3248"), "{store_raw}");
+
+            // Benign retry: a mismatch against an ALREADY SETTLED record is
+            // refused but not captured as a violation.
+            let mut settled = active_record("sess-owner");
+            settled.status = ExecutionControlStatus::Completed;
+            settled.settled_at = Some(Utc::now());
+            save(dir.path(), &settled).unwrap();
+            let (code, out) = run_cmd(dir.path(), ExecutionCommand::Complete).unwrap();
+            assert_eq!(code, 2, "{out}");
+            assert!(!out.contains("Self-improvement candidate"), "{out}");
+            let candidates = crate::cli::improvement::candidate_public_values(dir.path());
+            assert_eq!(
+                candidates[0]
+                    .get("legacy_occurrence_count")
+                    .and_then(|v| v.as_u64()),
+                Some(2),
+                "benign retry must not add an occurrence"
+            );
+        }
+
+        // T-125: crash/resume handoff lifecycle E2E — the adopt transfer is
+        // audited, verification evidence binds to the adopting session, and
+        // the Ready PR handoff refuses until that session produces fresh
+        // evidence.
+        #[test]
+        fn adopt_handoff_binds_evidence_to_new_session_and_gates_pr() {
+            let _env_lock = crate::env_test_lock()
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let home = tempfile::tempdir().unwrap();
+            let _home = ScopedEnvVar::set("HOME", home.path());
+            let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
+            let _session = ScopedEnvVar::set(gwt_agent::GWT_SESSION_ID_ENV, "sess-b");
+            let dir = tempfile::tempdir().unwrap();
+            crate::cli::trusted_store::init_git_repo_with_origin(dir.path());
+
+            // Session A launched the execution, then crashed.
+            materialize_at_launch(
+                dir.path(),
+                ExecutionOwnerKind::Spec,
+                3248,
+                "sess-a",
+                "$gwt-execute",
+                false,
+            )
+            .unwrap();
+
+            // Session B adopts with an audited reason.
+            let mut out = String::new();
+            run_adopt(dir.path(), "sess-b", "crash recovery", &mut out).unwrap();
+            let record = load(dir.path()).unwrap().unwrap();
+            assert_eq!(record.primary_session_id, "sess-b");
+            assert_eq!(record.transfers.len(), 1);
+            assert_eq!(record.transfers[0].from_session_id, "sess-a");
+            assert_eq!(record.transfers[0].reason, "crash recovery");
+            assert!(integrity_ok(&record));
+
+            // Ready handoff refuses: no evidence for the adopting session.
+            let refusal = pr_handoff_refusal(dir.path(), true);
+            assert!(
+                refusal.as_deref().unwrap_or("").contains("verify.run"),
+                "{refusal:?}"
+            );
+
+            // Session B registers the plan and runs it through the canonical
+            // executor — evidence binds to the new owner session.
+            use crate::cli::verification_record as vr;
+            vr::save_plan(
+                dir.path(),
+                &vr::VerificationPlanRecord {
+                    session_id: "sess-b".to_string(),
+                    owner_number: Some(3248),
+                    commands: vec!["git --version".to_string()],
+                    created_at: Utc::now(),
+                    content_hash: String::new(),
+                },
+            )
+            .unwrap();
+            let (run_record, _) =
+                vr::run_verification(dir.path(), "sess-b", &["git --version".to_string()]).unwrap();
+            assert!(run_record.all_passed && run_record.plan_covered);
+            assert_eq!(
+                vr::evaluate_evidence(dir.path(), "sess-b", Some(3248)),
+                vr::EvidenceStatus::Fresh
+            );
+            // The pre-crash session's claim to the same evidence stays dead.
+            assert_ne!(
+                vr::evaluate_evidence(dir.path(), "sess-a", Some(3248)),
+                vr::EvidenceStatus::Fresh
+            );
+
+            // Ready handoff now passes, and session B settles cleanly.
+            assert_eq!(pr_handoff_refusal(dir.path(), true), None);
+            let result = settle(dir.path(), "sess-b", ExecutionSettlement::Completed).unwrap();
+            assert!(matches!(result, SettleResult::Settled(_)));
         }
 
         #[test]

--- a/crates/gwt/src/cli/hook/execution_control_stop_check.rs
+++ b/crates/gwt/src/cli/hook/execution_control_stop_check.rs
@@ -42,11 +42,25 @@ pub fn handle_with_input(
     };
     // P9a (T-122): a record edited outside the canonical operations must not
     // release the gate — block with the repair path instead of trusting the
-    // edited status.
+    // edited status. T-124: repeated tamper blocks feed one deduped
+    // self-improvement candidate (owner id + violation kind only).
     if !execution_state::integrity_ok(&record) {
-        return HookOutput::stop_block(
-            "Execution control record failed integrity validation: it was edited outside the canonical operations. Repair it with JSON operation `execution.adopt` and a non-empty `params.reason`, then settle via `execution.complete` / `execution.blocked` with real verification evidence.",
-        );
+        let capture_note = if lane.policy_flags.self_improvement_capture {
+            crate::cli::improvement::execution_integrity_capture_note(
+                &resolved,
+                "Execution control record failed integrity validation at the Stop gate (edited outside the canonical operations)",
+                &format!(
+                    "{kind} #{number}: stop-gate tamper block (T-124)",
+                    kind = record.owner_kind.as_str(),
+                    number = record.owner_number,
+                ),
+            )
+        } else {
+            String::new()
+        };
+        return HookOutput::stop_block(format!(
+            "Execution control record failed integrity validation: it was edited outside the canonical operations. Repair it with JSON operation `execution.adopt` and a non-empty `params.reason`, then settle via `execution.complete` / `execution.blocked` with real verification evidence.{capture_note}",
+        ));
     }
     // Settlement requires GWT_SESSION_ID; a session without one (a bare,
     // non-gwt-launched agent in the worktree) could never satisfy the gate,
@@ -207,6 +221,50 @@ mod tests {
             handle_with_input(dir.path(), "{}", None),
             HookOutput::Silent
         );
+    }
+
+    // T-124: a tampered record does not just block — repeated tamper blocks
+    // auto-capture one deduped issue-spec-workflow improvement candidate
+    // (same dedupe key across repeats, no secrets in the summary).
+    #[test]
+    fn tampered_record_block_captures_improvement_candidate() {
+        // The capture store lives under gwt home; scope it thread-locally so
+        // parallel tests flipping HOME cannot split the two captures across
+        // different stores (ScopedGwtHome doc convention).
+        let home = tempfile::tempdir().unwrap();
+        let _gwt_home = gwt_core::test_support::ScopedGwtHome::set(home.path());
+        let dir = mk_worktree(Some(&EXECUTION_PROFILE));
+        materialize_at_launch(
+            dir.path(),
+            ExecutionOwnerKind::Spec,
+            3248,
+            "sess-1",
+            "$gwt-execute",
+            false,
+        )
+        .unwrap();
+        let path = crate::cli::execution_state::state_path(dir.path());
+        let tampered = std::fs::read_to_string(&path)
+            .unwrap()
+            .replace("$gwt-execute", "$gwt-forged");
+        std::fs::write(&path, tampered).unwrap();
+
+        for expected_occurrences in [1u64, 2u64] {
+            let output = handle_with_input(dir.path(), "{}", Some("sess-1"));
+            let HookOutput::StopBlock { reason } = output else {
+                panic!("expected StopBlock, got {output:?}");
+            };
+            assert!(reason.contains("integrity validation"), "{reason}");
+            assert!(reason.contains("Self-improvement candidate"), "{reason}");
+            let candidates = crate::cli::improvement::candidate_public_values(dir.path());
+            assert_eq!(candidates.len(), 1, "one deduped candidate expected");
+            assert_eq!(
+                candidates[0]
+                    .get("legacy_occurrence_count")
+                    .and_then(|v| v.as_u64()),
+                Some(expected_occurrences)
+            );
+        }
     }
 
     // Intake lanes are excluded — the intake artifact gate owns them.

--- a/crates/gwt/src/cli/hook/gwt_self_improvement_stop.rs
+++ b/crates/gwt/src/cli/hook/gwt_self_improvement_stop.rs
@@ -548,11 +548,13 @@ mod tests {
 
     use super::{
         apply_attempt_failure, evaluate_with_deadline, github_slug_from_remote_url,
-        load_candidate_store_after_projection_repair_with, origin_remote_url, render_stop_result,
+        load_candidate_store_after_projection_repair_with, render_stop_result,
         select_attempt_candidate, select_pending_owner_status_candidate, BlockedReason,
-        CandidateState, FailureSubcode, HookOutput, OwnerResolutionFailure, RepositoryProbeFailure,
-        ResolutionDeadline, StopCandidate, StopEvaluationFailure,
+        CandidateState, FailureSubcode, HookOutput, OwnerResolutionFailure, ResolutionDeadline,
+        StopCandidate, StopEvaluationFailure,
     };
+    #[cfg(unix)]
+    use super::{origin_remote_url, RepositoryProbeFailure};
     use crate::cli::TestEnv;
 
     fn stop_candidate(

--- a/crates/gwt/src/cli/improvement.rs
+++ b/crates/gwt/src/cli/improvement.rs
@@ -1929,6 +1929,68 @@ pub(crate) fn capture_intake_gate_violation(
         .map_err(|err| err.to_string())
 }
 
+/// Stable dedupe key for execution-integrity violations (SPEC-3248 P9,
+/// T-124): repeated tamper detections, unauthorized settlement attempts,
+/// and duplicate-owner takeover attempts all update one candidate.
+pub(crate) const EXECUTION_INTEGRITY_DEDUPE_KEY: &str = "issue-spec-workflow:execution-integrity";
+
+/// T-124 auto-capture for execution-integrity violations. Same env-free
+/// pipeline (validation, sanitization, dedupe, storage) and `medium`
+/// confidence as the intake gate capture; callers keep summaries/details to
+/// owner ids and violation kinds — never tokens, environment values, or
+/// record contents.
+pub(crate) fn capture_execution_integrity_violation(
+    worktree_root: &Path,
+    summary: &str,
+    details: &str,
+) -> Result<IntakeGateCaptureSummary, String> {
+    let command = ImprovementCaptureCommand {
+        source: "hook-runtime".to_string(),
+        target_artifact: "issue-spec-workflow".to_string(),
+        classification: "gwt-caused".to_string(),
+        confidence: "medium".to_string(),
+        summary: summary.to_string(),
+        details: Some(details.to_string()),
+        evidence_digest: None,
+        dedupe_key: Some(EXECUTION_INTEGRITY_DEDUPE_KEY.to_string()),
+        local_evidence: Vec::new(),
+        typed_evidence: None,
+    };
+    capture_candidate_core(worktree_root, command)
+        .map(|result| IntakeGateCaptureSummary {
+            id: result.candidate.id,
+            occurrences: result
+                .candidate
+                .legacy_occurrence_count
+                .unwrap_or(result.candidate.occurrences),
+            updated: result.updated_existing,
+        })
+        .map_err(|err| err.to_string())
+}
+
+/// Format the T-124 capture outcome as a note appended to gate messages:
+/// success → candidate id + occurrence count; failure → manual
+/// `improvement.capture` fallback (a capture failure must not be silent,
+/// T-085 convention).
+pub(crate) fn execution_integrity_capture_note(
+    worktree_root: &Path,
+    summary: &str,
+    details: &str,
+) -> String {
+    match capture_execution_integrity_violation(worktree_root, summary, details) {
+        Ok(result) => format!(
+            "\nSelf-improvement candidate {id} {verb} (occurrences: {count}).",
+            id = result.id,
+            verb = if result.updated { "updated" } else { "captured" },
+            count = result.occurrences,
+        ),
+        Err(error) => format!(
+            "\nSelf-improvement auto-capture failed ({error}). Record it manually: run JSON operation `improvement.capture` with `params.source:\"hook-runtime\"`, `params.target_artifact:\"issue-spec-workflow\"`, `params.classification:\"gwt-caused\"`, `params.confidence:\"medium\"`, `params.summary:\"execution integrity violation\"`, and `params.dedupe_key:\"{key}\"`.",
+            key = EXECUTION_INTEGRITY_DEDUPE_KEY,
+        ),
+    }
+}
+
 fn list(
     repo_root: &Path,
     command: ImprovementListCommand,

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -1,7 +1,8 @@
 //! T-112 (SPEC #1935) — workflow-policy gating tests.
 
+#[cfg(unix)]
+use std::env;
 use std::{
-    env,
     io::{ErrorKind, Read, Write},
     net::{TcpListener, TcpStream},
     path::{Path, PathBuf},

--- a/crates/gwt/tests/improvement_cli_test.rs
+++ b/crates/gwt/tests/improvement_cli_test.rs
@@ -715,6 +715,7 @@ fn write_canonical_store(
     path
 }
 
+#[cfg(unix)]
 fn save_session_path(home: &Path, project: &Path, repo_hash: &str) {
     let mut session = gwt_agent::Session::new(project, "test", gwt_agent::AgentId::Codex);
     session.repo_hash = Some(repo_hash.to_string());


### PR DESCRIPTION
## Summary

SPEC #3248 P9 remainder (T-124/T-125): 実行 integrity 違反の self-improvement 診断と crash/resume lifecycle E2E。

- **T-124**: Stop gate の tamper block・settlement の tamper 拒否・非 owner session の settlement 試行を、dedupe key `issue-spec-workflow:execution-integrity` の単一 improvement candidate として自動 capture（medium confidence、intake gate capture と同一の env-free pipeline）。details は owner kind/number + violation kind のみ（secrets 不含）。capture 失敗は手動 fallback を提示（T-085 慣例）。settled record への良性リトライは refuse のみで capture しない
- **T-125**: crash/resume handoff の managed lifecycle E2E — audited adopt transfer → 新 session への evidence binding → Ready PR handoff は evidence が揃うまで拒否 → settle Completed
- ride-along: write lease 参照タスク番号を T-149 に修正
- 付随 fix コミット: develop 由来の cfg(unix) テスト補助 3 箇所が Windows ローカル clippy を破っていたため cfg 整理（CI=ubuntu には影響なし）

## Rollback / Follow-up boundary

- Rollback: capture は gate message への追記 + improvement store への bookkeeping のみで、gate の block/refuse 挙動自体は不変。revert しても enforcement は P9a/P9b のまま
- Follow-up（配信 blocker ではない）: write lease（T-149）、store health gate（T-177）、monitor autonomous writer（T-121 完全版）

## Verification

- cargo fmt / clippy --all-targets --all-features -D warnings: PASS（Windows ローカル含む）
- 新規テスト 3 件 GREEN（5 連続実行で flake なし、capture テストは ScopedGwtHome で home 分離）
- gwt lib full: 既知のマシンローカル flaky（index_worker 4 + improvement/improvement_owner 系）のみ失敗、A/B stash で base 同一を確認。CI が正式ゲート
- adversarial review workflow（9 agents）: 4 指摘 confirmed → 全て本 PR 内で修正済み
- User Verification Result: n/a（UI 影響なし・hook/CLI 内部変更のみ）

Refs #3248

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Execution integrity violations now automatically create deduplicated self-improvement candidates.
  * Refusal messages provide capture details, candidate identifiers, and occurrence counts.
  * Session adoption now records the transfer reason and requires fresh verification evidence before handoff or settlement.

* **Bug Fixes**
  * Improved handling and messaging for unauthorized settlements and tampered execution records.
  * Repeated integrity violations are consolidated rather than creating duplicate candidates.

* **Tests**
  * Added coverage for tamper detection, session adoption, evidence requirements, and deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->