### PR TITLE
chore(release): v9.77.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@
 - 変更対象に応じた検証（テスト / lint / 型チェック）を実行し、成功を確認してから完了とする。
 - 実行不能な検証がある場合は、未実施理由・代替確認・残リスクを明示する。未検証のまま「完了」と報告しない。
 - gwtプロジェクトでは、単体テスト・結合テスト・E2Eテストを含む全体のテストカバレッジを 90% 以上で維持すること。
+- **GUI / フロントエンドに影響する変更では、必ず Headed ブラウザ（実 Chromium）による E2E テストを実施すること。** headless・linkedom・unit テストのみの検証で完了としない。`browser-check` skill の隔離起動（checkout の `target/debug/gwt` + fresh HOME）を用い、dark / light 両テーマの表示確認と console / page error が無いことまで確認してから完了とする。
 - **完了報告前のセルフチェックリスト（必須）:**
   - [ ] 対象の SPEC (GitHub Issue `gwt-spec` label) が最新状態に更新されているか
   - [ ] 全テスト通過・lint / 型チェック成功

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [9.77.0] - 2026-08-11
+
+### Bug Fixes
+
+- **pm:** Wake prompt と PM 送達の CR を独立した書き込みにして submit を成立させる (SPEC #3431 FR-108c / T-218)
+
+### Documentation
+
+- **agents:** GUI/フロントエンド変更で Headed ブラウザ E2E テストを必須化する
+- **pm:** FR-108(a) の harness スケジューラ契約を PM guidance へ追補する (SPEC #3431 T-202)
+
+### Features
+
+- **pm:** FR-111 PM 特権の pane メッセージ送達 pm.message.send を実装する (SPEC #3431 T-206)
+
+
 ## [9.76.0] - 2026-08-10
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,7 +1261,7 @@ dependencies = [
 
 [[package]]
 name = "gwt"
-version = "9.76.0"
+version = "9.77.0"
 dependencies = [
  "ammonia",
  "auto-launch",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-agent"
-version = "9.76.0"
+version = "9.77.0"
 dependencies = [
  "chrono",
  "dunce",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-ai"
-version = "9.76.0"
+version = "9.77.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-clipboard"
-version = "9.76.0"
+version = "9.77.0"
 dependencies = [
  "gwt-core",
  "tempfile",
@@ -1365,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-config"
-version = "9.76.0"
+version = "9.77.0"
 dependencies = [
  "dirs 6.0.0",
  "serde",
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-core"
-version = "9.76.0"
+version = "9.77.0"
 dependencies = [
  "base64 0.23.1",
  "chrono",
@@ -1414,7 +1414,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-docker"
-version = "9.76.0"
+version = "9.77.0"
 dependencies = [
  "gwt-core",
  "serde",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-git"
-version = "9.76.0"
+version = "9.77.0"
 dependencies = [
  "chrono",
  "dirs 6.0.0",
@@ -1440,7 +1440,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-github"
-version = "9.76.0"
+version = "9.77.0"
 dependencies = [
  "chrono",
  "gwt-core",
@@ -1456,7 +1456,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-skills"
-version = "9.76.0"
+version = "9.77.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-terminal"
-version = "9.76.0"
+version = "9.77.0"
 dependencies = [
  "gwt-core",
  "libc",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "gwt-voice"
-version = "9.76.0"
+version = "9.77.0"
 dependencies = [
  "gwt-core",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,7 +644,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -757,7 +757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1796,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8a7b8211e695a1d0cd91cace480d4d0bd57667ab10277cc412c5f7f4884f83"
+checksum = "0b17771570a2b94107741a7b033f19132c2eee21d59d21b24d2ced26500bd66e"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -2255,7 +2255,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.19",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2372,7 +2372,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3236,7 +3236,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3526,7 +3526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3729,7 +3729,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4160,7 +4160,7 @@ dependencies = [
  "once_cell",
  "png",
  "thiserror 2.0.19",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4608,7 +4608,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "9.76.0"
+version = "9.77.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/akiojin/gwt"

--- a/crates/gwt-skills/src/pm_guidance.rs
+++ b/crates/gwt-skills/src/pm_guidance.rs
@@ -128,6 +128,13 @@ You may watch the agents the Monitor launched. You may not drive them.
   to another agent. Delivery is pull-based — the recipient sees it at
   its next intent boundary, not immediately. A Board post never
   interrupts a running agent, so never wait on one as if it did.
+- `pm.message.send` with `params.id` (window id from `pane.list`) and
+  `params.text` delivers one line into another agent pane as TUI input
+  (FR-111). This is your privilege alone — ordinary agents keep the
+  self-only `pane.send` contract — and every attempt lands in a durable
+  receipt log. Use it to nudge an idle pane, announce a Board handoff,
+  or tell an agent to stop what it is doing; never to smuggle
+  instructions past the Monitor's launch path.
 
 You may also stop one. There are two ways, and they mean different
 things:
@@ -327,6 +334,9 @@ mod tests {
             "fall back to polling in the same cycle",
             "degraded (FR-109)",
             "never a reason to park",
+            // FR-111: PM-privileged pane message delivery with receipts.
+            "`pm.message.send`",
+            "receipt log",
             // FR-108(a): harness-native periodic wakeups with re-registration.
             "wakeup-scheduling tool",
             "re-register it before it expires",

--- a/crates/gwt-skills/src/pm_guidance.rs
+++ b/crates/gwt-skills/src/pm_guidance.rs
@@ -185,6 +185,13 @@ Hard limits, no exceptions:
 
 ## Resident loop (unattended)
 
+- Periodic wakeups (FR-108): if your harness has a native scheduler
+  (Claude Code exposes a wakeup-scheduling tool), register a periodic
+  wakeup job for your loop interval at the start of residency, and
+  re-register it before it expires — a lapsed schedule is a silently
+  dead loop. On runtimes without a scheduler (Codex), gwt itself wakes
+  you on the scheduled monitor tick, so no manual setup is needed;
+  treat an injected `[gwt]` wake prompt as the start of a normal cycle.
 - Run a bounded subscribe in the background: `daemon.subscribe` on the
   `issue_monitor` (and optionally `board`) channels with
   `params.timeout_seconds` set, so the stream ends and hands control
@@ -320,6 +327,10 @@ mod tests {
             "fall back to polling in the same cycle",
             "degraded (FR-109)",
             "never a reason to park",
+            // FR-108(a): harness-native periodic wakeups with re-registration.
+            "wakeup-scheduling tool",
+            "re-register it before it expires",
+            "scheduled monitor tick",
             // FR-023: observation of the other agents.
             "`board.show`",
             "`pane.list`",

--- a/crates/gwt/src/app_runtime/frontend_action_log.rs
+++ b/crates/gwt/src/app_runtime/frontend_action_log.rs
@@ -666,6 +666,9 @@ pub(super) fn frontend_user_action_log(event: &FrontendEvent) -> Option<Frontend
         FrontendEvent::PaneSendInput { session_id, .. } => {
             FrontendUserActionLog::new("pane_send_input", "terminal").target(session_id)
         }
+        FrontendEvent::PmPaneSendInput { window_id, .. } => {
+            FrontendUserActionLog::new("pm_pane_send_input", "terminal").target(window_id)
+        }
         FrontendEvent::SetIssueMonitorEnabled { enabled } => {
             FrontendUserActionLog::new("set_issue_monitor_enabled", "issue_monitor")
                 .mode(if *enabled { "on" } else { "off" })

--- a/crates/gwt/src/app_runtime/mod.rs
+++ b/crates/gwt/src/app_runtime/mod.rs
@@ -3866,6 +3866,11 @@ impl AppRuntime {
             FrontendEvent::PaneSendInput { session_id, text } => {
                 self.pane_send_input_events(client_id, &session_id, &text)
             }
+            FrontendEvent::PmPaneSendInput {
+                pm_session_id,
+                window_id,
+                text,
+            } => self.pm_pane_send_input_events(client_id, &pm_session_id, &window_id, &text),
             FrontendEvent::PasteImage {
                 id,
                 data_base64,

--- a/crates/gwt/src/app_runtime/pm.rs
+++ b/crates/gwt/src/app_runtime/pm.rs
@@ -21,6 +21,7 @@
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use gwt::persistence::{WindowGeometry, WindowProcessStatus};
 use gwt::pm_registry::{self, PmLaunchProfile, PmRegistration};
@@ -664,14 +665,10 @@ impl AppRuntime {
     fn write_pm_wake_prompt(&mut self, decision: &PmWakeDecision) -> Result<(), String> {
         match self.runtimes.get(&decision.window_id) {
             None => Err(format!("no live runtime for pane {}", decision.window_id)),
-            Some(runtime) => runtime
-                .pane
-                .lock()
-                .map_err(|error| error.to_string())
-                .and_then(|pane| {
-                    pane.write_input(decision.prompt.as_bytes())
-                        .map_err(|error| error.to_string())
-                }),
+            Some(runtime) => {
+                let pane = Arc::clone(&runtime.pane);
+                super::pty_io::write_pane_input_then_submit(&pane, &decision.prompt)
+            }
         }
     }
 

--- a/crates/gwt/src/app_runtime/pm.rs
+++ b/crates/gwt/src/app_runtime/pm.rs
@@ -26,7 +26,7 @@ use gwt::persistence::{WindowGeometry, WindowProcessStatus};
 use gwt::pm_registry::{self, PmLaunchProfile, PmRegistration};
 use gwt::PmAgentOption;
 
-use super::{AppRuntime, BackendEvent, OutboundEvent};
+use super::{AppRuntime, BackendEvent, ClientId, OutboundEvent};
 
 /// Fixed geometry for a freshly spawned PM pane.
 const PM_WINDOW_GEOMETRY: WindowGeometry = WindowGeometry {
@@ -587,6 +587,75 @@ impl AppRuntime {
             }
         }
         Vec::new()
+    }
+
+    /// SPEC-3431 FR-111 (T-206): PM-privileged message delivery into an
+    /// agent pane. The general SPEC-3050 self-only contract is untouched —
+    /// this separate path exists only for the live registered PM, and the
+    /// principal is re-verified here, immediately before the injection:
+    /// the presented session must be the durable `pm.json` registration of
+    /// the project that owns the target window, and that registration's own
+    /// pane must be live right now. Everything else is refused with a typed
+    /// reply and no write.
+    pub(crate) fn pm_pane_send_input_events(
+        &mut self,
+        client_id: ClientId,
+        pm_session_id: &str,
+        window_id: &str,
+        text: &str,
+    ) -> Vec<OutboundEvent> {
+        let refuse = |error: String| {
+            vec![OutboundEvent::reply(
+                client_id.clone(),
+                BackendEvent::PaneSendResult {
+                    ok: false,
+                    window_id: Some(window_id.to_string()),
+                    error: Some(error),
+                },
+            )]
+        };
+        // The window's owning tab decides which project's PM registration is
+        // the authority — a PM can never reach a pane of another project.
+        let Some(project_root) = self
+            .tabs
+            .iter()
+            .find(|tab| {
+                tab.workspace.persisted().windows.iter().any(|window| {
+                    crate::runtime_support::combined_window_id(&tab.id, &window.id) == window_id
+                })
+            })
+            .map(|tab| tab.project_root.clone())
+        else {
+            return refuse(format!(
+                "pm pane send: unknown pane {window_id} (FR-111 refuses cross-project delivery)"
+            ));
+        };
+        let prefs_path = pm_registry::pm_prefs_path_for_repo_path(&project_root);
+        let registration = match pm_registry::load_pm_prefs(&prefs_path) {
+            Ok(prefs) => prefs.registration,
+            Err(error) => {
+                return refuse(format!("pm pane send: pm registration unreadable: {error}"))
+            }
+        };
+        let Some(registration) = registration else {
+            return refuse(
+                "pm pane send: no registered PM for this project (FR-111 requires the live PM principal)"
+                    .to_string(),
+            );
+        };
+        if registration.session_id != pm_session_id {
+            return refuse(
+                "pm pane send: presented session is not the registered PM (FR-111 refuses foreign principals)"
+                    .to_string(),
+            );
+        }
+        if self.live_pm_window_id(&registration.session_id).is_none() {
+            return refuse(
+                "pm pane send: the registered PM has no live pane (stale registration; FR-111 refuses)"
+                    .to_string(),
+            );
+        }
+        self.pane_send_input_to_window_events(client_id, window_id, text)
     }
 
     /// The one PTY write the wake path performs, against the window id the

--- a/crates/gwt/src/app_runtime/pty_io.rs
+++ b/crates/gwt/src/app_runtime/pty_io.rs
@@ -28,6 +28,63 @@ use super::{
     Read as _, RuntimeStopThreads, UserEvent, WindowProcessStatus,
 };
 
+/// SPEC-3431 FR-108c: how long the TUI is given to render the injected body
+/// before the submit byte arrives. Claude Code and Codex both fold a carriage
+/// return that lands in the same PTY write as the text into the text itself —
+/// the line is inserted on the prompt but never submitted — so the submit has
+/// to be a write of its own, after the TUI has settled.
+const PANE_SUBMIT_SETTLE: Duration = Duration::from_millis(400);
+
+/// Split one pane payload into the body and its submit terminator. Input that
+/// carries no terminator is not a submit and is returned whole, so raw
+/// keystroke forwarding stays byte-exact.
+fn split_pane_submit(text: &str) -> (&str, Option<&str>) {
+    for terminator in ["\r\n", "\r", "\n"] {
+        if let Some(body) = text.strip_suffix(terminator) {
+            return (body, Some(terminator));
+        }
+    }
+    (text, None)
+}
+
+/// Write one pane payload as the TUIs expect it: the body first, then the
+/// submit byte on its own once the TUI has settled (SPEC-3431 FR-108c). The
+/// delay runs on a detached thread holding an `Arc` clone of the pane, so the
+/// event loop is never blocked and every other pane keeps streaming.
+pub(super) fn write_pane_input_then_submit(
+    pane: &Arc<Mutex<Pane>>,
+    text: &str,
+) -> Result<(), String> {
+    let (body, submit) = split_pane_submit(text);
+    if !body.is_empty() {
+        pane.lock()
+            .map_err(|error| error.to_string())
+            .and_then(|pane| {
+                pane.write_input(body.as_bytes())
+                    .map_err(|error| error.to_string())
+            })?;
+    }
+    let Some(submit) = submit else {
+        return Ok(());
+    };
+    let submit = submit.to_string();
+    let pane = Arc::clone(pane);
+    thread::spawn(move || {
+        thread::sleep(PANE_SUBMIT_SETTLE);
+        match pane.lock() {
+            Ok(pane) => {
+                if let Err(error) = pane.write_input(submit.as_bytes()) {
+                    tracing::warn!(%error, "pane submit byte could not be written");
+                }
+            }
+            Err(error) => {
+                tracing::warn!(%error, "pane submit byte skipped: pane lock poisoned");
+            }
+        }
+    });
+    Ok(())
+}
+
 /// Complete the stop phase for every runtime before any join can block.
 fn stop_all_before_joining<I, T>(
     ids: I,
@@ -118,14 +175,7 @@ impl AppRuntime {
     ) -> Vec<OutboundEvent> {
         let write_result = match self.runtimes.get(window_id) {
             None => Err(format!("no live runtime for pane {window_id}")),
-            Some(runtime) => runtime
-                .pane
-                .lock()
-                .map_err(|error| error.to_string())
-                .and_then(|pane| {
-                    pane.write_input(text.as_bytes())
-                        .map_err(|error| error.to_string())
-                }),
+            Some(runtime) => write_pane_input_then_submit(&runtime.pane, text),
         };
 
         match write_result {
@@ -488,6 +538,42 @@ impl AppRuntime {
                 Some(message.clone()),
             ),
         }
+    }
+}
+
+#[cfg(test)]
+mod submit_split_tests {
+    use super::split_pane_submit;
+
+    /// SPEC-3431 FR-108c: the body and the submit byte must be separable, so
+    /// the writer can put the carriage return in its own PTY write. A single
+    /// write of `body + CR` is what the TUIs mis-read as a literal newline.
+    #[test]
+    fn carriage_return_is_separated_from_the_body() {
+        assert_eq!(split_pane_submit("digest.\r"), ("digest.", Some("\r")));
+        assert_eq!(split_pane_submit("digest.\n"), ("digest.", Some("\n")));
+    }
+
+    /// A CRLF terminator is one submit, not a body that ends in CR: stripping
+    /// only the LF would leave a stray carriage return glued to the text.
+    #[test]
+    fn crlf_is_treated_as_a_single_submit_terminator() {
+        assert_eq!(split_pane_submit("digest.\r\n"), ("digest.", Some("\r\n")));
+    }
+
+    /// Input without a terminator is not a submit — `terminal_input` forwards
+    /// raw keystrokes through the same writer and must stay byte-exact.
+    #[test]
+    fn payload_without_a_terminator_is_written_whole() {
+        assert_eq!(split_pane_submit("partial"), ("partial", None));
+        assert_eq!(split_pane_submit(""), ("", None));
+    }
+
+    /// A bare terminator (the submit-only follow-up a caller may send) keeps an
+    /// empty body so the writer skips the first write entirely.
+    #[test]
+    fn bare_terminator_has_an_empty_body() {
+        assert_eq!(split_pane_submit("\r"), ("", Some("\r")));
     }
 }
 

--- a/crates/gwt/src/app_runtime/tests.rs
+++ b/crates/gwt/src/app_runtime/tests.rs
@@ -42881,3 +42881,83 @@ fn scheduled_tick_scans_enabled_projects_and_skips_disabled_ones() {
         "the tick must produce a monitor status snapshot for the enabled project"
     );
 }
+
+/// SPEC-3431 FR-111 (T-206): the server-side PM principal gate for pane
+/// message delivery — re-verified immediately before the injection. Ordinary
+/// sessions, stale registrations, and unknown windows are refused with a
+/// typed reply and zero writes; only the live registered PM reaches the
+/// authorized injection path.
+#[test]
+fn pm_pane_send_gate_refuses_everyone_but_the_live_registered_pm() {
+    let _env_lock = env_test_lock()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let temp = tempdir().expect("tempdir");
+    let _home = ScopedEnvVar::set("HOME", temp.path());
+    let _userprofile = ScopedEnvVar::set("USERPROFILE", temp.path());
+    let (_repo, mut runtime, pm_window_id) = pm_wake_fixture(&temp);
+    let target_window = "tab-1::other-window".to_string();
+
+    let refusal_of = |events: &[OutboundEvent]| -> String {
+        events
+            .iter()
+            .find_map(|event| match &event.event {
+                BackendEvent::PaneSendResult {
+                    ok: false,
+                    error: Some(error),
+                    ..
+                } => Some(error.clone()),
+                _ => None,
+            })
+            .expect("a refused send must reply with a typed error")
+    };
+
+    // A non-PM session is refused: the self-only world stays intact and the
+    // privileged path does not open for it.
+    let events = runtime.pm_pane_send_input_events(
+        "client-1".to_string(),
+        "other-session",
+        &target_window,
+        "hello\r",
+    );
+    assert!(
+        refusal_of(&events).contains("not the registered PM"),
+        "foreign principals must be refused"
+    );
+
+    // An unknown window is refused before any principal work.
+    let events = runtime.pm_pane_send_input_events(
+        "client-1".to_string(),
+        "pm-session-live",
+        "tab-9::ghost",
+        "hello\r",
+    );
+    assert!(refusal_of(&events).contains("unknown pane"));
+
+    // The live registered PM passes the gate; with no PTY runtime in the
+    // harness the write itself reports the missing runtime, which proves the
+    // authorized injection path was reached (not a principal refusal).
+    let events = runtime.pm_pane_send_input_events(
+        "client-1".to_string(),
+        "pm-session-live",
+        &target_window,
+        "hello\r",
+    );
+    assert!(
+        refusal_of(&events).contains("no live runtime"),
+        "the live PM must reach the injection path"
+    );
+
+    // A stale registration (PM pane gone) is refused at the liveness check.
+    runtime.active_agent_sessions.remove(&pm_window_id);
+    let events = runtime.pm_pane_send_input_events(
+        "client-1".to_string(),
+        "pm-session-live",
+        &target_window,
+        "hello\r",
+    );
+    assert!(
+        refusal_of(&events).contains("no live pane"),
+        "a stale PM registration must not deliver"
+    );
+}

--- a/crates/gwt/src/cli.rs
+++ b/crates/gwt/src/cli.rs
@@ -339,6 +339,11 @@ pub enum PaneCommand {
     /// `pane.send` (SPEC-3050: self-only injection
     /// into the calling agent's own pane).
     Send { id: Option<String>, text: String },
+    /// `pm.message.send` (SPEC-3431 FR-111 / T-206): PM-privileged delivery
+    /// into another agent pane of the same project. The live registered PM
+    /// principal is verified client-side and re-verified by the server
+    /// immediately before the injection.
+    PmSend { id: String, text: String },
 }
 /// Sub-action for `plan.*` / `build.*` (SPEC-1935 FR-014q/r).
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/gwt/src/cli/json_envelope.rs
+++ b/crates/gwt/src/cli/json_envelope.rs
@@ -462,6 +462,10 @@ fn parse(input: &str) -> Result<ParsedEnvelope, CliParseError> {
             id: optional_string(params, "id")?,
             text: required_string(params, "text")?,
         }),
+        "pm.message.send" | "pm.pane.send" => CliCommand::Pane(PaneCommand::PmSend {
+            id: required_string(params, "id")?,
+            text: required_string(params, "text")?,
+        }),
         "pm.status" => CliCommand::Pm(crate::cli::pm::PmCommand::Status {
             project_root: optional_string(params, "project_root")?,
         }),
@@ -1987,6 +1991,30 @@ mod tests {
         assert!(matches!(
             err("issue.monitor.failover", json!({"reason": "x"})),
             CliParseError::MissingFlag("number")
+        ));
+    }
+
+    /// SPEC-3431 FR-111 (T-206): the PM's privileged pane delivery is its own
+    /// operation with a mandatory exact target — never a loosened pane.send.
+    #[test]
+    fn pm_message_send_parses_with_mandatory_target_and_text() {
+        assert_eq!(
+            ok(
+                "pm.message.send",
+                json!({"id": "tab-1::agent-1", "text": "please report status"})
+            ),
+            CliCommand::Pane(PaneCommand::PmSend {
+                id: "tab-1::agent-1".to_string(),
+                text: "please report status".to_string(),
+            })
+        );
+        assert!(matches!(
+            err("pm.message.send", json!({"text": "hello"})),
+            CliParseError::MissingFlag("id")
+        ));
+        assert!(matches!(
+            err("pm.message.send", json!({"id": "tab-1::agent-1"})),
+            CliParseError::MissingFlag("text")
         ));
     }
 

--- a/crates/gwt/src/cli/pane.rs
+++ b/crates/gwt/src/cli/pane.rs
@@ -103,6 +103,125 @@ async fn run_async(
         PaneCommand::Send { id, text } => {
             send_pane_input(ws_url, project_root, id.as_deref(), &text).await
         }
+        PaneCommand::PmSend { id, text } => {
+            send_pm_pane_input(ws_url, project_root, &id, &text).await
+        }
+    }
+}
+
+/// SPEC-3431 FR-111 (T-206): PM-privileged delivery into another agent pane
+/// of the same project. Not a loosened `pane.send`: the SPEC-3050 self-only
+/// contract stays intact for every ordinary agent, and this path exists only
+/// for the live registered PM. The client verifies the durable registration
+/// up front (fast, typed refusal), the server re-verifies the live principal
+/// immediately before the injection, and the outcome is appended to a
+/// durable per-project receipt log either way.
+async fn send_pm_pane_input(
+    ws_url: &str,
+    project_root: &str,
+    requested_id: &str,
+    text: &str,
+) -> Result<String, String> {
+    let session_id = std::env::var(GWT_SESSION_ID_ENV)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            format!("{GWT_SESSION_ID_ENV} is not set; pm.message.send requires the PM session")
+        })?;
+    let project_path = std::path::PathBuf::from(project_root);
+    let prefs_path = crate::pm_registry::pm_prefs_path_for_repo_path(&project_path);
+    if !crate::pm_registry::session_is_registered_pm(&prefs_path, &session_id) {
+        let refusal =
+            "pm.message.send refused: the calling session is not the registered PM for this \
+             project (FR-111; ordinary agents keep the self-only pane.send contract)"
+                .to_string();
+        append_pm_message_receipt(
+            &project_path,
+            &session_id,
+            requested_id,
+            false,
+            Some(&refusal),
+        );
+        return Err(refusal);
+    }
+
+    let windows = request_window_list(ws_url, project_root).await?;
+    let Some(window_id) = resolve_window_id(&windows, requested_id) else {
+        let refusal = format!("pm.message.send: unknown pane {requested_id}");
+        append_pm_message_receipt(
+            &project_path,
+            &session_id,
+            requested_id,
+            false,
+            Some(&refusal),
+        );
+        return Err(refusal);
+    };
+    let window_id = window_id.to_string();
+    let line = ensure_trailing_submit(text);
+
+    let mut socket = connect_pane_websocket(ws_url).await?;
+    send_frontend_event(&mut socket, json!({ "kind": "frontend_ready" })).await?;
+    let _scoped = next_workspace_windows(&mut socket, project_root, "pm pane send").await?;
+    send_frontend_event(
+        &mut socket,
+        json!({
+            "kind": "pm_pane_send_input",
+            "pm_session_id": session_id,
+            "window_id": window_id,
+            "text": line,
+        }),
+    )
+    .await?;
+
+    for _ in 0..128 {
+        let value = next_backend_json(&mut socket).await?;
+        let Some(reply) = parse_pane_send_result(&value)? else {
+            continue;
+        };
+        return if reply.ok {
+            let delivered = reply.window_id.unwrap_or(window_id);
+            append_pm_message_receipt(&project_path, &session_id, &delivered, true, None);
+            Ok(format!("pm message delivered to {delivered}\n"))
+        } else {
+            let error = reply.error.unwrap_or_else(|| "unknown error".to_string());
+            append_pm_message_receipt(&project_path, &session_id, &window_id, false, Some(&error));
+            Err(format!("pm message refused: {error}"))
+        };
+    }
+    let error = "pm pane send: backend did not return pane_send_result".to_string();
+    append_pm_message_receipt(&project_path, &session_id, &window_id, false, Some(&error));
+    Err(error)
+}
+
+/// FR-111 audit trail: one JSONL line per delivery attempt, durable beside
+/// the project state so refusals are as visible as deliveries.
+fn append_pm_message_receipt(
+    project_root: &std::path::Path,
+    pm_session_id: &str,
+    window_id: &str,
+    delivered: bool,
+    error: Option<&str>,
+) {
+    let path = gwt_core::paths::gwt_project_dir_for_repo_path(project_root)
+        .join("project-state/pm-messages.jsonl");
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let line = json!({
+        "ts": chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        "pm_session_id": pm_session_id,
+        "window_id": window_id,
+        "delivered": delivered,
+        "error": error,
+    });
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        use std::io::Write as _;
+        let _ = writeln!(file, "{line}");
     }
 }
 

--- a/crates/gwt/src/protocol.rs
+++ b/crates/gwt/src/protocol.rs
@@ -363,6 +363,16 @@ pub enum FrontendEvent {
         session_id: String,
         text: String,
     },
+    /// SPEC-3431 FR-111 (T-206): PM-privileged message delivery into another
+    /// agent pane of the same project. Carries the PM's own session id so the
+    /// server re-verifies the live PM principal immediately before the
+    /// injection; the general self-only contract of
+    /// [`FrontendEvent::PaneSendInput`] is unchanged for every other caller.
+    PmPaneSendInput {
+        pm_session_id: String,
+        window_id: String,
+        text: String,
+    },
     PasteImage {
         id: String,
         data_base64: String,


### PR DESCRIPTION
## Release v9.77.0

develop で滞留していた release commit `461df142e`（chore(release): v9.77.0）の Release PR です。バージョン bump と CHANGELOG は develop に反映済みです。

### Features

- **pm:** FR-111 PM 特権の pane メッセージ送達 `pm.message.send` を実装する (SPEC #3431 T-206)

### Bug Fixes

- **pm:** wake prompt と PM 送達の CR を独立した書き込みにして submit を成立させる (SPEC #3431 FR-108c / T-218)

### Documentation

- **agents:** GUI/フロントエンド変更で Headed ブラウザ E2E テストを必須化する
- **pm:** FR-108(a) の harness スケジューラ契約を PM guidance へ追補する (SPEC #3431 T-202)

### Dependencies

- ignore 0.4.31 → 0.4.33

マージすると release.yml がタグ v9.77.0・GitHub Release 作成・Tauri ビルドを自動実行します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added privileged pane messaging, allowing authorized PM sessions to send text to another agent pane.
  * Added support for `pm.message.send` and `pm.pane.send` commands.
  * Added durable delivery receipts for successful and refused message attempts.
* **Bug Fixes**
  * Improved pane input delivery by separating message content from submit signals, supporting CR, LF, and CRLF endings reliably.
  * Added validation to prevent delivery to unknown, inactive, unauthorized, or stale panes.
* **Documentation**
  * Updated PM guidance and release documentation for pane messaging and wakeup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->