### PR TITLE
feat(hooks): SPEC-3248 T-181/T-182 core trusted storeのGCとlegacy import

### DIFF
--- a/crates/gwt/src/cli/execution_state.rs
+++ b/crates/gwt/src/cli/execution_state.rs
@@ -488,7 +488,12 @@ pub fn materialize_at_launch(
             entrypoint,
             resume,
         )
-    })
+    })?;
+    // T-181: launch is the cheap moment to sweep orphaned trusted entries
+    // (runs outside the lease; GC only touches sibling directories whose
+    // recorded worktree is gone).
+    crate::cli::trusted_store::gc_best_effort(worktree);
+    Ok(())
 }
 
 fn materialize_at_launch_locked(
@@ -508,6 +513,13 @@ fn materialize_at_launch_locked(
             && existing.owner_number == owner_number
             && existing.status != ExecutionControlStatus::Active
         {
+            // T-182 core: a settled record that only lives in the worktree
+            // mirror (pre-P9b) is promoted into the trusted store here —
+            // the resume path otherwise never rewrites it and the legacy
+            // fallback would linger past its sunset.
+            if crate::cli::trusted_store::read(worktree, "execution-control.json")?.is_none() {
+                save(worktree, &existing)?;
+            }
             return Ok(());
         }
         if existing.status == ExecutionControlStatus::Active
@@ -1773,6 +1785,52 @@ mod tests {
             load(dir.path()).unwrap().unwrap().status,
             ExecutionControlStatus::Active
         );
+    }
+
+    // T-182 core: resuming a settled pre-P9b worktree promotes the valid
+    // mirror-only record into the trusted store (the resume path otherwise
+    // never rewrites it).
+    #[test]
+    fn resume_imports_mirror_only_settled_record_into_trusted_store() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let home = tempfile::tempdir().unwrap();
+        let _home = ScopedEnvVar::set("HOME", home.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
+        let dir = tempfile::tempdir().unwrap();
+        crate::cli::trusted_store::init_git_repo_with_origin(dir.path());
+
+        // Pre-P9b shape: a settled record living only in the mirror.
+        let mut legacy = active_record("sess-old");
+        legacy.status = ExecutionControlStatus::Completed;
+        legacy.settled_at = Some(Utc::now());
+        legacy.content_hash = compute_content_hash(&legacy);
+        let serialized = serde_json::to_vec_pretty(&legacy).unwrap();
+        gwt_github::cache::write_atomic(&state_path(dir.path()), &serialized).unwrap();
+        assert!(
+            crate::cli::trusted_store::read(dir.path(), "execution-control.json")
+                .unwrap()
+                .is_none()
+        );
+
+        materialize_at_launch(
+            dir.path(),
+            ExecutionOwnerKind::Spec,
+            3248,
+            "sess-new",
+            "resume",
+            true,
+        )
+        .unwrap();
+        // The settled record is preserved AND now trusted-store resident.
+        let trusted = crate::cli::trusted_store::read(dir.path(), "execution-control.json")
+            .unwrap()
+            .expect("trusted copy imported");
+        let record: ExecutionControlRecord = serde_json::from_str(&trusted).unwrap();
+        assert_eq!(record.status, ExecutionControlStatus::Completed);
+        assert_eq!(record.primary_session_id, "sess-old");
+        assert!(integrity_ok(&record));
     }
 
     // P9b: a mirror-only record (written before the trusted store existed)

--- a/crates/gwt/src/cli/trusted_store.rs
+++ b/crates/gwt/src/cli/trusted_store.rs
@@ -122,6 +122,7 @@ pub fn write_with_mirror(
     let trusted_dir = trusted_dir_for_worktree(worktree);
     if let Some(dir) = &trusted_dir {
         gwt_github::cache::write_atomic(&dir.join(file_name), bytes)?;
+        stamp_worktree_marker(dir, worktree);
     }
     match gwt_github::cache::write_atomic(mirror_path, bytes) {
         Err(err) if trusted_dir.is_some() => {
@@ -134,6 +135,85 @@ pub fn write_with_mirror(
         }
         result => result,
     }
+}
+
+/// Marker file naming the worktree a trusted directory belongs to. The
+/// directory key is a one-way hash, so GC (T-181) needs this to decide
+/// whether the worktree still exists.
+const WORKTREE_MARKER_FILE: &str = "worktree-path.txt";
+
+/// How long an orphaned trusted directory survives after its worktree
+/// disappears (T-181). Long enough for post-deletion inspection and the
+/// T-182 relaunch import; short enough that ephemeral worktrees do not
+/// accumulate forever.
+const GC_RETENTION: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
+fn stamp_worktree_marker(trusted_dir: &Path, worktree: &Path) {
+    let marker = trusted_dir.join(WORKTREE_MARKER_FILE);
+    if marker.exists() {
+        return;
+    }
+    let canonical = dunce::canonicalize(worktree).unwrap_or_else(|_| worktree.to_path_buf());
+    if let Err(error) =
+        gwt_github::cache::write_atomic(&marker, canonical.to_string_lossy().as_bytes())
+    {
+        tracing::warn!(?error, "trusted store worktree marker write failed");
+    }
+}
+
+/// T-181 core: best-effort GC of sibling trusted directories whose recorded
+/// worktree no longer exists and whose newest file is older than the
+/// retention window. Marker-less directories (pre-T-181) are left alone —
+/// GC never guesses. Runs from launch materialization; failures only warn.
+pub fn gc_best_effort(current_worktree: &Path) {
+    gc_with_retention(current_worktree, GC_RETENTION);
+}
+
+fn gc_with_retention(current_worktree: &Path, retention: Duration) {
+    let Some(own_dir) = trusted_dir_for_worktree(current_worktree) else {
+        return;
+    };
+    let Some(root) = own_dir.parent() else {
+        return;
+    };
+    let Ok(entries) = fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let dir = entry.path();
+        if !dir.is_dir() || dir == own_dir {
+            continue;
+        }
+        let marker = dir.join(WORKTREE_MARKER_FILE);
+        let Ok(recorded) = fs::read_to_string(&marker) else {
+            continue;
+        };
+        if Path::new(recorded.trim()).exists() {
+            continue;
+        }
+        if newest_modification_age(&dir).is_none_or(|age| age < retention) {
+            continue;
+        }
+        if let Err(error) = fs::remove_dir_all(&dir) {
+            tracing::warn!(?error, path = %dir.display(), "trusted store GC failed");
+        } else {
+            tracing::info!(path = %dir.display(), "trusted store GC removed orphaned entry");
+        }
+    }
+}
+
+/// Age of the most recently modified file in the directory (None when the
+/// directory is unreadable or clocks misbehave — GC then keeps it).
+fn newest_modification_age(dir: &Path) -> Option<Duration> {
+    let mut newest: Option<std::time::SystemTime> = None;
+    for entry in fs::read_dir(dir).ok()?.flatten() {
+        let modified = entry.metadata().ok()?.modified().ok()?;
+        newest = Some(match newest {
+            Some(current) if current >= modified => current,
+            _ => modified,
+        });
+    }
+    newest?.elapsed().ok()
 }
 
 /// Bounded wait before a second concurrent writer is refused (T-149). Long
@@ -377,6 +457,73 @@ mod tests {
         assert!(!ran, "refused writer must not run its operation");
         release_tx.send(()).unwrap();
         holder.join().unwrap();
+    }
+
+    // T-181: GC removes orphaned sibling entries (marker points at a gone
+    // worktree, files older than retention) and keeps live and marker-less
+    // ones.
+    #[test]
+    fn gc_removes_only_orphaned_marked_siblings() {
+        let _env_lock = crate::env_test_lock()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let home = tempfile::tempdir().unwrap();
+        let _home = ScopedEnvVar::set("HOME", home.path());
+        let _userprofile = ScopedEnvVar::set("USERPROFILE", home.path());
+        let dir = tempfile::tempdir().unwrap();
+        init_git_repo_with_origin(dir.path());
+        write(dir.path(), "own.json", b"{}").unwrap();
+        let own_dir = trusted_dir_for_worktree(dir.path()).unwrap();
+        let root = own_dir.parent().unwrap().to_path_buf();
+
+        // Orphan: marker points at a deleted worktree.
+        let orphan = root.join("00000000deadbeef");
+        std::fs::create_dir_all(&orphan).unwrap();
+        std::fs::write(orphan.join("execution-control.json"), "{}").unwrap();
+        std::fs::write(
+            orphan.join(WORKTREE_MARKER_FILE),
+            dir.path()
+                .join("no-such-worktree")
+                .to_string_lossy()
+                .as_bytes(),
+        )
+        .unwrap();
+        // Live sibling: marker points at an existing path.
+        let live = root.join("00000000cafebabe");
+        std::fs::create_dir_all(&live).unwrap();
+        std::fs::write(live.join("execution-control.json"), "{}").unwrap();
+        std::fs::write(
+            live.join(WORKTREE_MARKER_FILE),
+            dir.path().to_string_lossy().as_bytes(),
+        )
+        .unwrap();
+        // Marker-less legacy sibling: never touched.
+        let legacy = root.join("00000000feedf00d");
+        std::fs::create_dir_all(&legacy).unwrap();
+        std::fs::write(legacy.join("execution-control.json"), "{}").unwrap();
+
+        gc_with_retention(dir.path(), Duration::ZERO);
+        assert!(!orphan.exists(), "orphaned entry must be removed");
+        assert!(live.exists(), "live entry must survive");
+        assert!(legacy.exists(), "marker-less legacy entry must survive");
+        assert!(own_dir.exists(), "own entry must survive");
+
+        // Fresh orphans inside the retention window survive.
+        std::fs::create_dir_all(&orphan).unwrap();
+        std::fs::write(orphan.join("execution-control.json"), "{}").unwrap();
+        std::fs::write(
+            orphan.join(WORKTREE_MARKER_FILE),
+            dir.path()
+                .join("no-such-worktree")
+                .to_string_lossy()
+                .as_bytes(),
+        )
+        .unwrap();
+        gc_with_retention(dir.path(), Duration::from_secs(3600));
+        assert!(
+            orphan.exists(),
+            "entries younger than retention must survive"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

SPEC #3248 T-181/T-182 core: trusted store の GC/retention と legacy import。

- T-181: 書込時の worktree-path marker + launch 時の best-effort GC（worktree 消滅済み & retention 7 日超過の marked sibling のみ削除。marker 無し dir と生存 entry は不可侵）
- T-182: resume の settled-preserve 経路が pre-P9b の mirror-only record を trusted store へ昇格（mirror fallback sunset を閉鎖）

## Rollback / Follow-up boundary

- Rollback: marker は無害な追加ファイル。GC/import 呼び出しのみ消える
- Follow-up: cross-worktree conflict surfacing、T-177 full

## Verification

- cargo fmt / clippy --all-targets --all-features -D warnings: PASS
- 新規テスト 2 件 + 関連 100 GREEN / hook integration 13+85 GREEN（4 件は base 同一の Windows パス既知族、CI 正式ゲート）
- User Verification Result: n/a（CLI 内部変更のみ）

Refs #3248

🤖 Generated with [Claude Code](https://claude.com/claude-code)