### PR TITLE
feat(github): SPEC-3248 T-274 Artifact Operability Record（SPEC書込台帳）

### DIFF
--- a/crates/gwt-github/src/client/http.rs
+++ b/crates/gwt-github/src/client/http.rs
@@ -841,24 +841,27 @@ fn resolve_gh_token_with_deadline(deadline: &ResolutionDeadline) -> Result<Strin
 
 #[cfg(test)]
 mod transport_tests {
-    use std::{
-        ffi::OsString,
-        sync::{Arc, Mutex},
-        time::Duration,
-    };
+    #[cfg(unix)]
+    use std::{ffi::OsString, sync::Mutex};
+    use std::{sync::Arc, time::Duration};
 
     use super::{
-        issue_generation, resolve_gh_token, resolve_gh_token_with_deadline, HttpError, HttpMethod,
-        HttpRequest, HttpTransport, ReqwestTransport, ResolutionDeadline,
+        issue_generation, HttpError, HttpMethod, HttpRequest, HttpTransport, ReqwestTransport,
+        ResolutionDeadline,
     };
+    #[cfg(unix)]
+    use super::{resolve_gh_token, resolve_gh_token_with_deadline};
 
+    #[cfg(unix)]
     static ENV_LOCK: Mutex<()> = Mutex::new(());
 
+    #[cfg(unix)]
     struct ScopedEnvVar {
         name: &'static str,
         previous: Option<OsString>,
     }
 
+    #[cfg(unix)]
     impl ScopedEnvVar {
         fn set(name: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
             let previous = std::env::var_os(name);
@@ -867,6 +870,7 @@ mod transport_tests {
         }
     }
 
+    #[cfg(unix)]
     impl Drop for ScopedEnvVar {
         fn drop(&mut self) {
             match self.previous.take() {

--- a/crates/gwt-github/src/spec_ops.rs
+++ b/crates/gwt-github/src/spec_ops.rs
@@ -52,6 +52,14 @@ pub struct WriteReceipt {
     pub bytes: usize,
     pub parts: usize,
     pub sha256: String,
+    /// Final resident location of the section: `"body"` or `"comments"`
+    /// (SPEC-3248 P7C T-274 operability facts).
+    pub location: String,
+    /// Comment ids now holding the section, in part order (empty for
+    /// body-resident sections).
+    pub comment_ids: Vec<u64>,
+    /// Largest single part payload in bytes (== `bytes` when unsplit).
+    pub largest_part_bytes: usize,
 }
 
 /// High-level SPEC operations backed by an [`IssueClient`] and a [`Cache`].
@@ -161,6 +169,7 @@ impl<C: IssueClient> SpecOps<C> {
         // Whether rolling back means restoring the original body text.
         let mut rollback_body = false;
         let parts_written: usize;
+        let mut largest_part_bytes = canonical.len();
 
         match (&prev_location, &new_location) {
             // Stay in body: rewrite the section between the markers, then patch.
@@ -193,6 +202,7 @@ impl<C: IssueClient> SpecOps<C> {
             (_, SectionLocation::Comments(_)) => {
                 let parts = split_section_into_parts(&canonical)?;
                 let total = parts.len();
+                largest_part_bytes = parts.iter().map(String::len).max().unwrap_or(0);
                 for (i, part) in parts.iter().enumerate() {
                     let comment_body = wrap_comment_part_body(name, part, i + 1, total);
                     let comment: CommentSnapshot =
@@ -252,10 +262,17 @@ impl<C: IssueClient> SpecOps<C> {
         }
         self.force_refresh_cache(number)?;
 
+        let (location, comment_ids) = match new_sections_index.0.get(name) {
+            Some(SectionLocation::Comments(ids)) => ("comments".to_string(), ids.clone()),
+            _ => ("body".to_string(), Vec::new()),
+        };
         Ok(WriteReceipt {
             bytes: canonical.len(),
             parts: parts_written,
             sha256: format!("{:x}", Sha256::digest(canonical.as_bytes())),
+            location,
+            comment_ids,
+            largest_part_bytes,
         })
     }
 

--- a/crates/gwt-github/tests/spec_ops_test.rs
+++ b/crates/gwt-github/tests/spec_ops_test.rs
@@ -278,6 +278,51 @@ fn red_90_multipart_write_creates_part_comments() {
     assert_eq!(got, huge);
 }
 
+// SPEC-3248 P7C T-274: the write receipt carries the operability facts the
+// Artifact Operability Record persists — resident location, comment ids in
+// part order, and the largest single part payload.
+#[test]
+fn t274_write_receipt_carries_operability_fields() {
+    let tmp = TempDir::new().unwrap();
+    let cache = Cache::new(tmp.path().to_path_buf());
+    let client = FakeIssueClient::new();
+    seed_spec(&client, &cache, 1, "v1", "t1");
+
+    let ops = SpecOps::new(client, cache);
+    // Body-resident write: no comment ids, one implicit part.
+    let receipt = ops
+        .write_section(IssueNumber(1), &n("tasks"), "t2")
+        .unwrap();
+    assert_eq!(receipt.location, "body");
+    assert!(receipt.comment_ids.is_empty());
+    assert_eq!(receipt.largest_part_bytes, receipt.bytes);
+
+    // Multipart comment-resident write: ids in part order, bounded parts.
+    let huge = oversized_content(70_000);
+    let receipt = ops
+        .write_section(IssueNumber(1), &n("tasks"), &huge)
+        .unwrap();
+    assert!(
+        receipt.parts >= 2,
+        "expected multipart, got {}",
+        receipt.parts
+    );
+    assert_eq!(receipt.location, "comments");
+    assert_eq!(receipt.comment_ids.len(), receipt.parts);
+    assert!(receipt.largest_part_bytes <= 65_536);
+    assert!(receipt.largest_part_bytes <= receipt.bytes);
+    // The recorded ids must be exactly the part comments, in order.
+    let comments = ops.client().comments(IssueNumber(1));
+    for (i, id) in receipt.comment_ids.iter().enumerate() {
+        let comment = comments.iter().find(|c| c.id.0 == *id).unwrap();
+        assert!(
+            comment.body.contains(&format!("part={}/", i + 1)),
+            "comment {id} must carry part={} marker",
+            i + 1
+        );
+    }
+}
+
 // RED-91: shrinking a multipart section back to a small single-comment
 // section swaps to one fresh comment and deletes the stale part comments.
 #[test]

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -6,6 +6,7 @@
 //! `gwt-github`, and writes the result to stdout/stderr.
 
 mod actions;
+pub(crate) mod artifact_operability;
 mod board;
 mod build;
 mod commands;

--- a/crates/gwt/src/cli/artifact_operability.rs
+++ b/crates/gwt/src/cli/artifact_operability.rs
@@ -1,0 +1,208 @@
+//! Artifact Operability Record (SPEC-3248 P7C, T-274 core).
+//!
+//! Oversized owners (like SPEC #3248 itself) route sections through the
+//! supported multipart writer. This module persists the machine-readable
+//! ledger of those writes per owner: for every section, the byte size,
+//! resident location, comment ids/parts, content hash, largest part
+//! payload, readback status, and write timestamp. Downstream consumers —
+//! the Phase Launch Packet (T-275) and stale-hash rejection (T-279) — read
+//! this record instead of re-deriving artifact shape from the GitHub
+//! snapshot.
+//!
+//! The record is machine-local, repo-scoped state:
+//! `~/.gwt/projects/<repo-hash>/operability/issue-<owner>.json`. Writes are
+//! best-effort from the `issue.spec.edit` success path (a ledger failure
+//! must not fail a verified write); unresolvable repo hashes (non-git dirs)
+//! skip persistence.
+//!
+//! Follow-ups (T-274 full): phase-slice binding, payload/token budgets,
+//! read/write strategy fields, and owner-revision binding for T-279.
+
+use std::{
+    collections::BTreeMap,
+    fs,
+    io::{self, ErrorKind},
+    path::{Path, PathBuf},
+};
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Per-section operability facts from one verified write.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SectionOperability {
+    pub bytes: usize,
+    /// Comment parts written (0 = body-resident).
+    pub parts: usize,
+    /// `"body"` or `"comments"`.
+    pub location: String,
+    /// Comment ids holding the section, in part order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub comment_ids: Vec<u64>,
+    /// sha256 of the canonical section content.
+    pub sha256: String,
+    pub largest_part_bytes: usize,
+    /// The write path readback-verified the content (the multipart writer
+    /// rolls back unverified writes, so persisted records are verified).
+    pub readback_verified: bool,
+    pub written_at: DateTime<Utc>,
+}
+
+/// The per-owner operability ledger.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactOperabilityRecord {
+    pub owner_number: u64,
+    pub sections: BTreeMap<String, SectionOperability>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Resolve the record path. `None` when the repo hash is unresolvable.
+#[must_use]
+pub fn record_path(repo_path: &Path, owner_number: u64) -> Option<PathBuf> {
+    let repo_hash = crate::index_worker::detect_repo_hash(repo_path)?;
+    Some(
+        gwt_core::paths::gwt_projects_dir()
+            .join(repo_hash.as_str())
+            .join("operability")
+            .join(format!("issue-{owner_number}.json")),
+    )
+}
+
+/// Load the owner's record. `Ok(None)` when absent or in degenerate mode.
+pub fn load(repo_path: &Path, owner_number: u64) -> io::Result<Option<ArtifactOperabilityRecord>> {
+    let Some(path) = record_path(repo_path, owner_number) else {
+        return Ok(None);
+    };
+    match fs::read_to_string(&path) {
+        Ok(contents) => {
+            let record = serde_json::from_str::<ArtifactOperabilityRecord>(&contents)
+                .map_err(|err| io::Error::new(ErrorKind::InvalidData, err))?;
+            Ok(Some(record))
+        }
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+/// Merge one verified write receipt into the owner's ledger. Best-effort
+/// no-op in degenerate mode.
+pub fn record_write(
+    repo_path: &Path,
+    owner_number: u64,
+    section: &str,
+    receipt: &gwt_github::WriteReceipt,
+) -> io::Result<()> {
+    let Some(path) = record_path(repo_path, owner_number) else {
+        return Ok(());
+    };
+    let mut record = match load(repo_path, owner_number) {
+        Ok(Some(record)) => record,
+        // Absent or unreadable ledgers restart cleanly — the ledger mirrors
+        // verified remote writes, so rebuilding from now-on is safe.
+        _ => ArtifactOperabilityRecord {
+            owner_number,
+            sections: BTreeMap::new(),
+            updated_at: Utc::now(),
+        },
+    };
+    record.sections.insert(
+        section.to_string(),
+        SectionOperability {
+            bytes: receipt.bytes,
+            parts: receipt.parts,
+            location: receipt.location.clone(),
+            comment_ids: receipt.comment_ids.clone(),
+            sha256: receipt.sha256.clone(),
+            largest_part_bytes: receipt.largest_part_bytes,
+            readback_verified: true,
+            written_at: Utc::now(),
+        },
+    );
+    record.updated_at = Utc::now();
+    let serialized = serde_json::to_vec_pretty(&record)
+        .map_err(|err| io::Error::new(ErrorKind::InvalidData, err))?;
+    gwt_github::cache::write_atomic(&path, &serialized)
+}
+
+/// Best-effort wrapper for the `issue.spec.edit` success path: a ledger
+/// failure is logged, never surfaced (the remote write is already verified).
+pub fn record_write_best_effort(
+    repo_path: &Path,
+    owner_number: u64,
+    section: &str,
+    receipt: &gwt_github::WriteReceipt,
+) {
+    if let Err(error) = record_write(repo_path, owner_number, section, receipt) {
+        tracing::warn!(
+            ?error,
+            owner_number,
+            section,
+            "artifact operability ledger update failed"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gwt_core::test_support::ScopedEnvVar;
+
+    fn receipt(bytes: usize, parts: usize) -> gwt_github::WriteReceipt {
+        gwt_github::WriteReceipt {
+            bytes,
+            parts,
+            sha256: format!("hash-{bytes}"),
+            location: if parts == 0 { "body" } else { "comments" }.to_string(),
+            comment_ids: (0..parts as u64).map(|i| 100 + i).collect(),
+            largest_part_bytes: if parts <= 1 { bytes } else { bytes / parts + 1 },
+        }
+    }
+
+    // T-274: verified writes accumulate into one per-owner ledger keyed by
+    // section, replacing the section entry on rewrite.
+    #[test]
+    fn record_write_accumulates_per_owner_ledger() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let home = tempfile::tempdir().unwrap();
+        let _home = ScopedEnvVar::set("HOME", home.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
+        let dir = tempfile::tempdir().unwrap();
+        crate::cli::trusted_store::init_git_repo_with_origin(dir.path());
+
+        record_write(dir.path(), 3248, "tasks", &receipt(90_000, 2)).unwrap();
+        record_write(dir.path(), 3248, "spec", &receipt(4_000, 0)).unwrap();
+        let record = load(dir.path(), 3248).unwrap().unwrap();
+        assert_eq!(record.owner_number, 3248);
+        assert_eq!(record.sections.len(), 2);
+        let tasks = &record.sections["tasks"];
+        assert_eq!(tasks.parts, 2);
+        assert_eq!(tasks.location, "comments");
+        assert_eq!(tasks.comment_ids, vec![100, 101]);
+        assert!(tasks.readback_verified);
+        assert_eq!(record.sections["spec"].location, "body");
+
+        // Rewriting a section replaces its entry.
+        record_write(dir.path(), 3248, "tasks", &receipt(95_000, 3)).unwrap();
+        let record = load(dir.path(), 3248).unwrap().unwrap();
+        assert_eq!(record.sections.len(), 2);
+        assert_eq!(record.sections["tasks"].parts, 3);
+        assert_eq!(record.sections["tasks"].sha256, "hash-95000");
+
+        // Owners do not share ledgers.
+        assert_eq!(load(dir.path(), 9999).unwrap(), None);
+        // The ledger lives under HOME, not the worktree.
+        let path = record_path(dir.path(), 3248).unwrap();
+        assert!(path.starts_with(home.path()));
+    }
+
+    // Degenerate mode (non-git dir): persistence is skipped, loads are None.
+    #[test]
+    fn non_git_dir_is_degenerate_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(record_path(dir.path(), 1).is_none());
+        record_write(dir.path(), 1, "tasks", &receipt(10, 0)).unwrap();
+        assert_eq!(load(dir.path(), 1).unwrap(), None);
+    }
+}

--- a/crates/gwt/src/cli/issue_spec/mod.rs
+++ b/crates/gwt/src/cli/issue_spec/mod.rs
@@ -483,6 +483,13 @@ fn write_spec_section<E: CliEnv>(
         super::intake_outcome::IntakeOutcomeKind::SpecUpdated,
         number,
     );
+    // T-274: verified writes feed the per-owner operability ledger.
+    super::artifact_operability::record_write_best_effort(
+        env.repo_path(),
+        number,
+        &section,
+        &receipt,
+    );
     out.push_str(&render_write_receipt(&section, &receipt));
     Ok(0)
 }
@@ -536,6 +543,12 @@ fn write_structured_spec_section<E: CliEnv>(
         "issue.spec.edit",
         super::intake_outcome::IntakeOutcomeKind::SpecUpdated,
         number,
+    );
+    super::artifact_operability::record_write_best_effort(
+        env.repo_path(),
+        number,
+        &section,
+        &receipt,
     );
     out.push_str(&render_write_receipt(&section, &receipt));
     Ok(0)


### PR DESCRIPTION
## Summary

SPEC #3248 P7C (T-274 core): Artifact Operability Record — 多部構成 SPEC 書込の機械可読台帳。

- `WriteReceipt` に resident location / part 順 comment_ids / largest_part_bytes を追加（全 write_section 分岐で正確に算出、rollback 経路は台帳を汚さない）
- `issue.spec.edit` 成功経路から per-owner 台帳（`~/.gwt/projects/<hash>/operability/issue-<n>.json`）へ section 単位の書込事実を best-effort 記録
- T-275 Phase Launch Packet / T-279 stale-hash 拒否の参照基盤
- 付随 fix: gwt-github transport_tests の unix 限定 helper cfg 整理（Windows ローカル clippy 修復、レビュー検出）

## Rollback / Follow-up boundary

- Rollback: 台帳は現時点で gate に消費されない純追加。revert しても挙動不変
- Follow-up: spec create 経路接続、phase-slice binding、token budget、owner-revision binding（T-279）、台帳 RMW の T-149 lease 化

## Verification

- cargo fmt / clippy --all-targets --all-features -D warnings PASS（-p 個別形式含む）
- gwt-github 15+44 GREEN（新 t274 receipt テスト込み）/ artifact_operability 2 GREEN / gwt lib full 1610 GREEN（既知のマシンローカル flaky 族のみ失敗、CI 正式ゲート）
- adversarial review workflow（4 agents）: T-274 diff 自体の欠陥ゼロ、pre-existing clippy 破損 1 件 → ride-along 修正済み
- User Verification Result: n/a（UI 影響なし・CLI/ライブラリ内部変更のみ）

Refs #3248

🤖 Generated with [Claude Code](https://claude.com/claude-code)