### PR TITLE
feat(hooks): SPEC-3248 T-149 owner write leaseでstate RMWを直列化

### DIFF
--- a/crates/gwt/src/cli/execution_state.rs
+++ b/crates/gwt/src/cli/execution_state.rs
@@ -24,9 +24,10 @@
 //!   transfer are P9a. A fresh relaunch takes over with a fresh active
 //!   record; a resume preserves an existing settled record for the same
 //!   owner.
-//! - Saves are atomic file replacements but the read-modify-write cycle is
-//!   not serialized across processes; the owner write lease (T-149) owns
-//!   real serialization.
+//! - Read-modify-write cycles (launch materialization, settlement,
+//!   adoption) run under the owner write lease
+//!   (`trusted_store::with_write_lease`, T-149): a second concurrent gwt
+//!   writer gets an explicit-retry refusal instead of last-writer-wins.
 
 use std::{
     fs,
@@ -191,6 +192,28 @@ pub fn materialize_at_launch(
     entrypoint: &str,
     resume: bool,
 ) -> io::Result<()> {
+    // T-149: the load-modify-save cycle runs under the owner write lease so
+    // concurrent launches cannot interleave into a lost update.
+    crate::cli::trusted_store::with_write_lease(worktree, || {
+        materialize_at_launch_locked(
+            worktree,
+            owner_kind,
+            owner_number,
+            session_id,
+            entrypoint,
+            resume,
+        )
+    })
+}
+
+fn materialize_at_launch_locked(
+    worktree: &Path,
+    owner_kind: ExecutionOwnerKind,
+    owner_number: u64,
+    session_id: &str,
+    entrypoint: &str,
+    resume: bool,
+) -> io::Result<()> {
     // Carry the audited transfer chain forward (P9a, T-118/T-123): taking
     // over another session's ACTIVE record — fresh launch or resume — is an
     // implicit, recorded transfer instead of a silent overwrite.
@@ -317,6 +340,17 @@ pub enum SettleResult {
 
 /// Settle the current worktree's record for `session_id`.
 pub fn settle(
+    worktree: &Path,
+    session_id: &str,
+    settlement: ExecutionSettlement,
+) -> io::Result<SettleResult> {
+    // T-149: settlement is a read-modify-write cycle — leased.
+    crate::cli::trusted_store::with_write_lease(worktree, || {
+        settle_locked(worktree, session_id, settlement)
+    })
+}
+
+fn settle_locked(
     worktree: &Path,
     session_id: &str,
     settlement: ExecutionSettlement,
@@ -612,6 +646,19 @@ fn run_adopt(
             "execution.adopt requires a non-empty params.reason".to_string(),
         )));
     }
+    // T-149: adoption is a read-modify-write cycle — leased.
+    crate::cli::trusted_store::with_write_lease(worktree, || {
+        Ok(run_adopt_locked(worktree, session_id, reason, out))
+    })
+    .map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?
+}
+
+fn run_adopt_locked(
+    worktree: &Path,
+    session_id: &str,
+    reason: &str,
+    out: &mut String,
+) -> Result<i32, SpecOpsError> {
     let Some(mut record) =
         load(worktree).map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?
     else {
@@ -743,6 +790,37 @@ mod tests {
         let loaded = load(dir.path()).unwrap().unwrap();
         assert_eq!(loaded.primary_session_id, "sess-1");
         assert!(!state_path(dir.path()).exists());
+    }
+
+    // T-149 wiring: settlement contends on the owner write lease — while a
+    // concurrent writer holds it past the bounded wait, settle() surfaces
+    // the explicit-retry error instead of interleaving.
+    #[test]
+    fn settle_refuses_with_retry_while_lease_is_held() {
+        let dir = tempfile::tempdir().unwrap();
+        save(dir.path(), &active_record("sess-1")).unwrap();
+
+        let worktree = dir.path().to_path_buf();
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let holder = std::thread::spawn(move || {
+            crate::cli::trusted_store::with_write_lease(&worktree, || {
+                acquired_tx.send(()).unwrap();
+                let _ = release_rx.recv_timeout(std::time::Duration::from_secs(10));
+                Ok(())
+            })
+            .unwrap();
+        });
+        acquired_rx.recv().unwrap();
+        let err = settle(dir.path(), "sess-1", ExecutionSettlement::Completed).unwrap_err();
+        assert!(err.to_string().contains("retry"), "{err}");
+        release_tx.send(()).unwrap();
+        holder.join().unwrap();
+        // The record is untouched by the refused settlement.
+        assert_eq!(
+            load(dir.path()).unwrap().unwrap().status,
+            ExecutionControlStatus::Active
+        );
     }
 
     // P9b: a mirror-only record (written before the trusted store existed)

--- a/crates/gwt/src/cli/intake_outcome.rs
+++ b/crates/gwt/src/cli/intake_outcome.rs
@@ -20,12 +20,12 @@
 //! errors are surfaced so hook callers can fail open (never mis-block) while
 //! explicit writers stay strict (FR-012 validation).
 //!
-//! Concurrency: every save is an atomic file replacement, but the
-//! read-modify-write cycle is not serialized across processes (the
-//! UserPromptSubmit hook and gwtd CLI operations are separate processes).
-//! The sub-millisecond lost-update window this leaves is a known, accepted
-//! bound for P7A — SPEC-3248 P9's Artifact Write Transaction / write-lease
-//! machinery owns real cross-process serialization as a dependent follow-up.
+//! Concurrency: every save is an atomic file replacement, and the
+//! read-modify-write cycles run under the owner write lease
+//! (`trusted_store::with_write_lease`, T-149). The UserPromptSubmit marker
+//! write uses a short lease wait with an unleased fallback — arming the
+//! gate must not be lost to contention (fail-open) while a lost concurrent
+//! outcome update only fails closed.
 
 use std::{
     fs,
@@ -200,7 +200,30 @@ pub fn save(worktree: &Path, state: &IntakeOutcomeState) -> io::Result<()> {
 /// owned by a different (previous) session is replaced wholesale. A
 /// malformed state file is replaced too: restoring the dirty marker restores
 /// the gate.
+/// Arm the intake gate for `session_id`. The only production caller is the
+/// blocking UserPromptSubmit hook, so the T-149 lease uses a short bounded
+/// wait and falls back to an unleased write on refusal: the rare interleave
+/// can only lose a concurrent outcome update, which fails CLOSED (the gate
+/// blocks and the outcome is re-recorded), while a dropped marker would
+/// fail OPEN (T-149 review).
 pub fn mark_required_since(worktree: &Path, session_id: &str, at: DateTime<Utc>) -> io::Result<()> {
+    match crate::cli::trusted_store::with_write_lease_wait(
+        worktree,
+        std::time::Duration::from_millis(300),
+        || mark_required_since_locked(worktree, session_id, at),
+    ) {
+        Err(err) if err.kind() == ErrorKind::WouldBlock => {
+            mark_required_since_locked(worktree, session_id, at)
+        }
+        result => result,
+    }
+}
+
+fn mark_required_since_locked(
+    worktree: &Path,
+    session_id: &str,
+    at: DateTime<Utc>,
+) -> io::Result<()> {
     let state = match load(worktree) {
         Ok(Some(existing)) if existing.session_id == session_id => IntakeOutcomeState {
             required_since: Some(at),
@@ -220,6 +243,19 @@ pub fn mark_required_since(worktree: &Path, session_id: &str, at: DateTime<Utc>)
 /// existing `required_since` for the same session is preserved so freshness
 /// evaluation stays correct.
 pub fn record_outcome(
+    worktree: &Path,
+    session_id: &str,
+    outcome: IntakeOutcome,
+) -> Result<(), String> {
+    // T-149: leased read-modify-write; a held lease surfaces as an
+    // explicit-retry error string.
+    crate::cli::trusted_store::with_write_lease(worktree, || {
+        Ok(record_outcome_locked(worktree, session_id, outcome))
+    })
+    .map_err(|err| err.to_string())?
+}
+
+fn record_outcome_locked(
     worktree: &Path,
     session_id: &str,
     outcome: IntakeOutcome,
@@ -380,6 +416,35 @@ mod tests {
         };
         save(dir.path(), &state).unwrap();
         assert_eq!(load(dir.path()).unwrap(), Some(state));
+    }
+
+    // T-149 review fix: the hook-side gate-arming write survives a wedged
+    // lease holder through the unleased fallback — a dropped marker would
+    // fail OPEN at the Stop gate.
+    #[test]
+    fn hook_marker_write_survives_held_lease() {
+        let dir = tempfile::tempdir().unwrap();
+        let worktree = dir.path().to_path_buf();
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let holder = std::thread::spawn(move || {
+            crate::cli::trusted_store::with_write_lease(&worktree, || {
+                acquired_tx.send(()).unwrap();
+                let _ = release_rx.recv_timeout(std::time::Duration::from_secs(10));
+                Ok(())
+            })
+            .unwrap();
+        });
+        acquired_rx.recv().unwrap();
+
+        mark_required_since(dir.path(), "sess-1", t(9, 0)).unwrap();
+        assert_eq!(
+            load(dir.path()).unwrap().unwrap().required_since,
+            Some(t(9, 0)),
+            "marker must be written even while the lease is held"
+        );
+        release_tx.send(()).unwrap();
+        holder.join().unwrap();
     }
 
     #[test]

--- a/crates/gwt/src/cli/trusted_store.rs
+++ b/crates/gwt/src/cli/trusted_store.rs
@@ -21,8 +21,10 @@ use std::{
     fs,
     io::{self, ErrorKind},
     path::{Path, PathBuf},
+    time::{Duration, Instant},
 };
 
+use fs2::FileExt;
 use sha2::{Digest, Sha256};
 
 /// Resolve the repo-scoped trusted directory for a worktree. `None` when the
@@ -113,6 +115,77 @@ pub fn write_with_mirror(
     }
 }
 
+/// Bounded wait before a second concurrent writer is refused (T-149). Long
+/// enough to ride out another writer's normal read-modify-write cycle,
+/// short enough that a stuck holder surfaces as an explicit retry error
+/// instead of a hang.
+const WRITE_LEASE_WAIT: Duration = Duration::from_secs(2);
+const WRITE_LEASE_POLL: Duration = Duration::from_millis(25);
+
+/// SPEC-3248 T-149 owner write lease: serialize gwt-originated
+/// read-modify-write cycles on this worktree's execution/verification/intake
+/// state records across processes. The lease is an fs2 advisory lock on
+/// `.write-lease` in the repo-scoped trusted directory (or, in degenerate
+/// mirror-only mode, in the worktree's `.gwt/skill-state/`), so every
+/// canonical writer for the same worktree contends on the same file. A
+/// second concurrent writer waits briefly, then gets an explicit-retry
+/// refusal — never a silent last-writer-wins interleave.
+///
+/// Callers wrap one whole RMW cycle and must not nest leases (fs2 locks on a
+/// second handle to the same file block within one process too).
+pub fn with_write_lease<T>(
+    worktree: &Path,
+    operation: impl FnOnce() -> io::Result<T>,
+) -> io::Result<T> {
+    with_write_lease_wait(worktree, WRITE_LEASE_WAIT, operation)
+}
+
+/// [`with_write_lease`] with an explicit wait bound (tests use a short one
+/// to assert the refusal path quickly).
+pub fn with_write_lease_wait<T>(
+    worktree: &Path,
+    wait: Duration,
+    operation: impl FnOnce() -> io::Result<T>,
+) -> io::Result<T> {
+    let dir = trusted_dir_for_worktree(worktree)
+        .unwrap_or_else(|| worktree.join(".gwt").join("skill-state"));
+    fs::create_dir_all(&dir)?;
+    let lock = fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(dir.join(".write-lease"))?;
+    let deadline = Instant::now() + wait;
+    // Contention is WouldBlock on Unix but a raw OS error (33) wrapped as
+    // Uncategorized on Windows — compare against fs2's canonical error.
+    let is_contended = |err: &io::Error| {
+        err.kind() == ErrorKind::WouldBlock
+            || err.raw_os_error() == fs2::lock_contended_error().raw_os_error()
+    };
+    loop {
+        match lock.try_lock_exclusive() {
+            Ok(()) => break,
+            Err(err) if is_contended(&err) => {
+                let now = Instant::now();
+                if now >= deadline {
+                    return Err(io::Error::new(
+                        ErrorKind::WouldBlock,
+                        "owner write lease is held by another gwt writer for this worktree — \
+                         retry the operation after the concurrent write settles (T-149; \
+                         last-writer-wins interleaving is refused)",
+                    ));
+                }
+                std::thread::sleep(WRITE_LEASE_POLL.min(deadline.saturating_duration_since(now)));
+            }
+            Err(err) => return Err(err),
+        }
+    }
+    let result = operation();
+    let _ = FileExt::unlock(&lock);
+    result
+}
+
 /// True when the worktree is under trusted-store management: launch
 /// materialization wrote the Execution Control Record's trusted copy, so
 /// every later canonical `verify.plan` / `verify.run` write produced a
@@ -155,6 +228,72 @@ pub(crate) fn init_git_repo_with_origin(dir: &Path) {
 mod tests {
     use super::*;
     use gwt_core::test_support::ScopedEnvVar;
+
+    // T-149: two concurrent writers serialize — the second waits for the
+    // first and both complete, in order.
+    #[test]
+    fn write_lease_serializes_concurrent_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let worktree = dir.path().to_path_buf();
+        let order = std::sync::Arc::new(std::sync::Mutex::new(Vec::<&str>::new()));
+
+        let order_a = order.clone();
+        let worktree_a = worktree.clone();
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+        let holder = std::thread::spawn(move || {
+            with_write_lease(&worktree_a, || {
+                order_a.lock().unwrap().push("a-start");
+                acquired_tx.send(()).unwrap();
+                std::thread::sleep(Duration::from_millis(300));
+                order_a.lock().unwrap().push("a-end");
+                Ok(())
+            })
+            .unwrap();
+        });
+        // Handshake: contend only after the holder actually holds the lease.
+        acquired_rx.recv().unwrap();
+        with_write_lease(&worktree, || {
+            order.lock().unwrap().push("b");
+            Ok(())
+        })
+        .unwrap();
+        holder.join().unwrap();
+        assert_eq!(*order.lock().unwrap(), vec!["a-start", "a-end", "b"]);
+    }
+
+    // T-149: a second writer that exceeds the bounded wait is refused with
+    // an explicit-retry error and its operation NEVER runs — no
+    // last-writer-wins interleave.
+    #[test]
+    fn write_lease_refuses_second_writer_with_explicit_retry() {
+        let dir = tempfile::tempdir().unwrap();
+        let worktree = dir.path().to_path_buf();
+
+        let worktree_a = worktree.clone();
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let holder = std::thread::spawn(move || {
+            with_write_lease(&worktree_a, || {
+                acquired_tx.send(()).unwrap();
+                let _ = release_rx.recv_timeout(Duration::from_secs(10));
+                Ok(())
+            })
+            .unwrap();
+        });
+        acquired_rx.recv().unwrap();
+        let mut ran = false;
+        let err = with_write_lease_wait(&worktree, Duration::from_millis(50), || {
+            ran = true;
+            Ok(())
+        })
+        .unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::WouldBlock);
+        assert!(err.to_string().contains("retry"), "{err}");
+        assert!(err.to_string().contains("T-149"), "{err}");
+        assert!(!ran, "refused writer must not run its operation");
+        release_tx.send(()).unwrap();
+        holder.join().unwrap();
+    }
 
     #[test]
     fn non_git_dir_is_degenerate_mirror_only() {


### PR DESCRIPTION
## Summary

SPEC #3248 T-149: owner write lease — 実行/intake state の read-modify-write を cross-process 直列化。

- `trusted_store::with_write_lease`: trusted dir（degenerate 時は `.gwt/skill-state`）の `.write-lease` への fs2 advisory lock。bounded wait（2s）超過で last-writer-wins ではなく明示 retry を要求する refuse。process 死で OS が解放するため stale lease なし
- lease 対象: `materialize_at_launch` / `settle` / `execution.adopt` / intake outcome の record・marker（各 RMW 全体、非入れ子）。read 経路（hook Stop check 等）は lease を取らずブロックしない
- UserPromptSubmit の gate-arming 書込は短 wait（300ms）+ 拒否時 unleased fallback（marker 喪失 = fail-open を防ぐ。並行 outcome 喪失は fail-closed で安全側）
- Windows contention（raw os error 33）は `fs2::lock_contended_error` 比較で判定

## Rollback / Follow-up boundary

- Rollback: revert すると RMW は P9b までの非直列化（atomic replace のみ）に戻る。record schema 変更なし
- Follow-up（配信 blocker ではない）: Runtime freshness lease（T-186）、Ready Evidence Lease（T-209）、store health gate（T-177）

## Verification

- cargo fmt / clippy --all-targets --all-features -D warnings: PASS
- lease テスト 4 件 GREEN（channel handshake で獲得順序決定、3 連続実行 flake なし）
- gwt lib full: 1604 GREEN（既知のマシンローカル flaky 族のみ失敗、CI 正式ゲート）
- adversarial review workflow（4 agents）: 2 指摘 confirmed → 全て本 PR 内で修正済み
- User Verification Result: n/a（UI 影響なし・hook/CLI 内部変更のみ）

Refs #3248

🤖 Generated with [Claude Code](https://claude.com/claude-code)