### PR TITLE
feat(hooks): SPEC-3248 T-248 absorbed core reopenのrecovery obligations

### DIFF
--- a/crates/gwt/src/cli/action_obligation.rs
+++ b/crates/gwt/src/cli/action_obligation.rs
@@ -335,6 +335,42 @@ pub fn defer_all_best_effort(worktree: &Path, session_id: &str, reason: &str) {
     );
 }
 
+/// T-248 absorbed core: a successful `execution.reopen` revives the
+/// obligations that `execution.blocked` deferred, for the kinds the
+/// recovery evidence does NOT cover (issue updates and PR work — the
+/// reopen contract already proves fresh implementation/verification
+/// evidence). Recovery therefore re-owes exactly the work the block
+/// parked, through the existing obligation gate — no separate Gate Doctor
+/// surface (user decision, 2026-07-28).
+pub fn revive_deferred_best_effort(worktree: &Path, session_id: &str, kinds: &[ObligationKind]) {
+    let result = crate::cli::trusted_store::with_write_lease(worktree, || {
+        let Some(mut state) = load(worktree)? else {
+            return Ok(());
+        };
+        if state.session_id != session_id || !integrity_ok(&state) {
+            return Ok(());
+        }
+        let mut changed = false;
+        for entry in &mut state.obligations {
+            let deferred = entry
+                .settled
+                .as_ref()
+                .is_some_and(|settlement| settlement.evidence.starts_with("deferred:"));
+            if deferred && kinds.contains(&entry.kind) {
+                entry.settled = None;
+                changed = true;
+            }
+        }
+        if changed {
+            save(worktree, &state)?;
+        }
+        Ok(())
+    });
+    if let Err(error) = result {
+        tracing::warn!(?error, "deferred obligation revival failed");
+    }
+}
+
 /// T-243 core: classify assertive completion claims in assistant prose.
 /// Deliberately narrow — only implemented/fixed and verified/tests-pass
 /// claim forms (ja+en). PR/issue mentions are excluded: they appear in
@@ -667,6 +703,49 @@ mod tests {
             "issue.comment",
         );
         assert!(open_obligation_refusal(dir.path(), "sess-1", &[ObligationKind::Pr]).is_none());
+    }
+
+    // T-248 absorbed core: revival reopens only DEFERRED entries of the
+    // requested kinds; evidence-settled entries and other sessions stay
+    // untouched.
+    #[test]
+    fn revive_deferred_reopens_only_deferred_kinds() {
+        let dir = tempfile::tempdir().unwrap();
+        mark_from_prompt(dir.path(), "sess-1", "Issue #1 にコメントを追加して").unwrap();
+        mark_from_prompt(dir.path(), "sess-1", "バグを修正して").unwrap();
+        // Implementation settles with real evidence; the issue update is
+        // deferred by execution.blocked.
+        settle_kinds_best_effort(
+            dir.path(),
+            "sess-1",
+            &[ObligationKind::Implementation],
+            "verify.run vr-1",
+        );
+        settle_kinds_best_effort(
+            dir.path(),
+            "sess-1",
+            &[ObligationKind::IssueUpdate],
+            "deferred: execution.blocked (cannot comment)",
+        );
+        assert!(open_kinds(dir.path(), "sess-1").is_empty());
+
+        revive_deferred_best_effort(
+            dir.path(),
+            "sess-1",
+            &[ObligationKind::IssueUpdate, ObligationKind::Pr],
+        );
+        assert_eq!(
+            open_kinds(dir.path(), "sess-1"),
+            vec![ObligationKind::IssueUpdate],
+            "only the deferred issue update revives; evidence-settled implementation stays settled"
+        );
+
+        // Cross-session revival is a no-op.
+        revive_deferred_best_effort(dir.path(), "sess-other", &[ObligationKind::IssueUpdate]);
+        assert_eq!(
+            open_kinds(dir.path(), "sess-1"),
+            vec![ObligationKind::IssueUpdate]
+        );
     }
 
     // No-secrets: raw prompts never persist, only digests.

--- a/crates/gwt/src/cli/execution_state.rs
+++ b/crates/gwt/src/cli/execution_state.rs
@@ -1079,14 +1079,32 @@ fn run_reopen(
             "execution.reopen requires a non-empty params.reason".to_string(),
         )));
     }
-    crate::cli::trusted_store::with_write_lease(worktree, || {
+    let code = crate::cli::trusted_store::with_write_lease(worktree, || {
         Ok(run_reopen_locked(worktree, session_id, reason, out))
     })
     .map_err(|err| {
         SpecOpsError::from(ApiError::Unexpected(
             crate::cli::trusted_store::store_health_error("settling execution state", &err),
         ))
-    })?
+    })??;
+    // T-248 absorbed core: a real reopen revives the obligations the block
+    // deferred, except the kinds the recovery evidence already covers
+    // (implementation/verification are proven by the mandatory post-block
+    // Fresh run). Runs after the lease — revival takes its own.
+    if code == 0 && out.contains("execution: reopened") {
+        crate::cli::action_obligation::revive_deferred_best_effort(
+            worktree,
+            session_id,
+            &[
+                crate::cli::action_obligation::ObligationKind::IssueUpdate,
+                crate::cli::action_obligation::ObligationKind::Pr,
+            ],
+        );
+        out.push_str(
+            "execution: deferred issue/pr obligations revived — recovery re-owes the parked work\n",
+        );
+    }
+    Ok(code)
 }
 
 fn run_reopen_locked(


### PR DESCRIPTION
## Summary

SPEC #3248 T-248 absorbed core: `execution.reopen` の recovery obligations（Gate Doctor 新 surface なし — 既存 obligation 基盤へ吸収、2026-07-28 ユーザー決定）。

- reopen 成功時、execution.blocked が defer した issue_update / pr の義務を open に復活（recovery が棚上げした仕事を正確に再負債化）
- implementation / verification は reopen 契約の post-block Fresh evidence が既に証明するため対象外
- enforcement は既存の obligation Stop gate / T-247 completion gate に委譲

## Rollback / Follow-up boundary

- Rollback: 復活呼び出しのみ消える。reopen の evidence 契約・obligation gate は不変
- Follow-up: T-243 full / T-241 full（recovery evidence の HEAD binding 等）

## Verification

- cargo fmt / clippy --all-targets --all-features -D warnings: PASS
- 新規テスト 1 件 + 関連 58 GREEN / hook integration 13+85 GREEN（4 件は base 同一の Windows パス既知族、CI 正式ゲート）
- User Verification Result: n/a（CLI 内部変更のみ）

Refs #3248

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reopening an execution now automatically reopens eligible deferred Issue Update and PR obligations.
  * Only obligations associated with the reopened session and specified obligation types are revived.
  * Obligations already settled with evidence remain unchanged.
  * A confirmation message is shown when deferred obligations are successfully revived.

* **Bug Fixes**
  * Improved handling of deferred obligations after a successful execution reopen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->