### PR TITLE
fix(lane): resolve session kind from the worktree lane file before env

### DIFF
--- a/crates/gwt-skills/src/lane.rs
+++ b/crates/gwt-skills/src/lane.rs
@@ -214,6 +214,19 @@ pub fn resolve_lane_for_worktree(worktree: &Path) -> &'static LaneProfile {
     }
 }
 
+/// [`SessionKind`] view of [`resolve_lane_for_worktree`] for call sites that
+/// still branch on the enum while hooks migrate lane-by-lane (#3377). The
+/// worktree lane file wins when present; only lane-file-less worktrees fall
+/// back to the ambient `GWT_SESSION_KIND` env fast-path.
+#[must_use]
+pub fn resolve_session_kind_for_worktree(worktree: &Path) -> SessionKind {
+    if resolve_lane_for_worktree(worktree).id == INTAKE_PROFILE.id {
+        SessionKind::Intake
+    } else {
+        SessionKind::Execution
+    }
+}
+
 /// Extract the `"lane"` string from the lane file body without pulling in a
 /// JSON dependency for such a tiny schema. Returns `None` on any shape it does
 /// not recognize (→ caller falls back to the default profile).
@@ -354,6 +367,32 @@ mod tests {
         write_lane_file(dir.path(), &EXECUTION_PROFILE).expect("write lane file");
         assert_eq!(resolve_lane_for_worktree(dir.path()), &EXECUTION_PROFILE);
         std::env::remove_var(crate::GWT_SESSION_KIND_ENV);
+    }
+
+    #[test]
+    fn resolve_session_kind_prefers_lane_file_over_env() {
+        let _guard = env_lock();
+        let dir = TempDir::new().expect("tempdir");
+        // Lane file wins over a conflicting ambient env (#3377: an intake
+        // session invoking gwtd against an execution worktree must not
+        // re-materialize it as intake).
+        std::env::set_var(crate::GWT_SESSION_KIND_ENV, "intake");
+        write_lane_file(dir.path(), &EXECUTION_PROFILE).expect("write lane file");
+        assert_eq!(
+            resolve_session_kind_for_worktree(dir.path()),
+            SessionKind::Execution
+        );
+        // A lane-file-less worktree keeps the env fast-path (transition).
+        let bare = TempDir::new().expect("tempdir");
+        assert_eq!(
+            resolve_session_kind_for_worktree(bare.path()),
+            SessionKind::Intake
+        );
+        std::env::remove_var(crate::GWT_SESSION_KIND_ENV);
+        assert_eq!(
+            resolve_session_kind_for_worktree(bare.path()),
+            SessionKind::Execution
+        );
     }
 
     #[test]

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -40,9 +40,10 @@ pub use hooks::{
     restore_from_backup, Hook, HooksConfig, HooksError,
 };
 pub use lane::{
-    lane_file_path, read_lane_profile, resolve_lane_for_worktree, write_lane_file, GuidanceVariant,
-    LanePolicyFlags, LaneProfile, LaneRegistry, EXECUTION_PROFILE, INTAKE_PROFILE,
-    LANE_FILE_RELATIVE, LANE_FILE_VERSION,
+    lane_file_path, read_lane_profile, resolve_lane_for_worktree,
+    resolve_session_kind_for_worktree, write_lane_file, GuidanceVariant, LanePolicyFlags,
+    LaneProfile, LaneRegistry, EXECUTION_PROFILE, INTAKE_PROFILE, LANE_FILE_RELATIVE,
+    LANE_FILE_VERSION,
 };
 pub use provider_hooks::{
     generate_hermes_hooks, generate_openclaw_hooks, generate_opencode_hooks, hermes_is_configured,

--- a/crates/gwt/src/cli/hook/event_dispatcher.rs
+++ b/crates/gwt/src/cli/hook/event_dispatcher.rs
@@ -822,6 +822,8 @@ mod tests {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let worktree = tempfile::tempdir().unwrap();
+        gwt_skills::write_lane_file(worktree.path(), gwt_skills::LaneRegistry::default_profile())
+            .expect("pin execution lane");
         let sessions_dir = worktree.path().join(".gwt").join("sessions");
         let mut session = Session::new(worktree.path(), "feature/demo", AgentId::Codex);
         session.agent_session_id = Some("agent-123".to_string());

--- a/crates/gwt/src/cli/hook/skill_build_spec_stop_check.rs
+++ b/crates/gwt/src/cli/hook/skill_build_spec_stop_check.rs
@@ -81,6 +81,8 @@ mod tests {
     #[test]
     fn blocks_when_build_state_active_and_includes_phase_in_reason() {
         let dir = tempfile::tempdir().unwrap();
+        gwt_skills::write_lane_file(dir.path(), gwt_skills::LaneRegistry::default_profile())
+            .expect("pin execution lane");
         save(
             dir.path(),
             SKILL_NAME,

--- a/crates/gwt/src/cli/hook/workflow_policy.rs
+++ b/crates/gwt/src/cli/hook/workflow_policy.rs
@@ -2265,6 +2265,10 @@ Coverage requirements.
             }
         }
 
+        let repo = tempfile::tempdir().expect("repo");
+        gwt_skills::write_lane_file(repo.path(), gwt_skills::LaneRegistry::default_profile())
+            .expect("pin execution lane");
+
         let event = HookEvent {
             tool_name: Some("Edit".to_string()),
             tool_input: Some(serde_json::json!({
@@ -2276,7 +2280,7 @@ Coverage requirements.
 
         let output = evaluate_with_context(
             &event,
-            std::path::Path::new("."),
+            repo.path(),
             &WorkflowContext::unknown().with_pending_discussion_goal(Some(pending_goal())),
         )
         .expect("guard output");
@@ -2305,7 +2309,7 @@ Coverage requirements.
         assert_eq!(
             evaluate_with_context(
                 &allowed,
-                std::path::Path::new("."),
+                repo.path(),
                 &WorkflowContext::unknown().with_pending_discussion_goal(Some(pending_goal())),
             )
             .expect("allowed output"),
@@ -2326,7 +2330,7 @@ Coverage requirements.
             assert_eq!(
                 evaluate_with_context(
                     &allowed,
-                    std::path::Path::new("."),
+                    repo.path(),
                     &WorkflowContext::unknown().with_pending_discussion_goal(Some(pending_goal())),
                 )
                 .expect("allowed JSON bookkeeping output"),
@@ -2358,6 +2362,8 @@ Coverage requirements.
     #[test]
     fn owner_guard_blocks_mutating_tools_without_owner() {
         let repo = tempfile::tempdir().expect("repo");
+        gwt_skills::write_lane_file(repo.path(), gwt_skills::LaneRegistry::default_profile())
+            .expect("pin execution lane");
         let event = HookEvent {
             tool_name: Some("Edit".to_string()),
             tool_input: Some(serde_json::json!({
@@ -2385,6 +2391,8 @@ Coverage requirements.
     #[test]
     fn owner_guard_requires_plan_and_tasks_for_spec_owner() {
         let repo = tempfile::tempdir().expect("repo");
+        gwt_skills::write_lane_file(repo.path(), gwt_skills::LaneRegistry::default_profile())
+            .expect("pin execution lane");
         let event = HookEvent {
             tool_name: Some("Write".to_string()),
             tool_input: Some(serde_json::json!({

--- a/crates/gwt/src/managed_assets.rs
+++ b/crates/gwt/src/managed_assets.rs
@@ -78,21 +78,16 @@ pub fn refresh_existing_managed_gwt_assets_for_worktree(worktree: &Path) -> io::
 }
 
 /// Determine the [`SessionKind`] for a non-launch (re-)materialization
-/// (SPEC-3247 FR-002 / FR-004). The refreshers that use this run either
-/// (a) inside an agent process — hook-time re-materialization, where the agent
-/// inherited `GWT_SESSION_KIND` from its launch env — or (b) from the GUI /
-/// startup / tests, where no such signal exists. Reading the ambient signal
-/// therefore keeps an intake agent's guidance intake on re-materialization,
-/// while every other caller decodes to Execution and preserves the current
-/// producing-work behavior. (The launch path does NOT use this: it passes the
-/// kind from `config.is_ephemeral` directly, because the launching GUI process
-/// has no intake env of its own — the signal is written into the *child*.)
-///
-/// `worktree` is currently unused because the deterministic intake-worktree
-/// probe lives in a binary-only module; the ambient signal is the lib-visible
-/// source of truth and is authoritative for the hook-time case this guards.
-fn session_kind_for_worktree(_worktree: &Path) -> SessionKind {
-    SessionKind::from_env()
+/// (SPEC-3247 FR-002 / FR-004). The worktree lane file is the source of truth
+/// (#3377): resolving from the ambient `GWT_SESSION_KIND` alone let an intake
+/// session's gwtd invocation against another worktree (e.g. develop) apply the
+/// reduced intake asset policy there and delete tracked skill files. Worktrees
+/// materialized before hooks v2 (no lane file) keep the env fast-path, which
+/// preserves hook-time re-materialization for old intake worktrees. (The
+/// launch path does NOT use this: it passes the kind from
+/// `config.is_ephemeral` directly.)
+fn session_kind_for_worktree(worktree: &Path) -> SessionKind {
+    gwt_skills::resolve_session_kind_for_worktree(worktree)
 }
 
 fn materialize_managed_gwt_assets_for_targets(
@@ -444,6 +439,31 @@ mod tests {
         assert!(
             msg.contains("issue-3206"),
             "error must name the failing worktree path, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn session_kind_for_worktree_prefers_lane_file_over_env() {
+        // #3377: an intake session invoking gwtd against an execution worktree
+        // (e.g. develop) must materialize with that worktree's lane, not the
+        // caller's ambient env — the env-only read applied the reduced intake
+        // skill set there and deleted tracked skill files.
+        let _lock = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _env = EnvVarGuard::set(gwt_skills::GWT_SESSION_KIND_ENV, "intake");
+        let worktree = tempfile::tempdir().expect("worktree");
+        gwt_skills::write_lane_file(worktree.path(), gwt_skills::LaneRegistry::default_profile())
+            .expect("write lane file");
+        assert_eq!(
+            super::session_kind_for_worktree(worktree.path()),
+            gwt_skills::SessionKind::Execution
+        );
+        // A pre-hooks-v2 worktree (no lane file) keeps the env fast-path.
+        let bare = tempfile::tempdir().expect("bare worktree");
+        assert_eq!(
+            super::session_kind_for_worktree(bare.path()),
+            gwt_skills::SessionKind::Intake
         );
     }
 

--- a/crates/gwt/tests/hook_exit_codes_test.rs
+++ b/crates/gwt/tests/hook_exit_codes_test.rs
@@ -239,6 +239,8 @@ fn event_dispatcher_keeps_blocked_stop_runtime_state_running() {
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let tmp = tempfile::tempdir().unwrap();
+    gwt_skills::write_lane_file(tmp.path(), gwt_skills::LaneRegistry::default_profile())
+        .expect("pin execution lane");
     let sessions_dir = tmp.path().join(".gwt").join("sessions");
     let mut session = Session::new(tmp.path(), "feature/demo", AgentId::Codex);
     session.agent_session_id = Some("agent-123".to_string());

--- a/crates/gwt/tests/hook_workflow_policy_test.rs
+++ b/crates/gwt/tests/hook_workflow_policy_test.rs
@@ -123,6 +123,7 @@ fn with_temp_home<T>(f: impl FnOnce(&TempDir) -> T) -> T {
     let home = tempfile::tempdir().expect("temp home");
     let _home = ScopedGwtHome::set(home.path());
     let _session_id = ScopedEnvVar::unset(GWT_SESSION_ID_ENV);
+    let _session_kind = ScopedEnvVar::unset(gwt_skills::GWT_SESSION_KIND_ENV);
 
     f(&home)
 }
@@ -1291,6 +1292,10 @@ fn allows_read_only_tools_without_owner() {
 
 #[test]
 fn blocks_worktree_internal_edit_without_owner() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let _session_kind = ScopedEnvVar::unset(gwt_skills::GWT_SESSION_KIND_ENV);
     let wt = root();
     let event = event(
         "Edit",
@@ -1305,6 +1310,10 @@ fn blocks_worktree_internal_edit_without_owner() {
 
 #[test]
 fn blocks_worktree_internal_edit_with_relative_path() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let _session_kind = ScopedEnvVar::unset(gwt_skills::GWT_SESSION_KIND_ENV);
     let event = event(
         "Edit",
         json!({ "file_path": "src/lib.rs", "old_string": "x", "new_string": "y" }),
@@ -1318,6 +1327,10 @@ fn blocks_worktree_internal_edit_with_relative_path() {
 
 #[test]
 fn blocks_edit_outside_worktree_without_owner() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let _session_kind = ScopedEnvVar::unset(gwt_skills::GWT_SESSION_KIND_ENV);
     let event = event(
         "Edit",
         json!({ "file_path": "/outside/project/src/lib.rs", "old_string": "x", "new_string": "y" }),
@@ -1331,6 +1344,10 @@ fn blocks_edit_outside_worktree_without_owner() {
 
 #[test]
 fn blocks_docs_edit_outside_worktree_without_owner() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let _session_kind = ScopedEnvVar::unset(gwt_skills::GWT_SESSION_KIND_ENV);
     let event = event(
         "Edit",
         json!({ "file_path": "/outside/project/README.md", "old_string": "x", "new_string": "y" }),
@@ -1369,6 +1386,10 @@ fn allows_docs_only_apply_patch_without_owner_as_chore_exemption() {
 
 #[test]
 fn blocks_source_apply_patch_without_owner() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let _session_kind = ScopedEnvVar::unset(gwt_skills::GWT_SESSION_KIND_ENV);
     let event = event(
         "apply_patch",
         json!({
@@ -1402,6 +1423,10 @@ fn allows_docs_only_apply_patch_for_spec_owner_before_plan_refresh() {
 
 #[test]
 fn allows_mutation_for_plain_issue_owner() {
+    let _guard = env_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let _session_kind = ScopedEnvVar::unset(gwt_skills::GWT_SESSION_KIND_ENV);
     let event = event(
         "Write",
         json!({ "file_path": "src/lib.rs", "content": "fn x() {}\n" }),
@@ -2392,6 +2417,7 @@ fn blocks_write_outside_worktree_non_plan_paths_without_owner() {
     let _guard = env_lock()
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let _session_kind = ScopedEnvVar::unset(gwt_skills::GWT_SESSION_KIND_ENV);
     let home = tempfile::tempdir().expect("temp home");
     let _home_env = gwt_core::test_support::ScopedEnvVar::set("HOME", home.path());
     let outside = home.path().join("elsewhere/notes.rs");

--- a/crates/gwt/tests/managed_assets_test.rs
+++ b/crates/gwt/tests/managed_assets_test.rs
@@ -170,6 +170,8 @@ fn intake_materialize_overrides_stale_tracked_gwt_skills() {
 fn refresh_managed_gwt_assets_materializes_skills_commands_hooks_and_excludes() {
     let dir = tempdir().expect("tempdir");
     run_git(dir.path(), &["init", "-q"]);
+    gwt_skills::write_lane_file(dir.path(), gwt_skills::LaneRegistry::default_profile())
+        .expect("pin execution lane");
     let _env_guard = env_lock();
     let cli_bin = dir.path().join("bin/gwtd");
     std::fs::create_dir_all(cli_bin.parent().expect("bin parent")).expect("create bin dir");
@@ -272,6 +274,8 @@ fn refresh_managed_gwt_assets_materializes_skills_commands_hooks_and_excludes() 
 fn refresh_managed_assets_for_codex_only_materializes_codex_assets() {
     let dir = tempdir().expect("tempdir");
     run_git(dir.path(), &["init", "-q"]);
+    gwt_skills::write_lane_file(dir.path(), gwt_skills::LaneRegistry::default_profile())
+        .expect("pin execution lane");
     let _env_guard = env_lock();
     let cli_bin = dir.path().join("bin/gwtd");
     std::fs::create_dir_all(cli_bin.parent().expect("bin parent")).expect("create bin dir");
@@ -319,6 +323,8 @@ fn refresh_managed_assets_for_codex_only_materializes_codex_assets() {
 fn refresh_managed_assets_for_hermes_materializes_hermes_home_skills_only() {
     let dir = tempdir().expect("tempdir");
     run_git(dir.path(), &["init", "-q"]);
+    gwt_skills::write_lane_file(dir.path(), gwt_skills::LaneRegistry::default_profile())
+        .expect("pin execution lane");
     let _env_guard = env_lock();
     let cli_bin = dir.path().join("bin/gwtd");
     std::fs::create_dir_all(cli_bin.parent().expect("bin parent")).expect("create bin dir");
@@ -362,6 +368,8 @@ fn refresh_managed_assets_for_hermes_materializes_hermes_home_skills_only() {
 fn refresh_existing_managed_assets_refreshes_only_present_provider_surfaces() {
     let dir = tempdir().expect("tempdir");
     run_git(dir.path(), &["init", "-q"]);
+    gwt_skills::write_lane_file(dir.path(), gwt_skills::LaneRegistry::default_profile())
+        .expect("pin execution lane");
     let _env_guard = env_lock();
     let cli_bin = dir.path().join("bin/gwtd");
     std::fs::create_dir_all(cli_bin.parent().expect("bin parent")).expect("create bin dir");
@@ -412,6 +420,8 @@ fn refresh_managed_gwt_assets_reports_the_failed_step() {
 fn refresh_managed_gwt_assets_keeps_command_assets_on_gwtd_cli_surface() {
     let dir = tempdir().expect("tempdir");
     run_git(dir.path(), &["init", "-q"]);
+    gwt_skills::write_lane_file(dir.path(), gwt_skills::LaneRegistry::default_profile())
+        .expect("pin execution lane");
 
     refresh_managed_gwt_assets_for_worktree(dir.path()).expect("refresh managed assets");
 


### PR DESCRIPTION
Closes #3377

## 問題

`session_kind_for_worktree`(managed_assets)が ambient `GWT_SESSION_KIND` env だけを読んでいたため:

1. intake セッションが他 worktree(develop 等)へ gwtd を実行すると、その worktree に intake の reduced asset policy が適用され **tracked SKILL.md 5 件が削除**された(実害 1)
2. セッション env を継承した `cargo test` で **lane 依存テスト 24 件が誤動作**(lib 5 + 統合 19)(実害 2)
3. その結果 husky pre-push の coverage が誤 FAIL し、**intake セッションからは git push 自体が不可能**だった(実害 3)

## 修正

- `gwt_skills::resolve_session_kind_for_worktree` を新設: worktree lane file(`.gwt/session-kind.json`)を source of truth とし、lane file の無い旧 worktree のみ env フォールバック(hooks v2 P0 の宣言済み設計に整合。hook 側 `hook/context.rs` は既に同方式)
- `managed_assets::session_kind_for_worktree` を新 resolver へ配線
- lane-file-less なテストフィクスチャに execution lane file を固定(`hook_exit_codes_test` / `managed_assets_test` 5 箇所 / lib フィクスチャ 5 箇所)
- 共有 `with_temp_home` ヘルパと共有 `root()` パスを評価するテスト 7 件で ambient session-kind env を scrub

## 検証

- RED: `GWT_SESSION_KIND=intake` で対象テスト群が FAIL(pre-push 失敗の完全再現を実測)
- GREEN: 同 env でフル lib 2085 passed / 0 failed、統合 3 バイナリ 113 passed / 0 failed
- クリーン env でも全 GREEN(挙動不変)/ fmt / clippy `-D warnings` / doc PASS
- **end-to-end: この push 自体を intake env のまま実行し、pre-push の llvm-cov フルスイート(`--tests -p gwt-core -p gwt`)が通過**(修正前は同条件で 2 回失敗)

## 備考

SPEC #3393(hooks 全体再設計)の「誤爆しないか」原則の先行修正。lane 廃止(#3393 とは別トラック)が landing するまでの間も毎日発火し得る実害を止める。work/issue-3393 の実装とはファイル衝突なし。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Lane selection now consistently respects the worktree’s lane configuration, taking precedence over environment settings.
  - Existing workflows without a lane configuration continue using environment-based behavior.

- **Bug Fixes**
  - Improved session and managed-asset behavior when lane settings differ from ambient environment values.

- **Tests**
  - Expanded coverage for lane precedence, workflow policies, stop hooks, runtime state, and asset management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->