### PR TITLE
feat(hooks): SPEC-3248 T-177 core trusted store破損時の修復導線

### DIFF
--- a/crates/gwt/src/cli/execution_state.rs
+++ b/crates/gwt/src/cli/execution_state.rs
@@ -878,9 +878,11 @@ pub(super) fn run<E: CliEnv>(
                 out.push_str(&format!("execution: completion refused — {refusal}\n"));
                 return Ok(2);
             }
-            match settle_completed_with_evidence(&worktree, &session_id, None)
-                .map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?
-            {
+            match settle_completed_with_evidence(&worktree, &session_id, None).map_err(|err| {
+                SpecOpsError::from(ApiError::Unexpected(
+                    crate::cli::trusted_store::store_health_error("settling execution state", &err),
+                ))
+            })? {
                 Ok(result) => result,
                 Err(status) => {
                     out.push_str(&format!(
@@ -909,7 +911,11 @@ pub(super) fn run<E: CliEnv>(
                     missing_verification,
                 },
             )
-            .map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?
+            .map_err(|err| {
+                SpecOpsError::from(ApiError::Unexpected(
+                    crate::cli::trusted_store::store_health_error("settling execution state", &err),
+                ))
+            })?
         }
     };
     match result {
@@ -1055,7 +1061,11 @@ fn run_reopen(
     crate::cli::trusted_store::with_write_lease(worktree, || {
         Ok(run_reopen_locked(worktree, session_id, reason, out))
     })
-    .map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?
+    .map_err(|err| {
+        SpecOpsError::from(ApiError::Unexpected(
+            crate::cli::trusted_store::store_health_error("settling execution state", &err),
+        ))
+    })?
 }
 
 fn run_reopen_locked(
@@ -1064,8 +1074,11 @@ fn run_reopen_locked(
     reason: &str,
     out: &mut String,
 ) -> Result<i32, SpecOpsError> {
-    let Some(mut record) =
-        load(worktree).map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?
+    let Some(mut record) = load(worktree).map_err(|err| {
+        SpecOpsError::from(ApiError::Unexpected(
+            crate::cli::trusted_store::store_health_error("settling execution state", &err),
+        ))
+    })?
     else {
         out.push_str(
             "execution: reopen refused — no execution control record exists; start the linked owner through gwt-execute\n",
@@ -1091,11 +1104,19 @@ fn run_reopen_locked(
             // Only an in-flight record with embedded recoveries needs the
             // rolling-upgrade write. A modern idempotent retry stays a true
             // no-op and cannot fail because of an unnecessary rewrite.
-            if recovery_storage_needs_upgrade(worktree)
-                .map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?
-            {
-                save(worktree, &record)
-                    .map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?;
+            if recovery_storage_needs_upgrade(worktree).map_err(|err| {
+                SpecOpsError::from(ApiError::Unexpected(
+                    crate::cli::trusted_store::store_health_error("settling execution state", &err),
+                ))
+            })? {
+                save(worktree, &record).map_err(|err| {
+                    SpecOpsError::from(ApiError::Unexpected(
+                        crate::cli::trusted_store::store_health_error(
+                            "settling execution state",
+                            &err,
+                        ),
+                    ))
+                })?;
             }
             out.push_str(&format!(
                 "execution: {kind} #{number} is already active for session {session}\n",
@@ -1141,8 +1162,11 @@ fn run_reopen_locked(
     }
 
     use crate::cli::verification_record as vr;
-    let Some(plan) = vr::load_plan(worktree)
-        .map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?
+    let Some(plan) = vr::load_plan(worktree).map_err(|err| {
+        SpecOpsError::from(ApiError::Unexpected(
+            crate::cli::trusted_store::store_health_error("settling execution state", &err),
+        ))
+    })?
     else {
         out.push_str(
             "execution: reopen refused — no verification plan exists; run verify.plan with params.derive:true, then verify.run\n",
@@ -1171,8 +1195,11 @@ fn run_reopen_locked(
         );
         return Ok(2);
     }
-    let Some(verification) =
-        vr::load(worktree).map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?
+    let Some(verification) = vr::load(worktree).map_err(|err| {
+        SpecOpsError::from(ApiError::Unexpected(
+            crate::cli::trusted_store::store_health_error("settling execution state", &err),
+        ))
+    })?
     else {
         out.push_str(
             "execution: reopen refused — no verification run record exists; run verify.run\n",
@@ -1252,8 +1279,11 @@ fn run_reopen_locked(
     });
     record.status = ExecutionControlStatus::Active;
     record.settled_at = None;
-    save(worktree, &record)
-        .map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?;
+    save(worktree, &record).map_err(|err| {
+        SpecOpsError::from(ApiError::Unexpected(
+            crate::cli::trusted_store::store_health_error("settling execution state", &err),
+        ))
+    })?;
     out.push_str(&format!(
         "execution: reopened {kind} #{number} for session {session} using verification record {record_id}; completion remains pending\n",
         kind = record.owner_kind.as_str(),
@@ -1288,7 +1318,11 @@ fn run_adopt(
     crate::cli::trusted_store::with_write_lease(worktree, || {
         Ok(run_adopt_locked(worktree, session_id, reason, out))
     })
-    .map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?
+    .map_err(|err| {
+        SpecOpsError::from(ApiError::Unexpected(
+            crate::cli::trusted_store::store_health_error("settling execution state", &err),
+        ))
+    })?
 }
 
 fn run_adopt_locked(
@@ -1297,8 +1331,11 @@ fn run_adopt_locked(
     reason: &str,
     out: &mut String,
 ) -> Result<i32, SpecOpsError> {
-    let Some(mut record) =
-        load(worktree).map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?
+    let Some(mut record) = load(worktree).map_err(|err| {
+        SpecOpsError::from(ApiError::Unexpected(
+            crate::cli::trusted_store::store_health_error("settling execution state", &err),
+        ))
+    })?
     else {
         out.push_str("execution: no execution control record to adopt — a linked-owner launch materializes one\n");
         return Ok(0);
@@ -1328,8 +1365,11 @@ fn run_adopt_locked(
         transferred_at: Utc::now(),
     });
     record.primary_session_id = session_id.to_string();
-    save(worktree, &record)
-        .map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?;
+    save(worktree, &record).map_err(|err| {
+        SpecOpsError::from(ApiError::Unexpected(
+            crate::cli::trusted_store::store_health_error("settling execution state", &err),
+        ))
+    })?;
     out.push_str(&format!(
         "execution: adopted {kind} #{number} for session {session} ({transfers} transfer(s) on record)\n",
         kind = record.owner_kind.as_str(),
@@ -2980,6 +3020,44 @@ mod tests {
                 load(dir.path()).unwrap().unwrap().status,
                 ExecutionControlStatus::Active,
                 "open obligations must keep the record active"
+            );
+        }
+
+        #[test]
+        fn store_health_failure_surfaces_repair_guidance() {
+            // T-177 core: a malformed record at a canonical operation
+            // surfaces the store-health repair path, not a raw
+            // network-flavored error. Hook readers stay fail-open.
+            let _env_lock = crate::env_test_lock()
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let _session = ScopedEnvVar::set(gwt_agent::GWT_SESSION_ID_ENV, "sess-health");
+            let dir = tempfile::tempdir().unwrap();
+            let path = state_path(dir.path());
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            fs::write(&path, "{not json").unwrap();
+
+            let err = run_cmd(
+                dir.path(),
+                ExecutionCommand::Blocked {
+                    reason: "runner down".to_string(),
+                    missing_verification: None,
+                },
+            )
+            .unwrap_err();
+            let message = err.to_string();
+            assert!(message.contains("trusted state unhealthy"), "{message}");
+            assert!(message.contains("execution.adopt"), "{message}");
+            assert!(!message.contains("network"), "{message}");
+
+            // The Stop gate keeps failing open on the same malformed state.
+            assert_eq!(
+                crate::cli::hook::execution_control_stop_check::handle_with_input(
+                    dir.path(),
+                    "{}",
+                    Some("sess-health"),
+                ),
+                crate::cli::hook::HookOutput::Silent
             );
         }
 

--- a/crates/gwt/src/cli/trusted_store.rs
+++ b/crates/gwt/src/cli/trusted_store.rs
@@ -253,6 +253,23 @@ fn with_write_lease_for_resolved_dir_wait<T>(
     result
 }
 
+/// T-177 core: turn a trusted-state I/O or parse failure into an
+/// actionable repair message for the canonical operations. The raw error
+/// used to surface as a misleading "network error"; store failures are a
+/// local health problem with local repair paths.
+#[must_use]
+pub fn store_health_error(context: &str, err: &std::io::Error) -> String {
+    format!(
+        "trusted state unhealthy while {context}: {err}. The execution/verification records \
+         under the repo-scoped trusted store (`~/.gwt/projects/<repo-hash>/trusted/<worktree-key>/`) \
+         or their worktree mirrors (`.gwt/skill-state/`) could not be read or parsed. Repair by \
+         rerunning the canonical writer: `execution.adopt` with a non-empty `params.reason` rewrites \
+         the execution control record; `verify.plan` / `verify.run` rewrite verification state; \
+         `intake.outcome.record` rewrites the intake outcome. If the failure persists, inspect the \
+         store directory for filesystem problems."
+    )
+}
+
 /// True when the worktree is under trusted-store management: launch
 /// materialization wrote the Execution Control Record's trusted copy, so
 /// every later canonical `verify.plan` / `verify.run` write produced a

--- a/crates/gwt/src/cli/verification_record.rs
+++ b/crates/gwt/src/cli/verification_record.rs
@@ -1542,8 +1542,16 @@ pub(super) fn run<E: CliEnv>(
                             .to_string(),
                     )));
                 }
-                let plan = register_plan(&worktree, &session_id, commands.clone(), false)
-                    .map_err(|err| SpecOpsError::from(ApiError::Network(err.to_string())))?;
+                let plan = register_plan(&worktree, &session_id, commands.clone(), false).map_err(
+                    |err| {
+                        SpecOpsError::from(ApiError::Unexpected(
+                            crate::cli::trusted_store::store_health_error(
+                                "updating verification state",
+                                &err,
+                            ),
+                        ))
+                    },
+                )?;
                 (commands, plan)
             };
             out.push_str(&format!(


### PR DESCRIPTION
## Summary

SPEC #3248 T-177 core: trusted store 破損時の actionable 修復導線。

- 破損 JSON / I/O 失敗が canonical 操作で 'network error' と誤表示されていたのを、store health 文言（対象 + `execution.adopt` / `verify.plan` / `verify.run` / `intake.outcome.record` による修復手順）へ置換
- Stop gate は同一破損 state で fail-open 維持（テスト固定）

## Rollback / Follow-up boundary

- Rollback: エラー文言のみ revert。ゲート挙動は不変
- Follow-up: schema 版数検査 / lease 不整合検出 / writer mismatch 分類（T-177 full）

## Verification

- cargo fmt / clippy --all-targets --all-features -D warnings: PASS
- 新規テスト 1 件 + 関連 95 GREEN / hook integration 13+85 GREEN（4 件は base 同一の Windows パス既知族、CI 正式ゲート）
- User Verification Result: n/a（エラー文言 / CLI 内部変更のみ）

Refs #3248

🤖 Generated with [Claude Code](https://claude.com/claude-code)