### PR TITLE
fix(guidance): route integrity-failed recovery to execution.repair

### DIFF
--- a/.claude/skills/gwt-execute/SKILL.md
+++ b/.claude/skills/gwt-execute/SKILL.md
@@ -87,8 +87,12 @@ When resuming or recovering another session's execution (crash, closed
 window), take over the record explicitly with JSON operation
 `execution.adopt` and a non-empty `params.reason` — takeovers are audited as
 an ownership transfer chain. Adopt requires a valid integrity record. An
-integrity-failed record cannot be repaired in the same execution lifetime
-without risking audit loss; use a fresh linked-owner launch instead.
+integrity-failed record is repaired in place with JSON operation
+`execution.repair`: it quarantines the corrupt record under a unique
+`.corrupt-*` path with a trusted audit entry and atomically materializes a
+fresh Active record, so the same execution lifetime can continue. Diagnose
+first with `execution.status` — its `available_recoveries` names the exact
+operation to run.
 
 ## Mode detection
 

--- a/.codex/skills/gwt-execute/SKILL.md
+++ b/.codex/skills/gwt-execute/SKILL.md
@@ -87,8 +87,12 @@ When resuming or recovering another session's execution (crash, closed
 window), take over the record explicitly with JSON operation
 `execution.adopt` and a non-empty `params.reason` — takeovers are audited as
 an ownership transfer chain. Adopt requires a valid integrity record. An
-integrity-failed record cannot be repaired in the same execution lifetime
-without risking audit loss; use a fresh linked-owner launch instead.
+integrity-failed record is repaired in place with JSON operation
+`execution.repair`: it quarantines the corrupt record under a unique
+`.corrupt-*` path with a trusted audit entry and atomically materializes a
+fresh Active record, so the same execution lifetime can continue. Diagnose
+first with `execution.status` — its `available_recoveries` names the exact
+operation to run.
 
 ## Mode detection
 

--- a/crates/gwt-skills/src/lib.rs
+++ b/crates/gwt-skills/src/lib.rs
@@ -870,8 +870,8 @@ mod tests {
                 "execution.reopen",
                 "temporary question",
                 "params.derive:true",
-                "cannot be repaired in the same execution lifetime",
-                "fresh linked-owner launch",
+                "execution.repair",
+                "execution.status",
             ] {
                 assert!(
                     execute_skill.contains(required),

--- a/crates/gwt/src/cli/execution_state.rs
+++ b/crates/gwt/src/cli/execution_state.rs
@@ -14374,6 +14374,7 @@ mod tests {
             .unwrap_err();
             let message = err.to_string();
             assert!(message.contains("trusted state unhealthy"), "{message}");
+            assert!(message.contains("execution.repair"), "{message}");
             assert!(message.contains("execution.adopt"), "{message}");
             assert!(!message.contains("network"), "{message}");
 

--- a/crates/gwt/src/cli/trusted_store.rs
+++ b/crates/gwt/src/cli/trusted_store.rs
@@ -424,8 +424,9 @@ pub fn store_health_error(context: &str, err: &std::io::Error) -> String {
         "trusted state unhealthy while {context}: {err}. The execution/verification records \
          under the repo-scoped trusted store (`~/.gwt/projects/<repo-hash>/trusted/<worktree-key>/`) \
          or their worktree mirrors (`.gwt/skill-state/`) could not be read or parsed. Repair by \
-         rerunning the canonical writer: `execution.adopt` with a non-empty `params.reason` rewrites \
-         the execution control record; `verify.plan` / `verify.run` rewrite verification state; \
+         rerunning the canonical writer: `execution.repair` quarantines an unreadable execution \
+         control record and materializes a fresh Active one (`execution.adopt` takes over only \
+         records that still pass integrity); `verify.plan` / `verify.run` rewrite verification state; \
          `intake.outcome.record` rewrites the intake outcome. If the failure persists, inspect the \
          store directory for filesystem problems."
     )

--- a/crates/gwt/src/embedded_server.rs
+++ b/crates/gwt/src/embedded_server.rs
@@ -2588,8 +2588,8 @@ async fn execution_binding_probe_handler(
     };
     // This route authorizes agent-initiated producing mutation. Prepared
     // authority is observation-only until the coordinator commits and
-    // promotes the bearer, so it must never receive a successful receipt
-    // through the same endpoint used by PreToolUse.
+    // promotes the bearer, so this probe must never hand it a successful
+    // receipt.
     let Some(execution_binding) = principal.active_execution_binding().cloned() else {
         return execution_binding_error_response(
             "execution_binding_probe_requires_active_execution_authority",


### PR DESCRIPTION
SPEC #3393 のマージ後検証（#3393 コメント 5114801630）で検出した「旧復旧手順の案内残存」ギャップの解消。

## 問題

gwt-execute SKILL.md と `store_health_error` が SPEC #3393 以前の復旧手順を案内したままだった:

- SKILL: 「integrity-failed な記録は同一 execution lifetime では修復不能。fresh linked-owner launch を使え」→ 実装済みの `execution.repair`（quarantine + fresh Active の原子的材料化）と矛盾し、エージェントを重い（かつ不要な）復旧へ誘導
- `store_health_error`: 読めない ECR の処方として `execution.adopt` を案内 → adopt は integrity 有効な記録専用で、このケースでは原理的に失敗する

実例: 本日 #3394 のブリック済みセッション記録（integrity failure）に対し、新バイナリの `execution.status` は `execution.repair` を提示するのに、SKILL とエラー文言は別の手順を指していた。

## 修正

- SKILL（.claude/.codex 両系、埋め込みバンドルは同一ソース）: `execution.status` → `execution.repair` の経路に置換。adopt は integrity 有効な記録の takeover 専用と明記
- `store_health_error`: repair を第一処方に、adopt の適用条件を併記
- 旧文言を固定していた 2 テスト（gwt-skills parity / execution_state store_health）を新経路の assertion に更新
- probe endpoint の PreToolUse 言及コメント（FR-002 で削除済みの経路への参照）を修正

## 検証

- gwt-skills 230 passed / gwt lib **2115 passed, 0 failed（exit code 実測）** / fmt / clippy `-D warnings` / doc PASS
- pre-push coverage hook PASS

Refs #3393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-place recovery path for integrity-failed execution records using `execution.repair`.
  * Added diagnostic guidance through `execution.status` and its available recovery actions.

* **Bug Fixes**
  * Updated repair guidance for malformed or unreadable execution records.
  * Clarified that prepared authority promotion remains observation-only until coordinator approval.

* **Tests**
  * Updated validation checks to cover the new repair and status workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->