### PR TITLE
feat(hooks): SPEC-3248 T-247 core completion/Ready操作のopen obligation拒否

### DIFF
--- a/crates/gwt/src/cli/action_obligation.rs
+++ b/crates/gwt/src/cli/action_obligation.rs
@@ -335,6 +335,34 @@ pub fn defer_all_best_effort(worktree: &Path, session_id: &str, reason: &str) {
     );
 }
 
+/// T-247: completion/ready operations refuse while producing obligations
+/// stay open. `excluding` lets self-settling operations skip their own
+/// kind (a PR mutation settles `pr` on success).
+pub fn open_obligation_refusal(
+    worktree: &Path,
+    session_id: &str,
+    excluding: &[ObligationKind],
+) -> Option<String> {
+    let open: Vec<ObligationKind> = open_kinds(worktree, session_id)
+        .into_iter()
+        .filter(|kind| !excluding.contains(kind))
+        .collect();
+    if open.is_empty() {
+        return None;
+    }
+    let kinds = open
+        .iter()
+        .map(|kind| kind.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(format!(
+        "open action obligations [{kinds}] from this session's prompts are unsettled (T-247). \
+         Settle them first — `issue.comment` / `issue.spec.edit` for issue_update, a plan-covering \
+         all-passing `verify.run` for implementation/verification, `pr.create` / `pr.edit` / `pr.ready` \
+         for pr — or defer them with `execution.blocked` and a non-empty `params.reason`."
+    ))
+}
+
 /// Open (unsettled) obligation kinds for the session — the Stop gate input.
 pub fn open_kinds(worktree: &Path, session_id: &str) -> Vec<ObligationKind> {
     match load(worktree) {
@@ -475,6 +503,32 @@ mod tests {
             .unwrap()
             .evidence
             .contains("deferred: execution.blocked"));
+    }
+
+    // T-247: the refusal helper lists open kinds and honors exclusions.
+    #[test]
+    fn open_obligation_refusal_lists_kinds_and_honors_exclusions() {
+        let dir = tempfile::tempdir().unwrap();
+        mark_from_prompt(dir.path(), "sess-1", "PR を作成して").unwrap();
+        mark_from_prompt(dir.path(), "sess-1", "Issue #1 にコメントを追加して").unwrap();
+
+        let refusal = open_obligation_refusal(dir.path(), "sess-1", &[]).unwrap();
+        assert!(refusal.contains("pr"), "{refusal}");
+        assert!(refusal.contains("issue_update"), "{refusal}");
+
+        // A PR mutation settles its own kind — excluding it leaves only the
+        // issue update in the way.
+        let refusal = open_obligation_refusal(dir.path(), "sess-1", &[ObligationKind::Pr]).unwrap();
+        assert!(refusal.contains("issue_update"), "{refusal}");
+        assert!(!refusal.contains("[pr"), "{refusal}");
+
+        settle_kinds_best_effort(
+            dir.path(),
+            "sess-1",
+            &[ObligationKind::IssueUpdate],
+            "issue.comment",
+        );
+        assert!(open_obligation_refusal(dir.path(), "sess-1", &[ObligationKind::Pr]).is_none());
     }
 
     // No-secrets: raw prompts never persist, only digests.

--- a/crates/gwt/src/cli/execution_state.rs
+++ b/crates/gwt/src/cli/execution_state.rs
@@ -729,6 +729,14 @@ pub(crate) fn settle_completed_best_effort(
     session_id: &str,
     expected_owner_number: u64,
 ) {
+    // T-247: build.complete settlement also skips while obligations stay
+    // open — the ECR stays active and the Stop gate keeps holding.
+    if let Some(refusal) =
+        crate::cli::action_obligation::open_obligation_refusal(worktree, session_id, &[])
+    {
+        tracing::warn!(%refusal, "execution control settlement skipped");
+        return;
+    }
     match settle_completed_with_evidence(worktree, session_id, Some(expected_owner_number)) {
         Ok(Ok(_)) => {}
         Ok(Err(status)) => {
@@ -862,6 +870,14 @@ pub(super) fn run<E: CliEnv>(
             unreachable!("handled above")
         }
         ExecutionCommand::Complete => {
+            // T-247: completion cannot paper over unhandled prompt
+            // obligations — settle or defer them first.
+            if let Some(refusal) =
+                crate::cli::action_obligation::open_obligation_refusal(&worktree, &session_id, &[])
+            {
+                out.push_str(&format!("execution: completion refused — {refusal}\n"));
+                return Ok(2);
+            }
             match settle_completed_with_evidence(&worktree, &session_id, None)
                 .map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?
             {
@@ -2900,6 +2916,68 @@ mod tests {
         // T-124: unauthorized settlement attempts (session mismatch) and
         // tampered-record refusals auto-capture one deduped
         // issue-spec-workflow improvement candidate.
+        #[test]
+        fn complete_refused_while_obligations_open_then_defer_clears() {
+            let _env_lock = crate::env_test_lock()
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let _session = ScopedEnvVar::set(gwt_agent::GWT_SESSION_ID_ENV, "sess-t247");
+            let dir = tempfile::tempdir().unwrap();
+            save(dir.path(), &active_record("sess-t247")).unwrap();
+
+            // An unsettled issue-update obligation refuses completion BEFORE
+            // the evidence gate (the message names the obligation, not the
+            // missing verification record).
+            crate::cli::action_obligation::mark_from_prompt(
+                dir.path(),
+                "sess-t247",
+                "Issue #1 にコメントを追加して",
+            )
+            .unwrap();
+            let (code, out) = run_cmd(dir.path(), ExecutionCommand::Complete).unwrap();
+            assert_eq!(code, 2, "{out}");
+            assert!(out.contains("open action obligations"), "{out}");
+            assert!(out.contains("issue_update"), "{out}");
+            assert_eq!(
+                load(dir.path()).unwrap().unwrap().status,
+                ExecutionControlStatus::Active
+            );
+
+            // Deferring through execution.blocked clears the refusal; the
+            // next completion attempt reaches the evidence gate instead.
+            let (code, out) = run_cmd(
+                dir.path(),
+                ExecutionCommand::Blocked {
+                    reason: "cannot comment".to_string(),
+                    missing_verification: None,
+                },
+            )
+            .unwrap();
+            assert_eq!(code, 0, "{out}");
+            let (code, out) = run_cmd(dir.path(), ExecutionCommand::Complete).unwrap();
+            assert_eq!(
+                code, 0,
+                "already settled records report idempotently: {out}"
+            );
+            assert!(!out.contains("open action obligations"), "{out}");
+        }
+
+        // T-247: build.complete settlement skips while obligations stay
+        // open — the ECR keeps holding the Stop gate.
+        #[test]
+        fn best_effort_settlement_skips_while_obligations_open() {
+            let dir = tempfile::tempdir().unwrap();
+            save(dir.path(), &active_record("sess-t247b")).unwrap();
+            crate::cli::action_obligation::mark_from_prompt(dir.path(), "sess-t247b", "実装して")
+                .unwrap();
+            settle_completed_best_effort(dir.path(), "sess-t247b", 3248);
+            assert_eq!(
+                load(dir.path()).unwrap().unwrap().status,
+                ExecutionControlStatus::Active,
+                "open obligations must keep the record active"
+            );
+        }
+
         #[test]
         fn blocked_defers_obligations_on_no_record_and_already_settled() {
             let _env_lock = crate::env_test_lock()

--- a/crates/gwt/src/cli/pr/mod.rs
+++ b/crates/gwt/src/cli/pr/mod.rs
@@ -131,6 +131,25 @@ pub(super) fn run<E: CliEnv>(
             out.push('\n');
             return Ok(2);
         }
+        // T-247: a Ready handoff with unsettled non-PR obligations is
+        // premature — draft creation and edits stay available mid-work.
+        if is_ready_handoff {
+            if let Some(session_id) = std::env::var(gwt_agent::GWT_SESSION_ID_ENV)
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+            {
+                let worktree = gwt_core::paths::resolve_current_worktree_root(env.repo_path());
+                if let Some(refusal) = crate::cli::action_obligation::open_obligation_refusal(
+                    &worktree,
+                    &session_id,
+                    &[crate::cli::action_obligation::ObligationKind::Pr],
+                ) {
+                    out.push_str(&format!("PR handoff refused: {refusal}\n"));
+                    return Ok(2);
+                }
+            }
+        }
     }
     let cmd_settles_pr_obligation = is_pr_mutation;
     let code = match cmd {


### PR DESCRIPTION
## Summary

SPEC #3248 T-247 core: completion / Ready 操作の open obligation 拒否。

- `execution.complete`: open な producing obligation を evidence gate より前段で refuse（settle か `execution.blocked` の defer を要求）
- build.complete 由来の best-effort ECR 設定も open obligation 中は skip（Stop gate 保持）
- Ready PR handoff（非 draft create / `pr.ready`）: Pr 以外の open obligation で refuse。PR mutation は成功時に pr kind を self-settle するため除外。draft create / `pr.edit` の mid-work 経路は不変

## Rollback / Follow-up boundary

- Rollback: 拒否チェックのみ消える。P11 の記録・settle・Stop gate は独立で不変
- Follow-up: T-243 / T-246 / T-248 / T-241 full

## Verification

- cargo fmt / clippy --all-targets --all-features -D warnings: PASS
- 新規テスト 3 件 + 関連 108 GREEN / hook integration 13+85 GREEN（4 件は base 同一の Windows パス既知族）
- User Verification Result: n/a（hook/CLI 内部変更のみ）

Refs #3248

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards that prevent execution completion while action obligations remain open.
  * Ready PR handoffs are now refused when related obligations are unsettled, with details about the outstanding items.
  * Best-effort build completion waits until open obligations are resolved.

* **Bug Fixes**
  * Completion can proceed after obligations are deferred or settled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->