### PR TITLE
feat(hooks): SPEC-3248 P10 core GitHub API mutationのmethod-aware分類とblock

### DIFF
--- a/crates/gwt/src/cli/hook/block_bash_policy.rs
+++ b/crates/gwt/src/cli/hook/block_bash_policy.rs
@@ -17,6 +17,7 @@ pub fn evaluate_bash_command(command: &str, worktree_root: &Path) -> Option<Hook
         .or_else(|| block_git_dir_override::evaluate_bash_command(command))
         .or_else(|| evaluate_long_pr_ci_polling_sleep(command))
         .or_else(|| evaluate_github_workflow_cli(command))
+        .or_else(|| evaluate_github_mutation_sinks(command))
 }
 
 pub fn evaluate(event: &HookEvent, worktree_root: &Path) -> Result<HookOutput, HookError> {
@@ -214,6 +215,268 @@ Blocked command: {command}"
     )
 }
 
+/// SPEC-3248 P10 (T-212/T-217 core): method-aware GitHub mutation-sink
+/// classification. The workflow-endpoint block above routes issue/PR/run
+/// reads to the gwtd operations; this classifier blocks WRITES to the
+/// GitHub API regardless of endpoint family — `gh api` with a mutating
+/// method (explicit `-X`/`--method` or field-implied POST), `gh release`
+/// mutation subcommands, GraphQL mutation documents, and `curl` mutations
+/// against a GitHub API host. Read-only calls outside the workflow
+/// endpoints stay available. `git push` remains the sanctioned PR handoff
+/// path (classified as a mutation sink but policed by the PR gates, not
+/// here). Approved wrapper intents and `hub` coverage are T-217 follow-ups.
+fn evaluate_github_mutation_sinks(command: &str) -> Option<HookOutput> {
+    for segment in super::segments::split_command_segments(command) {
+        let tokens = command_tokens(&segment);
+        let Some(first) = tokens.first().copied() else {
+            continue;
+        };
+        match normalize_command_name(first).as_str() {
+            "gh" => match tokens.get(1).copied() {
+                Some("api") if is_mutating_gh_api(&segment, &tokens) => {
+                    return Some(github_mutation_block_decision(command));
+                }
+                Some("release") if is_mutating_release_subcommand(tokens.get(2).copied()) => {
+                    return Some(github_mutation_block_decision(command));
+                }
+                _ => {}
+            },
+            "curl" if is_mutating_github_curl(&tokens) => {
+                return Some(github_mutation_block_decision(command));
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Normalize a method value for comparison (agents habitually quote it).
+fn normalize_method(value: &str) -> String {
+    value
+        .trim_matches(|ch| ch == '\'' || ch == '"')
+        .to_ascii_uppercase()
+}
+
+/// True when the GraphQL document in the segment contains a mutation
+/// OPERATION — not merely the word "mutation" inside a search string or an
+/// introspection field. Heuristic: a word-bounded `mutation` keyword
+/// followed (after optional name and variable definitions) by `{`.
+fn graphql_contains_mutation_operation(segment: &str) -> bool {
+    let lowered = segment.to_ascii_lowercase();
+    let bytes = lowered.as_bytes();
+    let is_word = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+    let mut search_from = 0;
+    while let Some(offset) = lowered[search_from..].find("mutation") {
+        let start = search_from + offset;
+        let end = start + "mutation".len();
+        search_from = end;
+        if start > 0 && is_word(bytes[start - 1]) {
+            continue;
+        }
+        if end < bytes.len() && is_word(bytes[end]) {
+            continue;
+        }
+        let mut rest = lowered[end..].trim_start();
+        // Optional operation name.
+        let name_len = rest
+            .find(|ch: char| !(ch.is_ascii_alphanumeric() || ch == '_'))
+            .unwrap_or(rest.len());
+        rest = rest[name_len..].trim_start();
+        // Optional variable definitions.
+        if let Some(stripped) = rest.strip_prefix('(') {
+            let Some(close) = stripped.find(')') else {
+                continue;
+            };
+            rest = stripped[close + 1..].trim_start();
+        }
+        if rest.starts_with('{') {
+            return true;
+        }
+    }
+    false
+}
+
+/// `gh api` method semantics: explicit `-X`/`--method` wins; otherwise any
+/// body field (`-f`/`-F`/`--input`) makes gh POST. GraphQL is mutating when
+/// the document contains a mutation operation; a file-based query
+/// (`--input`) cannot be classified and is refused fail-closed.
+fn is_mutating_gh_api(segment: &str, tokens: &[&str]) -> bool {
+    if gh_api_target(tokens) == Some("graphql") {
+        let opaque_query = tokens
+            .iter()
+            .any(|token| *token == "--input" || token.starts_with("--input="));
+        return opaque_query || graphql_contains_mutation_operation(segment);
+    }
+    let mut method: Option<String> = None;
+    let mut has_body_field = false;
+    let mut i = 2;
+    while i < tokens.len() {
+        let token = tokens[i];
+        match token {
+            "-X" | "--method" => {
+                method = tokens.get(i + 1).map(|value| normalize_method(value));
+                i += 2;
+                continue;
+            }
+            "-f" | "--field" | "-F" | "--raw-field" | "--input" => {
+                has_body_field = true;
+                i += 2;
+                continue;
+            }
+            _ => {}
+        }
+        // `--flag=value` and attached short-option spellings (`-XPOST`,
+        // `-fkey=value`) must not slip past the classifier.
+        if let Some(value) = token.strip_prefix("--method=") {
+            method = Some(normalize_method(value));
+        } else if token.starts_with("--field=")
+            || token.starts_with("--raw-field=")
+            || token.starts_with("--input=")
+        {
+            has_body_field = true;
+        } else if let Some(cluster) = token
+            .strip_prefix('-')
+            .filter(|rest| !rest.starts_with('-'))
+        {
+            for (idx, ch) in cluster.char_indices() {
+                match ch {
+                    'X' => {
+                        let attached = &cluster[idx + 1..];
+                        method = if attached.is_empty() {
+                            i += 1;
+                            tokens.get(i).map(|value| normalize_method(value))
+                        } else {
+                            Some(normalize_method(attached))
+                        };
+                        break;
+                    }
+                    'f' | 'F' => {
+                        has_body_field = true;
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        i += 1;
+    }
+    match method.as_deref() {
+        Some("GET" | "HEAD") => false,
+        Some(_) => true,
+        None => has_body_field,
+    }
+}
+
+fn is_mutating_release_subcommand(subcommand: Option<&str>) -> bool {
+    matches!(
+        subcommand,
+        Some("create" | "edit" | "delete" | "delete-asset" | "upload")
+    )
+}
+
+/// `curl` against a GitHub API host with a mutating method (explicit
+/// `-X`/`--request`, or implied by body/upload flags).
+fn is_mutating_github_curl(tokens: &[&str]) -> bool {
+    let targets_github_api = tokens.iter().any(|token| {
+        let lowered = token.to_ascii_lowercase();
+        lowered.contains("api.github.com") || lowered.contains("uploads.github.com")
+    });
+    if !targets_github_api {
+        return false;
+    }
+    let mut method: Option<String> = None;
+    let mut has_body = false;
+    let mut forces_get = false;
+    let mut i = 1;
+    while i < tokens.len() {
+        let token = tokens[i];
+        match token {
+            "-X" | "--request" => {
+                method = tokens.get(i + 1).map(|value| normalize_method(value));
+                i += 2;
+                continue;
+            }
+            "-G" | "--get" => {
+                forces_get = true;
+                i += 1;
+                continue;
+            }
+            "-d" | "--data" | "--data-raw" | "--data-binary" | "--data-urlencode" | "--json"
+            | "-F" | "--form" | "-T" | "--upload-file" => {
+                has_body = true;
+                i += 2;
+                continue;
+            }
+            _ => {}
+        }
+        if let Some(value) = token.strip_prefix("--request=") {
+            method = Some(normalize_method(value));
+        } else if [
+            "--data=",
+            "--data-raw=",
+            "--data-binary=",
+            "--data-urlencode=",
+            "--json=",
+            "--form=",
+            "--upload-file=",
+        ]
+        .iter()
+        .any(|prefix| token.starts_with(prefix))
+        {
+            has_body = true;
+        } else if let Some(cluster) = token
+            .strip_prefix('-')
+            .filter(|rest| !rest.starts_with('-'))
+        {
+            // Attached short-option spellings (`-XPUT`, `-sSXPOST`,
+            // `-d@body.json`, `-Gd q=x`): scan the cluster; booleans like
+            // `G` continue, value-consuming flags end it.
+            for (idx, ch) in cluster.char_indices() {
+                match ch {
+                    'G' => forces_get = true,
+                    'X' => {
+                        let attached = &cluster[idx + 1..];
+                        method = if attached.is_empty() {
+                            i += 1;
+                            tokens.get(i).map(|value| normalize_method(value))
+                        } else {
+                            Some(normalize_method(attached))
+                        };
+                        break;
+                    }
+                    'd' | 'F' | 'T' => {
+                        has_body = true;
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        }
+        i += 1;
+    }
+    // `-G`/`--get` converts body flags into GET query parameters.
+    match method.as_deref() {
+        Some("GET" | "HEAD") => false,
+        Some(_) => true,
+        None => has_body && !forces_get,
+    }
+}
+
+fn github_mutation_block_decision(command: &str) -> HookOutput {
+    HookOutput::pre_tool_use_permission(
+        "\u{1F6AB} Direct GitHub API mutations are not allowed",
+        format!(
+            "GitHub writes must go through the canonical gwt operations so the completion/PR gates and audit state see them (SPEC-3248 P10, T-217).\n\n\
+Recommended alternatives:\n\
+- PRs: JSON operations `pr.create`, `pr.edit`, `pr.ready`, `pr.draft`, `pr.comment`, `pr.review_threads.reply_and_resolve`\n\
+- Issues/SPECs: JSON operations `issue.create`, `issue.comment`, `issue.spec.*`\n\
+- lifecycle state: JSON operations `intake.outcome.record`, `execution.*`, `verify.*`\n\
+- releases: the release workflow owns publishing — not agent Bash\n\n\
+Blocked command: {command}"
+        ),
+    )
+}
+
 fn command_tokens(segment: &str) -> Vec<&str> {
     let raw: Vec<&str> = segment.split_whitespace().collect();
     let mut start = 0;
@@ -346,5 +609,127 @@ mod tests {
             evaluate_bash_command("sleep 30 && gwtd pr checks 123", Path::new("/worktree"));
 
         assert!(decision.is_none());
+    }
+
+    // SPEC-3248 P10 (T-212/T-217 core): GitHub API mutations are blocked
+    // regardless of endpoint family; reads outside the workflow endpoints
+    // stay available.
+    #[test]
+    fn blocks_mutating_gh_api_and_allows_reads() {
+        for command in [
+            "gh api -X POST repos/o/r/git/refs -f ref=refs/heads/x -f sha=abc",
+            "gh api --method DELETE repos/o/r/releases/123",
+            "gh api -X PUT repos/o/r/branches/main/protection --input p.json",
+            "gh api -f name=bug repos/o/r/labels",
+            "gh api -X PATCH repos/o/r/contents/README.md",
+            "gh api --method=DELETE repos/o/r/releases/123",
+            "gh api --field=name=bug repos/o/r/labels",
+            "gh api -XPOST repos/o/r/forks",
+            "gh api -fkey=value repos/o/r/forks",
+        ] {
+            let decision = evaluate_bash_command(command, Path::new("/worktree"))
+                .unwrap_or_else(|| panic!("expected block: {command}"));
+            assert_eq!(
+                decision.summary(),
+                "\u{1F6AB} Direct GitHub API mutations are not allowed",
+                "{command}"
+            );
+            assert!(decision.detail().contains("T-217"), "{command}");
+        }
+
+        for command in [
+            "gh api repos/o/r",
+            "gh api repos/o/r/git/refs/heads/main",
+            "gh api -X GET repos/o/r/releases",
+            "gh api rate_limit",
+            "gh api -XGET search/code -f q=foo",
+            "gh api -X \"GET\" repos/o/r/releases",
+        ] {
+            assert!(
+                evaluate_bash_command(command, Path::new("/worktree")).is_none(),
+                "read must pass: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn blocks_graphql_mutations_and_release_writes_but_not_reads() {
+        for command in [
+            r#"gh api graphql -f query='mutation { enablePullRequestAutoMerge(input: {}) { clientMutationId } }'"#,
+            r#"gh api graphql -f query='mutation AddStar($id: ID!) { addStar(input: {starrableId: $id}) { clientMutationId } }'"#,
+            "gh api graphql --input req.json",
+            "gh release create v1.0.0 --notes x",
+            "gh release delete v1.0.0 --yes",
+            "gh release edit v1.0.0 --draft=false",
+            "gh release upload v1.0.0 dist.tar.gz",
+        ] {
+            let decision = evaluate_bash_command(command, Path::new("/worktree"))
+                .unwrap_or_else(|| panic!("expected block: {command}"));
+            assert_eq!(
+                decision.summary(),
+                "\u{1F6AB} Direct GitHub API mutations are not allowed",
+                "{command}"
+            );
+        }
+
+        for command in [
+            "gh release list --repo akiojin/gwt --limit 1",
+            "gh release view v1.0.0",
+            "gh release download v1.0.0",
+            r#"gh api graphql -f query='query { viewer { login } }'"#,
+            r#"gh api graphql -f query='query { search(query: "mutation sink", type: DISCUSSION, first: 5) { discussionCount } }'"#,
+            r#"gh api graphql -f query='query { __schema { mutationType { name } } }'"#,
+        ] {
+            assert!(
+                evaluate_bash_command(command, Path::new("/worktree")).is_none(),
+                "read must pass: {command}"
+            );
+        }
+    }
+
+    #[test]
+    fn blocks_curl_mutations_against_github_api_but_not_reads() {
+        for command in [
+            "curl -X POST https://api.github.com/repos/o/r/merges -d '{}'",
+            "curl --request PUT https://api.github.com/repos/o/r/branches/main/protection",
+            "curl -d '{\"query\":\"mutation{}\"}' https://api.github.com/graphql",
+            "curl -T asset.zip https://uploads.github.com/repos/o/r/releases/1/assets",
+            "curl --request=PUT https://api.github.com/repos/o/r/branches/main/protection",
+            "curl --json='{}' https://api.github.com/repos/o/r/merges",
+            "curl -XPUT https://api.github.com/repos/o/r/pulls/1/merge",
+            "curl -sSXPOST https://api.github.com/repos/o/r/forks",
+            "curl https://api.github.com/repos/o/r/forks -d@body.json",
+        ] {
+            let decision = evaluate_bash_command(command, Path::new("/worktree"))
+                .unwrap_or_else(|| panic!("expected block: {command}"));
+            assert_eq!(
+                decision.summary(),
+                "\u{1F6AB} Direct GitHub API mutations are not allowed",
+                "{command}"
+            );
+        }
+
+        for command in [
+            "curl https://api.github.com/repos/o/r",
+            "curl -s -I https://example.com/upload -X POST",
+            "curl -X POST https://internal.example.com/hook",
+            "curl -G https://api.github.com/search/code -d q=foo",
+            "curl -Gd q=foo https://api.github.com/search/code",
+            "curl -X 'GET' https://api.github.com/repos/o/r",
+        ] {
+            assert!(
+                evaluate_bash_command(command, Path::new("/worktree")).is_none(),
+                "must pass: {command}"
+            );
+        }
+    }
+
+    // git push stays sanctioned — it is the PR handoff path and the PR
+    // gates own its policy (T-212 classification note).
+    #[test]
+    fn git_push_stays_allowed() {
+        assert!(
+            evaluate_bash_command("git push origin work/issue-1", Path::new("/worktree")).is_none()
+        );
     }
 }

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -2188,16 +2188,17 @@ fn blocks_gh_run_rerun_without_owner() {
 }
 
 #[test]
-fn blocks_gh_release_create_without_owner() {
+fn blocks_gh_release_create_as_mutation_sink() {
+    // SPEC-3248 P10 (T-217): release publishing is categorically blocked for
+    // agent Bash — the mutation-sink classifier fires before (and subsumes)
+    // the owner guard that used to gate this command.
     let event = event(
         "Bash",
         json!({ "command": "gh release create v9.99.0 --repo akiojin/gwt" }),
     );
     let decision = evaluate(&event, workflow_policy::WorkflowContext::unknown())
         .expect("gh release create mutates release state");
-    assert!(decision
-        .permission_decision_reason()
-        .contains("Owner Issue/SPEC"));
+    assert!(decision.permission_decision_reason().contains("T-217"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

SPEC #3248 P10 core (T-212/T-217): GitHub API mutation の method-aware 分類と block。

- `evaluate_github_mutation_sinks` を PreToolUse Bash chain に追加: gh api の mutating method（attached/cluster/equals/quoted 形式込み）、gh release mutation subcommand、GitHub API host への curl mutation を block し gwtd operations へ誘導
- GraphQL は mutation **operation** 検出（word-boundary + `{` 追従）で検索文字列・introspection の誤検知を排除。`--input` のファイルベース query は fail-closed
- read-only は通過、`git push` は sanctioned handoff path として非対象
- 位置づけ: careless mutation への policy 層（意図的 bypass は P9a integrity / evidence gate が深層）

## Rollback / Follow-up boundary

- Rollback: revert しても既存 workflow-endpoint block（gh issue/pr/run/api）は不変。新規分類のみ消える
- Follow-up: approved wrapper intents、hub / wget / PowerShell transport、endpoint matrix 完全化（T-217 full）

## Verification

- cargo fmt / clippy --all-targets --all-features -D warnings: PASS
- block_bash_policy 7 テスト + hook_exit_codes 13 GREEN / gwt lib full 1607 GREEN（既知のマシンローカル flaky 族のみ失敗、CI 正式ゲート）
- adversarial review workflow（6 agents）: 5 指摘 confirmed（うち major 1 は実証付き）→ 全て本 PR 内で修正済み
- User Verification Result: n/a（UI 影響なし・hook 内部変更のみ）

Refs #3248

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards that block direct GitHub write operations through command-line and API tools unless performed through approved workflow paths.
  * Added clear guidance to use canonical gwt JSON operations when a mutation is blocked.

* **Bug Fixes**
  * Improved detection of GitHub API, GraphQL, release, and upload mutations while preserving read-only requests and standard Git pushes.
  * Updated workflow policy messaging for blocked release creation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->