### PR TITLE
feat(hooks): SPEC-3248 T-243 core assistant commitment scanner

### DIFF
--- a/crates/gwt/src/cli/action_obligation.rs
+++ b/crates/gwt/src/cli/action_obligation.rs
@@ -335,6 +335,86 @@ pub fn defer_all_best_effort(worktree: &Path, session_id: &str, reason: &str) {
     );
 }
 
+/// T-243 core: classify assertive completion claims in assistant prose.
+/// Deliberately narrow — only implemented/fixed and verified/tests-pass
+/// claim forms (ja+en). PR/issue mentions are excluded: they appear in
+/// historical summaries far too often to classify safely (T-243 full).
+#[must_use]
+pub fn classify_commitments(text: &str) -> Vec<ObligationKind> {
+    let lower = text.to_lowercase();
+    let mut kinds = Vec::new();
+    const IMPLEMENTED_CLAIMS: &[&str] = &[
+        "実装しました",
+        "実装済み",
+        "実装完了",
+        "修正しました",
+        "修正済み",
+        "対応済み",
+        "implemented",
+        "fixed the",
+        "has been fixed",
+    ];
+    const VERIFIED_CLAIMS: &[&str] = &[
+        "検証しました",
+        "検証済み",
+        "テストは全て",
+        "全テスト成功",
+        "verified",
+        "all tests pass",
+        "tests pass",
+        "tests are green",
+    ];
+    if IMPLEMENTED_CLAIMS.iter().any(|claim| lower.contains(claim)) {
+        kinds.push(ObligationKind::Implementation);
+    }
+    if VERIFIED_CLAIMS.iter().any(|claim| lower.contains(claim)) {
+        kinds.push(ObligationKind::Verification);
+    }
+    kinds
+}
+
+/// T-243 core: turn UNBACKED completion claims into open obligations. A
+/// claim is backed when the session's ledger holds ANY entry of that kind
+/// (open entries already block; settled entries prove the canonical
+/// evidence ran). Sessions without a ledger are skipped entirely — the
+/// scanner never invents context (fail-open for pre-P11 flows). Returns
+/// the kinds it newly opened.
+pub fn mark_unbacked_commitments(
+    worktree: &Path,
+    session_id: &str,
+    claimed: &[ObligationKind],
+) -> io::Result<Vec<ObligationKind>> {
+    if claimed.is_empty() {
+        return Ok(Vec::new());
+    }
+    let Some(state) = load(worktree)? else {
+        return Ok(Vec::new());
+    };
+    if state.session_id != session_id || !integrity_ok(&state) {
+        return Ok(Vec::new());
+    }
+    let mut opened = Vec::new();
+    for kind in claimed {
+        if state.obligations.iter().any(|entry| entry.kind == *kind) {
+            continue;
+        }
+        let synthetic = format!("assistant-commitment:{}", kind.as_str());
+        match crate::cli::trusted_store::with_write_lease_wait(
+            worktree,
+            std::time::Duration::from_millis(300),
+            || mark_locked(worktree, session_id, &synthetic, *kind),
+        ) {
+            Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                mark_locked(worktree, session_id, &synthetic, *kind)?;
+            }
+            Err(err) => return Err(err),
+            Ok(()) => {}
+        }
+        opened.push(*kind);
+    }
+    Ok(opened)
+}
+
 /// T-247: completion/ready operations refuse while producing obligations
 /// stay open. `excluding` lets self-settling operations skip their own
 /// kind (a PR mutation settles `pr` on success).
@@ -503,6 +583,64 @@ mod tests {
             .unwrap()
             .evidence
             .contains("deferred: execution.blocked"));
