### PR TITLE
fix(launch): intake worktreeをfreshなorigin baseで実体化しstale skillsを自己修復する

### DIFF
--- a/crates/gwt-git/src/worktree.rs
+++ b/crates/gwt-git/src/worktree.rs
@@ -114,6 +114,16 @@ impl WorktreeManager {
         Ok(())
     }
 
+    /// Whether this repository has an `origin` remote configured.
+    pub fn has_origin_remote(&self) -> Result<bool> {
+        let output = gwt_core::process::run_git_logged(
+            &["remote", "get-url", "origin"],
+            Some(&self.repo_path),
+        )
+        .map_err(|e| GwtError::Git(format!("remote get-url origin: {e}")))?;
+        Ok(output.status.success())
+    }
+
     /// Prepare `origin/develop` as the canonical Start Work base.
     ///
     /// Fresh bare clones can lack both `remote.origin.fetch` and

--- a/crates/gwt-skills/src/distribute.rs
+++ b/crates/gwt-skills/src/distribute.rs
@@ -71,9 +71,37 @@ pub fn distribute_to_worktree(worktree: &Path) -> io::Result<DistributeReport> {
     distribute_to_worktree_for_targets(worktree, &ManagedAssetTarget::ALL)
 }
 
+/// How distribution treats an existing git-tracked copy of a managed asset.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TrackedAssetWritePolicy {
+    /// Preserve existing tracked files (default): never overwrite content a
+    /// project has checked in (SPEC #1942).
+    PreserveTracked,
+    /// Overwrite tracked copies of gwt-managed skill/command assets with the
+    /// embedded bundle. Used by ephemeral intake worktrees (#3374), where the
+    /// tracked copy can be months older than the running binary and the
+    /// worktree is disposable. Scoped to the same `gwt-*` namespaces the
+    /// intake reaper treats as disposable (`is_disposable_worktree_entry` in
+    /// gwt-git), so a refreshed file never makes an intake worktree look like
+    /// user work. Prune-side tracked protection is unchanged.
+    OverrideGwtManaged,
+}
+
 pub fn distribute_to_worktree_for_targets(
     worktree: &Path,
     targets: &[ManagedAssetTarget],
+) -> io::Result<DistributeReport> {
+    distribute_to_worktree_for_targets_with_policy(
+        worktree,
+        targets,
+        TrackedAssetWritePolicy::PreserveTracked,
+    )
+}
+
+pub fn distribute_to_worktree_for_targets_with_policy(
+    worktree: &Path,
+    targets: &[ManagedAssetTarget],
+    policy: TrackedAssetWritePolicy,
 ) -> io::Result<DistributeReport> {
     let mut report = DistributeReport::default();
     let tracked_paths = tracked_gwt_asset_paths(worktree);
@@ -87,6 +115,7 @@ pub fn distribute_to_worktree_for_targets(
             worktree,
             &worktree.join(".claude/skills"),
             &tracked_paths,
+            policy,
             &mut report,
         )?;
         write_dir_assets(
@@ -94,6 +123,7 @@ pub fn distribute_to_worktree_for_targets(
             worktree,
             &worktree.join(".claude/commands"),
             &tracked_paths,
+            policy,
             &mut report,
         )?;
     }
@@ -104,6 +134,7 @@ pub fn distribute_to_worktree_for_targets(
             worktree,
             &worktree.join(".codex/skills"),
             &tracked_paths,
+            policy,
             &mut report,
         )?;
     }
@@ -114,6 +145,7 @@ pub fn distribute_to_worktree_for_targets(
             worktree,
             &worktree.join(".gwt/hermes/skills"),
             &tracked_paths,
+            policy,
             &mut report,
         )?;
     }
