### PR TITLE
fix(workspace): split-root回復のレビュー指摘を解消

### DIFF
--- a/crates/gwt-core/src/error.rs
+++ b/crates/gwt-core/src/error.rs
@@ -68,6 +68,13 @@ pub enum GwtError {
         message: String,
     },
 
+    /// An externally coordinated Workspace operation was resolved through a
+    /// different current/WorkItems storage pair than the one it prepared.
+    #[error(
+        "external workspace operation {operation_id} is bound to a different current/work-items path pair"
+    )]
+    ExternalWorkspacePathPairMismatch { operation_id: String },
+
     /// Skill execution error.
     #[error("Skill error: {0}")]
     Skill(String),

--- a/crates/gwt-core/src/workspace_projection/persistence.rs
+++ b/crates/gwt-core/src/workspace_projection/persistence.rs
@@ -1177,12 +1177,37 @@ fn validate_legacy_reconciliation_assigned_targets(
     work_event_root: &Path,
     context: &str,
 ) -> Result<()> {
+    let canonical_work_event_root = canonical_session_bound_path(work_event_root)?;
     let session_ids = projection
         .agents
         .iter()
         .map(|agent| agent.session_id.as_str())
         .collect::<HashSet<_>>();
     for session_id in session_ids {
+        let Some(latest) = projection.latest_agent_for_session(session_id) else {
+            continue;
+        };
+        let latest_targets_work_event_root = projection
+            .agents
+            .iter()
+            .filter(|agent| {
+                agent.session_id == session_id
+                    && agent.updated_at == latest.updated_at
+                    && agent.affiliation_status == WorkspaceAgentAffiliationStatus::Assigned
+            })
+            .try_fold(false, |matched, agent| {
+                if matched {
+                    Ok(true)
+                } else {
+                    session_bound_candidate_path_matches(
+                        agent.worktree_path.as_deref(),
+                        &canonical_work_event_root,
+                    )
+                }
+            })?;
+        if !latest_targets_work_event_root {
+            continue;
+        }
         let Some(agent) =
             resolve_latest_session_bound_agent_authority(projection, session_id, context)?
         else {
@@ -2920,16 +2945,36 @@ fn session_bound_paths_match(left: Option<&Path>, right: Option<&Path>) -> Resul
     let (Some(left), Some(right)) = (left, right) else {
         return Ok(false);
     };
-    let canonicalize = |path: &Path| {
-        fs::canonicalize(path)
-            .map(|path| crate::paths::normalize_windows_child_process_path(&path))
-            .map_err(|_| {
-                GwtError::Other(
-                    "Session-bound workspace path could not be canonicalized".to_string(),
-                )
-            })
+    Ok(canonical_session_bound_path(left)? == canonical_session_bound_path(right)?)
+}
+
+fn canonical_session_bound_path(path: &Path) -> Result<PathBuf> {
+    fs::canonicalize(path)
+        .map(|path| crate::paths::normalize_windows_child_process_path(&path))
+        .map_err(|_| {
+            GwtError::Other("Session-bound workspace path could not be canonicalized".to_string())
+        })
+}
+
+/// Compare persisted candidate state with an already-canonical authority.
+/// A removed candidate cannot own current authority, while every other I/O
+/// failure remains fail-closed.
+fn session_bound_candidate_path_matches(
+    candidate: Option<&Path>,
+    canonical_authority: &Path,
+) -> Result<bool> {
+    let Some(candidate) = candidate else {
+        return Ok(false);
     };
-    Ok(canonicalize(left)? == canonicalize(right)?)
+    match fs::canonicalize(candidate) {
+        Ok(path) => {
+            Ok(crate::paths::normalize_windows_child_process_path(&path) == canonical_authority)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(_) => Err(GwtError::Other(
+            "Session-bound workspace path could not be canonicalized".to_string(),
+        )),
+    }
 }
 
 fn session_bound_optional_paths_match(left: Option<&Path>, right: Option<&Path>) -> Result<bool> {
@@ -3010,6 +3055,7 @@ fn validate_session_bound_work_authority_uniqueness(
     worktree_identity: &Path,
     context: &str,
 ) -> Result<()> {
+    let canonical_worktree_identity = canonical_session_bound_path(worktree_identity)?;
     for other in work_items
         .work_items
         .iter()
@@ -3029,9 +3075,9 @@ fn validate_session_bound_work_authority_uniqueness(
                 canonical_session_bound_branch(container.branch.as_deref().unwrap_or_default())
                     == canonical_session_bound_branch(branch_identity);
             if branch_matches
-                && session_bound_paths_match(
+                && session_bound_candidate_path_matches(
                     container.worktree_path.as_deref(),
-                    Some(worktree_identity),
+                    &canonical_worktree_identity,
                 )?
             {
                 return Err(GwtError::Other(format!(
@@ -3960,9 +4006,9 @@ fn resolve_workspace_state_external_commit_at_locked_with_commit_hook(
             if transaction.current_path != current_path
                 || transaction.work_items_path != work_items_path
             {
-                return Err(GwtError::Other(format!(
-                    "external workspace operation {operation_id} is bound to a different current/work-items path pair"
-                )));
+                return Err(GwtError::ExternalWorkspacePathPairMismatch {
+                    operation_id: operation_id.to_string(),
+                });
             }
             if decision == ExternalWorkspaceCommitDecision::Commit {
                 let pending_reconciliation = transaction

--- a/crates/gwt-core/src/workspace_projection/persistence.rs
+++ b/crates/gwt-core/src/workspace_projection/persistence.rs
@@ -607,7 +607,7 @@ pub fn transact_workspace_state_for_work_event_root_with_preflight<T>(
         work_event_root,
         &current_path,
         &work_items_path,
-        || {
+        |_| {
             let (projection, work_items, persisted) =
                 load_split_root_workspace_state_for_preflight_locked(
                     project_state_root,
@@ -655,13 +655,15 @@ pub fn recover_pending_workspace_state_transaction_for_work_event_root(
         work_event_root,
         &current_path,
         &work_items_path,
-        || {
-            materialize_split_root_workspace_state_paths_locked(
-                project_state_root,
-                work_event_root,
-                &current_path,
-                &work_items_path,
-            )?;
+        |recovered| {
+            if recovered {
+                materialize_split_root_workspace_state_paths_locked(
+                    project_state_root,
+                    work_event_root,
+                    &current_path,
+                    &work_items_path,
+                )?;
+            }
             Ok(())
         },
     )
@@ -1242,29 +1244,46 @@ fn split_root_workspace_state_paths(
     )
 }
 
+fn split_root_workspace_work_items_sources(
+    project_state_root: &Path,
+    work_event_root: &Path,
+    work_items_path: &Path,
+) -> Vec<PathBuf> {
+    let mut sources = Vec::new();
+    for source in [
+        work_items_path.to_path_buf(),
+        legacy_workspace_work_items_path_for_repo_path(project_state_root),
+        gwt_workspace_work_items_path_for_repo_path(work_event_root),
+        legacy_workspace_work_items_path_for_repo_path(work_event_root),
+    ] {
+        if !sources.contains(&source) {
+            sources.push(source);
+        }
+    }
+    sources
+}
+
 fn with_split_root_workspace_state_lock<T>(
     project_state_root: &Path,
     work_event_root: &Path,
     current_path: &Path,
     work_items_path: &Path,
-    operation: impl FnOnce() -> Result<T>,
+    operation: impl FnOnce(bool) -> Result<T>,
 ) -> Result<T> {
-    let legacy_worktree_work_items = gwt_workspace_work_items_path_for_repo_path(work_event_root);
-    let mut lock_targets = vec![
-        current_path.with_file_name("works.json"),
-        work_items_path.to_path_buf(),
-    ];
-    let mut marker_paths = vec![
-        pending_workspace_state_transaction_path(current_path),
-        pending_workspace_state_transaction_path_for_work_items(work_items_path),
-    ];
-    if project_state_root != work_event_root && legacy_worktree_work_items != work_items_path {
-        lock_targets.push(legacy_worktree_work_items.clone());
-        marker_paths.push(pending_workspace_state_transaction_path_for_work_items(
-            &legacy_worktree_work_items,
-        ));
-    }
-    with_workspace_transaction_recovery(lock_targets, marker_paths, operation)
+    let work_item_sources = split_root_workspace_work_items_sources(
+        project_state_root,
+        work_event_root,
+        work_items_path,
+    );
+    let mut lock_targets = vec![current_path.with_file_name("works.json")];
+    lock_targets.extend(work_item_sources.iter().cloned());
+    let mut marker_paths = vec![pending_workspace_state_transaction_path(current_path)];
+    marker_paths.extend(
+        work_item_sources
+            .iter()
+            .map(|path| pending_workspace_state_transaction_path_for_work_items(path)),
+    );
+    with_workspace_transaction_recovery_observed(lock_targets, marker_paths, operation)
 }
 
 /// Materialize legacy project-scoped sources while the caller continuously
@@ -1279,15 +1298,20 @@ fn materialize_split_root_workspace_state_paths_locked(
         &legacy_workspace_projection_path_for_repo_path(project_state_root),
         current_path,
     )?;
-    copy_validated_workspace_work_items_if_needed(
-        &legacy_workspace_work_items_path_for_repo_path(project_state_root),
-        work_items_path,
-    )?;
-    if project_state_root != work_event_root {
-        copy_validated_workspace_work_items_if_needed(
-            &gwt_workspace_work_items_path_for_repo_path(work_event_root),
+    if !work_items_path.exists() {
+        for source in split_root_workspace_work_items_sources(
+            project_state_root,
+            work_event_root,
             work_items_path,
-        )?;
+        )
+        .into_iter()
+        .skip(1)
+        {
+            copy_validated_workspace_work_items_if_needed(&source, work_items_path)?;
+            if work_items_path.exists() {
+                break;
+            }
+        }
     }
 
     // Preserve the destination root's normal migration precedence. Only if it
@@ -1324,12 +1348,11 @@ fn load_split_root_workspace_state_for_preflight_locked(
     };
     projection.project_root = project_state_root.to_path_buf();
 
-    let work_item_sources = [
-        work_items_path.to_path_buf(),
-        legacy_workspace_work_items_path_for_repo_path(project_state_root),
-        gwt_workspace_work_items_path_for_repo_path(work_event_root),
-    ];
-    for source in work_item_sources {
+    for source in split_root_workspace_work_items_sources(
+        project_state_root,
+        work_event_root,
+        work_items_path,
+    ) {
         if let Some(work_items) = load_workspace_work_items_from_path(&source)? {
             return Ok((projection, work_items, true));
         }
@@ -1423,7 +1446,7 @@ pub fn transact_workspace_state_for_work_event_root_with_commit<T>(
         work_event_root,
         &current_path,
         &work_items_path,
-        || {
+        |_| {
             if let Some(receipt) = load_external_workspace_commit_receipt(
                 &current_path,
                 &work_items_path,
@@ -3394,7 +3417,18 @@ fn with_workspace_transaction_recovery<T>(
     base_marker_paths: Vec<PathBuf>,
     operation: impl FnOnce() -> Result<T>,
 ) -> Result<T> {
+    with_workspace_transaction_recovery_observed(base_lock_targets, base_marker_paths, |_| {
+        operation()
+    })
+}
+
+fn with_workspace_transaction_recovery_observed<T>(
+    base_lock_targets: Vec<PathBuf>,
+    base_marker_paths: Vec<PathBuf>,
+    operation: impl FnOnce(bool) -> Result<T>,
+) -> Result<T> {
     let mut operation = Some(operation);
+    let mut recovered = false;
     loop {
         let mut marker_paths = base_marker_paths.clone();
         marker_paths.extend(discover_pending_workspace_state_transaction_coordinators(
@@ -3477,11 +3511,12 @@ fn with_workspace_transaction_recovery<T>(
                     &transaction,
                     true,
                 )?;
+                recovered = true;
             }
             let operation = operation
                 .take()
                 .expect("workspace state operation must run exactly once");
-            operation().map(Some)
+            operation(recovered).map(Some)
         })?;
         if let Some(result) = outcome {
             return Ok(result);

--- a/crates/gwt-core/src/workspace_projection/persistence_tests.rs
+++ b/crates/gwt-core/src/workspace_projection/persistence_tests.rs
@@ -1567,8 +1567,12 @@ fn workspace_state_transaction_resolver_rejects_a_cross_pair_operation_match() {
         ExternalWorkspaceCommitDecision::Reject,
     );
     assert!(
-        mismatched.is_err(),
-        "sharing one path and operation id must not authorize another path pair"
+        matches!(
+            mismatched,
+            Err(GwtError::ExternalWorkspacePathPairMismatch { operation_id })
+                if operation_id == "continue-operation-cross-pair"
+        ),
+        "sharing one path and operation id must return the typed path-pair mismatch"
     );
     assert!(
         pending_workspace_state_transaction_path(&current).exists()
@@ -3930,6 +3934,119 @@ fn t812_inject_authority_ambiguity(fixture: &T812Fixture, ambiguity: T812Authori
 }
 
 #[test]
+fn legacy_reconciliation_assigned_target_scope_ignores_unresolvable_unrelated_agent() {
+    let _guard = lock_test_env();
+    let home = tempfile::tempdir().expect("home");
+    let _home = ScopedHome::set(home.path());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let fixture = t812_seed_session_bound_fixture(temp.path());
+    let mut projection = load_workspace_projection_from_path(&fixture.current_path)
+        .expect("load current")
+        .expect("current");
+    let mut stale = projection.agents[0].clone();
+    stale.session_id = "unrelated-stale-session".to_string();
+    stale.workspace_id = Some("work-unrelated-stale".to_string());
+    stale.worktree_path = Some(temp.path().join("deleted-unrelated-worktree"));
+    stale.updated_at += chrono::Duration::seconds(1);
+    projection.agents.push(stale);
+    let work_items = load_workspace_work_items_from_path(&fixture.work_items_path)
+        .expect("load WorkItems")
+        .expect("WorkItems");
+
+    validate_legacy_reconciliation_assigned_targets(
+        &projection,
+        &work_items,
+        &fixture.target.work_event_root,
+        "legacy receipt reconciliation test",
+    )
+    .expect("an unrelated deleted Agent worktree must be outside reconciliation scope");
+}
+
+#[test]
+fn legacy_reconciliation_assigned_target_scope_rejects_unresolvable_authoritative_root() {
+    let _guard = lock_test_env();
+    let home = tempfile::tempdir().expect("home");
+    let _home = ScopedHome::set(home.path());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let fixture = t812_seed_session_bound_fixture(temp.path());
+    let projection = load_workspace_projection_from_path(&fixture.current_path)
+        .expect("load current")
+        .expect("current");
+    let work_items = load_workspace_work_items_from_path(&fixture.work_items_path)
+        .expect("load WorkItems")
+        .expect("WorkItems");
+
+    let result = validate_legacy_reconciliation_assigned_targets(
+        &projection,
+        &work_items,
+        &temp.path().join("deleted-authoritative-worktree"),
+        "legacy receipt reconciliation test",
+    );
+
+    assert!(
+        result.is_err(),
+        "an unresolvable authoritative work-event root must fail closed"
+    );
+}
+
+#[test]
+fn session_bound_work_authority_uniqueness_ignores_unresolvable_foreign_container() {
+    let _guard = lock_test_env();
+    let home = tempfile::tempdir().expect("home");
+    let _home = ScopedHome::set(home.path());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let fixture = t812_seed_session_bound_fixture(temp.path());
+    t812_inject_authority_ambiguity(&fixture, T812AuthorityAmbiguity::TerminalContainerShadow);
+    let mut work_items = load_workspace_work_items_from_path(&fixture.work_items_path)
+        .expect("load WorkItems")
+        .expect("WorkItems");
+    work_items
+        .work_items
+        .iter_mut()
+        .find(|item| item.id == "work-terminal-container-shadow")
+        .expect("foreign container shadow")
+        .execution_containers[0]
+        .worktree_path = Some(temp.path().join("deleted-foreign-worktree"));
+
+    validate_session_bound_work_authority_uniqueness(
+        &work_items,
+        T812_TARGET_WORK_ID,
+        T812_SESSION_ID,
+        T812_TARGET_BRANCH,
+        &fixture.target.worktree_identity,
+        "Session-bound workspace test",
+    )
+    .expect("a deleted foreign container cannot be current Work authority");
+}
+
+#[test]
+fn session_bound_work_authority_uniqueness_rejects_unresolvable_authoritative_target() {
+    let _guard = lock_test_env();
+    let home = tempfile::tempdir().expect("home");
+    let _home = ScopedHome::set(home.path());
+    let temp = tempfile::tempdir().expect("tempdir");
+    let fixture = t812_seed_session_bound_fixture(temp.path());
+    t812_inject_authority_ambiguity(&fixture, T812AuthorityAmbiguity::TerminalContainerShadow);
+    let work_items = load_workspace_work_items_from_path(&fixture.work_items_path)
+        .expect("load WorkItems")
+        .expect("WorkItems");
+
+    let result = validate_session_bound_work_authority_uniqueness(
+        &work_items,
+        T812_TARGET_WORK_ID,
+        T812_SESSION_ID,
+        T812_TARGET_BRANCH,
+        &temp.path().join("deleted-authoritative-worktree"),
+        "Session-bound workspace test",
+    );
+
+    assert!(
+        result.is_err(),
+        "an unresolvable authoritative target must fail closed"
+    );
+}
+
+#[test]
 fn session_bound_update_rejects_conflicting_current_and_terminal_authority_shadows() {
     let _guard = lock_test_env();
     let home = tempfile::tempdir().expect("home");
@@ -4156,7 +4273,7 @@ fn legacy_external_commit_waits_for_canonical_lock_before_publication() {
         "legacy Work must not publish before the canonical lock is acquired"
     );
 
-    canonical_lock.unlock().expect("release canonical lock");
+    FileExt::unlock(&canonical_lock).expect("release canonical lock");
     assert_eq!(
         result_rx
             .recv_timeout(Duration::from_secs(5))
@@ -7927,7 +8044,7 @@ fn record_workspace_work_event_does_not_advance_projection_when_append_fails() {
 
 #[test]
 fn record_workspace_work_event_waits_for_the_projection_transaction_lock() {
-    use fs2::FileExt as _;
+    use fs2::FileExt;
     use std::fs::OpenOptions;
     use std::sync::mpsc::TryRecvError;
     use std::time::Duration;
@@ -7970,7 +8087,7 @@ fn record_workspace_work_event_waits_for_the_projection_transaction_lock() {
         TryRecvError::Empty,
         "writer must not enter the projection transaction while the lock is held"
     );
-    lock.unlock().expect("release transaction lock");
+    FileExt::unlock(&lock).expect("release transaction lock");
     rx.recv_timeout(Duration::from_secs(2))
         .expect("writer result")
         .expect("writer succeeds after lock release");

--- a/crates/gwt-core/src/workspace_projection/persistence_tests.rs
+++ b/crates/gwt-core/src/workspace_projection/persistence_tests.rs
@@ -946,6 +946,63 @@ fn workspace_state_transaction_for_work_event_root_migrates_single_root_state() 
 }
 
 #[test]
+fn split_root_transaction_migrates_legacy_worktree_workspace_work_items() {
+    let _guard = lock_test_env();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let _home = ScopedHome::set(&home);
+    let (project_state_root, work_event_root) =
+        init_test_workspace_home_with_linked_worktree(temp.path());
+    let now = Utc.with_ymd_and_hms(2026, 8, 1, 3, 15, 0).unwrap();
+
+    let repo_global_works = gwt_workspace_work_items_path_for_repo_path(&project_state_root);
+    let legacy_worktree_works = legacy_workspace_work_items_path_for_repo_path(&work_event_root);
+    let topology_dependent_shadow = gwt_workspace_work_items_path_for_repo_path(&work_event_root);
+    let mut work_items = WorkItemsProjection::empty(now);
+    let mut start = WorkEvent::new(WorkEventKind::Start, "work-legacy-worktree", now);
+    start.id = "event-legacy-worktree".to_string();
+    start.title = Some("Legacy exact-worktree Work".to_string());
+    work_items.apply_event(start);
+    save_workspace_work_items_projection_to_path(&legacy_worktree_works, &work_items)
+        .expect("legacy exact-worktree WorkItems");
+    let legacy_bytes = std::fs::read(&legacy_worktree_works).expect("legacy exact-worktree bytes");
+
+    assert!(!repo_global_works.exists());
+    assert!(!topology_dependent_shadow.exists());
+    transact_workspace_state_for_work_event_root(
+        &project_state_root,
+        &work_event_root,
+        |_, existing, persisted| {
+            assert!(
+                persisted,
+                "legacy exact-worktree WorkItems are durable state"
+            );
+            assert!(existing
+                .work_items
+                .iter()
+                .any(|item| item.id == "work-legacy-worktree"));
+            Ok(((), Vec::new()))
+        },
+    )
+    .expect("migrate legacy exact-worktree WorkItems into repo-global state");
+
+    assert!(load_workspace_work_items_from_path(&repo_global_works)
+        .unwrap()
+        .unwrap()
+        .work_items
+        .iter()
+        .any(|item| item.id == "work-legacy-worktree"));
+    assert_eq!(
+        std::fs::read(&legacy_worktree_works).expect("legacy source remains immutable"),
+        legacy_bytes
+    );
+    assert!(
+        !topology_dependent_shadow.exists(),
+        "migration must not retain a second WorkItems SOT"
+    );
+}
+
+#[test]
 fn workspace_state_transaction_for_work_event_root_recovers_v1_single_root_marker() {
     let _guard = lock_test_env();
     let temp = tempfile::tempdir().expect("tempdir");
@@ -1020,6 +1077,110 @@ fn workspace_state_transaction_for_work_event_root_recovers_v1_single_root_marke
     assert!(std::fs::read_to_string(split_root_events)
         .expect("split-root recovered events")
         .contains("event-v1-recovery"));
+}
+
+#[test]
+fn split_root_recovery_without_pending_transaction_leaves_worktree_read_only() {
+    let _guard = lock_test_env();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let _home = ScopedHome::set(&home);
+    let (project_state_root, work_event_root) =
+        init_test_workspace_home_with_linked_worktree(temp.path());
+    let now = Utc.with_ymd_and_hms(2026, 8, 1, 3, 45, 0).unwrap();
+
+    let legacy_events = gwt_workspace_work_events_path_for_repo_path(&project_state_root);
+    let mut event = WorkEvent::new(WorkEventKind::Start, "work-no-pending-recovery", now);
+    event.id = "event-no-pending-recovery".to_string();
+    append_workspace_work_event_to_path(&legacy_events, &event).expect("legacy event source");
+    let legacy_bytes = std::fs::read(&legacy_events).expect("legacy event bytes");
+    let tracked_events = gwt_repo_local_work_events_path(&work_event_root);
+    let attributes = work_event_root.join(".gitattributes");
+    assert!(!tracked_events.exists());
+    assert!(!attributes.exists());
+
+    recover_pending_workspace_state_transaction_for_work_event_root(
+        &project_state_root,
+        &work_event_root,
+    )
+    .expect("no pending transaction is a read-only no-op");
+
+    assert_eq!(
+        std::fs::read(&legacy_events).expect("legacy source remains immutable"),
+        legacy_bytes
+    );
+    assert!(
+        !tracked_events.exists(),
+        "recovery without a transaction must not migrate tracked events"
+    );
+    assert!(
+        !attributes.exists(),
+        "recovery without a transaction must not dirty the checkout"
+    );
+}
+
+#[test]
+fn split_root_recovery_with_pending_transaction_migrates_recovered_events() {
+    let _guard = lock_test_env();
+    let temp = tempfile::tempdir().expect("tempdir");
+    let home = temp.path().join("home");
+    let _home = ScopedHome::set(&home);
+    let (project_state_root, work_event_root) =
+        init_test_workspace_home_with_linked_worktree(temp.path());
+    let now = Utc.with_ymd_and_hms(2026, 8, 1, 4, 0, 0).unwrap();
+
+    let current_path = gwt_workspace_projection_path_for_repo_path(&project_state_root);
+    let repo_global_works = gwt_workspace_work_items_path_for_repo_path(&project_state_root);
+    let single_root_events = gwt_repo_local_work_events_path(&project_state_root);
+    let tracked_events = gwt_repo_local_work_events_path(&work_event_root);
+    let mut projection = WorkspaceProjection::default_for_project(&project_state_root);
+    projection.title = "Recovered split-root pending state".to_string();
+    let mut event = WorkEvent::new(WorkEventKind::Start, "work-pending-split-recovery", now);
+    event.id = "event-pending-split-recovery".to_string();
+    let mut work_items = WorkItemsProjection::empty(now);
+    work_items.apply_event(event.clone());
+    let pending = PendingWorkspaceStateTransaction {
+        version: 1,
+        transaction_id: None,
+        current_path: current_path.clone(),
+        work_items_path: repo_global_works.clone(),
+        current_precondition: None,
+        work_items_precondition: None,
+        projection,
+        work_items: Some(work_items),
+        events_path: Some(single_root_events),
+        events: vec![event],
+        journal_path: None,
+        journal_entries: Vec::new(),
+        external_commit: None,
+    };
+    write_pending_transaction_markers(&pending);
+
+    recover_pending_workspace_state_transaction_for_work_event_root(
+        &project_state_root,
+        &work_event_root,
+    )
+    .expect("recover and migrate pending split-root transaction");
+
+    assert_eq!(
+        load_workspace_projection_from_path(&current_path)
+            .unwrap()
+            .unwrap()
+            .title,
+        "Recovered split-root pending state"
+    );
+    assert!(load_workspace_work_items_from_path(&repo_global_works)
+        .unwrap()
+        .unwrap()
+        .work_items
+        .iter()
+        .any(|item| item.id == "work-pending-split-recovery"));
+    assert!(std::fs::read_to_string(&tracked_events)
+        .expect("tracked recovered events")
+        .contains("event-pending-split-recovery"));
+    assert!(pending_workspace_state_transaction_paths(&pending)
+        .iter()
+        .all(|path| !path.exists()));
 }
 
 #[test]

--- a/crates/gwt/src/agent_project_state.rs
+++ b/crates/gwt/src/agent_project_state.rs
@@ -2131,7 +2131,7 @@ fn load_session_for_mutation(session_id: &str) -> Result<Session> {
     })
 }
 
-fn normalize_mutation_path(path: &Path) -> PathBuf {
+pub(crate) fn normalize_mutation_path(path: &Path) -> PathBuf {
     let path = normalize_windows_child_process_path(path);
     let path = dunce::canonicalize(&path).unwrap_or(path);
     normalize_windows_child_process_path(&path)
@@ -2252,7 +2252,7 @@ fn validate_project_state_anchor(
     )))
 }
 
-fn canonical_branch_identity(branch: &str) -> String {
+pub(crate) fn canonical_branch_identity(branch: &str) -> String {
     let branch = branch.trim();
     let branch = branch.strip_prefix("refs/heads/").unwrap_or(branch);
     let branch = branch.strip_prefix("refs/remotes/").unwrap_or(branch);

--- a/crates/gwt/src/app_runtime/continuation.rs
+++ b/crates/gwt/src/app_runtime/continuation.rs
@@ -487,12 +487,9 @@ pub(super) fn resolve_split_workspace_state_external_commit(
                 decision,
             )
         }
-        Err(gwt_core::error::GwtError::Other(message))
-            if message
-                == format!(
-                    "external workspace operation {operation_id} is bound to a different current/work-items path pair"
-                ) =>
-        {
+        Err(gwt_core::error::GwtError::ExternalWorkspacePathPairMismatch {
+            operation_id: bound_operation_id,
+        }) if bound_operation_id == operation_id => {
             resolve_legacy_split_workspace_state_external_commit(
                 project_root,
                 work_event_root,

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -18531,9 +18531,18 @@ fn app_runtime_linked_launch_projection_failure_is_visible_and_stops_session() {
     let project_state_path =
         gwt_core::paths::gwt_workspace_projection_path_for_repo_path(&project_root);
     let project_state_dir = project_state_path.parent().expect("project-state dir");
-    fs::create_dir_all(project_state_dir.parent().expect("project dir")).expect("project dir");
-    fs::write(project_state_dir, b"block projection directory")
-        .expect("block project-state writes");
+    fs::create_dir_all(project_state_dir).expect("create project-state directory");
+    fs::create_dir(&project_state_path).expect("block only the current projection target");
+    let repo_global_work_items_path =
+        gwt_core::paths::gwt_workspace_work_items_path_for_repo_path(&project_root);
+    let repo_global_close_events_path =
+        gwt_core::paths::gwt_workspace_work_events_closed_path_for_repo_path(&project_root);
+    assert!(
+        project_state_dir.is_dir()
+            && repo_global_work_items_path.parent() == Some(project_state_dir)
+            && repo_global_close_events_path.parent() == Some(project_state_dir),
+        "the projection failure fixture must leave sibling Work paths structurally writable"
+    );
     let (command, args) = if cfg!(windows) {
         (
             "cmd".to_string(),

--- a/crates/gwt/src/cli/workspace.rs
+++ b/crates/gwt/src/cli/workspace.rs
@@ -1526,13 +1526,13 @@ fn validate_workspace_ensure_recovery_state(
         let identity_matches = agent
             .branch
             .as_deref()
-            .map(workspace_ensure_branch_identity)
+            .map(crate::agent_project_state::canonical_branch_identity)
             .as_deref()
             == Some(recovery.branch_identity.as_str())
             && agent
                 .worktree_path
                 .as_deref()
-                .and_then(|path| dunce::canonicalize(path).ok())
+                .map(crate::agent_project_state::normalize_mutation_path)
                 .as_deref()
                 == Some(recovery.worktree_identity.as_path());
         if !identity_matches {
@@ -1686,23 +1686,16 @@ fn workspace_execution_container_matches_recovery(
     let branch_matches = container
         .branch
         .as_deref()
-        .map(workspace_ensure_branch_identity)
+        .map(crate::agent_project_state::canonical_branch_identity)
         .as_deref()
         == Some(recovery.branch_identity.as_str());
     let worktree_matches = container
         .worktree_path
         .as_deref()
-        .and_then(|path| dunce::canonicalize(path).ok())
+        .map(crate::agent_project_state::normalize_mutation_path)
         .as_deref()
         == Some(recovery.worktree_identity.as_path());
     branch_matches && worktree_matches
-}
-
-fn workspace_ensure_branch_identity(branch: &str) -> String {
-    let branch = branch.trim();
-    let branch = branch.strip_prefix("refs/heads/").unwrap_or(branch);
-    let branch = branch.strip_prefix("refs/remotes/").unwrap_or(branch);
-    branch.strip_prefix("origin/").unwrap_or(branch).to_string()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -4648,6 +4641,83 @@ pub(crate) mod tests {
             std::fs::read(events_path).expect("event log after retry"),
             before_retry,
             "response-loss retry must not duplicate recovery events"
+        );
+    }
+
+    #[test]
+    fn workspace_ensure_bound_host_retry_accepts_powershell_worktree_aliases() {
+        let _guard = env_guard();
+        let gwt_home = tempfile::tempdir().expect("gwt home");
+        let _home = ScopedHome::set(gwt_home.path());
+        let temp = tempfile::tempdir().expect("tempdir");
+        let project_root = temp.path().join("workspace-home");
+        let worktree = project_root.join("work").join("issue-3412");
+        let session_id = "session-powershell-worktree-alias";
+        write_bound_projectionless_session(session_id, &worktree, &project_root, 3412);
+        let work_id = seed_exact_workspace_work(
+            &project_root,
+            &worktree,
+            session_id,
+            Some("Issue #3412"),
+            "codex",
+        );
+        let canonical_worktree = dunce::canonicalize(&worktree).expect("canonical worktree");
+        let powershell_alias = PathBuf::from(format!(
+            r"Microsoft.PowerShell.Core\FileSystem::{}",
+            canonical_worktree.display()
+        ));
+
+        let mut projection = WorkspaceProjection::default_for_project(&project_root);
+        let mut agent = assigned_agent_with_window(session_id, "window-host", &worktree);
+        agent.workspace_id = Some(work_id.clone());
+        agent.worktree_path = Some(powershell_alias.clone());
+        projection.agents.push(agent);
+        save_workspace_projection(&project_root, &projection)
+            .expect("save aliased Host assignment");
+
+        let works_path =
+            gwt_core::paths::gwt_workspace_work_items_path_for_repo_path(&project_root);
+        let mut work_items =
+            gwt_core::workspace_projection::load_workspace_work_items_from_path(&works_path)
+                .expect("load exact WorkItems")
+                .expect("exact WorkItems");
+        let item = work_items
+            .work_items
+            .iter_mut()
+            .find(|item| item.id == work_id)
+            .expect("exact Work");
+        item.execution_containers[0].worktree_path = Some(powershell_alias);
+        gwt_core::workspace_projection::save_workspace_work_items_projection_to_path(
+            &works_path,
+            &work_items,
+        )
+        .expect("save aliased WorkItems");
+
+        let events_path = gwt_core::paths::gwt_repo_local_work_events_path(&worktree);
+        let before_events = std::fs::read(&events_path).expect("seeded Host event log");
+        let retry = ensure_workspace_for_agent(
+            &worktree,
+            WorkspaceEnsureInput {
+                agent_session: session_id.to_string(),
+                title_summary: "Existing aliased Host Work".to_string(),
+                current_focus: Some("Keep the existing assignment".to_string()),
+                spec: None,
+                issue: None,
+                topic: None,
+                boundary: None,
+            },
+        )
+        .expect("equivalent PowerShell worktree aliases must retain durable authority");
+
+        assert_eq!(
+            retry.disposition,
+            WorkspaceEnsureDisposition::AlreadyAssigned
+        );
+        assert_eq!(retry.workspace_id, work_id);
+        assert_eq!(
+            std::fs::read(events_path).expect("Host event log after retry"),
+            before_events,
+            "AlreadyAssigned retry must not append a Work event"
         );
     }
 


### PR DESCRIPTION
## Summary

- split-root recovery が repo-global WorkItems と linked-worktree event root の双方から旧状態を安全に回収できるようにします。
- Session-bound authority は authoritative path を fail-closed に保ちつつ、削除済みの無関係な Agent / container だけを候補外として扱います。
- Host retry と runtime continuation の identity / error 境界を typed contract と共有 normalizer へ揃え、PR #3416 後のレビュー指摘を回帰テストで固定します。

## Changes

- `gwt-core::workspace_projection::persistence`: split-root source precedence、pending recovery materialization、stale candidate path の scope 判定、authority uniqueness を修正しました。
- `gwt-core::error`: external transaction の path-pair mismatch を `ExternalWorkspacePathPairMismatch` として型付けしました。
- `gwt::agent_project_state` / `gwt::cli::workspace`: branch / worktree identity normalizer を共有し、PowerShell path alias の Host retry を同一 authority として扱います。
- `gwt::app_runtime::continuation`: legacy fallback を typed error と exact operation id に限定しました。
- `gwt-core` / `gwt` tests: stale Agent / container、split-root recovery、PowerShell alias、projection failure fixture、typed fallback の回帰テストを追加・強化しました。

## Testing

- [x] `cargo test -p gwt-core -p gwt --all-features -- --test-threads=1` — 全 suite PASS
- [x] `cargo llvm-cov -p gwt-core -p gwt --all-features --json --summary-only --output-path target/coverage-summary.json` — PASS
- [x] `node scripts/check-coverage-threshold.mjs target/coverage-summary.json 90` — 91.44%、閾値 PASS
- [x] `cargo fmt --all -- --check` — PASS
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — PASS
- [x] `cargo build -p gwt --bin gwt --bin gwtd` — PASS
- [x] canonical `verify.run` — 4/4 PASS、record `vrr-8ba8cb165cac4555b46fca3df9fafe92`
- [x] GitHub CI — 全 required checks PASS（Linux / Windows Rust、Build、Clippy/Rustfmt、Frontend/WebView、Commit lint、Cargo Deny）
- [x] User Verification — N/A（UI surface / user-visible copy の変更なし）

## PR Readiness

- State: Ready for review
- Releaseable slice: Yes — authority/recovery の追補修正と回帰テストが一体で、単独 revert 可能です
- Known blockers: None
- Remaining acceptance: None

## Closing Issues

- Closes #3412

## Related Issues / Links

- #2359
- #3411
- #3245
- #3416

## Checklist

- [x] Tests added/updated
- [x] Lint/format passed (`cargo clippy`, `cargo fmt`)
- [x] Documentation updated (N/A: user-facing docs / UI contract の変更なし)
- [x] Migration/backfill plan included (N/A: persisted schema 変更なし、既存 split-root source を transaction 内で回収)
- [x] CHANGELOG impact considered (patch-level bug fix、breaking change なし)

## Context

- PR #3416 は review fix `2f9c38262` の push 前に旧 HEAD `1fae240d7` を auto-merge したため、本 PR は develop に未収録の review fix と追加レビュー対応だけを追補します。
- #3411 と #3245 は generation-scoped Work receipt を既存 Session から回復できず PR gate で停止しており、本修正の安全な delivery を待っています。

## Risk / Impact

- **Affected areas**: Session-bound workspace.ensure/update、Start Work launch publication、split-root transaction recovery
- **Rollback plan**: 本 PR の source commits `2f9c38262` と `ec41d8f3b` を revert し、PR #3416 の挙動へ戻します

## Notes

- PR #3416 の post-merge review thread 13件は、修正コミットまたは非該当根拠を返信して全件 resolve 済みです。
- Ready 後に新規 review thread が発生した場合は Fix loop で返信・resolve します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace recovery and transaction handling for split-root workspaces.
  * Correctly detects mismatched workspace path pairs and prevents unsafe fallback behavior.
  * Handles legacy work-item sources and pending transactions more reliably.
  * Accepts equivalent PowerShell worktree path aliases without creating duplicate events.
  * Improves validation when workspace or project-state paths are unavailable or unresolvable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->