+    }
+
+    // T-243 core: only assertive completion claims classify; requests,
+    // status text, and historical PR mentions stay out.
+    #[test]
+    fn commitment_classifier_is_narrow() {
+        assert_eq!(
+            classify_commitments("バグを修正しました。全テスト成功です。"),
+            vec![ObligationKind::Implementation, ObligationKind::Verification]
+        );
+        assert_eq!(
+            classify_commitments("The fix has been fixed and all tests pass."),
+            vec![ObligationKind::Implementation, ObligationKind::Verification]
+        );
+        assert!(classify_commitments("バグを修正してください").is_empty());
+        assert!(classify_commitments("テストを実行して確認します").is_empty());
+        assert!(classify_commitments("PR #3308 マージ済み / 関連 95 GREEN").is_empty());
+        assert!(classify_commitments("fmt / clippy PASS").is_empty());
+    }
+
+    // T-243 core: unbacked claims open obligations; backed claims and
+    // ledger-less sessions never do.
+    #[test]
+    fn unbacked_commitments_open_obligations_backed_ones_pass() {
+        let dir = tempfile::tempdir().unwrap();
+        // No ledger at all → the scanner invents nothing.
+        assert!(
+            mark_unbacked_commitments(dir.path(), "sess-1", &[ObligationKind::Implementation],)
+                .unwrap()
+                .is_empty()
+        );
+
+        // Ledger exists (producing prompt) and implementation evidence is
+        // settled → an implementation claim is backed; a verification
+        // claim is not and opens the obligation.
+        mark_from_prompt(dir.path(), "sess-1", "バグを修正して").unwrap();
+        settle_kinds_best_effort(
+            dir.path(),
+            "sess-1",
+            &[ObligationKind::Implementation],
+            "verify.run vr-x",
+        );
+        let opened = mark_unbacked_commitments(
+            dir.path(),
+            "sess-1",
+            &[ObligationKind::Implementation, ObligationKind::Verification],
+        )
+        .unwrap();
+        assert_eq!(opened, vec![ObligationKind::Verification]);
+        assert_eq!(
+            open_kinds(dir.path(), "sess-1"),
+            vec![ObligationKind::Verification]
+        );
+        // Re-scanning does not stack duplicates.
+        let opened =
+            mark_unbacked_commitments(dir.path(), "sess-1", &[ObligationKind::Verification])
+                .unwrap();
+        assert!(opened.is_empty());
     }
 
     // T-247: the refusal helper lists open kinds and honors exclusions.

--- a/crates/gwt/src/cli/hook/action_obligation_stop_check.rs
+++ b/crates/gwt/src/cli/hook/action_obligation_stop_check.rs
@@ -14,7 +14,7 @@
 
 use std::path::Path;
 
-use super::{context::HookContext, envelope::stop_hook_active_from, HookOutput};
+use super::{context::HookContext, envelope::stop_hook_active_from, HookEvent, HookOutput};
 use crate::cli::action_obligation;
 
 /// UserPromptSubmit entry: arm typed obligations for producing prompts in
@@ -68,7 +68,44 @@ pub fn handle_with_input(
     };
     let open = action_obligation::open_kinds(&resolved, session.trim());
     if open.is_empty() {
-        return HookOutput::Silent;
+        // T-243 core: no open obligations — scan the latest assistant
+        // message for completion claims with no ledger backing. An
+        // unbacked "implemented"/"verified" claim opens the matching
+        // obligation and blocks through this same gate; claims backed by
+        // settled evidence pass. Unparsable transcripts and ledger-less
+        // sessions fail open.
+        let claimed = HookEvent::read_from_str(input)
+            .ok()
+            .flatten()
+            .and_then(|event| event.transcript_path)
+            .map(|transcript| {
+                super::execution_completion_stop_check::transcript_path_for_worktree(
+                    &resolved,
+                    &transcript,
+                )
+            })
+            .and_then(|path| {
+                super::execution_completion_stop_check::read_transcript_tail(&path).ok()
+            })
+            .and_then(|tail| super::execution_completion_stop_check::latest_assistant_text(&tail))
+            .map(|text| action_obligation::classify_commitments(&text))
+            .unwrap_or_default();
+        let opened =
+            action_obligation::mark_unbacked_commitments(&resolved, session.trim(), &claimed)
+                .unwrap_or_default();
+        if opened.is_empty() {
+            return HookOutput::Silent;
+        }
+        let kinds = opened
+            .iter()
+            .map(|kind| kind.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        return HookOutput::stop_block(format!(
+            "The latest assistant message claims completed work with no recorded evidence: [{kinds}] (assistant commitment scanner, SPEC-3248 T-243).
+             Prose is not evidence. Back the claim with the canonical operations — register the matrix with `verify.plan` (derive:true) and produce an all-passing `verify.run` — or, if the work is genuinely blocked, run `execution.blocked` with a non-empty `params.reason`.
+             Claims backed by recorded evidence pass this gate automatically."
+        ));
     }
     let kinds = open
         .iter()
@@ -124,6 +161,60 @@ mod tests {
         );
         assert_eq!(
             handle_with_input(dir.path(), "{}", Some("sess-1")),
+            HookOutput::Silent
+        );
+    }
+
+    // T-243 core: an unbacked completion claim in the latest assistant
+    // message blocks; the same claim backed by settled evidence passes.
+    #[test]
+    fn unbacked_assistant_claims_block_until_evidence_exists() {
+        let dir = mk_worktree(&EXECUTION_PROFILE);
+        // Ledger exists: the producing prompt opened (and evidence settled)
+        // an implementation obligation.
+        action_obligation::mark_from_prompt(dir.path(), "sess-1", "バグを修正して").unwrap();
+        action_obligation::settle_kinds_best_effort(
+            dir.path(),
+            "sess-1",
+            &[action_obligation::ObligationKind::Implementation],
+            "verify.run vr-x",
+        );
+
+        let transcript = dir.path().join("transcript.jsonl");
+        std::fs::write(
+            &transcript,
+            "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"検証しました。全テスト成功です。\"}]}}\n",
+        )
+        .unwrap();
+        let input =
+            serde_json::json!({ "transcript_path": transcript.to_string_lossy() }).to_string();
+
+        let output = handle_with_input(dir.path(), &input, Some("sess-1"));
+        let HookOutput::StopBlock { reason } = output else {
+            panic!("expected StopBlock, got {output:?}");
+        };
+        assert!(reason.contains("no recorded evidence"), "{reason}");
+        assert!(reason.contains("verification"), "{reason}");
+
+        // Settling the verification evidence backs the claim — the same
+        // transcript now passes.
+        action_obligation::settle_kinds_best_effort(
+            dir.path(),
+            "sess-1",
+            &[action_obligation::ObligationKind::Verification],
+            "verify.run vr-y",
+        );
+        assert_eq!(
+            handle_with_input(dir.path(), &input, Some("sess-1")),
+            HookOutput::Silent
+        );
+
+        // Ledger-less sessions are never scanned.
+        let bare = mk_worktree(&EXECUTION_PROFILE);
+        let input =
+            serde_json::json!({ "transcript_path": transcript.to_string_lossy() }).to_string();
+        assert_eq!(
+            handle_with_input(bare.path(), &input, Some("sess-1")),
             HookOutput::Silent
         );
     }