@@ -277,9 +309,10 @@ fn write_dir_assets(
     worktree: &Path,
     dest: &Path,
     tracked_paths: &HashSet<PathBuf>,
+    policy: TrackedAssetWritePolicy,
     report: &mut DistributeReport,
 ) -> io::Result<()> {
-    write_dir_assets_inner(source, worktree, dest, tracked_paths, false, report)
+    write_dir_assets_inner(source, worktree, dest, tracked_paths, policy, false, report)
 }
 
 fn write_gwt_skill_dir_assets(
@@ -287,9 +320,10 @@ fn write_gwt_skill_dir_assets(
     worktree: &Path,
     dest: &Path,
     tracked_paths: &HashSet<PathBuf>,
+    policy: TrackedAssetWritePolicy,
     report: &mut DistributeReport,
 ) -> io::Result<()> {
-    write_dir_assets_inner(source, worktree, dest, tracked_paths, true, report)
+    write_dir_assets_inner(source, worktree, dest, tracked_paths, policy, true, report)
 }
 
 fn write_dir_assets_inner(
@@ -297,6 +331,7 @@ fn write_dir_assets_inner(
     worktree: &Path,
     dest: &Path,
     tracked_paths: &HashSet<PathBuf>,
+    policy: TrackedAssetWritePolicy,
     root_gwt_only: bool,
     report: &mut DistributeReport,
 ) -> io::Result<()> {
@@ -305,7 +340,14 @@ fn write_dir_assets_inner(
         // Preserve existing tracked files so we do not overwrite user-checked-in
         // assets with an older bundle snapshot, but still recreate missing
         // tracked files so worktrees can self-heal after an accidental delete.
-        if target.exists() && should_skip_tracked_path(worktree, &target, tracked_paths) {
+        // #3374: ephemeral intake worktrees invert this for gwt-managed
+        // namespaces — there the tracked copy is a stale base-ref snapshot,
+        // not user content, and the embedded bundle wins.
+        if target.exists()
+            && should_skip_tracked_path(worktree, &target, tracked_paths)
+            && !(policy == TrackedAssetWritePolicy::OverrideGwtManaged
+                && is_gwt_managed_override_path(worktree, &target))
+        {
             continue;
         }
         if let Some(parent) = target.parent() {
@@ -328,6 +370,7 @@ fn write_dir_assets_inner(
             worktree,
             &dest.join(subdir_name),
             tracked_paths,
+            policy,
             report,
         )?;
     }
@@ -418,6 +461,30 @@ fn remove_path(path: &Path) -> io::Result<()> {
     } else {
         fs::remove_file(path)
     }
+}
+
+/// gwt-managed namespaces the intake override may refresh even when tracked
+/// (#3374). Must stay in lockstep with `is_disposable_worktree_entry` in
+/// gwt-git: refreshing a file OUTSIDE the reaper's disposable set would make a
+/// pristine intake worktree look like user work and leak it past cleanup.
+/// `.gwt/hermes/skills` is deliberately absent for the same reason.
+const GWT_MANAGED_OVERRIDE_PREFIXES: &[&str] = &[
+    ".claude/skills/gwt-",
+    ".claude/commands/gwt-",
+    ".codex/skills/gwt-",
+];
+
+fn is_gwt_managed_override_path(worktree: &Path, target: &Path) -> bool {
+    target
+        .strip_prefix(worktree)
+        .ok()
+        .and_then(|relative| relative.to_str())
+        .map(|relative| relative.replace('\\', "/"))
+        .is_some_and(|relative| {
+            GWT_MANAGED_OVERRIDE_PREFIXES
+                .iter()
+                .any(|prefix| relative.starts_with(prefix))
+        })
 }
 
 fn should_skip_tracked_path(
@@ -873,6 +940,58 @@ mod tests {
             tracked_codex_skill.exists(),
             "tracked codex gwt skill dir must not be pruned before the running binary bundles it: {}",
             tracked_codex_skill.display()
+        );
+    }
+
+    // #3374: an ephemeral intake worktree must surface the embedded bundle
+    // even where the project tracks gwt skills (the gwt repo itself). Tracked
+    // gwt-* copies are refreshed; non-gwt tracked files stay untouched; a
+    // tracked gwt dir absent from the bundle is still preserved (prune
+    // protection is unchanged).
+    #[test]
+    fn distribute_override_policy_refreshes_stale_tracked_gwt_assets_only() {
+        let dir = tempfile::tempdir().unwrap();
+        init_git_repo(dir.path());
+
+        let tracked_skill = dir.path().join(".claude/skills/gwt-manage-pr/SKILL.md");
+        let tracked_future_skill = dir.path().join(".claude/skills/gwt-future-search/SKILL.md");
+        let tracked_user_command = dir.path().join(".claude/commands/release.md");
+        fs::create_dir_all(tracked_skill.parent().unwrap()).unwrap();
+        fs::create_dir_all(tracked_future_skill.parent().unwrap()).unwrap();
+        fs::create_dir_all(tracked_user_command.parent().unwrap()).unwrap();
+        fs::write(&tracked_skill, "stale tracked skill").unwrap();
+        fs::write(&tracked_future_skill, "tracked future skill").unwrap();
+        fs::write(&tracked_user_command, "user release command").unwrap();
+        track_path(dir.path(), ".claude/skills/gwt-manage-pr/SKILL.md");
+        track_path(dir.path(), ".claude/skills/gwt-future-search/SKILL.md");
+        track_path(dir.path(), ".claude/commands/release.md");
+
+        distribute_to_worktree_for_targets_with_policy(
+            dir.path(),
+            &[ManagedAssetTarget::ClaudeCode],
+            TrackedAssetWritePolicy::OverrideGwtManaged,
+        )
+        .unwrap();
+
+        let refreshed = fs::read_to_string(&tracked_skill).unwrap();
+        let bundled = CLAUDE_SKILLS
+            .get_file("gwt-manage-pr/SKILL.md")
+            .expect("bundled skill")
+            .contents_utf8()
+            .expect("utf8 bundled skill");
+        assert_eq!(
+            refreshed, bundled,
+            "stale tracked gwt skill is refreshed from the embedded bundle"
+        );
+        assert_eq!(
+            fs::read_to_string(&tracked_future_skill).unwrap(),
+            "tracked future skill",
+            "a tracked gwt skill absent from the bundle is still preserved"
+        );
+        assert_eq!(
+            fs::read_to_string(&tracked_user_command).unwrap(),
+            "user release command",
+            "non-gwt tracked files are never overwritten"
         );
     }
 

--- a/crates/gwt-skills/src/lane.rs
+++ b/crates/gwt-skills/src/lane.rs
@@ -55,6 +55,11 @@ pub struct LanePolicyFlags {
     /// Distribute only the curation skill subset (P4). `false` today (all
     /// skills go to every lane).
     pub reduced_skill_set: bool,
+    /// Overwrite tracked copies of gwt-managed skill/command assets with the
+    /// embedded bundle at materialization (#3374). `true` only for ephemeral
+    /// intake worktrees, where a tracked copy inherited from the base ref can
+    /// be months older than the running binary and the worktree is disposable.
+    pub embedded_assets_override_tracked: bool,
 }
 
 /// A declarative profile for one lane. Adding a lane = adding a profile.
@@ -82,6 +87,7 @@ pub const EXECUTION_PROFILE: LaneProfile = LaneProfile {
         completion_gate: false,
         sessionstart_onboarding: false,
         reduced_skill_set: false,
+        embedded_assets_override_tracked: false,
     },
 };
 
@@ -107,6 +113,9 @@ pub const INTAKE_PROFILE: LaneProfile = LaneProfile {
         sessionstart_onboarding: true,
         // SPEC-3248 P4: intake surfaces only curation skills.
         reduced_skill_set: true,
+        // #3374: an ephemeral intake worktree surfaces the embedded bundle
+        // even where the project tracks gwt skills (the gwt repo itself).
+        embedded_assets_override_tracked: true,
     },
 };
 
@@ -277,6 +286,7 @@ mod tests {
                     completion_gate: false,
                     sessionstart_onboarding: false,
                     reduced_skill_set: false,
+                    embedded_assets_override_tracked: false,
                 },
             }
         );
@@ -296,6 +306,8 @@ mod tests {
                     completion_gate: true,
                     sessionstart_onboarding: true,
                     reduced_skill_set: true,
+                    // #3374: intake worktrees are refreshed from the bundle.
+                    embedded_assets_override_tracked: true,
                 },
             }
         );

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -30,8 +30,9 @@ pub use coordination_guidance::{
 };
 pub use distribute::{
     apply_reduced_skill_set, distribute_to_worktree, distribute_to_worktree_for_targets,
-    prune_stale_gwt_assets, prune_stale_gwt_assets_for_targets, DistributeReport,
-    ManagedAssetTarget, CURATION_EXCLUDED_SKILLS,
+    distribute_to_worktree_for_targets_with_policy, prune_stale_gwt_assets,
+    prune_stale_gwt_assets_for_targets, DistributeReport, ManagedAssetTarget,
+    TrackedAssetWritePolicy, CURATION_EXCLUDED_SKILLS,
 };
 pub use git_exclude::{update_git_exclude, update_git_exclude_for_targets};
 pub use hooks::{

--- a/crates/gwt/src/launch_runtime.rs
+++ b/crates/gwt/src/launch_runtime.rs
@@ -200,7 +200,33 @@ pub fn resolve_ephemeral_launch_worktree(
     // Default to HEAD: `git worktree add --detach <path> HEAD` always resolves
     // in a repo with commits. Callers (Phase 3 intake launch) pass an explicit
     // base ref such as `origin/develop` when they need a specific base.
+    // #3374: a remote base must reflect the FRESH origin state — fetch before
+    // materializing so the remote-tracking ref is not months stale. Unlike
+    // Start Work's prepare step, intake never creates remote branches: a repo
+    // without an origin remote, or whose origin lacks the base branch, falls
+    // back to HEAD (the local checkout is the only truth there).
     let base_ref = base_ref.unwrap_or("HEAD");
+    let base_ref = if base_ref.starts_with("origin/") {
+        let has_origin = manager
+            .has_origin_remote()
+            .map_err(|err| format!("failed to inspect origin remote: {err}"))?;
+        if has_origin {
+            manager
+                .fetch_origin()
+                .map_err(|err| format!("failed to fetch origin for intake base: {err}"))?;
+        }
+        if has_origin
+            && manager
+                .remote_branch_exists(base_ref)
+                .map_err(|err| format!("failed to verify intake base {base_ref}: {err}"))?
+        {
+            base_ref
+        } else {
+            "HEAD"
+        }
+    } else {
+        base_ref
+    };
     manager
         .create_detached(base_ref, &worktree_path)
         .map_err(|err| err.to_string())?;

--- a/crates/gwt/src/launch_wizard/launch_request.rs
+++ b/crates/gwt/src/launch_wizard/launch_request.rs
@@ -186,8 +186,11 @@ impl LaunchWizardState {
             // disposable detached worktree from the launch runtime. Clearing
             // branch/base/working_dir here is the invariant guard — no wizard
             // state may leak a named branch into an intake launch.
+            // #3374: the ephemeral base ref is NOT branch state — it is the
+            // intake base (e.g. `origin/develop`). Clearing it made the launch
+            // runtime fall back to `HEAD` and materialize a stale worktree.
             config.is_ephemeral = true;
-            config.ephemeral_base_ref = None;
+            config.ephemeral_base_ref = self.context.ephemeral_base_ref.clone();
             config.branch = None;
             config.base_branch = None;
             config.working_dir = None;
@@ -271,6 +274,33 @@ mod tests {
             config.base_branch.is_none(),
             "intake launch reserves no base branch"
         );
+    }
+
+    #[test]
+    fn build_launch_config_for_intake_wizard_mode_keeps_ephemeral_base_ref() {
+        // #3374: the production intake path goes through
+        // `mark_as_ephemeral_intake`, which sets `wizard_mode = Intake`. The
+        // Intake invariant guard must clear branch state WITHOUT wiping the
+        // ephemeral base ref — losing it makes the launch runtime fall back to
+        // `HEAD` (the possibly months-stale main checkout), which is exactly
+        // the stale-intake-worktree bug.
+        let mut state = LaunchWizardState::open_with(
+            context(branch("develop"), "develop"),
+            sample_agent_options(),
+            Vec::new(),
+        );
+        state.mark_as_ephemeral_intake("origin/develop");
+
+        let config = state.build_launch_config().expect("intake launch config");
+        assert!(config.is_ephemeral, "intake launch is ephemeral");
+        assert_eq!(
+            config.ephemeral_base_ref.as_deref(),
+            Some("origin/develop"),
+            "the Intake invariant guard must keep the ephemeral base ref"
+        );
+        assert!(config.branch.is_none(), "intake launch creates no branch");
+        assert!(config.base_branch.is_none());
+        assert!(config.working_dir.is_none());
     }
 
     #[test]

--- a/crates/gwt/src/main.rs
+++ b/crates/gwt/src/main.rs
@@ -6086,6 +6086,96 @@ mod tests {
     }
 
     #[test]
+    fn resolve_ephemeral_launch_worktree_fetches_origin_for_remote_base_ref() {
+        // #3374: an intake worktree must be based on the FRESH origin state,
+        // not the remote-tracking ref as of the last fetch. Advance origin
+        // develop after the clone; the resolved intake worktree must contain
+        // the new commit.
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        let origin = init_git_clone_with_origin(&repo);
+
+        // Advance origin: new commit in the seed repo, pushed to the bare
+        // origin. The clone's remote-tracking origin/develop stays stale.
+        let seed = temp.path().join("seed");
+        fs::write(seed.join("fresh.txt"), "fresh\n").expect("write fresh file");
+        for args in [
+            vec!["add", "fresh.txt"],
+            vec!["commit", "-qm", "advance develop"],
+        ] {
+            let status = gwt_core::process::hidden_command("git")
+                .args(&args)
+                .current_dir(&seed)
+                .status()
+                .expect("git seed advance");
+            assert!(status.success(), "git {:?} failed", args);
+        }
+        let status = gwt_core::process::hidden_command("git")
+            .arg("push")
+            .arg("-q")
+            .arg(&origin)
+            .arg("develop:develop")
+            .current_dir(&seed)
+            .status()
+            .expect("git push origin");
+        assert!(status.success(), "git push to origin failed");
+
+        let mut working_dir = None;
+        let mut env_vars = HashMap::new();
+        super::resolve_ephemeral_launch_worktree(
+            &repo,
+            Some("origin/develop"),
+            &mut working_dir,
+            &mut env_vars,
+        )
+        .expect("ephemeral intake worktree resolves");
+
+        let intake_dir = working_dir.expect("intake working_dir set");
+        assert!(
+            intake_dir.join("fresh.txt").exists(),
+            "intake worktree is based on the fetched origin tip, not the stale remote-tracking ref"
+        );
+    }
+
+    #[test]
+    fn resolve_ephemeral_launch_worktree_falls_back_to_head_without_origin_remote() {
+        // #3374: a repo with no origin remote cannot fetch; an `origin/*` base
+        // must fall back to HEAD instead of failing the intake launch.
+        let temp = tempdir().expect("tempdir");
+        let repo = temp.path().join("repo");
+        fs::create_dir_all(&repo).expect("repo dir");
+        for args in [
+            vec!["init", "-q", "-b", "develop"],
+            vec!["config", "user.name", "Codex Test"],
+            vec!["config", "user.email", "codex@example.com"],
+            vec!["commit", "-qm", "init", "--allow-empty"],
+        ] {
+            let status = gwt_core::process::hidden_command("git")
+                .args(&args)
+                .current_dir(&repo)
+                .status()
+                .expect("git local repo setup");
+            assert!(status.success(), "git {:?} failed", args);
+        }
+
+        let mut working_dir = None;
+        let mut env_vars = HashMap::new();
+        super::resolve_ephemeral_launch_worktree(
+            &repo,
+            Some("origin/develop"),
+            &mut working_dir,
+            &mut env_vars,
+        )
+        .expect("intake in a remote-less repo falls back to HEAD");
+
+        let intake_dir = working_dir.expect("intake working_dir set");
+        assert!(
+            intake_dir.exists(),
+            "intake worktree materialized from HEAD"
+        );
+    }
+
+    #[test]
     fn resolve_launch_worktree_helpers_cover_short_circuits_existing_and_remote_creation() {
         let temp = tempdir().expect("tempdir");
         let repo = temp.path().join("repo");

--- a/crates/gwt/src/managed_assets.rs
+++ b/crates/gwt/src/managed_assets.rs
@@ -10,7 +10,7 @@ use crate::cli::gwtd_resolver::{
 use crate::native_app::{GUI_FRONT_DOOR_BINARY_NAME, INTERNAL_DAEMON_BINARY_NAME};
 use gwt_agent::AgentId;
 use gwt_skills::{
-    distribute_to_worktree_for_targets, generate_codex_hooks_for_mode,
+    distribute_to_worktree_for_targets_with_policy, generate_codex_hooks_for_mode,
     generate_coordination_guidance_for_claude, generate_coordination_guidance_for_codex,
     generate_hermes_hooks, generate_openclaw_hooks, generate_opencode_hooks,
     generate_settings_local, update_git_exclude, update_git_exclude_for_targets,
@@ -117,16 +117,22 @@ fn materialize_managed_gwt_assets_for_targets(
             ),
         ));
     }
-    distribute_to_worktree_for_targets(worktree, targets).map_err(|error| {
+    let lane_flags = gwt_skills::LaneRegistry::for_session_kind(session_kind).policy_flags;
+    // #3374: an ephemeral intake worktree refreshes tracked gwt-* assets from
+    // the embedded bundle — its tracked copies are a stale base-ref snapshot,
+    // not user content. Execution lanes keep the preserve-tracked default.
+    let policy = if lane_flags.embedded_assets_override_tracked {
+        gwt_skills::TrackedAssetWritePolicy::OverrideGwtManaged
+    } else {
+        gwt_skills::TrackedAssetWritePolicy::PreserveTracked
+    };
+    distribute_to_worktree_for_targets_with_policy(worktree, targets, policy).map_err(|error| {
         io::Error::other(format!("failed to distribute gwt managed assets: {error}"))
     })?;
     // SPEC-3248 P4 (FR-011): a lane with a reduced skill set (intake) omits the
     // implementation skills/commands. Applied as a post-pass so the
     // distribution core is untouched; a non-reduced lane keeps the full set.
-    if gwt_skills::LaneRegistry::for_session_kind(session_kind)
-        .policy_flags
-        .reduced_skill_set
-    {
+    if lane_flags.reduced_skill_set {
         gwt_skills::apply_reduced_skill_set(worktree).map_err(|error| {
             io::Error::other(format!("failed to apply reduced skill set: {error}"))
         })?;

--- a/crates/gwt/tests/managed_assets_test.rs
+++ b/crates/gwt/tests/managed_assets_test.rs
@@ -105,6 +105,67 @@ fn intake_materialize_applies_reduced_skill_set() {
     );
 }
 
+/// #3374: an ephemeral intake worktree must surface the embedded (binary)
+/// skill bundle even where the project tracks gwt skills — the gwt repo
+/// itself tracks `.claude/skills/**`, so a stale-base worktree would
+/// otherwise pin months-old guidance that managed-asset distribution
+/// refuses to heal. Execution worktrees keep the tracked copies (SPEC #1942).
+#[test]
+fn intake_materialize_overrides_stale_tracked_gwt_skills() {
+    fn materialize_with_stale_tracked(kind: SessionKind) -> tempfile::TempDir {
+        let dir = tempdir().expect("tempdir");
+        run_git(dir.path(), &["init", "-q"]);
+        // A stale tracked copy of a curation skill (survives the reduced set).
+        let skill = dir
+            .path()
+            .join(".claude/skills/gwt-register-issue/SKILL.md");
+        std::fs::create_dir_all(skill.parent().expect("skill dir")).expect("create skill dir");
+        std::fs::write(&skill, "stale tracked skill").expect("write stale skill");
+        run_git(
+            dir.path(),
+            &["add", ".claude/skills/gwt-register-issue/SKILL.md"],
+        );
+
+        let _env_guard = env_lock();
+        let cli_bin = dir.path().join("bin/gwtd");
+        std::fs::create_dir_all(cli_bin.parent().expect("bin parent")).expect("create bin dir");
+        std::fs::write(&cli_bin, "#!/bin/sh\n").expect("write cli bin");
+        let _cli_bin_guard = ScopedEnvVar::set("GWT_HOOK_BIN", &cli_bin);
+        refresh_managed_gwt_assets_for_agent_with_codex_hook_discovery_mode(
+            dir.path(),
+            &AgentId::ClaudeCode,
+            CodexHookDiscoveryMode::WorkspaceHome,
+            kind,
+        )
+        .expect("materialize managed assets");
+        dir
+    }
+
+    let intake = materialize_with_stale_tracked(SessionKind::Intake);
+    let refreshed = std::fs::read_to_string(
+        intake
+            .path()
+            .join(".claude/skills/gwt-register-issue/SKILL.md"),
+    )
+    .expect("read refreshed skill");
+    assert_ne!(
+        refreshed, "stale tracked skill",
+        "intake must refresh a stale tracked gwt skill from the embedded bundle"
+    );
+
+    let execution = materialize_with_stale_tracked(SessionKind::Execution);
+    let preserved = std::fs::read_to_string(
+        execution
+            .path()
+            .join(".claude/skills/gwt-register-issue/SKILL.md"),
+    )
+    .expect("read preserved skill");
+    assert_eq!(
+        preserved, "stale tracked skill",
+        "execution must keep the tracked copy (SPEC #1942 preserve-tracked)"
+    );
+}
+
 #[test]
 fn refresh_managed_gwt_assets_materializes_skills_commands_hooks_and_excludes() {
     let dir = tempdir().expect("tempdir");


### PR DESCRIPTION
## Summary

intake (Curate) セッションの `.intake-*` worktree が数ヶ月前のスキル/ガイダンスで起動する問題（#3374）を根本修正します。原因は 3 層の複合でした:

1. **主因**: `build_launch_config` の Intake invariant guard が `ephemeral_base_ref` までクリアしていたため、`mark_as_ephemeral_intake("origin/develop")` で設定した base が消え、materialization が `HEAD`（stale な main worktree の状態）にフォールバックしていた（SPEC-3214 Phase 3 の 95d387e15 で混入）
2. `resolve_ephemeral_launch_worktree` が fetch を一切行わないため、`origin/develop` remote-tracking ref 自体が最終 fetch 時点のまま stale だった
3. managed-asset 配布の preserve-tracked 動作により、`.claude/skills` 等を track する gwt リポジトリ自身の worktree では埋め込み bundle が stale tracked copy を修復できなかった

## Changes

- `crates/gwt/src/launch_wizard/launch_request.rs` — Intake guard が `ephemeral_base_ref` を context から保持するよう修正（branch 状態のみクリア）
- `crates/gwt/src/launch_runtime.rs` — `resolve_ephemeral_launch_worktree` が `origin/*` base 指定時に `fetch_origin` してから実体化。origin remote が無い / base branch が origin に無い repo は `HEAD` へ fallback（Start Work と異なり remote branch は作成しない）
- `crates/gwt-git/src/worktree.rs` — `WorktreeManager::has_origin_remote` を追加
- `crates/gwt-skills/src/lane.rs` — `LanePolicyFlags.embedded_assets_override_tracked` を追加（execution=false / intake=true）
- `crates/gwt-skills/src/distribute.rs` — `TrackedAssetWritePolicy` を追加。intake では tracked gwt-* スキル/コマンドを埋め込み bundle で上書き修復。上書き範囲は orphan reaper の disposable namespace（`.claude/skills/gwt-*` / `.claude/commands/gwt-*` / `.codex/skills/gwt-*`）と同一に限定し、非 gwt tracked ファイル（例: `.claude/commands/release.md`）と `.gwt/hermes/skills` は不変。prune 側の tracked 保護も不変
- `crates/gwt/src/managed_assets.rs` — lane flag から policy を選択して配布

## Testing

TDD（RED → GREEN）で実施。新規テスト 5 本:

- `build_launch_config_for_intake_wizard_mode_keeps_ephemeral_base_ref`（production 経路の wizard_mode=Intake で base ref 保持を検証）
- `resolve_ephemeral_launch_worktree_fetches_origin_for_remote_base_ref`（origin が advance した clone で fresh tip から materialize されることを検証）
- `resolve_ephemeral_launch_worktree_falls_back_to_head_without_origin_remote`
- `distribute_override_policy_refreshes_stale_tracked_gwt_assets_only`（gwt-* のみ上書き・非 gwt tracked は不変）
- `intake_materialize_overrides_stale_tracked_gwt_skills`（Intake は修復 / Execution は preserve-tracked 維持）

検証コマンド（gwtd `verify.run` 記録済み・全 PASS, record vrr-c56f769d09d744e0b8b5149291440d86）:

- `cargo fmt --check` / `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p gwt-skills`（235 passed）
- `cargo test -p gwt --test managed_assets_test`（9 passed）
- `cargo test -p gwt --bin gwt resolve_ephemeral_launch_worktree`（3 passed）
- `cargo test -p gwt --lib launch_wizard`（168 passed）
- `cargo test -p gwt-git --lib worktree`（40 passed）

フルマトリクス `cargo test -p gwt-core -p gwt --all-features --no-fail-fast` はこの実行環境で 43 件失敗するが、**変更を stash したクリーンツリーでも同一 43 件（+2 件の flaky）が失敗**することを diff で確認済み。本変更起因の regression はゼロ。失敗は gwt 管理下セッション環境（GWT_* env / 常駐 daemon / lock contention / 非 ASCII ユーザー名の 8.3 短縮パス）による pre-existing。

## PR Readiness

- State: Ready
- `gwt-verify` 相当 pre-PR 検証: PASS（上記 verify.run record）
- User Verification Result: n/a（Rust バックエンドのみの変更で UI surface 変更なし。挙動は自動テストで検証済み）
- Rollback: 本 PR 単体で revert 可能。follow-up 依存なし

## Closing Issues

Closes #3374

## Related Issues

- #3248（managed-hooks v2 lane 再設計 — `LanePolicyFlags` の拡張ポイントを使用）
- #3247（intake/execution SessionKind — 配布時の kind 判定を使用）

## Checklist

- [x] Conventional Commits（commitlint ローカル PASS）
- [x] テスト追加（RED 確認済み）・全対象テスト PASS
- [x] clippy / fmt PASS
- [x] コミット＆プッシュ済み