--- a/crates/gwt/src/cli/hook/execution_completion_stop_check.rs
+++ b/crates/gwt/src/cli/hook/execution_completion_stop_check.rs
@@ -46,7 +46,7 @@ pub fn handle_with_input(worktree: &Path, input: &str) -> HookOutput {
     HookOutput::Silent
 }
 
-fn transcript_path_for_worktree(worktree: &Path, transcript_path: &str) -> PathBuf {
+pub(super) fn transcript_path_for_worktree(worktree: &Path, transcript_path: &str) -> PathBuf {
     let path = PathBuf::from(transcript_path);
     if path.is_absolute() {
         path
@@ -55,7 +55,7 @@ fn transcript_path_for_worktree(worktree: &Path, transcript_path: &str) -> PathB
     }
 }
 
-fn read_transcript_tail(path: &Path) -> std::io::Result<String> {
+pub(super) fn read_transcript_tail(path: &Path) -> std::io::Result<String> {
     let mut file = File::open(path)?;
     let len = file.metadata()?.len();
     let start = len.saturating_sub(TRANSCRIPT_TAIL_LIMIT);
@@ -65,7 +65,7 @@ fn read_transcript_tail(path: &Path) -> std::io::Result<String> {
     Ok(String::from_utf8_lossy(&buf).into_owned())
 }
 
-fn latest_assistant_text(transcript_tail: &str) -> Option<String> {
+pub(super) fn latest_assistant_text(transcript_tail: &str) -> Option<String> {
     let mut latest = None;
     for line in transcript_tail.lines() {
         let Ok(value) = serde_json::from_str::<Value>(line) else {


### PR DESCRIPTION
## Summary

SPEC #3248 T-243 core: assistant commitment scanner。

- 最新 assistant message の assertive な完了宣言（実装/修正/implemented/検証/all tests pass の狭い ja+en 形）を検出し、ledger に裏付け（settled evidence）が無い kind だけ open obligation 化して Stop を block
- settled evidence があれば自動通過（正直な verify.run 済み session は影響なし）。PR/issue 言及・ledger 無し session・解析不能 transcript は fail-open
- 既存の transcript 走査基盤と P11 obligation gate を再利用（新規ゲート機構なし）

## Rollback / Follow-up boundary

- Rollback: scanner 呼び出しのみ消える。P11 の記録・settle・Stop gate は不変
- Follow-up: PR/issue 宣言の分類、will-do 系未来形の追跡（T-243 full）

## Verification

- cargo fmt / clippy --all-targets --all-features -D warnings: PASS
- 新規テスト 3 件 + 関連 59 GREEN / hook integration 13+85 GREEN（4 件は base 同一の Windows パス既知族、CI 正式ゲート）
- User Verification Result: n/a（hook 内部変更のみ）

Refs #3248

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for unsupported assistant completion claims such as “implemented,” “fixed,” or “verified.”
  * Opens an action obligation when a completion claim lacks corresponding evidence.
  * Prompts completion of verification steps or recording a justified deferral.

* **Bug Fixes**
  * Prevents duplicate obligations when the same claim is detected repeatedly.
  * Preserves silent, non-blocking behavior when session or transcript information is unavailable.

* **Tests**
  * Added coverage for claim classification, verification blocking, duplicate prevention, and ledger-less sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->